### PR TITLE
feat: long press voice button to pick audio file from device

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -143,8 +143,12 @@
   },
   "recordingWithDuration": "Recording: {duration}",
   "playing": "Playing...",
+  "selectedAudio": "Selected audio",
   "recordedAudio": "Recorded audio",
   "recordLabel": "Record",
+  "stopRecordingFirst": "Please stop recording first",
+  "selectAudioFailed": "Failed to select audio",
+  "unsupportedAudioFormat": "This audio format is not supported yet",
   "smartSuggesting": "Smart suggesting...",
   "noTaskData": "No task data",
   "@createdAtDate": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -656,6 +656,12 @@ abstract class AppLocalizations {
   /// **'Playing...'**
   String get playing;
 
+  /// No description provided for @selectedAudio.
+  ///
+  /// In en, this message translates to:
+  /// **'Selected audio'**
+  String get selectedAudio;
+
   /// No description provided for @recordedAudio.
   ///
   /// In en, this message translates to:
@@ -667,6 +673,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Record'**
   String get recordLabel;
+
+  /// No description provided for @stopRecordingFirst.
+  ///
+  /// In en, this message translates to:
+  /// **'Please stop recording first'**
+  String get stopRecordingFirst;
+
+  /// No description provided for @selectAudioFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to select audio'**
+  String get selectAudioFailed;
+
+  /// No description provided for @unsupportedAudioFormat.
+  ///
+  /// In en, this message translates to:
+  /// **'This audio format is not supported yet'**
+  String get unsupportedAudioFormat;
 
   /// No description provided for @smartSuggesting.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -318,10 +318,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get playing => 'Playing...';
 
   @override
+  String get selectedAudio => 'Selected audio';
+
+  @override
   String get recordedAudio => 'Recorded audio';
 
   @override
   String get recordLabel => 'Record';
+
+  @override
+  String get stopRecordingFirst => 'Please stop recording first';
+
+  @override
+  String get selectAudioFailed => 'Failed to select audio';
+
+  @override
+  String get unsupportedAudioFormat => 'This audio format is not supported yet';
 
   @override
   String get smartSuggesting => 'Smart suggesting...';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -309,10 +309,22 @@ class AppLocalizationsZh extends AppLocalizations {
   String get playing => '播放中...';
 
   @override
+  String get selectedAudio => '已选择音频';
+
+  @override
   String get recordedAudio => '已录制音频';
 
   @override
   String get recordLabel => '记录';
+
+  @override
+  String get stopRecordingFirst => '请先停止录音';
+
+  @override
+  String get selectAudioFailed => '选择音频失败';
+
+  @override
+  String get unsupportedAudioFormat => '暂不支持该音频格式';
 
   @override
   String get smartSuggesting => '智能建议中...';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -143,8 +143,12 @@
   },
   "recordingWithDuration": "录音中: {duration}",
   "playing": "播放中...",
+  "selectedAudio": "已选择音频",
   "recordedAudio": "已录制音频",
   "recordLabel": "记录",
+  "stopRecordingFirst": "请先停止录音",
+  "selectAudioFailed": "选择音频失败",
+  "unsupportedAudioFormat": "暂不支持该音频格式",
   "smartSuggesting": "智能建议中...",
   "noTaskData": "暂无任务数据",
   "@createdAtDate": {

--- a/lib/ui/main_screen/widgets/input_sheet.dart
+++ b/lib/ui/main_screen/widgets/input_sheet.dart
@@ -9,6 +9,7 @@ import 'package:audioplayers/audioplayers.dart';
 import 'package:crypto/crypto.dart';
 import 'dart:convert';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
+import 'package:file_picker/file_picker.dart';
 
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -74,6 +75,12 @@ class _InputSheetState extends State<InputSheet>
 
   List<XFile> _selectedImages = [];
   final Map<String, String> _originalFilenames = {};
+  static const Set<String> _supportedAudioExtensions = {
+    'm4a',
+    'mp3',
+    'wav',
+    'ogg',
+  };
   String? _audioPath;
   bool _isRecording = false;
   Duration _recordingDuration = Duration.zero;
@@ -425,6 +432,72 @@ class _InputSheetState extends State<InputSheet>
         setState(() {
           _isRecording = false;
         });
+      }
+    }
+  }
+
+  Future<void> _pickAudioFile() async {
+    if (_isRecording) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(UserStorage.l10n.stopRecordingFirst)),
+        );
+      }
+      return;
+    }
+
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowMultiple: false,
+        allowedExtensions: _supportedAudioExtensions.toList(),
+      );
+
+      if (result == null || result.files.isEmpty) return;
+
+      final filePath = result.files.single.path;
+      if (filePath == null || filePath.isEmpty) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(UserStorage.l10n.selectAudioFailed)),
+          );
+        }
+        return;
+      }
+
+      final extension = filePath.split('.').last.toLowerCase();
+      if (!_supportedAudioExtensions.contains(extension)) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(UserStorage.l10n.unsupportedAudioFormat)),
+          );
+        }
+        return;
+      }
+
+      final file = File(filePath);
+      if (!await file.exists()) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(UserStorage.l10n.selectAudioFailed)),
+          );
+        }
+        return;
+      }
+
+      await _audioPlayer.stop();
+      if (!mounted) return;
+
+      setState(() {
+        _audioPath = filePath;
+        _isPlaying = false;
+        _isRecording = false;
+      });
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(UserStorage.l10n.selectAudioFailed)),
+        );
       }
     }
   }
@@ -848,7 +921,7 @@ class _InputSheetState extends State<InputSheet>
                                                             ? UserStorage
                                                                 .l10n.playing
                                                             : UserStorage.l10n
-                                                                .recordedAudio),
+                                                                .selectedAudio),
                                                     style: TextStyle(
                                                       color: _isPlaying
                                                           ? AppColors.primary
@@ -883,6 +956,7 @@ class _InputSheetState extends State<InputSheet>
                                             onTap: _isRecording
                                                 ? _stopRecording
                                                 : _startRecording,
+                                            onLongPress: _pickAudioFile,
                                             child: Container(
                                               width: 48,
                                               height: 48,


### PR DESCRIPTION
## Summary

- Adds **long press** gesture on the mic/voice button in the input sheet
- Opens a file picker to select an existing audio file from device storage
- Supported formats: `m4a`, `mp3`, `wav`, `ogg`
- Adds i18n strings for English and Chinese (error messages and audio label)
- Shows a snackbar if user tries to pick while recording is active

## How it works

| Gesture | Action |
|---------|--------|
| Tap | Start/stop recording (existing behavior) |
| Long press | Open file picker to select an audio file |

## Testing

- [x] Tested on real Android device (Samsung SM F966U1, Android 16)
- [ ] **Please test on iOS** — not verified by the author; the `file_picker` package supports iOS but behavior on iOS has not been confirmed

## Notes

This uses the existing `file_picker` dependency. No new packages were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)