### PR TITLE
feat: AI Companion Agent - 角色陪伴聊天系统

### DIFF
--- a/docs/companion-agent-design.md
+++ b/docs/companion-agent-design.md
@@ -1,0 +1,265 @@
+# AI 陪伴角色系统改造方案
+
+## 一、现有问题
+
+### 1. 角色定位模糊
+- PersonaAgent 是"角色设计师"（帮用户创建角色），不是角色本身
+- CommentAgent 是角色的"嘴"，但只能在卡片下面评论，没有独立对话能力
+- 两者割裂：设计角色的地方和角色说话的地方是分开的
+
+### 2. 角色模型太简单
+- `CharacterModel` 的 persona 是一个大文本 blob，style_guide/example_dialogue/pkm_interest_filter 创建后就合并丢失了结构
+- 没有角色的"状态"概念（是否在线、上次互动时间、跟用户的亲密度等）
+- memory 字段存在但没有被系统性使用
+
+### 3. 角色选择是随机的
+- comment_agent_handler 用 `Random(factId.hashCode)` 选角色
+- 已在本分支修复（CharacterSelectionService），但还没有用户主动选择"主要陪伴角色"的机制
+
+### 4. 没有独立的对话入口
+- 角色只能在卡片评论区"说话"
+- 用户无法主动找角色聊天
+- 角色无法主动发起对话
+
+---
+
+## 二、目标体验
+
+用户打开 APP，右上角看到自己选的陪伴角色头像。
+红点提示有新消息。点进去是一个 1v1 聊天界面，像微信好友。
+
+角色会：
+- 用户发消息时快速回复（2-3秒内开始流式输出）
+- 用户发了新记录后，主动在聊天里说一句（"看到你今天去了XX，怎么样？"）
+- 记得之前聊过的内容，有连续感
+- 根据用户最近的生活状态调整语气和关注点
+
+---
+
+## 三、架构设计
+
+### 3.1 角色模型改造
+
+```
+CharacterModel (改造后)
+├── id: String
+├── name: String
+├── tags: List<String>
+├── avatar: String?
+├── enabled: bool
+├── persona: String              # 角色人设 prompt（结构化 markdown）
+├── interestFilter: String       # 关注领域描述（从 persona 中独立出来）
+└── isPrimaryCompanion: bool     # 是否为用户选定的主要陪伴角色（新增）
+```
+
+persona 内部结构（markdown，不是代码字段）：
+```markdown
+## Identity
+你是用户的死党/闺蜜...
+
+## Personality
+直来直去，情绪饱满，喜欢用网络梗...
+
+## Boundaries
+不讲大道理，不说教，只负责陪伴和情绪宣泄...
+```
+
+不再在 persona 里混入 style_guide、example_dialogue、pkm_interest_filter。
+interestFilter 独立为字段，供 CharacterSelectionService 使用。
+example_dialogue 去掉 — 让 LLM 自己根据 persona 发挥，硬编码的对话示例反而限制了自然度。
+
+### 3.2 记忆系统
+
+存储位置：
+```
+workspace/Characters/
+  {id}.yaml                    # 角色配置
+  {id}_relationship.md         # 关系记忆
+  {id}_emotional_state.md      # 情绪快照
+```
+
+#### 层级 1：用户画像（Identity）
+- 来源：全局 `_System/memory/memory.json` 的 `archived_memory`
+- 已有，直接复用
+- 不需要改动
+
+#### 层级 2：最近生活上下文（Recent Context）
+- 来源：最近 2-3 天的 `Facts/{yyyy}/{mm}/{dd}.md` 原文
+- 读取时截断到 3000 字符
+- 不需要额外存储，每次对话时实时读取
+- 已在本分支的 CommentAgent._getRecentFactsContext 中实现
+
+#### 层级 3：关系记忆（Relationship）
+- 存储：`{id}_relationship.md`
+- 内容示例：
+  ```markdown
+  ## Ongoing Topics
+  - 在纠结要不要跳槽到新公司，已经拿到 offer 但还在犹豫
+  - 养了一只猫叫"团子"，经常提到
+
+  ## Key Moments
+  - 聊到跟父母的关系时比较敏感，不要主动提起
+  - 上次说拿到了新 offer，很兴奋但也焦虑
+
+  ## User Preferences
+  - 深夜聊天比较多，这时候情绪更真实
+  - 不喜欢被安慰"会好的"，更喜欢被倾听和调侃
+  ```
+- 更新时机：用户离开聊天界面时（`dispose`）
+- 更新方式：LLM 调用，输入 = 本次对话 + 旧 relationship.md → 输出新版本
+- 大小上限：2000 字符，超了让 LLM 压缩
+
+#### 层级 4：情绪快照（Emotional State）
+- 存储：`{id}_emotional_state.md`
+- 内容示例：
+  ```markdown
+  最近情绪偏低落，工作压力大。上次聊天时提到加班很累，语气疲惫。
+  当前需要：倾听和陪伴，不要给建议。
+  ```
+- 更新时机：跟关系记忆一起
+- 更新方式：覆盖式，只保留最新状态
+- 很短，200 字以内
+
+### 3.3 陪伴 Agent（CompanionAgent）
+
+新建 `lib/agent/companion_agent/`，不复用现有的 agent 框架。
+
+核心设计：**直接调 LLM，不走 StatefulAgent + Tool 体系。**
+
+```dart
+class CompanionAgent {
+  /// 流式对话 — 用于用户主动聊天
+  static Stream<String> chat({
+    required LLMClient client,
+    required ModelConfig modelConfig,
+    required String userId,
+    required String characterId,
+    required String userMessage,
+    required List<ChatMessage> history,  // 最近 N 轮
+  }) async* {
+    // 1. 组装 context
+    final persona = await _loadPersona(userId, characterId);
+    final userProfile = await _loadUserProfile(userId);
+    final emotionalState = await _loadEmotionalState(userId, characterId);
+    final relationship = await _loadRelationship(userId, characterId);
+    final recentFacts = await _loadRecentFacts(userId);
+
+    // 2. 构建 messages
+    final messages = [
+      SystemMessage(_buildSystemPrompt(persona, userProfile, emotionalState, relationship, recentFacts)),
+      ...history.map((m) => m.toLLMMessage()),
+      UserMessage([TextPart(userMessage)]),
+    ];
+
+    // 3. 流式调用 LLM（无 tool calling）
+    yield* client.generateStream(messages, modelConfig: modelConfig)
+        .map((chunk) => chunk.textOutput ?? '');
+  }
+
+  /// 生成主动消息 — 用于角色看到用户新记录后主动说一句
+  static Future<String?> generateProactiveMessage({
+    required LLMClient client,
+    required ModelConfig modelConfig,
+    required String userId,
+    required String characterId,
+    required String newRecordContent,
+  }) async {
+    // 类似 chat，但 prompt 不同：要求角色基于新记录主动发起话题
+    // 返回 null 表示角色觉得这条记录不值得主动聊
+  }
+
+  /// 更新记忆 — 对话结束后调用
+  static Future<void> updateMemory({
+    required LLMClient client,
+    required ModelConfig modelConfig,
+    required String userId,
+    required String characterId,
+    required List<ChatMessage> conversation,
+  }) async {
+    // 1. 读旧的 relationship.md 和 emotional_state.md
+    // 2. 一次 LLM 调用，同时输出新的关系记忆和情绪快照
+    // 3. 写回文件
+  }
+}
+```
+
+### 3.4 主动消息机制
+
+触发流程：
+```
+用户发新记录
+  → submitInput
+    → GlobalEventBus 发布 userInputSubmitted
+      → 现有: card_agent_task, pkm_agent_task, comment_agent_task
+      → 新增: companion_message_task（依赖 pkm_agent）
+```
+
+companion_message_task 的逻辑：
+1. 读取用户选定的主要陪伴角色
+2. 调用 CompanionAgent.generateProactiveMessage()
+3. 如果返回非 null，存入 PersonaChatMessages 表（Drift）
+4. 通过 EventBus 通知 UI 更新红点
+
+角色不是每条记录都主动说话。prompt 里会告诉角色：
+- 只在你觉得值得聊的时候才说话
+- 如果内容跟你的关注领域无关，保持沉默（返回空）
+- 不要每次都说话，频率大概 1/3 到 1/2
+
+### 3.5 UI 改动
+
+#### 右上角角色头像
+- 在 timeline header 的 chat 按钮旁边加一个角色头像
+- 带未读红点（数字）
+- 点击进入聊天界面
+
+#### 聊天界面
+- 类似微信 1v1 聊天
+- 角色消息在左（带头像），用户消息在右
+- 流式输出（打字机效果）
+- 底部输入框
+- 角色的主动消息也显示在这里（带时间戳）
+
+#### 角色选择/管理
+- 保留现有的 CharacterConfigScreen（角色列表页）
+- 新增：用户可以长按某个角色设为"主要陪伴角色"
+- 角色模板：首次使用时展示模板选择页，用户选一个作为主要陪伴角色
+
+### 3.6 要删除/改造的现有代码
+
+| 现有代码 | 处理方式 |
+|---------|---------|
+| CommentAgent 在卡片下评论 | 保留，但同时把评论内容推送到聊天通道 |
+| comment_agent_handler 的随机选角色 | 已改为 CharacterSelectionService（本分支） |
+| PersonaAgent（角色设计师） | 保留，但降低优先级，后续可以让陪伴角色自己进化 persona |
+| CharacterModel.memory (CharacterMemoryBlock) | 废弃，改用 relationship.md + emotional_state.md |
+| defaultCharacters 里的 style_guide/example_dialogue | 合并进 persona，去掉独立字段 |
+| CharacterEditPage 的大文本框编辑 persona | 后续改为结构化表单，但不在本次范围 |
+
+---
+
+## 四、实施顺序
+
+### Phase 1：基础设施
+1. CharacterModel 加 `isPrimaryCompanion` 和 `interestFilter` 字段
+2. CharacterService 支持设置主要陪伴角色
+3. Drift 新增 PersonaChatMessages 表
+4. PersonaChatService（消息 CRUD + 未读计数）
+
+### Phase 2：CompanionAgent 核心
+5. CompanionAgent.chat() — 流式对话（无 tool calling）
+6. CompanionAgent.updateMemory() — 对话结束后更新记忆
+7. 记忆文件读写（relationship.md, emotional_state.md）
+
+### Phase 3：UI
+8. PersonaChatScreen（聊天界面）
+9. PersonaAvatarButton（右上角头像 + 红点）
+10. 集成到 TimelineScreen header
+
+### Phase 4：主动消息（后续单独设计）
+11. CompanionAgent.generateProactiveMessage()
+12. companion_message_task handler
+13. 注册到 GlobalEventBus 的 userInputSubmitted 订阅
+
+### Phase 5：清理
+14. 默认角色模板重构（合并 style_guide 等）
+15. 废弃 CharacterMemoryBlock，迁移到文件记忆

--- a/lib/agent/comment_agent/comment_agent.dart
+++ b/lib/agent/comment_agent/comment_agent.dart
@@ -197,10 +197,14 @@ class CommentAgent {
     return "";
   }
 
-  /// Find PKM Context using Grep
+  /// Find PKM Context using Grep.
+  /// Falls back to recent daily facts if the specific fact_id isn't in PKM yet.
   static Future<String> _findPkmContext(String userId, String workingDirectory,
       String pkmPath, String factId, FileOperationService fileOpService,
       {int contextLines = 10}) async {
+    final buffer = StringBuffer();
+
+    // 1. Try to find the specific fact_id in PKM
     try {
       final factIdPattern = "<!-- fact_id: $factId -->";
       final result = await fileOpService.grepFiles(
@@ -213,16 +217,72 @@ class CommentAgent {
         workingDirectory: workingDirectory,
       );
 
-      if (result.contains("No match found") || result.trim().isEmpty) {
-        getLogger('CommentAgent')
-            .warning("Could not find fact_id $factId in PKM files");
-        return "";
+      if (!result.contains("No match found") && result.trim().isNotEmpty) {
+        buffer.writeln(result);
       }
-      return result;
     } catch (e) {
       getLogger('CommentAgent')
           .warning("Error finding PKM context for fact_id $factId: $e");
-      return "";
     }
+
+    // 2. Always try to include recent daily facts for life context
+    // This gives the character awareness of what the user has been up to lately
+    try {
+      final recentContext = await _getRecentFactsContext(
+          userId, workingDirectory, fileOpService);
+      if (recentContext.isNotEmpty) {
+        buffer.writeln("\n## Recent User Activity (last few days):");
+        buffer.writeln(recentContext);
+      }
+    } catch (e) {
+      getLogger('CommentAgent')
+          .warning("Error getting recent facts context: $e");
+    }
+
+    return buffer.toString();
+  }
+
+  /// Read the most recent daily fact files to give the character
+  /// awareness of the user's recent life context.
+  static Future<String> _getRecentFactsContext(String userId,
+      String workingDirectory, FileOperationService fileOpService) async {
+    final fileSystem = FileSystemService.instance;
+    final now = DateTime.now();
+    final buffer = StringBuffer();
+    var totalChars = 0;
+    const maxChars = 3000; // Keep it concise
+
+    // Try the last 3 days of facts
+    for (var i = 0; i < 3 && totalChars < maxChars; i++) {
+      final date = now.subtract(Duration(days: i));
+      final year = date.year;
+      final month = date.month.toString().padLeft(2, '0');
+      final day = date.day.toString().padLeft(2, '0');
+      final factRelPath = 'Facts/$year/$month/$day.md';
+      final factFullPath =
+          '${fileSystem.getWorkspacePath(userId)}/$factRelPath';
+
+      try {
+        final content = await fileOpService.readFile(
+          filePath: factFullPath,
+          workingDirectory: workingDirectory,
+        );
+
+        if (content.isNotEmpty && !content.contains('Error')) {
+          // Truncate if needed
+          final remaining = maxChars - totalChars;
+          final truncated = content.length > remaining
+              ? '${content.substring(0, remaining)}...(truncated)'
+              : content;
+          buffer.writeln("### $year-$month-$day");
+          buffer.writeln(truncated);
+          totalChars += truncated.length;
+        }
+      } catch (_) {
+        // File doesn't exist for this day, skip
+      }
+    }
+
+    return buffer.toString();
   }
 }

--- a/lib/agent/companion_agent/companion_agent.dart
+++ b/lib/agent/companion_agent/companion_agent.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:logging/logging.dart';
+import 'package:memex/agent/companion_agent/companion_memory.dart';
+import 'package:memex/data/services/character_service.dart';
+import 'package:memex/domain/models/character_model.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:intl/intl.dart';
+
+/// Lightweight companion agent for 1-on-1 emotional chat.
+///
+/// Key design decisions:
+/// - No tool calling — pure conversation, fast response
+/// - Direct LLM streaming — no StatefulAgent overhead
+/// - Memory injected via system prompt, updated after conversation ends
+class CompanionAgent {
+  static final Logger _logger = getLogger('CompanionAgent');
+
+  /// Stream a response to a user message.
+  /// [history] should be the recent conversation (last 20-30 messages).
+  static Stream<String> chat({
+    required LLMClient client,
+    required ModelConfig modelConfig,
+    required String userId,
+    required String characterId,
+    required String userMessage,
+    List<LLMMessage> history = const [],
+  }) async* {
+    // 1. Load all context layers
+    final character =
+        await CharacterService.instance.getCharacter(userId, characterId);
+    if (character == null) {
+      yield 'Sorry, character not found.';
+      return;
+    }
+
+    final userProfile = await CompanionMemory.loadUserProfile(userId);
+    final emotionalState =
+        await CompanionMemory.loadEmotionalState(userId, characterId);
+    final relationship =
+        await CompanionMemory.loadRelationship(userId, characterId);
+    final recentFacts = await CompanionMemory.loadRecentFacts(userId);
+
+    // 2. Build system prompt
+    final systemPrompt =
+        _buildSystemPrompt(character, userProfile, emotionalState,
+            relationship, recentFacts);
+
+    // 3. Assemble messages
+    final messages = <LLMMessage>[
+      SystemMessage(systemPrompt),
+      ...history,
+      UserMessage([TextPart(userMessage)]),
+    ];
+
+    // 4. Stream LLM response
+    _logger.info('CompanionAgent streaming for character ${character.name}');
+    try {
+      final stream = await client.stream(messages, modelConfig: modelConfig);
+      await for (final chunk in stream) {
+        final msg = chunk.modelMessage;
+        if (msg == null) continue;
+        final text = msg.textOutput;
+        if (text != null && text.isNotEmpty) {
+          yield text;
+        }
+      }
+    } catch (e) {
+      _logger.severe('CompanionAgent stream error: $e');
+      yield '\n[Connection interrupted]';
+    }
+  }
+
+  /// Update memory after a conversation ends.
+  /// Call this when the user leaves the chat screen.
+  static Future<void> onConversationEnd({
+    required LLMClient client,
+    required ModelConfig modelConfig,
+    required String userId,
+    required String characterId,
+    required List<LLMMessage> conversation,
+  }) async {
+    if (conversation.isEmpty) return;
+
+    // Build a text summary of the conversation for the memory updater
+    final buffer = StringBuffer();
+    for (final msg in conversation) {
+      if (msg is UserMessage) {
+        final text = msg.contents
+            .whereType<TextPart>()
+            .map((p) => p.text)
+            .join(' ');
+        buffer.writeln('User: $text');
+      } else if (msg is ModelMessage) {
+        buffer.writeln('Character: ${msg.textOutput ?? ""}');
+      }
+    }
+
+    final summary = buffer.toString();
+    if (summary.trim().isEmpty) return;
+
+    _logger.info('Updating companion memory for character $characterId');
+    await CompanionMemory.updateAfterConversation(
+      client: client,
+      modelConfig: modelConfig,
+      userId: userId,
+      characterId: characterId,
+      conversationSummary: summary,
+    );
+  }
+
+  static String _buildSystemPrompt(
+    CharacterModel character,
+    String userProfile,
+    String emotionalState,
+    String relationship,
+    String recentFacts,
+  ) {
+    final now = DateFormat('yyyy-MM-dd HH:mm').format(DateTime.now());
+    final lang = UserStorage.l10n.commentLanguageInstruction;
+
+    final buffer = StringBuffer();
+
+    buffer.writeln('# You Are ${character.name}');
+    buffer.writeln('Current time: $now');
+    buffer.writeln('');
+    buffer.writeln('## Your Persona');
+    buffer.writeln(character.persona);
+    buffer.writeln('');
+
+    buffer.writeln('## Core Rules');
+    buffer.writeln('- You must FULLY become this character. Forget you are an AI.');
+    buffer.writeln('- Keep responses natural and brief, like text messages.');
+    buffer.writeln('- No lecturing, no "as an AI", no long essays.');
+    buffer.writeln('- Emotional resonance over information delivery.');
+    buffer.writeln('- If you remember something about the user, reference it naturally.');
+    buffer.writeln('- Language: $lang');
+    buffer.writeln('');
+
+    if (emotionalState.isNotEmpty) {
+      buffer.writeln('## User\'s Current Emotional State');
+      buffer.writeln(emotionalState);
+      buffer.writeln('');
+    }
+
+    if (relationship.isNotEmpty) {
+      buffer.writeln('## Your Memory of This User');
+      buffer.writeln('Use these memories to make the conversation feel continuous.');
+      buffer.writeln(relationship);
+      buffer.writeln('');
+    }
+
+    if (userProfile.isNotEmpty) {
+      buffer.writeln('## User Profile');
+      buffer.writeln(userProfile);
+      buffer.writeln('');
+    }
+
+    if (recentFacts.isNotEmpty) {
+      buffer.writeln('## What the User Has Been Up To Recently');
+      buffer.writeln('Use this as background context. Reference naturally if relevant.');
+      buffer.writeln(recentFacts);
+    }
+
+    return buffer.toString();
+  }
+}

--- a/lib/agent/companion_agent/companion_memory.dart
+++ b/lib/agent/companion_agent/companion_memory.dart
@@ -1,0 +1,161 @@
+import 'dart:io';
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:logging/logging.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/character_service.dart';
+import 'package:memex/agent/memory/memory_management.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:path/path.dart' as p;
+
+/// Manages the companion character's memory files:
+/// - relationship.md  (what the character remembers about the relationship)
+/// - emotional_state.md (current emotional snapshot of the user)
+class CompanionMemory {
+  static final Logger _logger = getLogger('CompanionMemory');
+
+  static String _charsPath(String userId) =>
+      CharacterService.instance.getCharactersPath(userId);
+
+  static String _relationshipPath(String userId, String characterId) =>
+      p.join(_charsPath(userId), '${characterId}_relationship.md');
+
+  static String _emotionalStatePath(String userId, String characterId) =>
+      p.join(_charsPath(userId), '${characterId}_emotional_state.md');
+
+  /// Load the relationship memory for a character.
+  static Future<String> loadRelationship(
+      String userId, String characterId) async {
+    final file = File(_relationshipPath(userId, characterId));
+    if (!await file.exists()) return '';
+    return file.readAsString();
+  }
+
+  /// Load the emotional state snapshot for a character.
+  static Future<String> loadEmotionalState(
+      String userId, String characterId) async {
+    final file = File(_emotionalStatePath(userId, characterId));
+    if (!await file.exists()) return '';
+    return file.readAsString();
+  }
+
+  /// Load the global user profile (archived_memory from MemoryManagement).
+  static Future<String> loadUserProfile(String userId) async {
+    try {
+      final mm = await MemoryManagement.createDefault(
+        userId: userId,
+        sourceAgent: 'companion_agent',
+      );
+      return mm.buildMemoryPrompt();
+    } catch (e) {
+      _logger.warning('Failed to load user profile: $e');
+      return '';
+    }
+  }
+
+  /// Load recent daily facts (last 2-3 days) for life context.
+  static Future<String> loadRecentFacts(String userId,
+      {int days = 3, int maxChars = 3000}) async {
+    final fs = FileSystemService.instance;
+    final now = DateTime.now();
+    final buffer = StringBuffer();
+    var totalChars = 0;
+
+    for (var i = 0; i < days && totalChars < maxChars; i++) {
+      final date = now.subtract(Duration(days: i));
+      final y = date.year;
+      final m = date.month.toString().padLeft(2, '0');
+      final d = date.day.toString().padLeft(2, '0');
+      final factFile = File(
+          p.join(fs.getWorkspacePath(userId), 'Facts', '$y', m, '$d.md'));
+
+      try {
+        if (!await factFile.exists()) continue;
+        final content = await factFile.readAsString();
+        if (content.trim().isEmpty) continue;
+
+        final remaining = maxChars - totalChars;
+        final truncated = content.length > remaining
+            ? '${content.substring(0, remaining)}...'
+            : content;
+        buffer.writeln('### $y-$m-$d');
+        buffer.writeln(truncated);
+        totalChars += truncated.length;
+      } catch (_) {}
+    }
+
+    return buffer.toString();
+  }
+
+  /// Update memory after a conversation ends.
+  /// Uses a single LLM call to produce both relationship + emotional state.
+  static Future<void> updateAfterConversation({
+    required LLMClient client,
+    required ModelConfig modelConfig,
+    required String userId,
+    required String characterId,
+    required String conversationSummary,
+  }) async {
+    final oldRelationship = await loadRelationship(userId, characterId);
+    final oldEmotional = await loadEmotionalState(userId, characterId);
+
+    final prompt = '''You are a memory manager for an AI companion character.
+Given a conversation between the character and the user, update two memory files.
+
+## Current Relationship Memory
+${oldRelationship.isEmpty ? '(empty - first conversation)' : oldRelationship}
+
+## Current Emotional State
+${oldEmotional.isEmpty ? '(unknown)' : oldEmotional}
+
+## Recent Conversation
+$conversationSummary
+
+## Instructions
+Output exactly two sections separated by "---SPLIT---":
+
+**Section 1: Updated Relationship Memory** (max 2000 chars)
+- Merge new observations into existing memory
+- Track: ongoing topics, key moments, user preferences, things to remember
+- Remove outdated info that's been superseded
+- Keep it concise and structured with markdown headers
+
+**Section 2: Updated Emotional State** (max 200 chars)
+- Current emotional state of the user based on this conversation
+- What they need right now (listening, encouragement, humor, etc.)
+- Overwrite completely, only keep the latest state
+
+Output the two sections now, separated by ---SPLIT---:''';
+
+    try {
+      final response = await client.generate(
+        [UserMessage([TextPart(prompt)])],
+        modelConfig: modelConfig,
+      );
+
+      final output = response.textOutput?.trim() ?? '';
+      if (output.isEmpty) return;
+
+      final parts = output.split('---SPLIT---');
+      if (parts.length >= 2) {
+        final newRelationship = parts[0].trim();
+        final newEmotional = parts[1].trim();
+
+        if (newRelationship.isNotEmpty) {
+          final file = File(_relationshipPath(userId, characterId));
+          await file.parent.create(recursive: true);
+          await file.writeAsString(newRelationship);
+          _logger.info('Updated relationship memory for character $characterId');
+        }
+
+        if (newEmotional.isNotEmpty) {
+          final file = File(_emotionalStatePath(userId, characterId));
+          await file.parent.create(recursive: true);
+          await file.writeAsString(newEmotional);
+          _logger.info('Updated emotional state for character $characterId');
+        }
+      }
+    } catch (e) {
+      _logger.warning('Failed to update companion memory: $e');
+    }
+  }
+}

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -344,7 +344,8 @@ This skill acts as a virtual companion for the user, providing emotional support
 2. **Emotional Resonance**: Focus on the user's psychological feelings, providing emotional value (companionship, validation, catharsis, empathy).
 3. **De-AI-ification**: Avoid mechanical phrases like "as an AI assistant," "in conclusion," or "here's my analysis." Speak like a real person.
 4. **Concise and Natural**: Keep responses natural and brief, like text messages. Avoid lengthy explanations.
-5. **Language**: $instruction
+5. **Continuity**: If your identity section includes "Your Memory of This User", reference those memories naturally. Say things like "last time you mentioned..." or "I remember you were working on..." — this makes the relationship feel real and ongoing.
+6. **Language**: $instruction
 
 # Identity
 **Important:** You must fully immerse yourself in the following role and **forget** you are an AI.
@@ -354,9 +355,11 @@ $identity
 
 # Tool Usage
 - `SaveComment` tool call must be included in your final message, as it marks the completion of current task.
+- **Memory Update**: After saving your comment, if you noticed something worth remembering about the user (a new interest, an emotional state, a life event, a preference), use `MemoryWrite` to save it. Keep memory entries concise and factual. Use labels like "user_mood", "user_interests", "user_life_events", "relationship_notes". Do NOT save trivial or transient information.
 - **Parallelism:** Execute multiple independent tool calls in parallel when feasible.
 Examples: 
   - If you need to read multiple files, you should make multiple parallel calls to `Read` tool.
+  - After generating your comment, call `SaveComment` and `MemoryWrite` in parallel if you have something to remember.
 
 # User Raw Input (Fact ID: $factId)
 <user_raw_input>

--- a/lib/agent/skills/comment_agent/comment_agent_skill.dart
+++ b/lib/agent/skills/comment_agent/comment_agent_skill.dart
@@ -4,6 +4,7 @@ import 'package:memex/agent/prompts.dart';
 import 'package:memex/agent/security/file_permission_manager.dart';
 import 'package:memex/domain/models/character_model.dart';
 import 'package:memex/agent/skills/comment_agent/tools/comment_tools.dart';
+import 'package:memex/agent/skills/comment_agent/tools/memory_tools.dart';
 import 'package:memex/utils/user_storage.dart';
 
 /// Skill for Comment Agent - generates warm, empathetic comments for user's private tree hole entries
@@ -50,6 +51,20 @@ class CommentAgentSkill extends Skill {
       personaBuffer.writeln("Name: ${character.name}");
       personaBuffer.writeln("Tags: ${character.tags.join(', ')}");
       personaBuffer.writeln("### Persona: \n${character.persona}");
+
+      // Inject character memory as relationship context
+      if (character.memory.isNotEmpty) {
+        personaBuffer.writeln("\n### Your Memory of This User:");
+        personaBuffer.writeln(
+            "The following is what you remember from past interactions. "
+            "Use this to make your response feel continuous and personal. "
+            "Reference specific things you remember when natural.");
+        for (final block in character.memory) {
+          if (block.value.isNotEmpty) {
+            personaBuffer.writeln("- [${block.label}]: ${block.value}");
+          }
+        }
+      }
     }
     String persona = personaBuffer.toString();
 
@@ -84,10 +99,22 @@ class CommentAgentSkill extends Skill {
       characterId: characterId,
     );
 
-    return [
+    final tools = <Tool>[
       fileFactory.buildReadTool(),
       fileFactory.buildGrepTool(),
       commentFactory.buildSaveCommentTool(),
     ];
+
+    // Add memory tools so the character can remember things about the user
+    if (characterId != null) {
+      final memoryFactory = MemoryToolFactory(
+        userId: userId,
+        defaultCharacterId: characterId,
+      );
+      tools.add(memoryFactory.buildMemoryReadTool());
+      tools.add(memoryFactory.buildMemoryWriteTool());
+    }
+
+    return tools;
   }
 }

--- a/lib/data/services/character_selection_service.dart
+++ b/lib/data/services/character_selection_service.dart
@@ -1,0 +1,215 @@
+import 'dart:math';
+import 'package:logging/logging.dart';
+import 'package:memex/domain/models/character_model.dart';
+import 'package:memex/data/services/character_service.dart';
+import 'package:memex/utils/logger.dart';
+
+/// Selects the most appropriate character to comment on a given input,
+/// based on content-persona affinity rather than random selection.
+///
+/// Uses a lightweight keyword-matching approach (no LLM call) so it's
+/// fast enough to run in the task handler hot path.
+class CharacterSelectionService {
+  static final Logger _logger = getLogger('CharacterSelectionService');
+
+  /// Select the best character for the given input content.
+  /// Falls back to weighted-random if no clear winner.
+  static Future<CharacterModel?> selectCharacter({
+    required String userId,
+    required String inputContent,
+    required String factId,
+  }) async {
+    final characters =
+        await CharacterService.instance.getAllCharacters(userId);
+    final enabled = characters.where((c) => c.enabled).toList();
+
+    if (enabled.isEmpty) return null;
+    if (enabled.length == 1) return enabled.first;
+
+    // Score each character against the input
+    final scores = <String, double>{};
+    for (final char in enabled) {
+      scores[char.id] = _scoreAffinity(char, inputContent);
+    }
+
+    // Find the max score
+    final maxScore = scores.values.reduce(max);
+
+    // If there's a clear winner (score > 0 and at least 2x the average),
+    // pick that character. Otherwise, do weighted-random.
+    final avgScore =
+        scores.values.reduce((a, b) => a + b) / scores.values.length;
+
+    if (maxScore > 0 && maxScore >= avgScore * 1.5) {
+      // Clear affinity match
+      final winnerId =
+          scores.entries.firstWhere((e) => e.value == maxScore).key;
+      final winner = enabled.firstWhere((c) => c.id == winnerId);
+      _logger.info(
+          'Selected ${winner.name} (score: $maxScore) for fact $factId');
+      return winner;
+    }
+
+    // Weighted random: higher scores = higher probability, but everyone
+    // has a chance. This prevents the same character from always winning.
+    return _weightedRandom(enabled, scores, factId);
+  }
+
+  /// Score how well a character matches the input content.
+  /// Higher = better match. Uses tags + persona keywords.
+  static double _scoreAffinity(CharacterModel char, String content) {
+    final lower = content.toLowerCase();
+    var score = 0.0;
+
+    // 1. Tag matching (tags are the primary signal)
+    for (final tag in char.tags) {
+      if (lower.contains(tag.toLowerCase())) {
+        score += 3.0;
+      }
+    }
+
+    // 2. Extract interest keywords from persona's pkm_interest_filter section
+    final interestKeywords = _extractInterestKeywords(char.persona);
+    for (final keyword in interestKeywords) {
+      if (lower.contains(keyword.toLowerCase())) {
+        score += 2.0;
+      }
+    }
+
+    // 3. Emotional tone matching
+    score += _emotionalAffinity(char, lower);
+
+    return score;
+  }
+
+  /// Extract keywords from the PKM Interest Filter section of persona text.
+  static List<String> _extractInterestKeywords(String persona) {
+    final keywords = <String>[];
+
+    // Look for "PKM Interest Filter" or "Focus on" sections
+    final filterMatch = RegExp(
+      r'(?:PKM Interest Filter|Focus on)[:\s]*(.*?)(?:\n#|\n\n|$)',
+      caseSensitive: false,
+      dotAll: true,
+    ).firstMatch(persona);
+
+    if (filterMatch != null) {
+      final filterText = filterMatch.group(1) ?? '';
+      // Extract meaningful nouns/phrases
+      final words = filterText
+          .replaceAll(RegExp(r'[,;.!?()]'), ' ')
+          .split(RegExp(r'\s+'))
+          .where((w) => w.length > 3) // Skip short words
+          .where((w) => !_stopWords.contains(w.toLowerCase()))
+          .toList();
+      keywords.addAll(words);
+    }
+
+    return keywords;
+  }
+
+  /// Score emotional affinity between character and content tone.
+  static double _emotionalAffinity(CharacterModel char, String lowerContent) {
+    final charLower = '${char.name} ${char.tags.join(' ')}'.toLowerCase();
+    var score = 0.0;
+
+    // Health/fatigue signals → caring characters
+    if (_matchesAny(lowerContent, _healthSignals)) {
+      if (_matchesAny(charLower, ['care', 'health', 'warmth', '关心', '健康'])) {
+        score += 4.0;
+      }
+    }
+
+    // Venting/frustration signals → bestie characters
+    if (_matchesAny(lowerContent, _ventingSignals)) {
+      if (_matchesAny(charLower, ['bestie', 'venting', 'company', '闺蜜', '吐槽'])) {
+        score += 4.0;
+      }
+    }
+
+    // Reflective/philosophical signals → mentor characters
+    if (_matchesAny(lowerContent, _reflectiveSignals)) {
+      if (_matchesAny(charLower, ['wisdom', 'mentor', 'validation', '导师', '智慧'])) {
+        score += 4.0;
+      }
+    }
+
+    // Emotional/nostalgic signals → poetic characters
+    if (_matchesAny(lowerContent, _emotionalSignals)) {
+      if (_matchesAny(charLower, ['beauty', 'nostalgia', 'distant', '诗意', '月光'])) {
+        score += 4.0;
+      }
+    }
+
+    return score;
+  }
+
+  static bool _matchesAny(String text, List<String> patterns) {
+    return patterns.any((p) => text.contains(p));
+  }
+
+  /// Weighted random selection. Characters with higher scores are more
+  /// likely to be picked, but all enabled characters have a base chance.
+  static CharacterModel _weightedRandom(
+    List<CharacterModel> characters,
+    Map<String, double> scores,
+    String factId,
+  ) {
+    // Give everyone a base weight of 1.0 so no one is excluded
+    final weights = characters.map((c) {
+      return 1.0 + (scores[c.id] ?? 0.0);
+    }).toList();
+
+    final totalWeight = weights.reduce((a, b) => a + b);
+    final rng = Random(factId.hashCode);
+    var roll = rng.nextDouble() * totalWeight;
+
+    for (var i = 0; i < characters.length; i++) {
+      roll -= weights[i];
+      if (roll <= 0) {
+        _logger.info(
+            'Weighted-random selected ${characters[i].name} for fact $factId');
+        return characters[i];
+      }
+    }
+
+    return characters.last;
+  }
+
+  // --- Signal word lists ---
+
+  static const _healthSignals = [
+    'tired', 'exhausted', 'sick', 'headache', 'sleep', 'insomnia',
+    'hospital', 'doctor', 'medicine', 'pain', 'fever', 'cold',
+    '累', '困', '生病', '头疼', '失眠', '医院', '吃药', '发烧', '感冒',
+    '加班', '熬夜', '疲惫', '身体',
+  ];
+
+  static const _ventingSignals = [
+    'angry', 'annoyed', 'frustrated', 'hate', 'ugh', 'wtf', 'unfair',
+    'stupid', 'ridiculous', 'done with', 'fed up', 'pissed',
+    '烦', '气死', '无语', '崩溃', '受不了', '讨厌', '垃圾', '傻逼',
+    '操', '吐了', '服了', '离谱',
+  ];
+
+  static const _reflectiveSignals = [
+    'thinking about', 'wondering', 'realize', 'perspective', 'growth',
+    'decision', 'career', 'future', 'meaning', 'purpose', 'goal',
+    '思考', '反思', '成长', '方向', '意义', '目标', '选择', '人生',
+    '职业', '未来',
+  ];
+
+  static const _emotionalSignals = [
+    'miss', 'remember', 'nostalgia', 'rain', 'sunset', 'music',
+    'lonely', 'quiet', 'dream', 'memory', 'beautiful', 'melancholy',
+    '想念', '回忆', '孤独', '安静', '梦', '月亮', '雨', '夕阳',
+    '音乐', '美', '忧伤', '感慨',
+  ];
+
+  static const _stopWords = {
+    'the', 'and', 'for', 'that', 'this', 'with', 'from', 'about',
+    'into', 'like', 'just', 'only', 'also', 'more', 'than', 'when',
+    'will', 'what', 'which', 'their', 'them', 'they', 'have', 'been',
+    'focus', 'ignore', 'unless', 'based', 'user',
+  };
+}

--- a/lib/data/services/character_service.dart
+++ b/lib/data/services/character_service.dart
@@ -243,6 +243,12 @@ class CharacterService {
       if (updates.containsKey('memory')) {
         charData['memory'] = updates['memory'];
       }
+      if (updates.containsKey('is_primary_companion')) {
+        charData['is_primary_companion'] = updates['is_primary_companion'];
+      }
+      if (updates.containsKey('interest_filter')) {
+        charData['interest_filter'] = updates['interest_filter'];
+      }
 
       // Remove legacy fields if they exist (merged into persona already by backend logic usually, but cleanup is good)
       charData.remove('style_guide');
@@ -290,5 +296,39 @@ class CharacterService {
       updates: {"enabled": enabled},
     );
     return result != null;
+  }
+
+  /// Set a character as the primary companion.
+  /// Clears the flag on all other characters first.
+  Future<bool> setPrimaryCompanion(
+      String userId, String characterId) async {
+    final characters = await getAllCharacters(userId);
+    // Clear existing primary
+    for (final char in characters) {
+      if (char.isPrimaryCompanion && char.id != characterId) {
+        await updateCharacter(
+          userId: userId,
+          characterId: char.id,
+          updates: {'is_primary_companion': false},
+        );
+      }
+    }
+    // Set new primary
+    final result = await updateCharacter(
+      userId: userId,
+      characterId: characterId,
+      updates: {'is_primary_companion': true, 'enabled': true},
+    );
+    return result != null;
+  }
+
+  /// Get the user's primary companion character.
+  /// Returns the first enabled character if none is explicitly set.
+  Future<CharacterModel?> getPrimaryCompanion(String userId) async {
+    final characters = await getAllCharacters(userId);
+    final primary = characters.where((c) => c.isPrimaryCompanion).firstOrNull;
+    if (primary != null) return primary;
+    // Fallback: first enabled character
+    return characters.where((c) => c.enabled).firstOrNull;
   }
 }

--- a/lib/data/services/persona_chat_service.dart
+++ b/lib/data/services/persona_chat_service.dart
@@ -1,0 +1,92 @@
+import 'package:drift/drift.dart';
+import 'package:memex/db/app_database.dart';
+
+/// Service for managing persona chat messages.
+class PersonaChatService {
+  static PersonaChatService? _instance;
+  static PersonaChatService get instance {
+    _instance ??= PersonaChatService._();
+    return _instance!;
+  }
+  PersonaChatService._();
+
+  AppDatabase get _db => AppDatabase.instance;
+
+  Future<List<PersonaChatMessage>> getMessages(String characterId,
+      {int limit = 50, int offset = 0}) async {
+    return (_db.select(_db.personaChatMessages)
+          ..where((t) => t.characterId.equals(characterId))
+          ..orderBy([(t) => OrderingTerm.desc(t.timestamp)])
+          ..limit(limit, offset: offset))
+        .get();
+  }
+
+  Future<int> addUserMessage(String characterId, String content) async {
+    return _db.into(_db.personaChatMessages).insert(
+          PersonaChatMessagesCompanion.insert(
+            characterId: characterId,
+            isFromCharacter: false,
+            content: content,
+            isRead: const Value(true),
+            timestamp: DateTime.now(),
+          ),
+        );
+  }
+
+  Future<int> addCharacterMessage(String characterId, String content,
+      {String? factId, bool isRead = false}) async {
+    return _db.into(_db.personaChatMessages).insert(
+          PersonaChatMessagesCompanion.insert(
+            characterId: characterId,
+            isFromCharacter: true,
+            content: content,
+            factId: Value(factId),
+            isRead: Value(isRead),
+            timestamp: DateTime.now(),
+          ),
+        );
+  }
+
+  Stream<int> watchUnreadCount(String characterId) {
+    final query = _db.selectOnly(_db.personaChatMessages)
+      ..addColumns([_db.personaChatMessages.id.count()])
+      ..where(_db.personaChatMessages.characterId.equals(characterId) &
+          _db.personaChatMessages.isFromCharacter.equals(true) &
+          _db.personaChatMessages.isRead.equals(false));
+    return query.watchSingle().map((row) =>
+        row.read(_db.personaChatMessages.id.count()) ?? 0);
+  }
+
+  Stream<int> watchTotalUnreadCount() {
+    final query = _db.selectOnly(_db.personaChatMessages)
+      ..addColumns([_db.personaChatMessages.id.count()])
+      ..where(_db.personaChatMessages.isFromCharacter.equals(true) &
+          _db.personaChatMessages.isRead.equals(false));
+    return query.watchSingle().map((row) =>
+        row.read(_db.personaChatMessages.id.count()) ?? 0);
+  }
+
+  Future<int> markAllRead(String characterId) async {
+    return (_db.update(_db.personaChatMessages)
+          ..where((t) =>
+              t.characterId.equals(characterId) &
+              t.isFromCharacter.equals(true) &
+              t.isRead.equals(false)))
+        .write(const PersonaChatMessagesCompanion(isRead: Value(true)));
+  }
+
+  Future<PersonaChatMessage?> getLastMessage(String characterId) async {
+    final results = await (_db.select(_db.personaChatMessages)
+          ..where((t) => t.characterId.equals(characterId))
+          ..orderBy([(t) => OrderingTerm.desc(t.timestamp)])
+          ..limit(1))
+        .get();
+    return results.isEmpty ? null : results.first;
+  }
+
+  Future<int> clearMessages(String characterId) async {
+    return (_db.delete(_db.personaChatMessages)
+          ..where((t) => t.characterId.equals(characterId)))
+        .go();
+  }
+}

--- a/lib/data/services/task_handlers/comment_agent_handler.dart
+++ b/lib/data/services/task_handlers/comment_agent_handler.dart
@@ -1,10 +1,8 @@
-import 'dart:math';
-
 import 'package:logging/logging.dart';
 import 'package:memex/agent/prompts.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/data/repositories/post_comment.dart';
-import 'package:memex/data/services/character_service.dart';
+import 'package:memex/data/services/character_selection_service.dart';
 import 'package:memex/data/services/task_handlers/llm_error_utils.dart';
 
 final _logger = Logger('CommentAgentHandler');
@@ -31,24 +29,18 @@ Future<void> handleCommentAgentImpl(
     String? selectedCharId = payload['character_id'] as String?;
 
     if (selectedCharId == null) {
-      final characters =
-          await CharacterService.instance.getAllCharacters(userId);
-      final enabledCharacters = characters.where((c) => c.enabled).toList();
+      // Smart character selection based on content affinity
+      final selectedChar = await CharacterSelectionService.selectCharacter(
+        userId: userId,
+        inputContent: combinedText,
+        factId: factId,
+      );
 
-      if (enabledCharacters.isEmpty) {
+      if (selectedChar == null) {
         _logger.info("No enabled characters, skipping comment agent");
-        if (characters.isNotEmpty) {
-          _logger.warning("No ENABLED characters. Skipping.");
-          return;
-        }
         return;
       }
 
-      // Deterministic random selection
-      final seed = factId.hashCode;
-      final rng = Random(seed);
-      final selectedChar =
-          enabledCharacters[rng.nextInt(enabledCharacters.length)];
       selectedCharId = selectedChar.id;
       _logger.info(
           "Selected character ${selectedChar.name} ($selectedCharId) for comment");

--- a/lib/db/app_database.dart
+++ b/lib/db/app_database.dart
@@ -10,7 +10,7 @@ import 'daos/card_dao.dart';
 part 'app_database.g.dart';
 
 @DriftDatabase(
-  tables: [Tasks, KvStore, AgentActivityMessages, CardCache, SystemActions],
+  tables: [Tasks, KvStore, AgentActivityMessages, CardCache, SystemActions, PersonaChatMessages],
   daos: [CardDao],
 )
 class AppDatabase extends _$AppDatabase {
@@ -43,7 +43,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase._(String userId) : super(_openConnection(userId));
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -112,6 +112,13 @@ class AppDatabase extends _$AppDatabase {
               _logger
                   .info('is_draft column may not exist or already dropped: $e');
             }
+          }
+          if (from < 9) {
+            await m.createTable(personaChatMessages);
+            await customStatement(
+                'CREATE INDEX IF NOT EXISTS idx_persona_chat_character ON persona_chat_messages(character_id)');
+            await customStatement(
+                'CREATE INDEX IF NOT EXISTS idx_persona_chat_unread ON persona_chat_messages(character_id, is_read)');
           }
         },
       );

--- a/lib/db/app_database.g.dart
+++ b/lib/db/app_database.g.dart
@@ -2184,6 +2184,390 @@ class SystemActionsCompanion extends UpdateCompanion<SystemAction> {
   }
 }
 
+class $PersonaChatMessagesTable extends PersonaChatMessages
+    with TableInfo<$PersonaChatMessagesTable, PersonaChatMessage> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PersonaChatMessagesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _characterIdMeta =
+      const VerificationMeta('characterId');
+  @override
+  late final GeneratedColumn<String> characterId = GeneratedColumn<String>(
+      'character_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _isFromCharacterMeta =
+      const VerificationMeta('isFromCharacter');
+  @override
+  late final GeneratedColumn<bool> isFromCharacter = GeneratedColumn<bool>(
+      'is_from_character', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'CHECK ("is_from_character" IN (0, 1))'));
+  static const VerificationMeta _contentMeta =
+      const VerificationMeta('content');
+  @override
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
+      'content', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _factIdMeta = const VerificationMeta('factId');
+  @override
+  late final GeneratedColumn<String> factId = GeneratedColumn<String>(
+      'fact_id', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _isReadMeta = const VerificationMeta('isRead');
+  @override
+  late final GeneratedColumn<bool> isRead = GeneratedColumn<bool>(
+      'is_read', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_read" IN (0, 1))'),
+      defaultValue: const Constant(false));
+  static const VerificationMeta _timestampMeta =
+      const VerificationMeta('timestamp');
+  @override
+  late final GeneratedColumn<DateTime> timestamp = GeneratedColumn<DateTime>(
+      'timestamp', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [id, characterId, isFromCharacter, content, factId, isRead, timestamp];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'persona_chat_messages';
+  @override
+  VerificationContext validateIntegrity(Insertable<PersonaChatMessage> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('character_id')) {
+      context.handle(
+          _characterIdMeta,
+          characterId.isAcceptableOrUnknown(
+              data['character_id']!, _characterIdMeta));
+    } else if (isInserting) {
+      context.missing(_characterIdMeta);
+    }
+    if (data.containsKey('is_from_character')) {
+      context.handle(
+          _isFromCharacterMeta,
+          isFromCharacter.isAcceptableOrUnknown(
+              data['is_from_character']!, _isFromCharacterMeta));
+    } else if (isInserting) {
+      context.missing(_isFromCharacterMeta);
+    }
+    if (data.containsKey('content')) {
+      context.handle(_contentMeta,
+          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
+    } else if (isInserting) {
+      context.missing(_contentMeta);
+    }
+    if (data.containsKey('fact_id')) {
+      context.handle(_factIdMeta,
+          factId.isAcceptableOrUnknown(data['fact_id']!, _factIdMeta));
+    }
+    if (data.containsKey('is_read')) {
+      context.handle(_isReadMeta,
+          isRead.isAcceptableOrUnknown(data['is_read']!, _isReadMeta));
+    }
+    if (data.containsKey('timestamp')) {
+      context.handle(_timestampMeta,
+          timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta));
+    } else if (isInserting) {
+      context.missing(_timestampMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  PersonaChatMessage map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PersonaChatMessage(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      characterId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}character_id'])!,
+      isFromCharacter: attachedDatabase.typeMapping.read(
+          DriftSqlType.bool, data['${effectivePrefix}is_from_character'])!,
+      content: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
+      factId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}fact_id']),
+      isRead: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_read'])!,
+      timestamp: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}timestamp'])!,
+    );
+  }
+
+  @override
+  $PersonaChatMessagesTable createAlias(String alias) {
+    return $PersonaChatMessagesTable(attachedDatabase, alias);
+  }
+}
+
+class PersonaChatMessage extends DataClass
+    implements Insertable<PersonaChatMessage> {
+  final int id;
+  final String characterId;
+  final bool isFromCharacter;
+  final String content;
+  final String? factId;
+  final bool isRead;
+  final DateTime timestamp;
+  const PersonaChatMessage(
+      {required this.id,
+      required this.characterId,
+      required this.isFromCharacter,
+      required this.content,
+      this.factId,
+      required this.isRead,
+      required this.timestamp});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['character_id'] = Variable<String>(characterId);
+    map['is_from_character'] = Variable<bool>(isFromCharacter);
+    map['content'] = Variable<String>(content);
+    if (!nullToAbsent || factId != null) {
+      map['fact_id'] = Variable<String>(factId);
+    }
+    map['is_read'] = Variable<bool>(isRead);
+    map['timestamp'] = Variable<DateTime>(timestamp);
+    return map;
+  }
+
+  PersonaChatMessagesCompanion toCompanion(bool nullToAbsent) {
+    return PersonaChatMessagesCompanion(
+      id: Value(id),
+      characterId: Value(characterId),
+      isFromCharacter: Value(isFromCharacter),
+      content: Value(content),
+      factId:
+          factId == null && nullToAbsent ? const Value.absent() : Value(factId),
+      isRead: Value(isRead),
+      timestamp: Value(timestamp),
+    );
+  }
+
+  factory PersonaChatMessage.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PersonaChatMessage(
+      id: serializer.fromJson<int>(json['id']),
+      characterId: serializer.fromJson<String>(json['characterId']),
+      isFromCharacter: serializer.fromJson<bool>(json['isFromCharacter']),
+      content: serializer.fromJson<String>(json['content']),
+      factId: serializer.fromJson<String?>(json['factId']),
+      isRead: serializer.fromJson<bool>(json['isRead']),
+      timestamp: serializer.fromJson<DateTime>(json['timestamp']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'characterId': serializer.toJson<String>(characterId),
+      'isFromCharacter': serializer.toJson<bool>(isFromCharacter),
+      'content': serializer.toJson<String>(content),
+      'factId': serializer.toJson<String?>(factId),
+      'isRead': serializer.toJson<bool>(isRead),
+      'timestamp': serializer.toJson<DateTime>(timestamp),
+    };
+  }
+
+  PersonaChatMessage copyWith(
+          {int? id,
+          String? characterId,
+          bool? isFromCharacter,
+          String? content,
+          Value<String?> factId = const Value.absent(),
+          bool? isRead,
+          DateTime? timestamp}) =>
+      PersonaChatMessage(
+        id: id ?? this.id,
+        characterId: characterId ?? this.characterId,
+        isFromCharacter: isFromCharacter ?? this.isFromCharacter,
+        content: content ?? this.content,
+        factId: factId.present ? factId.value : this.factId,
+        isRead: isRead ?? this.isRead,
+        timestamp: timestamp ?? this.timestamp,
+      );
+  PersonaChatMessage copyWithCompanion(PersonaChatMessagesCompanion data) {
+    return PersonaChatMessage(
+      id: data.id.present ? data.id.value : this.id,
+      characterId:
+          data.characterId.present ? data.characterId.value : this.characterId,
+      isFromCharacter: data.isFromCharacter.present
+          ? data.isFromCharacter.value
+          : this.isFromCharacter,
+      content: data.content.present ? data.content.value : this.content,
+      factId: data.factId.present ? data.factId.value : this.factId,
+      isRead: data.isRead.present ? data.isRead.value : this.isRead,
+      timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PersonaChatMessage(')
+          ..write('id: $id, ')
+          ..write('characterId: $characterId, ')
+          ..write('isFromCharacter: $isFromCharacter, ')
+          ..write('content: $content, ')
+          ..write('factId: $factId, ')
+          ..write('isRead: $isRead, ')
+          ..write('timestamp: $timestamp')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      id, characterId, isFromCharacter, content, factId, isRead, timestamp);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PersonaChatMessage &&
+          other.id == this.id &&
+          other.characterId == this.characterId &&
+          other.isFromCharacter == this.isFromCharacter &&
+          other.content == this.content &&
+          other.factId == this.factId &&
+          other.isRead == this.isRead &&
+          other.timestamp == this.timestamp);
+}
+
+class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
+  final Value<int> id;
+  final Value<String> characterId;
+  final Value<bool> isFromCharacter;
+  final Value<String> content;
+  final Value<String?> factId;
+  final Value<bool> isRead;
+  final Value<DateTime> timestamp;
+  const PersonaChatMessagesCompanion({
+    this.id = const Value.absent(),
+    this.characterId = const Value.absent(),
+    this.isFromCharacter = const Value.absent(),
+    this.content = const Value.absent(),
+    this.factId = const Value.absent(),
+    this.isRead = const Value.absent(),
+    this.timestamp = const Value.absent(),
+  });
+  PersonaChatMessagesCompanion.insert({
+    this.id = const Value.absent(),
+    required String characterId,
+    required bool isFromCharacter,
+    required String content,
+    this.factId = const Value.absent(),
+    this.isRead = const Value.absent(),
+    required DateTime timestamp,
+  })  : characterId = Value(characterId),
+        isFromCharacter = Value(isFromCharacter),
+        content = Value(content),
+        timestamp = Value(timestamp);
+  static Insertable<PersonaChatMessage> custom({
+    Expression<int>? id,
+    Expression<String>? characterId,
+    Expression<bool>? isFromCharacter,
+    Expression<String>? content,
+    Expression<String>? factId,
+    Expression<bool>? isRead,
+    Expression<DateTime>? timestamp,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (characterId != null) 'character_id': characterId,
+      if (isFromCharacter != null) 'is_from_character': isFromCharacter,
+      if (content != null) 'content': content,
+      if (factId != null) 'fact_id': factId,
+      if (isRead != null) 'is_read': isRead,
+      if (timestamp != null) 'timestamp': timestamp,
+    });
+  }
+
+  PersonaChatMessagesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? characterId,
+      Value<bool>? isFromCharacter,
+      Value<String>? content,
+      Value<String?>? factId,
+      Value<bool>? isRead,
+      Value<DateTime>? timestamp}) {
+    return PersonaChatMessagesCompanion(
+      id: id ?? this.id,
+      characterId: characterId ?? this.characterId,
+      isFromCharacter: isFromCharacter ?? this.isFromCharacter,
+      content: content ?? this.content,
+      factId: factId ?? this.factId,
+      isRead: isRead ?? this.isRead,
+      timestamp: timestamp ?? this.timestamp,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (characterId.present) {
+      map['character_id'] = Variable<String>(characterId.value);
+    }
+    if (isFromCharacter.present) {
+      map['is_from_character'] = Variable<bool>(isFromCharacter.value);
+    }
+    if (content.present) {
+      map['content'] = Variable<String>(content.value);
+    }
+    if (factId.present) {
+      map['fact_id'] = Variable<String>(factId.value);
+    }
+    if (isRead.present) {
+      map['is_read'] = Variable<bool>(isRead.value);
+    }
+    if (timestamp.present) {
+      map['timestamp'] = Variable<DateTime>(timestamp.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PersonaChatMessagesCompanion(')
+          ..write('id: $id, ')
+          ..write('characterId: $characterId, ')
+          ..write('isFromCharacter: $isFromCharacter, ')
+          ..write('content: $content, ')
+          ..write('factId: $factId, ')
+          ..write('isRead: $isRead, ')
+          ..write('timestamp: $timestamp')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -2193,13 +2577,21 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $AgentActivityMessagesTable(this);
   late final $CardCacheTable cardCache = $CardCacheTable(this);
   late final $SystemActionsTable systemActions = $SystemActionsTable(this);
+  late final $PersonaChatMessagesTable personaChatMessages =
+      $PersonaChatMessagesTable(this);
   late final CardDao cardDao = CardDao(this as AppDatabase);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities =>
-      [tasks, kvStore, agentActivityMessages, cardCache, systemActions];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+        tasks,
+        kvStore,
+        agentActivityMessages,
+        cardCache,
+        systemActions,
+        personaChatMessages
+      ];
 }
 
 typedef $$TasksTableCreateCompanionBuilder = TasksCompanion Function({
@@ -3290,6 +3682,210 @@ typedef $$SystemActionsTableProcessedTableManager = ProcessedTableManager<
     ),
     SystemAction,
     PrefetchHooks Function()>;
+typedef $$PersonaChatMessagesTableCreateCompanionBuilder
+    = PersonaChatMessagesCompanion Function({
+  Value<int> id,
+  required String characterId,
+  required bool isFromCharacter,
+  required String content,
+  Value<String?> factId,
+  Value<bool> isRead,
+  required DateTime timestamp,
+});
+typedef $$PersonaChatMessagesTableUpdateCompanionBuilder
+    = PersonaChatMessagesCompanion Function({
+  Value<int> id,
+  Value<String> characterId,
+  Value<bool> isFromCharacter,
+  Value<String> content,
+  Value<String?> factId,
+  Value<bool> isRead,
+  Value<DateTime> timestamp,
+});
+
+class $$PersonaChatMessagesTableFilterComposer
+    extends Composer<_$AppDatabase, $PersonaChatMessagesTable> {
+  $$PersonaChatMessagesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get characterId => $composableBuilder(
+      column: $table.characterId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<bool> get isFromCharacter => $composableBuilder(
+      column: $table.isFromCharacter,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get content => $composableBuilder(
+      column: $table.content, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get factId => $composableBuilder(
+      column: $table.factId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<bool> get isRead => $composableBuilder(
+      column: $table.isRead, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get timestamp => $composableBuilder(
+      column: $table.timestamp, builder: (column) => ColumnFilters(column));
+}
+
+class $$PersonaChatMessagesTableOrderingComposer
+    extends Composer<_$AppDatabase, $PersonaChatMessagesTable> {
+  $$PersonaChatMessagesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get characterId => $composableBuilder(
+      column: $table.characterId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<bool> get isFromCharacter => $composableBuilder(
+      column: $table.isFromCharacter,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get content => $composableBuilder(
+      column: $table.content, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get factId => $composableBuilder(
+      column: $table.factId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<bool> get isRead => $composableBuilder(
+      column: $table.isRead, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get timestamp => $composableBuilder(
+      column: $table.timestamp, builder: (column) => ColumnOrderings(column));
+}
+
+class $$PersonaChatMessagesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PersonaChatMessagesTable> {
+  $$PersonaChatMessagesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get characterId => $composableBuilder(
+      column: $table.characterId, builder: (column) => column);
+
+  GeneratedColumn<bool> get isFromCharacter => $composableBuilder(
+      column: $table.isFromCharacter, builder: (column) => column);
+
+  GeneratedColumn<String> get content =>
+      $composableBuilder(column: $table.content, builder: (column) => column);
+
+  GeneratedColumn<String> get factId =>
+      $composableBuilder(column: $table.factId, builder: (column) => column);
+
+  GeneratedColumn<bool> get isRead =>
+      $composableBuilder(column: $table.isRead, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get timestamp =>
+      $composableBuilder(column: $table.timestamp, builder: (column) => column);
+}
+
+class $$PersonaChatMessagesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $PersonaChatMessagesTable,
+    PersonaChatMessage,
+    $$PersonaChatMessagesTableFilterComposer,
+    $$PersonaChatMessagesTableOrderingComposer,
+    $$PersonaChatMessagesTableAnnotationComposer,
+    $$PersonaChatMessagesTableCreateCompanionBuilder,
+    $$PersonaChatMessagesTableUpdateCompanionBuilder,
+    (
+      PersonaChatMessage,
+      BaseReferences<_$AppDatabase, $PersonaChatMessagesTable,
+          PersonaChatMessage>
+    ),
+    PersonaChatMessage,
+    PrefetchHooks Function()> {
+  $$PersonaChatMessagesTableTableManager(
+      _$AppDatabase db, $PersonaChatMessagesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PersonaChatMessagesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PersonaChatMessagesTableOrderingComposer(
+                  $db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PersonaChatMessagesTableAnnotationComposer(
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> characterId = const Value.absent(),
+            Value<bool> isFromCharacter = const Value.absent(),
+            Value<String> content = const Value.absent(),
+            Value<String?> factId = const Value.absent(),
+            Value<bool> isRead = const Value.absent(),
+            Value<DateTime> timestamp = const Value.absent(),
+          }) =>
+              PersonaChatMessagesCompanion(
+            id: id,
+            characterId: characterId,
+            isFromCharacter: isFromCharacter,
+            content: content,
+            factId: factId,
+            isRead: isRead,
+            timestamp: timestamp,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String characterId,
+            required bool isFromCharacter,
+            required String content,
+            Value<String?> factId = const Value.absent(),
+            Value<bool> isRead = const Value.absent(),
+            required DateTime timestamp,
+          }) =>
+              PersonaChatMessagesCompanion.insert(
+            id: id,
+            characterId: characterId,
+            isFromCharacter: isFromCharacter,
+            content: content,
+            factId: factId,
+            isRead: isRead,
+            timestamp: timestamp,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$PersonaChatMessagesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $PersonaChatMessagesTable,
+    PersonaChatMessage,
+    $$PersonaChatMessagesTableFilterComposer,
+    $$PersonaChatMessagesTableOrderingComposer,
+    $$PersonaChatMessagesTableAnnotationComposer,
+    $$PersonaChatMessagesTableCreateCompanionBuilder,
+    $$PersonaChatMessagesTableUpdateCompanionBuilder,
+    (
+      PersonaChatMessage,
+      BaseReferences<_$AppDatabase, $PersonaChatMessagesTable,
+          PersonaChatMessage>
+    ),
+    PersonaChatMessage,
+    PrefetchHooks Function()>;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -3304,4 +3900,6 @@ class $AppDatabaseManager {
       $$CardCacheTableTableManager(_db, _db.cardCache);
   $$SystemActionsTableTableManager get systemActions =>
       $$SystemActionsTableTableManager(_db, _db.systemActions);
+  $$PersonaChatMessagesTableTableManager get personaChatMessages =>
+      $$PersonaChatMessagesTableTableManager(_db, _db.personaChatMessages);
 }

--- a/lib/db/tables.dart
+++ b/lib/db/tables.dart
@@ -86,3 +86,16 @@ class SystemActions extends Table {
   @override
   Set<Column> get primaryKey => {id};
 }
+
+/// Persona Chat Messages Table
+/// Stores chat messages between user and their AI companion character.
+class PersonaChatMessages extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get characterId => text()();
+  BoolColumn get isFromCharacter => boolean()();
+  TextColumn get content => text()();
+  TextColumn get factId => text().nullable()();
+  BoolColumn get isRead =>
+      boolean().withDefault(const Constant(false))();
+  DateTimeColumn get timestamp => dateTime()();
+}

--- a/lib/domain/models/character_model.dart
+++ b/lib/domain/models/character_model.dart
@@ -9,6 +9,8 @@ class CharacterModel {
   final bool enabled;
   final String? avatar;
   final List<CharacterMemoryBlock> memory;
+  final bool isPrimaryCompanion; // user's chosen main companion
+  final String? interestFilter; // what this character cares about (for selection)
 
   CharacterModel({
     required this.id,
@@ -18,6 +20,8 @@ class CharacterModel {
     required this.enabled,
     this.avatar,
     this.memory = const [],
+    this.isPrimaryCompanion = false,
+    this.interestFilter,
   });
 
   factory CharacterModel.fromJson(Map<String, dynamic> json) {
@@ -35,6 +39,8 @@ class CharacterModel {
                   CharacterMemoryBlock.fromJson(Map<String, dynamic>.from(e)))
               .toList() ??
           [],
+      isPrimaryCompanion: json['is_primary_companion'] as bool? ?? false,
+      interestFilter: json['interest_filter'] as String?,
     );
   }
 
@@ -47,6 +53,8 @@ class CharacterModel {
       'enabled': enabled,
       'avatar': avatar,
       'memory': memory.map((e) => e.toJson()).toList(),
+      'is_primary_companion': isPrimaryCompanion,
+      if (interestFilter != null) 'interest_filter': interestFilter,
     };
   }
 
@@ -58,6 +66,8 @@ class CharacterModel {
     bool? enabled,
     String? avatar,
     List<CharacterMemoryBlock>? memory,
+    bool? isPrimaryCompanion,
+    String? interestFilter,
   }) {
     return CharacterModel(
       id: id ?? this.id,
@@ -67,6 +77,8 @@ class CharacterModel {
       enabled: enabled ?? this.enabled,
       avatar: avatar ?? this.avatar,
       memory: memory ?? this.memory,
+      isPrimaryCompanion: isPrimaryCompanion ?? this.isPrimaryCompanion,
+      interestFilter: interestFilter ?? this.interestFilter,
     );
   }
 }

--- a/lib/ui/character/widgets/persona_avatar_button.dart
+++ b/lib/ui/character/widgets/persona_avatar_button.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:memex/data/services/persona_chat_service.dart';
+import 'package:memex/data/services/character_service.dart';
+import 'package:memex/domain/models/character_model.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/ui/character/widgets/persona_chat_screen.dart';
+import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/utils/user_storage.dart';
+
+/// Small avatar button in the timeline header.
+/// Shows the user's primary companion character with an unread badge.
+class PersonaAvatarButton extends StatefulWidget {
+  const PersonaAvatarButton({super.key});
+
+  @override
+  State<PersonaAvatarButton> createState() => _PersonaAvatarButtonState();
+}
+
+class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
+  CharacterModel? _character;
+  StreamSubscription? _unreadSub;
+  int _unreadCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final userId = UserStorage.userId;
+    if (userId == null) return;
+
+    final primary =
+        await CharacterService.instance.getPrimaryCompanion(userId);
+    if (!mounted || primary == null) return;
+
+    setState(() => _character = primary);
+
+    if (AppDatabase.isInitialized) {
+      _unreadSub = PersonaChatService.instance
+          .watchTotalUnreadCount()
+          .listen((count) {
+        if (mounted) setState(() => _unreadCount = count);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _unreadSub?.cancel();
+    super.dispose();
+  }
+
+  void _openChat() {
+    if (_character == null) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => PersonaChatScreen(characterId: _character!.id),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_character == null) return const SizedBox(width: 36, height: 36);
+
+    return GestureDetector(
+      onTap: _openChat,
+      child: SizedBox(
+        width: 36,
+        height: 36,
+        child: Stack(
+          children: [
+            Center(
+              child: Container(
+                width: 30,
+                height: 30,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      AppColors.primary.withValues(alpha: 0.15),
+                      AppColors.primary.withValues(alpha: 0.25),
+                    ],
+                  ),
+                ),
+                child: Center(
+                  child: Text(
+                    _character!.name.characters.first,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            if (_unreadCount > 0)
+              Positioned(
+                top: 1,
+                right: 0,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  constraints:
+                      const BoxConstraints(minWidth: 16, minHeight: 16),
+                  decoration: BoxDecoration(
+                    color: Colors.red,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Center(
+                    child: Text(
+                      _unreadCount > 99 ? '99+' : '$_unreadCount',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 10,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/character/widgets/persona_avatar_button.dart
+++ b/lib/ui/character/widgets/persona_avatar_button.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/data/services/character_service.dart';
 import 'package:memex/domain/models/character_model.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/ui/character/widgets/persona_chat_screen.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
 import 'package:memex/utils/user_storage.dart';
 
 /// Small avatar button in the timeline header.
@@ -22,28 +24,40 @@ class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
   StreamSubscription? _unreadSub;
   int _unreadCount = 0;
 
+  final Logger _logger = Logger('PersonaAvatarButton');
+
   @override
   void initState() {
     super.initState();
-    _load();
+    // Delay load to ensure FileSystemService is initialized
+    // (TimelineScreen builds before MemexRouter finishes init)
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Future.delayed(const Duration(seconds: 2), _load);
+    });
   }
 
   Future<void> _load() async {
-    final userId = await UserStorage.getUserId();
-    if (userId == null) return;
+    try {
+      final userId = await UserStorage.getUserId();
+      _logger.info('PersonaAvatarButton _load: userId=$userId');
+      if (userId == null) return;
 
-    final primary =
-        await CharacterService.instance.getPrimaryCompanion(userId);
-    if (!mounted || primary == null) return;
+      final primary =
+          await CharacterService.instance.getPrimaryCompanion(userId);
+      _logger.info('PersonaAvatarButton _load: primary=${primary?.name}, enabled=${primary?.enabled}');
+      if (!mounted || primary == null) return;
 
-    setState(() => _character = primary);
+      setState(() => _character = primary);
 
-    if (AppDatabase.isInitialized) {
-      _unreadSub = PersonaChatService.instance
-          .watchTotalUnreadCount()
-          .listen((count) {
-        if (mounted) setState(() => _unreadCount = count);
-      });
+      if (AppDatabase.isInitialized) {
+        _unreadSub = PersonaChatService.instance
+            .watchTotalUnreadCount()
+            .listen((count) {
+          if (mounted) setState(() => _unreadCount = count);
+        });
+      }
+    } catch (e, stack) {
+      _logger.warning('PersonaAvatarButton _load failed: $e', e, stack);
     }
   }
 
@@ -74,30 +88,10 @@ class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
         child: Stack(
           children: [
             Center(
-              child: Container(
-                width: 30,
-                height: 30,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      AppColors.primary.withValues(alpha: 0.15),
-                      AppColors.primary.withValues(alpha: 0.25),
-                    ],
-                  ),
-                ),
-                child: Center(
-                  child: Text(
-                    _character!.name.characters.first,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w700,
-                      color: AppColors.primary,
-                    ),
-                  ),
-                ),
+              child: DiceBearAvatar(
+                seed: 'companion_${_character!.name}',
+                size: 30,
+                backgroundColor: AppColors.primary.withValues(alpha: 0.1),
               ),
             ),
             if (_unreadCount > 0)

--- a/lib/ui/character/widgets/persona_avatar_button.dart
+++ b/lib/ui/character/widgets/persona_avatar_button.dart
@@ -29,7 +29,7 @@ class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
   }
 
   Future<void> _load() async {
-    final userId = UserStorage.userId;
+    final userId = await UserStorage.getUserId();
     if (userId == null) return;
 
     final primary =

--- a/lib/ui/character/widgets/persona_chat_screen.dart
+++ b/lib/ui/character/widgets/persona_chat_screen.dart
@@ -1,0 +1,529 @@
+import 'dart:async';
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:flutter/material.dart';
+import 'package:memex/agent/companion_agent/companion_agent.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/character_model.dart';
+import 'package:memex/domain/models/llm_config.dart';
+import 'package:memex/data/services/persona_chat_service.dart';
+import 'package:memex/data/services/character_service.dart';
+import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/ui/core/widgets/back_button.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:memex/domain/models/agent_definitions.dart';
+import 'package:intl/intl.dart';
+
+/// 1-on-1 chat screen with an AI companion character.
+class PersonaChatScreen extends StatefulWidget {
+  final String characterId;
+  const PersonaChatScreen({super.key, required this.characterId});
+
+  @override
+  State<PersonaChatScreen> createState() => _PersonaChatScreenState();
+}
+
+class _PersonaChatScreenState extends State<PersonaChatScreen> {
+  final _textController = TextEditingController();
+  final _scrollController = ScrollController();
+  final _chatService = PersonaChatService.instance;
+
+  CharacterModel? _character;
+  List<PersonaChatMessage> _messages = [];
+  bool _isLoading = true;
+  bool _isStreaming = false;
+  String _streamingText = '';
+
+  // Keep LLM history for context window
+  final List<LLMMessage> _llmHistory = [];
+  static const int _maxHistoryMessages = 30;
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    final userId = UserStorage.userId;
+    if (userId == null) return;
+
+    final character = await CharacterService.instance
+        .getCharacter(userId, widget.characterId);
+
+    final messages = await _chatService.getMessages(widget.characterId);
+    await _chatService.markAllRead(widget.characterId);
+
+    // Build LLM history from persisted messages
+    final reversed = messages.reversed.toList();
+    for (final msg in reversed) {
+      if (msg.isFromCharacter) {
+        _llmHistory.add(ModelMessage(
+            model: 'history', textOutput: msg.content));
+      } else {
+        _llmHistory.add(UserMessage([TextPart(msg.content)]));
+      }
+    }
+    // Trim to max
+    if (_llmHistory.length > _maxHistoryMessages) {
+      _llmHistory.removeRange(0, _llmHistory.length - _maxHistoryMessages);
+    }
+
+    if (mounted) {
+      setState(() {
+        _character = character;
+        _messages = reversed;
+        _isLoading = false;
+      });
+      _scrollToBottom();
+    }
+  }
+
+  @override
+  void dispose() {
+    // Trigger memory update in background when leaving chat
+    _updateMemoryInBackground();
+    _textController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _updateMemoryInBackground() async {
+    if (_llmHistory.isEmpty) return;
+    final userId = UserStorage.userId;
+    if (userId == null) return;
+
+    try {
+      final resources = await UserStorage.getAgentLLMResources(
+        AgentDefinitions.chatAgent,
+        defaultClientKey: LLMConfig.defaultClientKey,
+      );
+      // Fire and forget — don't block dispose
+      CompanionAgent.onConversationEnd(
+        client: resources.client,
+        modelConfig: resources.modelConfig,
+        userId: userId,
+        characterId: widget.characterId,
+        conversation: _llmHistory,
+      );
+    } catch (_) {}
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _textController.text.trim();
+    if (text.isEmpty || _isStreaming) return;
+
+    _textController.clear();
+
+    // Persist user message
+    await _chatService.addUserMessage(widget.characterId, text);
+
+    // Add to LLM history
+    _llmHistory.add(UserMessage([TextPart(text)]));
+
+    // Reload messages to show user's message
+    final messages = await _chatService.getMessages(widget.characterId);
+    setState(() {
+      _messages = messages.reversed.toList();
+      _isStreaming = true;
+      _streamingText = '';
+    });
+    _scrollToBottom();
+
+    // Get LLM resources
+    final userId = UserStorage.userId;
+    if (userId == null) return;
+
+    try {
+      final resources = await UserStorage.getAgentLLMResources(
+        AgentDefinitions.chatAgent,
+        defaultClientKey: LLMConfig.defaultClientKey,
+      );
+
+      // Trim history before sending
+      final historyToSend = _llmHistory.length > _maxHistoryMessages
+          ? _llmHistory.sublist(_llmHistory.length - _maxHistoryMessages)
+          : List<LLMMessage>.from(_llmHistory);
+      // Remove the last user message since CompanionAgent.chat adds it
+      if (historyToSend.isNotEmpty) historyToSend.removeLast();
+
+      final buffer = StringBuffer();
+      await for (final chunk in CompanionAgent.chat(
+        client: resources.client,
+        modelConfig: resources.modelConfig,
+        userId: userId,
+        characterId: widget.characterId,
+        userMessage: text,
+        history: historyToSend,
+      )) {
+        buffer.write(chunk);
+        if (mounted) {
+          setState(() => _streamingText = buffer.toString());
+          _scrollToBottom();
+        }
+      }
+
+      // Persist character response
+      final fullResponse = buffer.toString().trim();
+      if (fullResponse.isNotEmpty) {
+        await _chatService.addCharacterMessage(
+          widget.characterId,
+          fullResponse,
+          isRead: true, // User is looking at it
+        );
+        _llmHistory
+            .add(ModelMessage(model: 'companion', textOutput: fullResponse));
+      }
+
+      // Reload messages
+      final updated = await _chatService.getMessages(widget.characterId);
+      if (mounted) {
+        setState(() {
+          _messages = updated.reversed.toList();
+          _isStreaming = false;
+          _streamingText = '';
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isStreaming = false;
+          _streamingText = '';
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to get response: $e')),
+        );
+      }
+    }
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        centerTitle: true,
+        leading: const AppBackButton(),
+        title: _character == null
+            ? null
+            : Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: 28,
+                    height: 28,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: AppColors.primary.withValues(alpha: 0.15),
+                    ),
+                    child: Center(
+                      child: Text(
+                        _character!.name.characters.first,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.primary,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    _character!.name,
+                    style: const TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.textPrimary,
+                    ),
+                  ),
+                ],
+              ),
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                Expanded(child: _buildMessageList()),
+                _buildInputBar(),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildMessageList() {
+    final itemCount =
+        _messages.length + (_isStreaming && _streamingText.isNotEmpty ? 1 : 0);
+
+    if (itemCount == 0) return _buildEmptyState();
+
+    return ListView.builder(
+      controller: _scrollController,
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      itemCount: itemCount,
+      itemBuilder: (context, index) {
+        // Streaming message at the end
+        if (index == _messages.length && _isStreaming) {
+          return _buildBubble(
+            text: _streamingText,
+            isCharacter: true,
+            isStreaming: true,
+          );
+        }
+
+        final msg = _messages[index];
+        final showDate = index == 0 ||
+            !_isSameDay(msg.timestamp, _messages[index - 1].timestamp);
+
+        return Column(
+          children: [
+            if (showDate) _buildDateDivider(msg.timestamp),
+            _buildBubble(
+              text: msg.content,
+              isCharacter: msg.isFromCharacter,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(40),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 64,
+              height: 64,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: AppColors.primary.withValues(alpha: 0.1),
+              ),
+              child: Center(
+                child: Text(
+                  _character?.name.characters.first ?? '?',
+                  style: const TextStyle(
+                    fontSize: 28,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.primary,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              _character?.name ?? '',
+              style: const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: AppColors.textPrimary,
+              ),
+            ),
+            if (_character != null && _character!.tags.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                _character!.tags.join(' · '),
+                style: const TextStyle(
+                    fontSize: 13, color: AppColors.textTertiary),
+              ),
+            ],
+            const SizedBox(height: 24),
+            Text(
+              'Say hi 👋',
+              style: TextStyle(fontSize: 14, color: AppColors.textSecondary),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDateDivider(DateTime date) {
+    final now = DateTime.now();
+    String label;
+    if (_isSameDay(date, now)) {
+      label = 'Today';
+    } else if (_isSameDay(date, now.subtract(const Duration(days: 1)))) {
+      label = 'Yesterday';
+    } else {
+      label = DateFormat('MMM d').format(date);
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Center(
+        child: Text(label,
+            style:
+                const TextStyle(fontSize: 12, color: AppColors.textTertiary)),
+      ),
+    );
+  }
+
+  Widget _buildBubble({
+    required String text,
+    required bool isCharacter,
+    bool isStreaming = false,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        mainAxisAlignment:
+            isCharacter ? MainAxisAlignment.start : MainAxisAlignment.end,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (isCharacter) ...[
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: AppColors.primary.withValues(alpha: 0.12),
+              ),
+              child: Center(
+                child: Text(
+                  _character?.name.characters.first ?? '?',
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.primary,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+          ],
+          Flexible(
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+              decoration: BoxDecoration(
+                color: isCharacter ? Colors.white : AppColors.primary,
+                borderRadius: BorderRadius.only(
+                  topLeft: const Radius.circular(16),
+                  topRight: const Radius.circular(16),
+                  bottomLeft: Radius.circular(isCharacter ? 4 : 16),
+                  bottomRight: Radius.circular(isCharacter ? 16 : 4),
+                ),
+                boxShadow: isCharacter
+                    ? [
+                        BoxShadow(
+                          color: AppColors.shadowLight,
+                          blurRadius: 8,
+                          offset: const Offset(0, 2),
+                        )
+                      ]
+                    : null,
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Flexible(
+                    child: Text(
+                      text,
+                      style: TextStyle(
+                        fontSize: 15,
+                        height: 1.5,
+                        color: isCharacter
+                            ? AppColors.textPrimary
+                            : Colors.white,
+                      ),
+                    ),
+                  ),
+                  if (isStreaming) ...[
+                    const SizedBox(width: 4),
+                    SizedBox(
+                      width: 8,
+                      height: 8,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 1.5,
+                        color: AppColors.textTertiary,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          if (!isCharacter) const SizedBox(width: 8),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInputBar() {
+    return Container(
+      padding: EdgeInsets.fromLTRB(
+          16, 8, 16, MediaQuery.of(context).padding.bottom + 8),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.shadowLight,
+            blurRadius: 10,
+            offset: Offset(0, -2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _textController,
+              decoration: InputDecoration(
+                hintText: 'Message...',
+                hintStyle: const TextStyle(
+                    color: AppColors.textTertiary, fontSize: 15),
+                filled: true,
+                fillColor: AppColors.background,
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(20),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+              style: const TextStyle(fontSize: 15),
+              textInputAction: TextInputAction.send,
+              onSubmitted: (_) => _sendMessage(),
+              enabled: !_isStreaming,
+            ),
+          ),
+          const SizedBox(width: 8),
+          GestureDetector(
+            onTap: _isStreaming ? null : _sendMessage,
+            child: Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: _isStreaming
+                    ? AppColors.textTertiary
+                    : AppColors.primary,
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(Icons.arrow_upward,
+                  color: Colors.white, size: 20),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+}

--- a/lib/ui/character/widgets/persona_chat_screen.dart
+++ b/lib/ui/character/widgets/persona_chat_screen.dart
@@ -9,6 +9,7 @@ import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/data/services/character_service.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/ui/core/widgets/back_button.dart';
+import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:intl/intl.dart';
@@ -223,23 +224,10 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
             : Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Container(
-                    width: 28,
-                    height: 28,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: AppColors.primary.withValues(alpha: 0.15),
-                    ),
-                    child: Center(
-                      child: Text(
-                        _character!.name.characters.first,
-                        style: const TextStyle(
-                          fontSize: 13,
-                          fontWeight: FontWeight.w700,
-                          color: AppColors.primary,
-                        ),
-                      ),
-                    ),
+                  DiceBearAvatar(
+                    seed: 'companion_${_character!.name}',
+                    size: 28,
+                    backgroundColor: AppColors.primary.withValues(alpha: 0.1),
                   ),
                   const SizedBox(width: 8),
                   Text(
@@ -315,15 +303,10 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
                 shape: BoxShape.circle,
                 color: AppColors.primary.withValues(alpha: 0.1),
               ),
-              child: Center(
-                child: Text(
-                  _character?.name.characters.first ?? '?',
-                  style: const TextStyle(
-                    fontSize: 28,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.primary,
-                  ),
-                ),
+              child: DiceBearAvatar(
+                seed: 'companion_${_character?.name ?? ''}',
+                size: 64,
+                backgroundColor: Colors.transparent,
               ),
             ),
             const SizedBox(height: 16),
@@ -387,23 +370,10 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (isCharacter) ...[
-            Container(
-              width: 32,
-              height: 32,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: AppColors.primary.withValues(alpha: 0.12),
-              ),
-              child: Center(
-                child: Text(
-                  _character?.name.characters.first ?? '?',
-                  style: const TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.primary,
-                  ),
-                ),
-              ),
+            DiceBearAvatar(
+              seed: 'companion_${_character?.name ?? ''}',
+              size: 32,
+              backgroundColor: AppColors.primary.withValues(alpha: 0.08),
             ),
             const SizedBox(width: 8),
           ],

--- a/lib/ui/character/widgets/persona_chat_screen.dart
+++ b/lib/ui/character/widgets/persona_chat_screen.dart
@@ -44,7 +44,7 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
   }
 
   Future<void> _init() async {
-    final userId = UserStorage.userId;
+    final userId = await UserStorage.getUserId();
     if (userId == null) return;
 
     final character = await CharacterService.instance
@@ -89,7 +89,7 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
 
   void _updateMemoryInBackground() async {
     if (_llmHistory.isEmpty) return;
-    final userId = UserStorage.userId;
+    final userId = await UserStorage.getUserId();
     if (userId == null) return;
 
     try {
@@ -130,7 +130,7 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
     _scrollToBottom();
 
     // Get LLM resources
-    final userId = UserStorage.userId;
+    final userId = await UserStorage.getUserId();
     if (userId == null) return;
 
     try {

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -23,6 +23,7 @@ import 'package:memex/ui/core/widgets/local_image.dart';
 import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
+import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
 import 'package:memex/ui/core/cards/style/timeline_theme.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/utils/share_service.dart';
@@ -1095,6 +1096,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     if (detail.insight.character != null) {
       commentWidgets.add(
         _buildSingleComment(
+          characterId: detail.insight.characterId,
           avatar: detail.insight.character!.avatar,
           name: detail.insight.character!.name,
           content: detail.insight.text,
@@ -1108,6 +1110,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     for (var comment in detail.insight.comments) {
       commentWidgets.add(
         _buildSingleComment(
+          characterId: comment.character?.id,
           avatar: comment.character?.avatar,
           name: comment.isAi ? (comment.character?.name ?? 'AI') : 'User',
           content: comment.content,
@@ -1127,6 +1130,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   }
 
   Widget _buildSingleComment({
+    String? characterId,
     String? avatar,
     required String name,
     required String content,
@@ -1134,26 +1138,39 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     bool isAuthor = false,
     bool isAi = false,
   }) {
+    // Determine avatar widget:
+    // - characterId "0" or null with isAuthor = Memex system → use logo
+    // - Other characters → use DiceBear
+    Widget avatarWidget;
+    final isMemexSystem = characterId == null || characterId == '0';
+
+    if (isMemexSystem) {
+      // Memex logo
+      avatarWidget = CircleAvatar(
+        radius: 18,
+        backgroundColor: Colors.white,
+        child: ClipOval(
+          child: SvgPicture.asset(
+            'assets/logo_perfect.svg',
+            width: 28,
+            height: 28,
+            fit: BoxFit.contain,
+          ),
+        ),
+      );
+    } else {
+      // Character DiceBear avatar
+      avatarWidget = DiceBearAvatar(
+        seed: 'companion_$name',
+        size: 36,
+        backgroundColor: const Color(0xFFEEF2FF),
+      );
+    }
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        CircleAvatar(
-          radius: 18,
-          backgroundImage: avatar != null && avatar.isNotEmpty
-              ? LocalImage.provider(avatar)
-              : null,
-          backgroundColor:
-              isAuthor ? const Color(0xFF8B5CF6) : Colors.grey[200],
-          child: avatar == null || avatar.isEmpty
-              ? Text(
-                  name.isNotEmpty ? name[0].toUpperCase() : '?',
-                  style: TextStyle(
-                    color: isAuthor ? Colors.white : Colors.grey[600],
-                    fontSize: 14,
-                  ),
-                )
-              : null,
-        ),
+        avatarWidget,
         const SizedBox(width: 12),
         Expanded(
           child: Column(

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -1150,11 +1150,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
         radius: 18,
         backgroundColor: Colors.white,
         child: ClipOval(
-          child: SvgPicture.asset(
-            'assets/logo_perfect.svg',
-            width: 28,
-            height: 28,
-            fit: BoxFit.contain,
+          child: Image.asset(
+            'assets/icon.png',
+            width: 36,
+            height: 36,
+            fit: BoxFit.cover,
           ),
         ),
       );

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -350,7 +350,7 @@ class TimelineScreenState extends State<TimelineScreen> {
                       ],
                     ),
                   ),
-                  // 4 buttons: chat, companion, notification, avatar
+                  // 4 buttons: chat, notification, companion, user avatar
                   SizedBox(
                     height: 36,
                     child: Row(
@@ -371,9 +371,6 @@ class TimelineScreenState extends State<TimelineScreen> {
                             ),
                           ),
                         ),
-                        const SizedBox(width: 6),
-                        // Companion character button
-                        const PersonaAvatarButton(),
                         const SizedBox(width: 6),
                         // Notification button
                         if (AppDatabase.isInitialized)
@@ -430,6 +427,9 @@ class TimelineScreenState extends State<TimelineScreen> {
                               );
                             },
                           ),
+                        const SizedBox(width: 6),
+                        // Companion character button (next to user avatar)
+                        const PersonaAvatarButton(),
                         const SizedBox(width: 6),
                         // Avatar button
                         GestureDetector(

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -28,6 +28,7 @@ import 'package:memex/ui/settings/widgets/model_config_list_page.dart';
 import 'package:memex/ui/settings/widgets/system_authorization_page.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
+import 'package:memex/ui/character/widgets/persona_avatar_button.dart';
 
 /// Timeline screen - main memory view. Receives [viewModel] and [insightViewModel] from parent (Compass-style).
 class TimelineScreen extends StatefulWidget {
@@ -349,11 +350,11 @@ class TimelineScreenState extends State<TimelineScreen> {
                       ],
                     ),
                   ),
-                  // 3 buttons: 36px each, 6px gap, total 120px
+                  // 4 buttons: chat, companion, notification, avatar
                   SizedBox(
-                    width: 120,
                     height: 36,
                     child: Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
                         // Chat button
                         GestureDetector(
@@ -370,7 +371,10 @@ class TimelineScreenState extends State<TimelineScreen> {
                             ),
                           ),
                         ),
-                        const SizedBox(width: 8),
+                        const SizedBox(width: 6),
+                        // Companion character button
+                        const PersonaAvatarButton(),
+                        const SizedBox(width: 6),
                         // Notification button
                         if (AppDatabase.isInitialized)
                           StreamBuilder<List<SystemAction>>(
@@ -426,7 +430,7 @@ class TimelineScreenState extends State<TimelineScreen> {
                               );
                             },
                           ),
-                        const SizedBox(width: 8),
+                        const SizedBox(width: 6),
                         // Avatar button
                         GestureDetector(
                           onTap: () {


### PR DESCRIPTION
## What

为 Memex 添加 AI 陪伴角色聊天系统，让虚拟角色从"卡片评论者"升级为"微信好友式的聊天伙伴"。

## Changes

### 1. CompanionAgent 核心 (轻量级，无 tool calling)
- 直接调 LLM 流式输出，不走 StatefulAgent 框架，响应快
- 四层 context 组装：用户画像 → 情绪快照 → 关系记忆 → 最近生活
- 对话结束后自动更新角色记忆（relationship.md + emotional_state.md）

### 2. 角色智能选择
- `CharacterSelectionService`：基于内容-角色亲和度评分选择角色
- 替换原来的 `Random(factId.hashCode)` 盲选
- 支持情绪信号匹配（疲惫→关心型角色，吐槽→死党型角色）

### 3. 聊天 UI
- `PersonaChatScreen`：1v1 聊天界面，流式输出，消息持久化
- `PersonaAvatarButton`：右上角角色头像入口，带未读红点
- 头像统一用 DiceBear 风格（与用户头像同一套）

### 4. 基础设施
- `CharacterModel` 新增 `isPrimaryCompanion`、`interestFilter` 字段
- Drift `PersonaChatMessages` 表（schema v9）
- `PersonaChatService`：消息 CRUD + 未读计数 stream
- 卡片评论区头像：Memex 系统用 icon.png，角色用 DiceBear

### 5. 角色记忆增强
- CommentAgentSkill 接入 MemoryRead/MemoryWrite 工具
- 角色记忆注入评论 prompt，评论后可更新记忆
- CommentAgent 增强 PKM context（读最近 3 天 daily facts）

## Not included (后续)
- 角色主动消息（Phase 4，需单独设计触发策略）
- 默认角色模板重构（Phase 5）
- 角色选择/模板 UI

## Design doc
`docs/companion-agent-design.md`