### PR TITLE
feat: add quick action shortcut for fast note input via app icon long…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data android:name="io.flutter.embedding.android.NormalTheme" android:resource="@style/NormalTheme" />
+            <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/app/src/main/res/drawable/ic_quick_note.xml
+++ b/android/app/src/main/res/drawable/ic_quick_note.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="shortcut_quick_note">记一下</string>
+    <string name="shortcut_quick_note_long">快速记录</string>
+</resources>

--- a/android/app/src/main/res/xml/shortcuts.xml
+++ b/android/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="quick_note"
+        android:enabled="true"
+        android:icon="@drawable/ic_quick_note"
+        android:shortcutShortLabel="@string/shortcut_quick_note"
+        android:shortcutLongLabel="@string/shortcut_quick_note_long">
+        <intent
+            android:action="android.intent.action.RUN"
+            android:targetPackage="com.memexlab.memex"
+            android:targetClass="com.memexlab.memex.MainActivity">
+            <extra android:name="some unique action key" android:value="quick_note" />
+        </intent>
+    </shortcut>
+</shortcuts>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -108,6 +108,17 @@
 		<array>
 			<string>workmanager.background.task</string>
 		</array>
+		<key>UIApplicationShortcutItems</key>
+		<array>
+			<dict>
+				<key>UIApplicationShortcutItemType</key>
+				<string>quick_note</string>
+				<key>UIApplicationShortcutItemTitle</key>
+				<string>记一下</string>
+				<key>UIApplicationShortcutItemIconType</key>
+				<string>UIApplicationShortcutIconTypeCompose</string>
+			</dict>
+		</array>
 		<key>NSAppTransportSecurity</key>
 		<dict>
 			<key>NSAllowsArbitraryLoads</key>

--- a/lib/data/services/quick_action_service.dart
+++ b/lib/data/services/quick_action_service.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+import 'package:logging/logging.dart';
+import 'package:memex/utils/logger.dart';
+
+/// Manages app-icon quick actions (long-press shortcuts).
+///
+/// Handles both cold-start and warm-start scenarios by queuing the action
+/// until a listener is ready to consume it. This decouples the platform
+/// channel callback timing from the widget lifecycle.
+class QuickActionService {
+  QuickActionService._();
+  static final QuickActionService instance = QuickActionService._();
+
+  final Logger _logger = getLogger('QuickActionService');
+
+  /// The action ID that was tapped, if not yet consumed.
+  String? _pendingAction;
+
+  /// Listener notified when an action arrives or becomes consumable.
+  Completer<void>? _actionReady;
+
+  /// Whether a listener is currently attached and ready.
+  bool _hasListener = false;
+
+  /// Called by the platform quick_actions callback.
+  void handleAction(String actionType) {
+    _logger.info('Quick action received: $actionType');
+    _pendingAction = actionType;
+    if (_hasListener) {
+      // Listener is ready — deliver immediately.
+      _actionReady?.complete();
+    }
+  }
+
+  /// Register that [MainScreen] is ready to handle actions.
+  void attach() {
+    _hasListener = true;
+  }
+
+  /// Detach when [MainScreen] is disposed.
+  void detach() {
+    _hasListener = false;
+    _actionReady?.complete();
+    _actionReady = null;
+  }
+
+  /// Wait for and consume the pending action.
+  ///
+  /// Returns the action type, or `null` if no action is pending.
+  /// If an action arrives after this call, it will be delivered via
+  /// the returned future (with a reasonable timeout).
+  Future<String?> consumePendingAction() async {
+    // Already have a pending action — consume immediately.
+    if (_pendingAction != null) {
+      final action = _pendingAction;
+      _pendingAction = null;
+      return action;
+    }
+
+    // No action yet — wait briefly for a late-arriving callback.
+    _actionReady = Completer<void>();
+    try {
+      await _actionReady!.future.timeout(const Duration(seconds: 2));
+    } on TimeoutException {
+      // No action arrived within the window.
+    }
+    _actionReady = null;
+
+    final action = _pendingAction;
+    _pendingAction = null;
+    return action;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,7 @@ import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/core/themes/app_theme.dart';
 import 'dart:io';
 import 'package:memex/ui/main_screen/widgets/radial_menu.dart';
-import 'package:memex/domain/models/shortcut_item.dart';
+import 'package:memex/domain/models/shortcut_item.dart' as app_shortcut;
 import 'package:record/record.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -52,6 +52,8 @@ import 'package:memex/routing/router.dart';
 import 'package:memex/data/services/onboarding_service.dart';
 import 'package:memex/ui/core/widgets/coach_mark_overlay.dart';
 import 'package:memex/ui/main_screen/widgets/share_intent_handler.dart';
+import 'package:quick_actions/quick_actions.dart';
+import 'package:memex/data/services/quick_action_service.dart';
 
 final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();
 final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
@@ -101,6 +103,13 @@ void main() async {
 
   final appRouter =
       createAppRouter(rootNavigatorKey, () => RootShell(key: rootShellKey));
+
+  // Initialize quick actions (app icon long-press shortcuts).
+  const QuickActions quickActions = QuickActions();
+  quickActions.initialize((String shortcutType) {
+    QuickActionService.instance.handleAction(shortcutType);
+  });
+
   runApp(MultiProvider(
     providers: dependencyProviders,
     child: MemexApp(router: appRouter),
@@ -413,7 +422,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
   // Radial Menu & Recording State
   bool _isRadialMenuOpen = false;
-  List<ShortcutItem> _shortcuts = [];
+  List<app_shortcut.ShortcutItem> _shortcuts = [];
   final AudioRecorder _audioRecorder = AudioRecorder();
   String? _recordingPath;
   StreamingTranscriber? _quickTranscriber;
@@ -475,6 +484,10 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         });
       },
     )..init();
+
+    // Consume pending quick action (app icon long-press shortcut).
+    QuickActionService.instance.attach();
+    _consumeQuickActionIfNeeded();
   }
 
   void _handleInvalidModelConfig(EventBusMessage message) {
@@ -808,6 +821,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     WidgetsBinding.instance.removeObserver(this);
     _memoryButtonTapTimer?.cancel();
     _knowledgeBaseButtonTapTimer?.cancel();
+    QuickActionService.instance.detach();
     _shareIntentHandler.dispose();
     _eventBus.removeHandler(
         EventBusMessageType.invalidModelConfig, _handleInvalidModelConfig);
@@ -1071,7 +1085,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     }
   }
 
-  void _handleShortcutSelect(ShortcutItem? item) async {
+  void _handleShortcutSelect(app_shortcut.ShortcutItem? item) async {
     final hasRecording = _recordingPath != null;
 
     if (item != null) {
@@ -1107,6 +1121,23 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     }
   }
 
+  /// Consume a pending quick action (e.g. "记一下" from app icon long-press).
+  /// Handles cold-start (action queued before widget built) and warm-start
+  /// (action arrives while app is in background).
+  void _consumeQuickActionIfNeeded() {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final action =
+          await QuickActionService.instance.consumePendingAction();
+      if (!mounted) return;
+      if (action == 'quick_note') {
+        _logger.info('Quick action: opening input sheet');
+        setState(() {
+          _isInputOpen = true;
+        });
+      }
+    });
+  }
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     // when app enters foreground, ensure event bus is connected
@@ -1114,6 +1145,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       if (!_eventBus.isConnected) {
         _eventBus.connect();
       }
+      // Also consume any quick action that arrived while in background.
+      _consumeQuickActionIfNeeded();
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1357,6 +1357,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quick_actions:
+    dependency: "direct main"
+    description:
+      name: quick_actions
+      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  quick_actions_android:
+    dependency: transitive
+    description:
+      name: quick_actions_android
+      sha256: "8acaeb18ef926ae1ca6214e51b717ebb592b899f3f97674262d21e010061e5fb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.28"
+  quick_actions_ios:
+    dependency: transitive
+    description:
+      name: quick_actions_ios
+      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
+  quick_actions_platform_interface:
+    dependency: transitive
+    description:
+      name: quick_actions_platform_interface
+      sha256: "1fec7068db5122cd019e9340d3d7be5d36eab099695ef3402c7059ee058329a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   recase:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   shared_preferences: ^2.2.2
   path_provider: ^2.1.1
 
+  # Quick Actions (app icon long-press shortcuts)
+  quick_actions: ^1.1.0
+
   # Media
   image_picker: ^1.0.7
   record: ^6.0.0

--- a/test/data/services/quick_action_service_test.dart
+++ b/test/data/services/quick_action_service_test.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/quick_action_service.dart';
+
+void main() {
+  late QuickActionService service;
+
+  setUp(() {
+    service = QuickActionService.instance;
+  });
+
+  tearDown(() {
+    // Reset internal state between tests
+    service.detach();
+  });
+
+  group('QuickActionService', () {
+    test('consumePendingAction returns null when no action queued', () async {
+      service.attach();
+      final action = await service.consumePendingAction();
+      expect(action, isNull);
+    });
+
+    test('handleAction then consumePendingAction returns the action', () async {
+      service.attach();
+      service.handleAction('quick_note');
+      final action = await service.consumePendingAction();
+      expect(action, 'quick_note');
+    });
+
+    test('consumePendingAction is idempotent — second call returns null',
+        () async {
+      service.attach();
+      service.handleAction('quick_note');
+      await service.consumePendingAction();
+      final action2 = await service.consumePendingAction();
+      expect(action2, isNull);
+    });
+
+    test('cold start: action queued before attach is still consumed', () async {
+      // Simulate: platform callback fires before MainScreen is built
+      service.handleAction('quick_note');
+
+      // Only after widget is ready:
+      service.attach();
+      final action = await service.consumePendingAction();
+      expect(action, 'quick_note');
+    });
+
+    test('warm start: action arrives while no listener is attached', () async {
+      service.attach();
+      // Consume any initial pending action
+      await service.consumePendingAction();
+
+      // Simulate: action arrives after detach (app went to background)
+      service.detach();
+      service.handleAction('quick_note');
+
+      // App comes back to foreground — re-attach and consume
+      service.attach();
+      final action = await service.consumePendingAction();
+      expect(action, 'quick_note');
+    });
+
+    test('multiple actions — only the last one is kept', () async {
+      service.attach();
+      service.handleAction('action_a');
+      service.handleAction('quick_note');
+      final action = await service.consumePendingAction();
+      // Last one wins (realistic — user can only tap one shortcut)
+      expect(action, 'quick_note');
+    });
+
+    test('unknown action type is still passed through', () async {
+      service.attach();
+      service.handleAction('unknown_action');
+      final action = await service.consumePendingAction();
+      expect(action, 'unknown_action');
+    });
+
+    test('consumePendingAction times out gracefully', () async {
+      service.attach();
+      // No action queued — should timeout and return null
+      final action = await service.consumePendingAction();
+      expect(action, isNull);
+    });
+  });
+}


### PR DESCRIPTION
概要                                                                          
                                               
  - 在 Android 和 iOS 上添加"记一下"快捷操作，用户长按 App                      
  图标即可快速进入输入面板记录内容。
                                                                                
  改动                                                                          
   
  Android                                                                       
  - 新增静态快捷方式定义（res/xml/shortcuts.xml），intent extra key 与
  quick_actions 插件对齐                                                        
  - 新增 vector drawable 图标（ic_quick_note.xml）及字符串资源    
  - 在 AndroidManifest.xml 中通过 android.app.shortcuts meta-data 注册快捷方式  
                                                                                
  iOS                                                                           
  - 在 Info.plist 中添加 UIApplicationShortcutItems，使用系统编辑图标（UIApplica
  tionShortcutIconTypeCompose）                                                 
                                                                                
  Flutter                                                                       
  - 引入 quick_actions 插件处理跨平台快捷方式回调                               
  - 新增 QuickActionService 解耦快捷方式回调与 Widget                           
  生命周期的时序问题，覆盖冷启动（action 在 Widget 树构建前到达）和热启动（App  
  在后台时触发）两种场景                                                        
  - 在 MainScreen.initState 和 didChangeAppLifecycleState(resumed) 中消费
  pending action                                                                
                                                                                
  测试
  - QuickActionService 单元测试 8/8 通过，覆盖冷启动、热启动、幂等性、超时、未知
   action 等场景                                                                
                                                                                
  测试                                                                          
                                                                                
  - Android（小米 13 Ultra）：长按图标 → 显示"记一下" → 点击 → 弹出输入面板     
  - iOS（iPhone SE 3）：长按图标 → 显示"记一下" → 点击 → 弹出输入面板           
  - 冷启动：杀掉 App → 长按图标 → "记一下" → App 启动后弹出输入面板             
  - 热启动：App 在后台 → 长按图标 → "记一下" → App 恢复后弹出输入面板           
  - 开启 App Lock：快捷方式打开 App → 解锁后输入面板正常显示                    
  - flutter analyze — 0 errors                                                  
  - flutter test — 8/8 passed 