### PR TITLE
fix: PKM nested directory and graceful missing dir handling

### DIFF
--- a/lib/agent/pkm_agent/pkm_agent.dart
+++ b/lib/agent/pkm_agent/pkm_agent.dart
@@ -377,7 +377,7 @@ $instruction
       final reminderParts = <String>[];
       if (!check.wrotePara) {
         reminderParts.add(
-            'Write to P.A.R.A.: use the Write or Edit tool to organize the current raw input under /PKM and record the current fact_id in the file (e.g. as a comment: <!-- fact_id: ... -->)');
+            'Write to P.A.R.A.: use the Write or Edit tool to organize the current raw input under / and record the current fact_id in the file (e.g. as a comment: <!-- fact_id: ... -->)');
       }
       if (!check.updatedInsight) {
         reminderParts.add(

--- a/lib/data/repositories/pkm.dart
+++ b/lib/data/repositories/pkm.dart
@@ -61,7 +61,7 @@ Future<Map<String, dynamic>> listPkmDirectory({String? path}) async {
           'Projects': '项目',
           'Areas': '领域',
           'Resources': '资源',
-          'Archives': '存档',
+          'Archives': '归档',
         };
 
         if (categoryMapping.containsKey(dirPath)) {
@@ -77,7 +77,11 @@ Future<Map<String, dynamic>> listPkmDirectory({String? path}) async {
     }
 
     if (!await targetDir.exists()) {
-      throw ApiException('Directory not found: $dirPath');
+      _logger.info('PKM directory not found: $dirPath, returning empty list');
+      return {
+        'items': <Map<String, dynamic>>[],
+        'current_path': dirPath ?? '',
+      };
     }
 
     // List directory contents

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -2358,7 +2358,7 @@ class FileSystemService {
       'Projects': '项目',
       'Areas': '领域',
       'Resources': '资源',
-      'Archives': '存档',
+      'Archives': '归档',
     };
 
     for (final relativePath in paths) {


### PR DESCRIPTION
## Summary

PKM 知识库在已使用的设备上无法显示 PARA 分类内容，点击项目/领域/资源/归档四个卡片时目录不存在报错，但在全新设备上正常工作。

## Root Cause

PkmAgent 的 retry 机制在提示 LLM 补写文件时使用了错误路径 `/PKM`，导致创建嵌套的 `PKM/PKM/` 目录结构。

**触发链路：**
1. PkmAgent 首次运行时 LLM 写了文件但未在内容中包含 `fact_id`
2. `_checkPkmRunComplete` 检测到 `wrotePara = false`，触发 retry
3. Retry reminder（`pkm_agent.dart:380`）指示 LLM "organize under `/PKM`"
4. LLM 写入 `/PKM/项目/xxx.md`，`_resolvePath` 将其解析为 `workspace/PKM/PKM/项目/xxx.md`——多了一层
5. 一旦 `PKM/PKM/` 结构建立，`_getPkmOverview` 展示该错误结构给 LLM，后续运行持续沿用，形成恶性循环

**路径体系对比：**
- SuperAgent: file tools 工作目录 = `workspace/`，PkmSkill workingDirectory = `/PKM` → `/PKM/项目/` 解析正确
- PkmAgent: file tools 工作目录 = `workspace/PKM/`，PkmSkill workingDirectory = `/` → retry reminder 里的 `/PKM` 就变成了 `PKM/PKM/`

**附加问题：**
- `listPkmDirectory` 对不存在的目录直接抛 `ApiException`，UI 无兜底
- 中文 PARA 示例用 `归档`，代码映射用 `存档`，名称不一致

## Changes

- **`lib/agent/pkm_agent/pkm_agent.dart`**: retry reminder 路径从 `/PKM` 改为 `/`
- **`lib/data/repositories/pkm.dart`**: 目录不存在时返回空列表而非抛异常；`存档` → `归档`
- **`lib/data/services/file_system_service.dart`**: `存档` → `归档`

## Test plan

- [x] 全新设备上提交多条内容，确认 PARA 目录结构为 `PKM/项目/`、`PKM/领域/` 等（无嵌套）
- [x] 模拟 retry 场景（首次写入不带 fact_id），确认 retry 后路径不会产生 `PKM/PKM/`
- [x] 点击知识库四个 PARA 分类卡片，已存在内容的分类正常展示，空分类显示空列表不报错
- [x] LLM 使用中文命名时，`归档` 目录能被正确映射和显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)