### PR TITLE
fix: PKM PARA目录名随locale重复创建 + 备份恢复顺序问题

### DIFF
--- a/lib/data/repositories/pkm.dart
+++ b/lib/data/repositories/pkm.dart
@@ -246,7 +246,7 @@ Future<Map<String, dynamic>> readPkmFileEndpoint(String filePath) async {
         // Check for invalid UTF-8
         if (content.contains('\uFFFD')) {
           // Replacement char present, likely binary
-          throw FormatException('Binary file detected');
+          throw const FormatException('Binary file detected');
         }
         isBinary = false;
       } catch (e) {

--- a/lib/data/repositories/pkm.dart
+++ b/lib/data/repositories/pkm.dart
@@ -140,6 +140,7 @@ Future<Map<String, dynamic>> listPkmDirectory({String? path}) async {
 
     // List directory contents
     final items = <Map<String, dynamic>>[];
+    final seenNames = <String>{};
     try {
       await for (final entity in targetDir.list()) {
         // Skip hidden files
@@ -149,6 +150,7 @@ Future<Map<String, dynamic>> listPkmDirectory({String? path}) async {
           continue;
         }
 
+        seenNames.add(name);
         final isDirectory = await FileSystemEntity.isDirectory(entityPath);
         final item = <String, dynamic>{
           'name': name,
@@ -165,6 +167,42 @@ Future<Map<String, dynamic>> listPkmDirectory({String? path}) async {
         }
 
         items.add(item);
+      }
+
+      // For PARA root categories: if Chinese dir still exists (has leftover
+      // duplicates that couldn't be moved), merge its items into the listing
+      // with deduplication by name.
+      if (dirPath != null &&
+          dirPath.isNotEmpty &&
+          _isParaRootCategory(dirPath)) {
+        final chineseName = _paraCategoryMapping[dirPath]!;
+        final chineseDir = Directory(p.join(pkmRoot, chineseName));
+        if (await chineseDir.exists()) {
+          await for (final entity in chineseDir.list()) {
+            final name = p.basename(entity.path);
+            if (name.startsWith('.')) continue;
+            if (seenNames.contains(name)) continue;
+
+            seenNames.add(name);
+            final isDirectory =
+                await FileSystemEntity.isDirectory(entity.path);
+            final item = <String, dynamic>{
+              'name': name,
+              'path': p.relative(entity.path, from: pkmRoot),
+              'is_directory': isDirectory,
+            };
+
+            if (!isDirectory) {
+              final file = File(entity.path);
+              if (await file.exists()) {
+                final stat = await file.stat();
+                item['size'] = stat.size;
+              }
+            }
+
+            items.add(item);
+          }
+        }
       }
     } catch (e) {
       _logger.severe('Error listing directory ${targetDir.path}: $e');
@@ -246,7 +284,7 @@ Future<Map<String, dynamic>> readPkmFileEndpoint(String filePath) async {
         // Check for invalid UTF-8
         if (content.contains('\uFFFD')) {
           // Replacement char present, likely binary
-          throw const FormatException('Binary file detected');
+          throw FormatException('Binary file detected');
         }
         isBinary = false;
       } catch (e) {

--- a/lib/data/repositories/pkm.dart
+++ b/lib/data/repositories/pkm.dart
@@ -9,6 +9,62 @@ import 'package:path/path.dart' as p;
 final _logger = getLogger('PkmEndpoint');
 final _fileSystemService = FileSystemService.instance;
 
+/// English → Chinese mapping for PARA root categories.
+const _paraCategoryMapping = <String, String>{
+  'Projects': '项目',
+  'Areas': '领域',
+  'Resources': '资源',
+  'Archives': '归档',
+};
+
+/// Check if [dirPath] is a PARA root category path (e.g. "Projects", "Areas").
+bool _isParaRootCategory(String dirPath) {
+  // Only top-level paths like "Projects", not "Projects/Foo"
+  return _paraCategoryMapping.containsKey(dirPath);
+}
+
+/// Migrate Chinese PARA root directory contents into the English directory.
+///
+/// Moves all files/subdirectories from the Chinese-named directory into the
+/// English-named one, then removes the now-empty Chinese directory.
+/// Silently skips if either directory is missing or if individual items
+/// already exist in the target (no overwrite).
+Future<void> _migrateChineseToEnglish(
+    String pkmRoot, String englishName, String chineseName) async {
+  final englishDir = Directory(p.join(pkmRoot, englishName));
+  final chineseDir = Directory(p.join(pkmRoot, chineseName));
+
+  if (!await chineseDir.exists()) return;
+  if (!await englishDir.exists()) return; // nothing to migrate into
+
+  try {
+    await for (final entity in chineseDir.list()) {
+      final name = p.basename(entity.path);
+      if (name.startsWith('.')) continue;
+
+      final targetPath = p.join(englishDir.path, name);
+      if (await FileSystemEntity.isDirectory(targetPath) ||
+          await FileSystemEntity.isFile(targetPath)) {
+        // Already exists in target, skip
+        continue;
+      }
+      await entity.rename(targetPath);
+    }
+
+    // Remove Chinese dir if empty
+    final remaining = await chineseDir.list().toList();
+    final nonHidden =
+        remaining.where((e) => !p.basename(e.path).startsWith('.')).toList();
+    if (nonHidden.isEmpty) {
+      await chineseDir.delete(recursive: false);
+      _logger.info(
+          'Migrated PARA category $chineseName → $englishName and removed empty dir');
+    }
+  } catch (e) {
+    _logger.warning('Failed to migrate PARA category $chineseName: $e');
+  }
+}
+
 /// List PKM directory contents
 ///
 /// Args:
@@ -55,18 +111,16 @@ Future<Map<String, dynamic>> listPkmDirectory({String? path}) async {
 
       targetDir = Directory(targetPath);
 
-      // Special handling for English/Chinese root PKM categories
-      if (!await targetDir.exists()) {
-        final Map<String, String> categoryMapping = {
-          'Projects': '项目',
-          'Areas': '领域',
-          'Resources': '资源',
-          'Archives': '归档',
-        };
+      // For PARA root categories: migrate Chinese dirs into English and merge listing
+      if (_isParaRootCategory(dirPath)) {
+        final chineseName = _paraCategoryMapping[dirPath]!;
 
-        if (categoryMapping.containsKey(dirPath)) {
-          final chinesePath = p.join(pkmRoot, categoryMapping[dirPath]!);
-          final chineseDir = Directory(chinesePath);
+        // Auto-migrate: move contents from Chinese dir into English dir
+        await _migrateChineseToEnglish(pkmRoot, dirPath, chineseName);
+
+        // If English dir doesn't exist but Chinese does, use Chinese as fallback
+        if (!await targetDir.exists()) {
+          final chineseDir = Directory(p.join(pkmRoot, chineseName));
           if (await chineseDir.exists()) {
             targetDir = chineseDir;
           }

--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -97,19 +97,44 @@ class BackupService {
     String backupFilePath, {
     void Function(String status)? onProgress,
   }) async {
-    final userId = await UserStorage.getUserId();
-    if (userId == null) throw Exception('No user logged in');
-
-    final fs = FileSystemService.instance;
-    final workspacePath = fs.getWorkspacePath(userId);
-    final appDir = await getApplicationDocumentsDirectory();
+    final currentUserId = await UserStorage.getUserId();
+    if (currentUserId == null) throw Exception('No user logged in');
 
     try {
       onProgress?.call('Reading backup...');
       final bytes = await File(backupFilePath).readAsBytes();
       final archive = ZipDecoder().decodeBytes(bytes);
 
-      // 1. Restore workspace files
+      // 1. Restore settings FIRST to get the correct userId from backup
+      onProgress?.call('Restoring settings...');
+      for (final file in archive) {
+        if (file.name == 'settings.json' && file.isFile) {
+          final jsonStr = utf8.decode(file.content as List<int>);
+          final settings = jsonDecode(jsonStr) as Map<String, dynamic>;
+          final prefs = await SharedPreferences.getInstance();
+          for (final entry in settings.entries) {
+            final value = entry.value;
+            if (value is String) {
+              await prefs.setString(entry.key, value);
+            } else if (value is int) {
+              await prefs.setInt(entry.key, value);
+            } else if (value is double) {
+              await prefs.setDouble(entry.key, value);
+            } else if (value is bool) {
+              await prefs.setBool(entry.key, value);
+            }
+          }
+          _logger.info('Restored ${settings.length} settings');
+        }
+      }
+
+      // Use the restored userId (from backup settings) for workspace and DB paths
+      final restoredUserId = await UserStorage.getUserId() ?? currentUserId;
+      final fs = FileSystemService.instance;
+      final workspacePath = fs.getWorkspacePath(restoredUserId);
+      final appDir = await getApplicationDocumentsDirectory();
+
+      // 2. Restore workspace files
       onProgress?.call('Restoring workspace...');
       for (final file in archive) {
         if (file.name.startsWith('workspace/') && !file.isFile) continue;
@@ -126,7 +151,7 @@ class BackupService {
         await File(targetPath).writeAsBytes(file.content as List<int>);
       }
 
-      // 2. Restore DB
+      // 3. Restore DB
       onProgress?.call('Restoring database...');
       // Close current DB first
       if (AppDatabase.isInitialized) {
@@ -156,34 +181,11 @@ class BackupService {
       }
 
       // Re-init DB
-      await AppDatabase.init(userId);
-
-      // 3. Restore settings
-      onProgress?.call('Restoring settings...');
-      for (final file in archive) {
-        if (file.name == 'settings.json' && file.isFile) {
-          final jsonStr = utf8.decode(file.content as List<int>);
-          final settings = jsonDecode(jsonStr) as Map<String, dynamic>;
-          final prefs = await SharedPreferences.getInstance();
-          for (final entry in settings.entries) {
-            final value = entry.value;
-            if (value is String) {
-              await prefs.setString(entry.key, value);
-            } else if (value is int) {
-              await prefs.setInt(entry.key, value);
-            } else if (value is double) {
-              await prefs.setDouble(entry.key, value);
-            } else if (value is bool) {
-              await prefs.setBool(entry.key, value);
-            }
-          }
-          _logger.info('Restored ${settings.length} settings');
-        }
-      }
+      await AppDatabase.init(restoredUserId);
 
       // 4. Rebuild card cache
       onProgress?.call('Rebuilding cache...');
-      await fs.rebuildCardCache(userId);
+      await fs.rebuildCardCache(restoredUserId);
 
       _logger.info('Backup restored successfully');
       return true;
@@ -191,7 +193,8 @@ class BackupService {
       _logger.severe('Restore failed: $e', e, stack);
       // Try to re-init DB even on failure
       try {
-        await AppDatabase.init(userId);
+        final userId = await UserStorage.getUserId();
+        if (userId != null) await AppDatabase.init(userId);
       } catch (_) {}
       rethrow;
     }

--- a/lib/l10n/app_localizations_ext_en.dart
+++ b/lib/l10n/app_localizations_ext_en.dart
@@ -118,7 +118,7 @@ class AppLocalizationsExtEn extends AppLocalizationsEn
 
   @override
   String get pkmFileLanguageInstruction =>
-      'All file contents, filenames, and folder names created in the P.A.R.A. knowledge base MUST be in English.';
+      'P.A.R.A. root category folders (Projects, Areas, Resources, Archives) must always use these exact English names. All other file contents, subfolder names, and filenames inside the P.A.R.A. knowledge base MUST be in English.';
 
   @override
   String get pkmInsightLanguageInstruction =>

--- a/lib/l10n/app_localizations_ext_zh.dart
+++ b/lib/l10n/app_localizations_ext_zh.dart
@@ -71,7 +71,7 @@ class AppLocalizationsExtZh extends AppLocalizationsZh
   @override
   String get pkmPARAStructureExample => '''## P.A.R.A. 知识库结构示例（根据用户实际输入灵活组织）：
 │
-├── 项目
+├── Projects
 │   ├── 2025春节全家三亚旅游/      <-- 涉及行程、机票、酒店，使用文件夹
 │   │   ├── 行程规划日程表.md
 │   │   └── 机票酒店预订确认单.md
@@ -81,7 +81,7 @@ class AppLocalizationsExtZh extends AppLocalizationsZh
 │   ├── 考取驾照_C1.md             <-- 目标单一，单文件即可
 │   └── 12月工作汇报PPT准备.md
 │
-├── 领域
+├── Areas
 │   ├── 健康与医疗/
 │   │   ├── 家庭成员体检报告汇总.md
 │   │   └── 健身打卡与体重记录.md     <-- 适合追加写入
@@ -93,7 +93,7 @@ class AppLocalizationsExtZh extends AppLocalizationsZh
 │   └── 职业发展/
 │       └── 个人简历_通用版维护.md    <-- 会随时间不断更新
 │
-├── 资源
+├── Resources
 │   ├── 烹饪美食/
 │   │   ├── 减脂餐食谱收藏.md
 │   │   └── 家电使用指南.md
@@ -105,7 +105,7 @@ class AppLocalizationsExtZh extends AppLocalizationsZh
 │   └── 家居生活技巧/
 │       └── 收纳整理术笔记.md
 │
-└── 归档
+└── Archives
     ├── [已完成]购买第一辆车.md
     └── [已失效]旧租房合同资料/
            ├── 租房合同.md
@@ -117,7 +117,7 @@ class AppLocalizationsExtZh extends AppLocalizationsZh
 
   @override
   String get pkmFileLanguageInstruction =>
-      'All file contents, filenames, and folder names created in the P.A.R.A. knowledge base MUST be in Simplified Chinese (zh-CN).';
+      'P.A.R.A. root category folders (Projects, Areas, Resources, Archives) must always use these exact English names. All other file contents, subfolder names, and filenames inside the P.A.R.A. knowledge base MUST be in Simplified Chinese (zh-CN).';
 
   @override
   String get pkmInsightLanguageInstruction =>


### PR DESCRIPTION
## 现象

### 问题一：PARA 目录中英文重复导致计数与列表不一致

用户在知识库页面点击"资源"等 PARA 分类卡片时，只显示部分文件（如 1/3），但首页卡片上的数量计数正确。

进一步排查发现：
- PKM 目录下同时存在中英文两套 PARA 目录：`Projects/` + `项目/`、`Areas/` + `领域/`、`Resources/` + `资源/`
- `countPkmItems` 对两套目录求和（显示正确总数）
- `listPkmDirectory` 只列出英文目录（显示部分文件）
- 导致计数与列表不一致

### 问题二：备份恢复到新设备后需要操作两次才能看到完整数据

新装 APP 后恢复备份，第一次只能看到用户名，需要再操作一次恢复才能看到完整的卡片和知识库。

## 根因

### 问题一根因

PKM Agent 的 `pkmFileLanguageInstruction` 指示 LLM 用**用户当前语言**创建所有文件和文件夹名，包括 PARA 四个根目录。`pkmPARAStructureExample` 示例也随语言变化（中文版展示 `项目/领域/资源/归档`，英文版展示 `Projects/Areas/Resources/Archives`）。

当用户切换 App 语言或 LLM 在不同运行中做出不同选择时，就会创建两套同名不同语言的目录，且后续运行不会自动合并。

此外，代码层面 `countPkmItems` 和 `listPkmDirectory` 对中英文目录的处理策略不一致：
- `countPkmItems`：同时查英文和中文目录，**求和**
- `listPkmDirectory`：先查英文目录，存在就用，**不查中文目录**

### 问题二根因

`BackupService.restoreBackup` 先恢复 workspace 文件和数据库（使用**当前用户**的路径），再恢复 settings.json（此时 userId 才变成备份中的原用户）。新设备上用户名不同时，workspace 和 DB 被写入错误路径。第二次恢复时 userId 已正确，路径才对。

## 解决方案

### 问题一：Prompt 定规则 + 代码做兜底

1. **Prompt 层**：修改 `pkmFileLanguageInstruction`（中英文版本），明确 PARA 根目录名始终使用英文（Projects, Areas, Resources, Archives），只有子目录名和文件内容跟随用户语言。修改中文 `pkmPARAStructureExample` 根目录名从中文改为英文。

2. **代码层 - 自动迁移**：新增 `_migrateChineseToEnglish`，在 `listPkmDirectory` 访问 PARA 分类时自动将中文目录内容移到英文目录下。

3. **代码层 - 合并列表**：迁移后如果中文目录仍有残留（同名文件无法覆盖），listing 阶段合并中文目录的非重名文件，按名字去重。

### 问题二：调整恢复顺序

将 settings.json 恢复提到最前面，用恢复后的 userId 解析 workspace 和 DB 路径，确保文件写入正确位置。

## Changes

- `lib/l10n/app_localizations_ext_zh.dart`：PARA 示例根目录名改英文；语言指令加 PARA 根目录固定英文约束
- `lib/l10n/app_localizations_ext_en.dart`：语言指令加 PARA 根目录固定英文约束
- `lib/data/repositories/pkm.dart`：新增 `_migrateChineseToEnglish` 自动迁移函数；重构 `listPkmDirectory` 的 PARA 分类处理逻辑，合并中英文目录列表
- `lib/data/services/backup_service.dart`：调整恢复顺序，先恢复 settings 再恢复 workspace 和 DB

## Test plan

- [ ] 中文环境下新建 PKM 内容，确认 LLM 创建 `Projects/` 而非 `项目/`
- [ ] 英文环境下新建 PKM 内容，确认 PARA 根目录名仍为英文
- [ ] 手动创建中英文并存目录（如 `Resources/` + `资源/`），访问知识库后确认中文目录内容自动迁移到英文目录
- [ ] 迁移后确认首页计数与目录列表一致（含同名文件残留场景）
- [ ] 确认子目录名和文件内容仍遵循用户语言设置
- [ ] 新设备安装 → 注册 → 恢复备份 → 确认一次恢复即可看到完整数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)