### PR TITLE
feat: add read-only mode toggle in Chat dialog

### DIFF
--- a/lib/agent/super_agent/super_agent.dart
+++ b/lib/agent/super_agent/super_agent.dart
@@ -16,9 +16,21 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/utils/logger.dart';
 
+/// Read-only tool names available in Quick Query mode.
+const _readOnlyToolNames = {
+  'LS', 'Glob', 'Grep', 'Read', 'BatchRead',
+  'search_event_logs', 'getCurrentTime', 'get_pkm_overview',
+};
+
+/// Skills excluded in Quick Query mode (those that create/modify data).
+const _quickQueryExcludedSkills = {
+  'manage_timeline_card',
+};
+
 class SuperAgent {
   static final Logger _logger = getLogger('SuperAgent');
 
+  /// Whether this agent operates in read-only Quick Query mode.
   static Future<StatefulAgent> createAgent(
       {required LLMClient client,
       required ModelConfig modelConfig,
@@ -28,6 +40,7 @@ class SuperAgent {
       AgentController? controller,
       List<String>? forceActiveSkills,
       bool disableSubAgents = false,
+      bool quickQuery = false,
       String? additionalSystemPrompt}) async {
     final fileService = FileSystemService.instance;
 
@@ -37,11 +50,11 @@ class SuperAgent {
 
     final workingDirectory = fileService.getWorkspacePath(userId);
 
-    // SuperAgent has full access to the workspace
+    // SuperAgent has full access to the workspace (read-only in Quick Query)
     final permissionManager = FilePermissionManager(userId, [
       PermissionRule(
           rootPath: fileService.getWorkspacePath(userId),
-          access: FileAccessType.write),
+          access: quickQuery ? FileAccessType.read : FileAccessType.write),
     ]);
 
     final fileToolFactory = FileToolFactory(
@@ -49,7 +62,7 @@ class SuperAgent {
       workingDirectory: workingDirectory,
     );
 
-    final tools = [
+    final allTools = [
       fileToolFactory.buildLSTool(),
       fileToolFactory.buildGlobTool(),
       fileToolFactory.buildGrepTool(),
@@ -64,25 +77,37 @@ class SuperAgent {
       getPkmOverviewTool
     ];
 
-    // Memory Management
+    // Filter tools in Quick Query mode — only keep read-only tools
+    final tools = quickQuery
+        ? allTools.where((t) => _readOnlyToolNames.contains(t.name)).toList()
+        : allTools;
+
+    // Memory Management (skip write tools in Quick Query mode)
     final memoryManagement = await MemoryManagement.createDefault(
       userId: userId,
       sourceAgent: name,
     );
     final memoryManagementPrompt =
         await memoryManagement.buildMemoryManagementPrompt();
-    final memoryManagementTools = memoryManagement.buildMemoryManagementTools();
-    tools.addAll(memoryManagementTools);
+    if (!quickQuery) {
+      final memoryManagementTools = memoryManagement.buildMemoryManagementTools();
+      tools.addAll(memoryManagementTools);
+    }
 
     final userMemory = await memoryManagement.buildMemoryPrompt();
     state.systemReminders["user_memory"] = userMemory;
 
-    final skills = [
+    var skills = [
       KnowledgeInsightSkill(),
       TimelineCardSkill(),
       PkmSkill(workingDirectory: '/PKM'),
       SystemActionSkill(),
     ];
+    if (quickQuery) {
+      skills = skills
+          .where((s) => !_quickQueryExcludedSkills.contains(s.name))
+          .toList();
+    }
     if (forceActiveSkills != null) {
       for (var skill in skills) {
         if (forceActiveSkills.contains(skill.name)) {
@@ -92,6 +117,15 @@ class SuperAgent {
     }
 
     final systemPrompts = [superAgentSystemPrompt, memoryManagementPrompt];
+    if (quickQuery) {
+      systemPrompts.add(
+        '## Quick Query Mode\n'
+        'You are in **Quick Query** (read-only) mode. You can ONLY read and search existing data.\n'
+        'You MUST NOT create, modify, or delete any records, cards, knowledge entries, or files.\n'
+        'If the user asks you to create or change something, explain that this is a read-only mode '
+        'and suggest they use the full Chat mode instead.',
+      );
+    }
     if (additionalSystemPrompt != null) {
       systemPrompts.add(additionalSystemPrompt);
     }

--- a/lib/data/repositories/chat.dart
+++ b/lib/data/repositories/chat.dart
@@ -120,6 +120,7 @@ Future<List<Map<String, dynamic>>> fetchChatSessionsEndpoint({
               DateTime.now().toIso8601String(),
           'message_count': messages.length,
           'last_message_preview': lastMessagePreview,
+          'is_quick_query': sessionData['is_quick_query'] == true,
         });
       } catch (e) {
         _logger.warning('Failed to load session from ${sessionFile.path}: $e');

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -941,22 +941,8 @@ class MemexRouter {
     String? scene = 'assistant',
     String? sceneId,
     List<Map<String, String>>? refs,
+    bool isQuickQuery = false,
   }) {
-    // Local implementation delegates to ChatService
-    // ChatService uses imported ChatEvent which matches the interface
-    // but ChatService.sendMessage returns Stream<ChatEvent> from package:memex/data/services/chat_service.dart
-    // which exports package:memex/data/model/chat_events.dart
-    // So types should be compatible.
-
-    // Check if we need to initialize something?
-    // ChatService handles its own initialization somewhat, but depends on global state.
-    // _ensureInitialized might be needed if ChatService uses DB or FileSystem that we init.
-    // However, ChatService.instance uses FileSystemService.instance which is static.
-    // MemexRouter inits FileSystemService.
-
-    // We can't await inside a sync generator or stream return easily without Stream.fromFuture or async*
-    // ChatService.sendMessage is async*.
-
     return ChatService.instance.sendMessage(
       message,
       sessionId: sessionId,
@@ -964,6 +950,7 @@ class MemexRouter {
       scene: scene,
       sceneId: sceneId,
       refs: refs,
+      isQuickQuery: isQuickQuery,
     );
   }
 

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -34,7 +34,10 @@ class ChatService {
   final FileSystemService _fileService = FileSystemService.instance;
   final Uuid _uuid = const Uuid();
 
-  /// Send a message and get a stream of events
+  /// Send a message and get a stream of events.
+  ///
+  /// When [isQuickQuery] is true, the agent operates in read-only mode
+  /// (filtered tools/skills), but the session is still persisted normally.
   Stream<ChatEvent> sendMessage(
     String message, {
     String? sessionId,
@@ -42,6 +45,7 @@ class ChatService {
     String? scene = 'assistant',
     String? sceneId,
     List<Map<String, String>>? refs,
+    bool isQuickQuery = false,
   }) async* {
     _logger.info(
         'sendMessage: sessionId=$sessionId, message=$message, refs=${refs?.length}');
@@ -88,6 +92,7 @@ class ChatService {
             'session_id': finalSessionId,
             'message': message,
             'has_refs': refs != null && refs.isNotEmpty,
+            'is_quick_query': isQuickQuery,
           },
         );
       } catch (e) {
@@ -216,6 +221,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
           controller: controller,
           disableSubAgents: false,
           forceActiveSkills: forceActiveSkills,
+          quickQuery: isQuickQuery,
           additionalSystemPrompt: additionalSystemPrompt,
         );
       }

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -63,7 +63,7 @@ class ChatService {
       if (finalSessionId.isEmpty) {
         finalSessionId = await _createSession(userId, agentName, [
           {'type': 'text', 'text': message}
-        ]);
+        ], isQuickQuery: isQuickQuery);
       }
 
       // Notify UI of the active session ID immediately
@@ -77,7 +77,8 @@ class ChatService {
           [
             {'type': 'text', 'text': message}
           ],
-          refs: refs);
+          refs: refs,
+          isQuickQuery: isQuickQuery);
 
       // Log chat event
       try {
@@ -567,8 +568,9 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
   Future<String> _createSession(
     String userId,
     String? agentName,
-    List<Map<String, dynamic>> initialContent,
-  ) async {
+    List<Map<String, dynamic>> initialContent, {
+    bool isQuickQuery = false,
+  }) async {
     final uuidStr = _uuid.v4();
     final sessionId = agentName != null && agentName.isNotEmpty
         ? '${agentName}_$uuidStr'
@@ -590,6 +592,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
       'title': title ?? 'New Chat',
       'created_at': now.toIso8601String(),
       'updated_at': now.toIso8601String(),
+      'is_quick_query': isQuickQuery,
       'messages': <dynamic>[],
     };
 
@@ -608,6 +611,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
     List<Map<String, dynamic>> content, {
     Map<String, dynamic>? usage,
     List<Map<String, String>>? refs,
+    bool? isQuickQuery,
   }) async {
     final sessionFile = _getSessionFilePath(userId, sessionId);
     if (!await sessionFile.exists()) return null;
@@ -652,6 +656,11 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
         'total_cost': (currentTotal['total_cost'] as double? ?? 0.0) +
             (usage['total_cost'] as double? ?? 0.0),
       };
+    }
+
+    // Update session-level mode flag so history can restore it
+    if (isQuickQuery != null) {
+      sessionData['is_quick_query'] = isQuickQuery;
     }
 
     sessionData['updated_at'] = DateTime.now().toIso8601String();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -892,5 +892,16 @@
   "demoStartTour": "Start Tour",
   "demoGetStarted": "Get Started",
   "demoSkip": "Skip",
-  "demoPrefillText": "Hello Memex! This is my first record 🎉"
+  "demoPrefillText": "Hello Memex! This is my first record 🎉",
+
+  "quickQueryTitle": "Quick Query",
+  "quickQueryTabLabel": "Quick Query",
+  "quickQueryReadOnlyBadge": "READ-ONLY",
+  "quickQueryEmptyHint": "Ask anything about your records — read-only, no data will be created.",
+  "quickQuerySwitchTitle": "Switch Mode",
+  "quickQuerySwitchToQuickQuery": "Switch to Quick Query? Current conversation will be cleared.",
+  "quickQuerySwitchToChat": "Switch to Chat? Current conversation will be cleared.",
+
+  "readOnlyMode": "Read-Only Mode",
+  "readOnlyBadge": "READ-ONLY"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -894,14 +894,6 @@
   "demoSkip": "Skip",
   "demoPrefillText": "Hello Memex! This is my first record 🎉",
 
-  "quickQueryTitle": "Quick Query",
-  "quickQueryTabLabel": "Quick Query",
-  "quickQueryReadOnlyBadge": "READ-ONLY",
-  "quickQueryEmptyHint": "Ask anything about your records — read-only, no data will be created.",
-  "quickQuerySwitchTitle": "Switch Mode",
-  "quickQuerySwitchToQuickQuery": "Switch to Quick Query? Current conversation will be cleared.",
-  "quickQuerySwitchToChat": "Switch to Chat? Current conversation will be cleared.",
-
   "readOnlyMode": "Read-Only Mode",
   "readOnlyBadge": "READ-ONLY"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3637,6 +3637,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Hello Memex! This is my first record 🎉'**
   String get demoPrefillText;
+
+  /// No description provided for @quickQueryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Quick Query'**
+  String get quickQueryTitle;
+
+  /// No description provided for @quickQueryTabLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Quick Query'**
+  String get quickQueryTabLabel;
+
+  /// No description provided for @quickQueryReadOnlyBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'READ-ONLY'**
+  String get quickQueryReadOnlyBadge;
+
+  /// No description provided for @quickQueryEmptyHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Ask anything about your records — read-only, no data will be created.'**
+  String get quickQueryEmptyHint;
+
+  /// No description provided for @quickQuerySwitchTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Switch Mode'**
+  String get quickQuerySwitchTitle;
+
+  /// No description provided for @quickQuerySwitchToQuickQuery.
+  ///
+  /// In en, this message translates to:
+  /// **'Switch to Quick Query? Current conversation will be cleared.'**
+  String get quickQuerySwitchToQuickQuery;
+
+  /// No description provided for @quickQuerySwitchToChat.
+  ///
+  /// In en, this message translates to:
+  /// **'Switch to Chat? Current conversation will be cleared.'**
+  String get quickQuerySwitchToChat;
+
+  /// No description provided for @readOnlyMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Read-Only Mode'**
+  String get readOnlyMode;
+
+  /// No description provided for @readOnlyBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'READ-ONLY'**
+  String get readOnlyBadge;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3638,48 +3638,6 @@ abstract class AppLocalizations {
   /// **'Hello Memex! This is my first record 🎉'**
   String get demoPrefillText;
 
-  /// No description provided for @quickQueryTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Quick Query'**
-  String get quickQueryTitle;
-
-  /// No description provided for @quickQueryTabLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Quick Query'**
-  String get quickQueryTabLabel;
-
-  /// No description provided for @quickQueryReadOnlyBadge.
-  ///
-  /// In en, this message translates to:
-  /// **'READ-ONLY'**
-  String get quickQueryReadOnlyBadge;
-
-  /// No description provided for @quickQueryEmptyHint.
-  ///
-  /// In en, this message translates to:
-  /// **'Ask anything about your records — read-only, no data will be created.'**
-  String get quickQueryEmptyHint;
-
-  /// No description provided for @quickQuerySwitchTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Switch Mode'**
-  String get quickQuerySwitchTitle;
-
-  /// No description provided for @quickQuerySwitchToQuickQuery.
-  ///
-  /// In en, this message translates to:
-  /// **'Switch to Quick Query? Current conversation will be cleared.'**
-  String get quickQuerySwitchToQuickQuery;
-
-  /// No description provided for @quickQuerySwitchToChat.
-  ///
-  /// In en, this message translates to:
-  /// **'Switch to Chat? Current conversation will be cleared.'**
-  String get quickQuerySwitchToChat;
-
   /// No description provided for @readOnlyMode.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1984,4 +1984,34 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get demoPrefillText => 'Hello Memex! This is my first record 🎉';
+
+  @override
+  String get quickQueryTitle => 'Quick Query';
+
+  @override
+  String get quickQueryTabLabel => 'Quick Query';
+
+  @override
+  String get quickQueryReadOnlyBadge => 'READ-ONLY';
+
+  @override
+  String get quickQueryEmptyHint =>
+      'Ask anything about your records — read-only, no data will be created.';
+
+  @override
+  String get quickQuerySwitchTitle => 'Switch Mode';
+
+  @override
+  String get quickQuerySwitchToQuickQuery =>
+      'Switch to Quick Query? Current conversation will be cleared.';
+
+  @override
+  String get quickQuerySwitchToChat =>
+      'Switch to Chat? Current conversation will be cleared.';
+
+  @override
+  String get readOnlyMode => 'Read-Only Mode';
+
+  @override
+  String get readOnlyBadge => 'READ-ONLY';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1986,30 +1986,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get demoPrefillText => 'Hello Memex! This is my first record 🎉';
 
   @override
-  String get quickQueryTitle => 'Quick Query';
-
-  @override
-  String get quickQueryTabLabel => 'Quick Query';
-
-  @override
-  String get quickQueryReadOnlyBadge => 'READ-ONLY';
-
-  @override
-  String get quickQueryEmptyHint =>
-      'Ask anything about your records — read-only, no data will be created.';
-
-  @override
-  String get quickQuerySwitchTitle => 'Switch Mode';
-
-  @override
-  String get quickQuerySwitchToQuickQuery =>
-      'Switch to Quick Query? Current conversation will be cleared.';
-
-  @override
-  String get quickQuerySwitchToChat =>
-      'Switch to Chat? Current conversation will be cleared.';
-
-  @override
   String get readOnlyMode => 'Read-Only Mode';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1914,4 +1914,31 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get demoPrefillText => '你好 Memex！这是我的第一条记录 🎉';
+
+  @override
+  String get quickQueryTitle => '快速查询';
+
+  @override
+  String get quickQueryTabLabel => '快速查询';
+
+  @override
+  String get quickQueryReadOnlyBadge => '只读';
+
+  @override
+  String get quickQueryEmptyHint => '向你的记录提问 — 只读模式，不会创建任何数据。';
+
+  @override
+  String get quickQuerySwitchTitle => '切换模式';
+
+  @override
+  String get quickQuerySwitchToQuickQuery => '切换到快速查询？当前对话将被清除。';
+
+  @override
+  String get quickQuerySwitchToChat => '切换到聊天？当前对话将被清除。';
+
+  @override
+  String get readOnlyMode => '只读模式';
+
+  @override
+  String get readOnlyBadge => '只读';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1916,27 +1916,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get demoPrefillText => '你好 Memex！这是我的第一条记录 🎉';
 
   @override
-  String get quickQueryTitle => '快速查询';
-
-  @override
-  String get quickQueryTabLabel => '快速查询';
-
-  @override
-  String get quickQueryReadOnlyBadge => '只读';
-
-  @override
-  String get quickQueryEmptyHint => '向你的记录提问 — 只读模式，不会创建任何数据。';
-
-  @override
-  String get quickQuerySwitchTitle => '切换模式';
-
-  @override
-  String get quickQuerySwitchToQuickQuery => '切换到快速查询？当前对话将被清除。';
-
-  @override
-  String get quickQuerySwitchToChat => '切换到聊天？当前对话将被清除。';
-
-  @override
   String get readOnlyMode => '只读模式';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -870,5 +870,16 @@
   "demoStartTour": "开始体验",
   "demoGetStarted": "开始使用",
   "demoSkip": "跳过",
-  "demoPrefillText": "你好 Memex！这是我的第一条记录 🎉"
+  "demoPrefillText": "你好 Memex！这是我的第一条记录 🎉",
+
+  "quickQueryTitle": "快速查询",
+  "quickQueryTabLabel": "快速查询",
+  "quickQueryReadOnlyBadge": "只读",
+  "quickQueryEmptyHint": "向你的记录提问 — 只读模式，不会创建任何数据。",
+  "quickQuerySwitchTitle": "切换模式",
+  "quickQuerySwitchToQuickQuery": "切换到快速查询？当前对话将被清除。",
+  "quickQuerySwitchToChat": "切换到聊天？当前对话将被清除。",
+
+  "readOnlyMode": "只读模式",
+  "readOnlyBadge": "只读"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -872,14 +872,6 @@
   "demoSkip": "跳过",
   "demoPrefillText": "你好 Memex！这是我的第一条记录 🎉",
 
-  "quickQueryTitle": "快速查询",
-  "quickQueryTabLabel": "快速查询",
-  "quickQueryReadOnlyBadge": "只读",
-  "quickQueryEmptyHint": "向你的记录提问 — 只读模式，不会创建任何数据。",
-  "quickQuerySwitchTitle": "切换模式",
-  "quickQuerySwitchToQuickQuery": "切换到快速查询？当前对话将被清除。",
-  "quickQuerySwitchToChat": "切换到聊天？当前对话将被清除。",
-
   "readOnlyMode": "只读模式",
   "readOnlyBadge": "只读"
 }

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -5,7 +5,6 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/data/model/chat_events.dart';
 import 'package:memex/utils/toast_helper.dart';
-import 'package:provider/provider.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
@@ -98,6 +97,11 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   bool _isStreaming = false;
   bool _isLoadingAgent = false;
   ChatTokenUsageEvent? _lastTokenUsage;
+  bool _isReadOnly = false;
+  // Tracks whether the user switched from read-only to normal (but hasn't sent a message yet).
+  bool _previouslyReadOnly = false;
+  // Once the user sends a message in normal mode after having been in read-only, lock permanently.
+  bool _readOnlyLocked = false;
 
   // Controllers
   final TextEditingController _messageController = TextEditingController();
@@ -217,6 +221,12 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       _contextSent = true;
     }
 
+    // Lock read-only if user sends a message in normal mode after having been in read-only
+    if (!_isReadOnly && _previouslyReadOnly) {
+      _readOnlyLocked = true;
+      _previouslyReadOnly = false;
+    }
+
     setState(() {
       _items.add(UserMessageItem(finalMessage, refs: refs));
       _isStreaming = true;
@@ -234,6 +244,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       scene: widget.scene,
       sceneId: widget.sceneId,
       refs: refs,
+      isQuickQuery: _isReadOnly,
     )
         .listen(
       (event) {
@@ -445,6 +456,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                     ),
                     _buildTokenUsageDisplay(),
                     _buildContextIndicator(),
+                    _buildModeToggle(),
                     _buildInput(),
                   ],
                 ),
@@ -508,6 +520,24 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                 fontWeight: FontWeight.bold,
                 color: AppColors.textPrimary),
           ),
+          if (_isReadOnly) ...[
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.orange.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                UserStorage.l10n.readOnlyBadge,
+                style: const TextStyle(
+                  fontSize: 10,
+                  color: Colors.orange,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
           const Spacer(),
           IconButton(
             icon: const Icon(Icons.history,
@@ -531,6 +561,60 @@ class _AgentChatDialogState extends State<AgentChatDialog>
             icon: const Icon(Icons.close,
                 size: 20, color: AppColors.textTertiary),
             onPressed: () => Navigator.of(context).pop(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildModeToggle() {
+    final locked = _readOnlyLocked;
+    final canToggle = !locked && !_isStreaming;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: canToggle
+                ? () {
+                    setState(() {
+                      if (_isReadOnly) {
+                        _isReadOnly = false;
+                        _previouslyReadOnly = true;
+                      } else {
+                        _isReadOnly = true;
+                        _previouslyReadOnly = false;
+                      }
+                    });
+                  }
+                : null,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+              decoration: BoxDecoration(
+                color: _isReadOnly ? AppColors.primary : Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: _isReadOnly
+                      ? AppColors.primary
+                      : locked
+                          ? const Color(0xFFF0F0F0)
+                          : const Color(0xFFE2E8F0),
+                ),
+              ),
+              child: Text(
+                UserStorage.l10n.readOnlyMode,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: _isReadOnly
+                      ? Colors.white
+                      : locked
+                          ? AppColors.textTertiary
+                          : AppColors.textSecondary,
+                ),
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -98,10 +98,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   bool _isLoadingAgent = false;
   ChatTokenUsageEvent? _lastTokenUsage;
   bool _isReadOnly = false;
-  // Tracks whether the user switched from read-only to normal (but hasn't sent a message yet).
-  bool _previouslyReadOnly = false;
-  // Once the user sends a message in normal mode after having been in read-only, lock permanently.
-  bool _readOnlyLocked = false;
+  // Whether the user has sent at least one message in normal mode — prevents switching to read-only.
+  bool _hasSentInNormalMode = false;
 
   // Controllers
   final TextEditingController _messageController = TextEditingController();
@@ -201,6 +199,11 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         _items = historyItems;
         _lastTokenUsage = restoredUsage;
         _isLoading = false;
+        // Restore read-only mode from persisted session
+        final wasQuickQuery = sessionData['is_quick_query'] == true;
+        _isReadOnly = wasQuickQuery;
+        // If session was in normal mode (or field missing for old sessions), lock toggle
+        _hasSentInNormalMode = !wasQuickQuery;
       });
       _scrollToBottom();
     } catch (e) {
@@ -221,10 +224,9 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       _contextSent = true;
     }
 
-    // Lock read-only if user sends a message in normal mode after having been in read-only
-    if (!_isReadOnly && _previouslyReadOnly) {
-      _readOnlyLocked = true;
-      _previouslyReadOnly = false;
+    // Lock read-only toggle once user sends in normal mode
+    if (!_isReadOnly) {
+      _hasSentInNormalMode = true;
     }
 
     setState(() {
@@ -568,7 +570,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   }
 
   Widget _buildModeToggle() {
-    final locked = _readOnlyLocked;
+    // Can always switch FROM read-only; can switch TO read-only only if never sent in normal mode
+    final locked = !_isReadOnly && _hasSentInNormalMode;
     final canToggle = !locked && !_isStreaming;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
@@ -578,13 +581,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
             onTap: canToggle
                 ? () {
                     setState(() {
-                      if (_isReadOnly) {
-                        _isReadOnly = false;
-                        _previouslyReadOnly = true;
-                      } else {
-                        _isReadOnly = true;
-                        _previouslyReadOnly = false;
-                      }
+                      _isReadOnly = !_isReadOnly;
                     });
                   }
                 : null,

--- a/lib/ui/chat/widgets/chat_history_screen.dart
+++ b/lib/ui/chat/widgets/chat_history_screen.dart
@@ -256,6 +256,44 @@ class _ChatHistoryScreenState extends State<ChatHistoryScreen> {
                                                         AppColors.textTertiary,
                                                   ),
                                                 ),
+                                                if (session['is_quick_query'] ==
+                                                    true) ...[
+                                                  const SizedBox(width: 8),
+                                                  const Text(
+                                                    '•',
+                                                    style: TextStyle(
+                                                      fontSize: 12,
+                                                      color:
+                                                          AppColors.textTertiary,
+                                                    ),
+                                                  ),
+                                                  const SizedBox(width: 8),
+                                                  Container(
+                                                    padding: const EdgeInsets
+                                                        .symmetric(
+                                                        horizontal: 6,
+                                                        vertical: 2),
+                                                    decoration: BoxDecoration(
+                                                      color: AppColors.primary
+                                                          .withValues(
+                                                              alpha: 0.1),
+                                                      borderRadius:
+                                                          BorderRadius.circular(
+                                                              4),
+                                                    ),
+                                                    child: Text(
+                                                      UserStorage
+                                                          .l10n.readOnlyBadge,
+                                                      style: TextStyle(
+                                                        fontSize: 10,
+                                                        fontWeight:
+                                                            FontWeight.w600,
+                                                        color:
+                                                            AppColors.primary,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                ],
                                               ],
                                             ),
                                           ],


### PR DESCRIPTION
## Summary

Closes #6

在 Chat 对话框中增加"只读模式"开关，让 SuperAgent 仅执行只读操作（不创建卡片、不改 PKM、不写文件）。

### 改动内容

**Agent 层**
- `SuperAgent.createAgent` 新增 `quickQuery` 参数
- 只读模式下：过滤只读 tools（LS/Glob/Grep/Read/BatchRead 等）、排除 `manage_timeline_card` skill、排除 memory 写入 tools、`FilePermissionManager` 降级为 `read`、注入只读 system prompt

**UI 层**
- 输入框上方增加"只读模式" tag，点击切换
- Header 在只读时显示 "READ-ONLY" badge
- 单向锁定：从只读切回正常并发送消息后，不可再切回只读
- 未发送消息时可自由切换

**Session 处理**
- 对话历史始终持久化（只读约束的是 agent 能力，不是对话存留）

**i18n**
- 新增 `readOnlyMode`、`readOnlyBadge` 等中英文文本

### Test plan

- [ ] 打开 Chat 对话框，确认底部输入框上方显示"只读模式" tag
- [ ] 点击 tag 切入只读模式，Header 出现 "READ-ONLY" badge
- [ ] 只读模式下提问，确认 agent 不会创建卡片或修改文件
- [ ] 点击 tag 切回正常模式，发送一条消息，确认 tag 变灰不可再点
- [ ] 空对话状态下反复切换，确认无锁定
- [ ] 对话历史在两种模式下均正常保存和加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)