### PR TITLE
fix: prevent quick record dialog from re-appearing on app resume

### DIFF
--- a/android/app/src/main/kotlin/com/weshop/memex/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/weshop/memex/MainActivity.kt
@@ -20,6 +20,16 @@ class MainActivity : FlutterFragmentActivity() {
     private val CHANNEL = "com.memexlab.memex/webview"
     private val AUDIO_CHANNEL = "com.memexlab.memex/audio_converter"
 
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        // If the Activity is being recreated (system killed it in background),
+        // clear the stale shortcut extra so the quick_actions plugin won't
+        // re-deliver an already-consumed action on the next attach cycle.
+        if (savedInstanceState != null) {
+            intent?.removeExtra("some unique action key")
+        }
+        super.onCreate(savedInstanceState)
+    }
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         

--- a/lib/data/services/quick_action_service.dart
+++ b/lib/data/services/quick_action_service.dart
@@ -16,6 +16,12 @@ class QuickActionService {
   /// The action ID that was tapped, if not yet consumed.
   String? _pendingAction;
 
+  /// The last action type that was consumed.
+  /// Used to deduplicate the double delivery from quick_actions_android
+  /// (onAttachedToActivity fires once, then initialize()→getLaunchAction()
+  /// fires again ~1 s later with the same action).
+  String? _consumedAction;
+
   /// Listener notified when an action arrives or becomes consumable.
   Completer<void>? _actionReady;
 
@@ -25,6 +31,10 @@ class QuickActionService {
   /// Called by the platform quick_actions callback.
   void handleAction(String actionType) {
     _logger.info('Quick action received: $actionType');
+    if (actionType == _consumedAction) {
+      _logger.info('Ignoring re-delivered action: $actionType');
+      return;
+    }
     _pendingAction = actionType;
     if (_hasListener) {
       // Listener is ready — deliver immediately.
@@ -44,6 +54,19 @@ class QuickActionService {
     _actionReady = null;
   }
 
+  /// Consume the pending action synchronously without waiting.
+  ///
+  /// Use this when the platform callback is expected to have already fired
+  /// (e.g. on app resume). Unlike [consumePendingAction], this does NOT wait
+  /// for a late-arriving callback, which prevents re-delivered shortcut
+  /// intents from re-triggering the action.
+  String? consumeIfPending() {
+    final action = _pendingAction;
+    _pendingAction = null;
+    if (action != null) _consumedAction = action;
+    return action;
+  }
+
   /// Wait for and consume the pending action.
   ///
   /// Returns the action type, or `null` if no action is pending.
@@ -54,6 +77,7 @@ class QuickActionService {
     if (_pendingAction != null) {
       final action = _pendingAction;
       _pendingAction = null;
+      _consumedAction = action;
       return action;
     }
 
@@ -68,6 +92,14 @@ class QuickActionService {
 
     final action = _pendingAction;
     _pendingAction = null;
+    if (action != null) _consumedAction = action;
     return action;
+  }
+
+  /// Reset the dedup tracking so the same action type can be consumed again.
+  /// Called when the app goes to background, allowing a fresh shortcut trigger
+  /// on the next foreground session.
+  void resetConsumed() {
+    _consumedAction = null;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1115,13 +1115,28 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) {
+      // Reset consumed-action dedup so the same shortcut can be triggered
+      // on the next foreground session.
+      QuickActionService.instance.resetConsumed();
+    }
     // when app enters foreground, ensure event bus is connected
     if (state == AppLifecycleState.resumed) {
       if (!_eventBus.isConnected) {
         _eventBus.connect();
       }
-      // Also consume any quick action that arrived while in background.
-      _consumeQuickActionIfNeeded();
+      // Consume any quick action that arrived while in background.
+      // Use synchronous check — platform callback fires before resumed,
+      // so no need for the 2-sec wait (which could catch a re-delivered intent).
+      final action = QuickActionService.instance.consumeIfPending();
+      if (action == 'quick_note' && mounted) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            _logger.info('Quick action (resumed): opening input sheet');
+            setState(() => _isInputOpen = true);
+          }
+        });
+      }
     }
   }
 

--- a/test/data/services/quick_action_service_test.dart
+++ b/test/data/services/quick_action_service_test.dart
@@ -12,6 +12,7 @@ void main() {
   tearDown(() {
     // Reset internal state between tests
     service.detach();
+    service.resetConsumed();
   });
 
   group('QuickActionService', () {
@@ -83,6 +84,64 @@ void main() {
       // No action queued — should timeout and return null
       final action = await service.consumePendingAction();
       expect(action, isNull);
+    });
+
+    test('consumeIfPending returns action immediately when queued', () {
+      service.attach();
+      service.handleAction('quick_note');
+      final action = service.consumeIfPending();
+      expect(action, 'quick_note');
+    });
+
+    test('consumeIfPending returns null when nothing queued', () {
+      service.attach();
+      final action = service.consumeIfPending();
+      expect(action, isNull);
+    });
+  });
+
+  group('dedup — double delivery from quick_actions_android', () {
+    test(
+        'second handleAction with same action is ignored after consumption',
+        () async {
+      service.attach();
+      // 1. First delivery (from onAttachedToActivity)
+      service.handleAction('quick_note');
+      // 2. Consumed by initState
+      final action1 = await service.consumePendingAction();
+      expect(action1, 'quick_note');
+      // 3. Second delivery (from initialize→getLaunchAction, ~1s later)
+      service.handleAction('quick_note');
+      // 4. _pendingAction should NOT be set — dedup blocks it
+      final action2 = service.consumeIfPending();
+      expect(action2, isNull);
+    });
+
+    test('same action is allowed again after resetConsumed', () async {
+      service.attach();
+      service.handleAction('quick_note');
+      final action1 = await service.consumePendingAction();
+      expect(action1, 'quick_note');
+
+      // Reset (app goes to background)
+      service.resetConsumed();
+
+      // User triggers the same shortcut again
+      service.handleAction('quick_note');
+      final action2 = service.consumeIfPending();
+      expect(action2, 'quick_note');
+    });
+
+    test('different action type is not blocked by dedup', () async {
+      service.attach();
+      service.handleAction('quick_note');
+      final action1 = await service.consumePendingAction();
+      expect(action1, 'quick_note');
+
+      // A different action type should not be blocked
+      service.handleAction('other_action');
+      final action2 = service.consumeIfPending();
+      expect(action2, 'other_action');
     });
   });
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `quick_actions_android` plugin delivers the shortcut action **twice** — once synchronously via `onAttachedToActivity→onNewIntent`, and again asynchronously ~1s later via `initialize()→getLaunchAction()`. The first delivery is consumed by `initState`, but the second re-sets `_pendingAction`, so `consumeIfPending()` on resume picks it up and opens the dialog again.
- **QuickActionService dedup**: track the last consumed action type; ignore `handleAction` calls with the same action until `resetConsumed()` is called (on `AppLifecycleState.paused`).
- **Synchronous resume check**: replace `consumePendingAction()` (2-sec wait) with `consumeIfPending()` (instant) in `didChangeAppLifecycleState(resumed)`.
- **Android native safety net**: clear stale shortcut extra from the intent when the Activity is being recreated (system killed process in background), preventing re-delivery on the next attach cycle.

## Test plan

- [x] Long-press app icon → "快速记录" → dialog opens
- [x] Dismiss dialog by tapping outside → switch to home → tap icon to re-enter → dialog does NOT re-appear
- [x] Repeat quick note shortcut after going to background → dialog opens correctly
- [x] All 13 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)