### PR TITLE
feat: enable text selection in chat messages

### DIFF
--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -716,7 +716,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                         }).toList(),
                       ),
                     ),
-                  Text(
+                  SelectableText(
                     item.text,
                     style: const TextStyle(
                         fontSize: 14, color: Colors.white, height: 1.5),
@@ -750,7 +750,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                     .copyWith(topLeft: const Radius.circular(4)),
                 border: Border.all(color: const Color(0xFFF7F8FA)),
               ),
-              child: Text(
+              child: SelectableText(
                 item.text,
                 style: TextStyle(
                     fontSize: 14, color: AppColors.textSecondary, height: 1.5),


### PR DESCRIPTION
## Summary
- Replace `Text` with `SelectableText` in user and AI message bubbles
- Users can now long-press to select and copy message content using native system controls

## Test plan
- [ ] Long-press on user message → text selection handles appear
- [ ] Long-press on AI message → text selection handles appear
- [ ] Select text and tap "Copy" → text copied to clipboard
- [ ] "Select All" from context menu → entire message selected
- [ ] Verify scrolling still works normally (no gesture conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)