### PR TITLE
支持重处理卡片时重新分析媒体资产

### DIFF
--- a/lib/data/services/model_list_service.dart
+++ b/lib/data/services/model_list_service.dart
@@ -20,9 +20,7 @@ class ModelListService {
     _log.info('Fetching models from $endpoint (type=$type)');
 
     try {
-      final headers = <String, String>{
-        'Accept': 'application/json',
-      };
+      final headers = <String, String>{'Accept': 'application/json'};
 
       // Gemini uses ?key= query parameter for auth, not Bearer token
       Uri requestUri;
@@ -37,7 +35,14 @@ class ModelListService {
       } else {
         requestUri = Uri.parse(endpoint);
         if (apiKey.isNotEmpty) {
-          headers['Authorization'] = 'Bearer $apiKey';
+          if (type == LLMConfig.typeClaude ||
+              type == LLMConfig.typeMinimax ||
+              type == LLMConfig.typeMimo) {
+            headers['x-api-key'] = apiKey;
+            headers['anthropic-version'] = '2023-06-01';
+          } else {
+            headers['Authorization'] = 'Bearer $apiKey';
+          }
         }
       }
 
@@ -47,7 +52,8 @@ class ModelListService {
 
       if (response.statusCode != 200) {
         _log.warning(
-            'Failed to fetch models: HTTP ${response.statusCode} from $endpoint\n${response.body}');
+          'Failed to fetch models: HTTP ${response.statusCode} from $endpoint\n${response.body}',
+        );
         return [];
       }
 

--- a/lib/data/services/task_handlers/analyze_assets_handler.dart
+++ b/lib/data/services/task_handlers/analyze_assets_handler.dart
@@ -84,7 +84,8 @@ Future<void> handleAnalyzeAssetsImpl(
   TaskContext context,
 ) async {
   _logger.info(
-      'Executing handleAnalyzeAssets for task ${context.taskId}, bizId: ${context.bizId}');
+    'Executing handleAnalyzeAssets for task ${context.taskId}, bizId: ${context.bizId}',
+  );
 
   final data = AnalyzeAssetsPayload.fromJson(payload);
 
@@ -94,7 +95,28 @@ Future<void> handleAnalyzeAssetsImpl(
     return;
   }
 
-  // Initialize FileSystem Service
+  final assetAnalyses = await analyzeAssetsForFact(
+    userId: userId,
+    factId: data.factId,
+    assetPaths: data.assetPaths,
+  );
+
+  await _updateTaskResult(userId, context.taskId, assetAnalyses);
+}
+
+/// Analyze all assets for a fact and persist `{asset}.analysis.txt` files.
+///
+/// This is used both by the normal submit-input pipeline and by historical
+/// reprocessing when old media descriptions need to be regenerated.
+Future<List<AssetAnalysisResult>> analyzeAssetsForFact({
+  required String userId,
+  required String factId,
+  required List<String> assetPaths,
+}) async {
+  if (assetPaths.isEmpty) {
+    return const [];
+  }
+
   final fileSystem = FileSystemService.instance;
 
   // Skip LLM analysis if not configured — card agent will use rule-based matching.
@@ -103,10 +125,8 @@ Future<void> handleAnalyzeAssetsImpl(
     defaultClientKey: LLMConfig.defaultClientKey,
   );
   if (!llmConfig.isValid) {
-    _logger
-        .info('No LLM configured — skipping asset analysis for ${data.factId}');
-    await _updateTaskResult(userId, context.taskId, []);
-    return;
+    _logger.info('No LLM configured — skipping asset analysis for $factId');
+    return const [];
   }
 
   // 1. Get LLM Resources (Default to Gemini Flash for Asset Analysis)
@@ -117,16 +137,18 @@ Future<void> handleAnalyzeAssetsImpl(
 
   final futures = <Future<AssetAnalysisResult?>>[];
 
-  for (var i = 0; i < data.assetPaths.length; i++) {
-    futures.add(_analyzeSingleAsset(
-      userId: userId,
-      factId: data.factId,
-      originalAssetPath: data.assetPaths[i],
-      index: i,
-      fileSystem: fileSystem,
-      client: resources.client,
-      modelConfig: resources.modelConfig,
-    ));
+  for (var i = 0; i < assetPaths.length; i++) {
+    futures.add(
+      _analyzeSingleAsset(
+        userId: userId,
+        factId: factId,
+        originalAssetPath: assetPaths[i],
+        index: i,
+        fileSystem: fileSystem,
+        client: resources.client,
+        modelConfig: resources.modelConfig,
+      ),
+    );
   }
 
   final results = await Future.wait(futures);
@@ -135,7 +157,7 @@ Future<void> handleAnalyzeAssetsImpl(
   // Sort by index to maintain order
   assetAnalyses.sort((a, b) => a.index.compareTo(b.index));
 
-  await _updateTaskResult(userId, context.taskId, assetAnalyses);
+  return assetAnalyses;
 }
 
 Future<AssetAnalysisResult?> _analyzeSingleAsset({
@@ -154,7 +176,8 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
     final file = File(assetPath);
     if (!file.existsSync()) {
       _logger.warning(
-          'Asset not found: $assetPath (original: $originalAssetPath)');
+        'Asset not found: $assetPath (original: $originalAssetPath)',
+      );
       return null;
     }
     final assetName = path.basename(assetPath);
@@ -173,7 +196,7 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
       '.heif',
       '.webp',
       '.gif',
-      '.bmp'
+      '.bmp',
     };
     const audioExtensions = {
       '.mp3',
@@ -184,7 +207,7 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
       '.aiff',
       '.aif',
       '.m4a',
-      '.wma'
+      '.wma',
     };
 
     final isImage = imageExtensions.contains(extension);
@@ -222,15 +245,17 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
       // Add image dimensions to EXIF info
       if (width > 0 && height > 0) {
         infoLines.add('${Prompts.imageDimensions}: $width x $height');
-        infoLines
-            .add('${Prompts.aspectRatio}: ${aspectRatio.toStringAsFixed(2)}');
+        infoLines.add(
+          '${Prompts.aspectRatio}: ${aspectRatio.toStringAsFixed(2)}',
+        );
       }
 
       if (exif.isNotEmpty) {
         // Handle Timestamp
         if (exif.containsKey('datetime_original_str')) {
-          infoLines
-              .add('${Prompts.captureTime}: ${exif['datetime_original_str']}');
+          infoLines.add(
+            '${Prompts.captureTime}: ${exif['datetime_original_str']}',
+          );
         }
         if (exif.containsKey('datetime_original')) {
           datetimeOriginal = exif['datetime_original'] as DateTime?;
@@ -245,15 +270,19 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
             gpsCoordinates = [lat, lng];
 
             infoLines.add(
-                'Gps Coordinates: ${lat.toStringAsFixed(6)}, ${lng.toStringAsFixed(6)}');
+              'Gps Coordinates: ${lat.toStringAsFixed(6)}, ${lng.toStringAsFixed(6)}',
+            );
 
             address = await ExifUtils.reverseGeocode(lat, lng);
             if (address != null) {
               var addressLine = 'Nearest Address (from GPS): $address';
 
               // Check nearest user location
-              final markAddress =
-                  await fileSystem.getNearestUserLocation(userId, lat, lng);
+              final markAddress = await fileSystem.getNearestUserLocation(
+                userId,
+                lat,
+                lng,
+              );
               if (markAddress != null) {
                 addressLine +=
                     ', very close to user marked location ($markAddress) (less than 50 meters)';
@@ -284,10 +313,7 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
     ModelUsage? toolUsage;
     String toolModel = 'unknown';
     try {
-      final tool = AssetAnalysisTool(
-        client: client,
-        modelConfig: modelConfig,
-      );
+      final tool = AssetAnalysisTool(client: client, modelConfig: modelConfig);
 
       // Build prompt with metadata for images
       String finalPrompt = Prompts.assetAnalysisPrompt(
@@ -297,16 +323,19 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
         final metadataLines = <String>[];
         if (structuredExifData.datetimeOriginal != null) {
           metadataLines.add(
-              "${Prompts.captureTime}: ${structuredExifData.datetimeOriginal!.toLocal().toString().substring(0, 19)}");
+            "${Prompts.captureTime}: ${structuredExifData.datetimeOriginal!.toLocal().toString().substring(0, 19)}",
+          );
         }
         if (structuredExifData.address != null) {
-          metadataLines
-              .add("${Prompts.captureLocation}: ${structuredExifData.address}");
+          metadataLines.add(
+            "${Prompts.captureLocation}: ${structuredExifData.address}",
+          );
         }
         if (structuredExifData.gpsCoordinates != null &&
             structuredExifData.gpsCoordinates!.length >= 2) {
           metadataLines.add(
-              "${Prompts.gpsCoordinates}: ${Prompts.latitude} ${structuredExifData.gpsCoordinates![0].toStringAsFixed(6)}, ${Prompts.longitude} ${structuredExifData.gpsCoordinates![1].toStringAsFixed(6)}");
+            "${Prompts.gpsCoordinates}: ${Prompts.latitude} ${structuredExifData.gpsCoordinates![0].toStringAsFixed(6)}, ${Prompts.longitude} ${structuredExifData.gpsCoordinates![1].toStringAsFixed(6)}",
+          );
         }
         if (metadataLines.isNotEmpty) {
           finalPrompt +=
@@ -333,7 +362,8 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
         analysisResult = toolResult;
       }
       _logger.info(
-          "Asset analyzed: ${path.basename(assetPath)}, result: $toolResult");
+        "Asset analyzed: ${path.basename(assetPath)}, result: $toolResult",
+      );
 
       // Record LLM call if usage is available
       if (toolUsage != null) {
@@ -376,17 +406,21 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
       try {
         final assetFilename = path.basename(assetPath);
         final analysisFilename = "$assetFilename.analysis.txt";
-        final analysisFile =
-            File(path.join(path.dirname(assetPath), analysisFilename));
+        final analysisFile = File(
+          path.join(path.dirname(assetPath), analysisFilename),
+        );
         await analysisFile.writeAsString(finalAnalysisResult);
         _logger.info(
-            "Saved asset analysis (with EXIF info) to: ${analysisFile.path}");
+          "Saved asset analysis (with EXIF info) to: ${analysisFile.path}",
+        );
 
         // Log event
         try {
           final workspacePath = fileSystem.getWorkspacePath(userId);
-          final relativePath = fileSystem.toRelativePath(analysisFile.path,
-              rootPath: workspacePath);
+          final relativePath = fileSystem.toRelativePath(
+            analysisFile.path,
+            rootPath: workspacePath,
+          );
           await fileSystem.eventLogService.logFileCreated(
             userId: userId,
             filePath: relativePath,
@@ -408,8 +442,9 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
       name: assetName,
       path: assetPath,
       index: index + 1,
-      analysis:
-          finalAnalysisResult.isNotEmpty ? finalAnalysisResult : analysisResult,
+      analysis: finalAnalysisResult.isNotEmpty
+          ? finalAnalysisResult
+          : analysisResult,
       exifData: structuredExifData,
     );
   } catch (e, stack) {
@@ -419,10 +454,15 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
 }
 
 Future<void> _updateTaskResult(
-    String userId, String taskId, List<AssetAnalysisResult> results) async {
+  String userId,
+  String taskId,
+  List<AssetAnalysisResult> results,
+) async {
   final resultData = {
     'asset_analyses': results.map((e) => e.toJson()).toList(),
   };
-  await LocalTaskExecutor.instance
-      .updateTaskResult(taskId, jsonEncode(resultData));
+  await LocalTaskExecutor.instance.updateTaskResult(
+    taskId,
+    jsonEncode(resultData),
+  );
 }

--- a/lib/data/services/task_handlers/card_agent_handler.dart
+++ b/lib/data/services/task_handlers/card_agent_handler.dart
@@ -42,9 +42,13 @@ Future<void> processWithCardAgent({
     );
     if (!llmConfig.isValid) {
       _logger.info(
-          'No LLM configured — using rule-based card matching for $factId');
+        'No LLM configured — using rule-based card matching for $factId',
+      );
       await _applyRuleBasedCard(
-          userId: userId, factId: factId, combinedText: contentText);
+        userId: userId,
+        factId: factId,
+        combinedText: contentText,
+      );
       return;
     }
 
@@ -59,8 +63,10 @@ Future<void> processWithCardAgent({
     // 2. Prepare Fact Content (merge assets info if needed)
     var enhancedFactContent = contentText;
     if (assetAnalyses != null && assetAnalyses.isNotEmpty) {
-      enhancedFactContent +=
-          formatAssetAnalysis(assetAnalyses, includeExif: true);
+      enhancedFactContent += formatAssetAnalysis(
+        assetAnalyses,
+        includeExif: true,
+      );
     }
 
     // 3. (Client initialized above)
@@ -70,7 +76,10 @@ Future<void> processWithCardAgent({
 
     final userMessageContent =
         Prompts.cardAgentUserMessagePromptForPublishNewContent(
-            publishTime, factId, enhancedFactContent);
+          publishTime,
+          factId,
+          enhancedFactContent,
+        );
 
     // 4. Run Agent
     await CardAgent.runWithContent(
@@ -97,12 +106,12 @@ Future<void> _applyRuleBasedCard({
   final fs = FileSystemService.instance;
 
   // Extract image URLs and audio URL from combinedText markdown refs
-  final imageUrls = RegExp(r'!\[.*?\]\((fs://[^\)]+)\)')
-      .allMatches(combinedText)
-      .map((m) => m.group(1)!)
-      .toList();
-  final audioMatch =
-      RegExp(r'\[audio\]\((fs://[^\)]+)\)').firstMatch(combinedText);
+  final imageUrls = RegExp(
+    r'!\[.*?\]\((fs://[^\)]+)\)',
+  ).allMatches(combinedText).map((m) => m.group(1)!).toList();
+  final audioMatch = RegExp(
+    r'\[audio\]\((fs://[^\)]+)\)',
+  ).firstMatch(combinedText);
   final audioUrl = audioMatch?.group(1);
 
   final result = await fs.updateCardFile(userId, factId, (existing) {
@@ -119,7 +128,8 @@ Future<void> _applyRuleBasedCard({
     return;
   }
   _logger.info(
-      'Rule-based card written for $factId: ${result.uiConfigs.first.templateId}');
+    'Rule-based card written for $factId: ${result.uiConfigs.first.templateId}',
+  );
 }
 
 /// Task Handler implementation for `card_agent_task`.
@@ -151,7 +161,10 @@ Future<void> handleCardAgentImpl(
       try {
         final analysisResult = await LocalTaskExecutor.instance
             .getTaskResultByBizId(
-                userId, 'handle_analyze_assets', taskContext.bizId!);
+              userId,
+              'handle_analyze_assets',
+              taskContext.bizId!,
+            );
 
         if (analysisResult != null &&
             analysisResult.containsKey('asset_analyses')) {
@@ -177,15 +190,18 @@ Future<void> handleCardAgentImpl(
     _logger.info("Card Agent task completed successfully for $factId");
 
     // 5. Render and Push Update
-    await _renderAndPushUpdate(userId, factId, combinedText);
+    await renderAndPushCardUpdate(userId, factId, combinedText);
   } catch (e, stack) {
     _logger.severe("Card Agent Handler failed: $e", e, stack);
     rethrow;
   }
 }
 
-Future<void> _renderAndPushUpdate(
-    String userId, String factId, String combinedText) async {
+Future<void> renderAndPushCardUpdate(
+  String userId,
+  String factId,
+  String combinedText,
+) async {
   final fs = FileSystemService.instance;
   CardData? cardData;
   try {
@@ -196,7 +212,8 @@ Future<void> _renderAndPushUpdate(
   }
 
   final tags = cardData?.tags ?? <String>[];
-  final cardForRender = cardData ??
+  final cardForRender =
+      cardData ??
       CardData(
         factId: factId,
         timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
@@ -220,18 +237,20 @@ Future<void> _renderAndPushUpdate(
       .toList();
   final rawText = assetsAndText['rawText'] as String?;
 
-  EventBusService.instance.emitEvent(CardUpdatedMessage(
-    id: factId,
-    html: renderResult.html ?? '',
-    timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-    tags: tags,
-    status: renderResult.status,
-    title: title,
-    uiConfigs: renderResult.uiConfigs,
-    assets: assets.isNotEmpty ? assets : null,
-    rawText: rawText,
-    address: cardData?.address,
-  ));
+  EventBusService.instance.emitEvent(
+    CardUpdatedMessage(
+      id: factId,
+      html: renderResult.html ?? '',
+      timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      tags: tags,
+      status: renderResult.status,
+      title: title,
+      uiConfigs: renderResult.uiConfigs,
+      assets: assets.isNotEmpty ? assets : null,
+      rawText: rawText,
+      address: cardData?.address,
+    ),
+  );
 }
 
 /// Failure handler for card agent task
@@ -244,13 +263,15 @@ Future<void> handleCardAgentFailureImpl(
   StackTrace? stackTrace,
 ) async {
   _logger.severe(
-      'Card Agent task failed permanently for user: $userId, error: $error, stackTrace: ${stackTrace?.toString()}');
+    'Card Agent task failed permanently for user: $userId, error: $error, stackTrace: ${stackTrace?.toString()}',
+  );
 
   try {
     final factId = payload['fact_id'] as String?;
     if (factId == null) {
-      _logger
-          .warning('Cannot update card status: fact_id is missing in payload');
+      _logger.warning(
+        'Cannot update card status: fact_id is missing in payload',
+      );
       return;
     }
 
@@ -261,26 +282,23 @@ Future<void> handleCardAgentFailureImpl(
     final fs = FileSystemService.instance;
 
     // Update status to 'failed' using updateCardFile for concurrent safety
-    final cardData = await fs.updateCardFile(
-      userId,
-      factId,
-      (card) {
-        // Handle uiConfigs: preserve existing or set classic_card fallback
-        final uiConfigs = card.uiConfigs.isEmpty
-            ? [const UiConfig(templateId: 'classic_card', data: {})]
-            : card.uiConfigs;
+    final cardData = await fs.updateCardFile(userId, factId, (card) {
+      // Handle uiConfigs: preserve existing or set classic_card fallback
+      final uiConfigs = card.uiConfigs.isEmpty
+          ? [const UiConfig(templateId: 'classic_card', data: {})]
+          : card.uiConfigs;
 
-        return card.copyWith(
-          status: 'failed',
-          failureReason: friendlyMessage,
-          uiConfigs: uiConfigs,
-        );
-      },
-    );
+      return card.copyWith(
+        status: 'failed',
+        failureReason: friendlyMessage,
+        uiConfigs: uiConfigs,
+      );
+    });
 
     if (cardData == null) {
       _logger.warning(
-          'Cannot update card status: card file not found for $factId');
+        'Cannot update card status: card file not found for $factId',
+      );
       return;
     }
 
@@ -305,36 +323,36 @@ Future<void> handleCardAgentFailureImpl(
           .toList();
       final rawText = assetsAndText['rawText'] as String?;
 
-      EventBusService.instance.emitEvent(CardUpdatedMessage(
-        id: factId,
-        html: renderResult.html ?? '',
-        timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-        tags: tags,
-        status: 'failed',
-        title: title,
-        uiConfigs: renderResult.uiConfigs,
-        assets: assets.isNotEmpty ? assets : null,
-        rawText: rawText,
-        address: cardData.address,
-        failureReason: friendlyMessage,
-      ));
+      EventBusService.instance.emitEvent(
+        CardUpdatedMessage(
+          id: factId,
+          html: renderResult.html ?? '',
+          timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          tags: tags,
+          status: 'failed',
+          title: title,
+          uiConfigs: renderResult.uiConfigs,
+          assets: assets.isNotEmpty ? assets : null,
+          rawText: rawText,
+          address: cardData.address,
+          failureReason: friendlyMessage,
+        ),
+      );
 
       // Emit error notification for UI dialog
-      EventBusService.instance.emitEvent(ErrorNotificationMessage(
-        errorCategory: category.name,
-        errorMessage: friendlyMessage,
-        cardId: factId,
-      ));
+      EventBusService.instance.emitEvent(
+        ErrorNotificationMessage(
+          errorCategory: category.name,
+          errorMessage: friendlyMessage,
+          cardId: factId,
+        ),
+      );
     } catch (e) {
       _logger.warning('Failed to send EventBus update for failed card: $e');
       // Don't throw - status update is more important
     }
   } catch (e, stack) {
-    _logger.severe(
-      'Error in card agent failure handler for $userId',
-      e,
-      stack,
-    );
+    _logger.severe('Error in card agent failure handler for $userId', e, stack);
     // Don't rethrow - failure handler should not cause additional failures
   }
 }

--- a/lib/data/services/task_handlers/reprocess_cards_handler.dart
+++ b/lib/data/services/task_handlers/reprocess_cards_handler.dart
@@ -3,6 +3,7 @@ import 'package:logging/logging.dart';
 import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/data/services/task_handlers/analyze_assets_handler.dart';
 import 'package:memex/data/services/task_handlers/card_agent_handler.dart';
 import 'package:memex/data/services/task_handlers/llm_error_utils.dart';
 import 'package:memex/utils/logger.dart';
@@ -26,12 +27,14 @@ Future<void> handleReprocessCardsImpl(
     // 1. Get or restore progress.
     Map<String, dynamic>? progress;
     try {
-      final existingResult =
-          await LocalTaskExecutor.instance.getTaskResult(context.taskId);
+      final existingResult = await LocalTaskExecutor.instance.getTaskResult(
+        context.taskId,
+      );
       if (existingResult != null && existingResult.containsKey('progress')) {
         progress = existingResult['progress'] as Map<String, dynamic>;
         _logger.info(
-            'Resuming from progress: ${progress['currentIndex']}/${progress['total']}');
+          'Resuming from progress: ${progress['currentIndex']}/${progress['total']}',
+        );
       }
     } catch (e) {
       _logger.warning('Failed to retrieve progress: $e');
@@ -90,8 +93,11 @@ Future<void> handleReprocessCardsImpl(
       for (final factId in allFactIds) {
         try {
           final factDate = fileSystem.parseFactIdDate(factId);
-          final cardDate =
-              DateTime(factDate.year, factDate.month, factDate.day);
+          final cardDate = DateTime(
+            factDate.year,
+            factDate.month,
+            factDate.day,
+          );
 
           if (dateFrom != null && cardDate.isBefore(dateFrom)) {
             continue;
@@ -128,7 +134,10 @@ Future<void> handleReprocessCardsImpl(
 
     final total = factIds.length;
     _logger.info(
-        'Processing ${total - currentIndex} cards (starting from index $currentIndex), batch size: $_batchSize');
+      'Processing ${total - currentIndex} cards (starting from index $currentIndex), batch size: $_batchSize',
+    );
+
+    final reanalyzeAssets = payload['reanalyze_assets'] as bool? ?? false;
 
     // 3. Process in batches: up to [_batchSize] cards per batch concurrently; run next batch after current batch completes.
     while (currentIndex < factIds.length) {
@@ -138,10 +147,14 @@ Future<void> handleReprocessCardsImpl(
       final totalBatches = (total + _batchSize - 1) ~/ _batchSize;
 
       _logger.info(
-          'Processing batch $batchNumber/$totalBatches: cards ${currentIndex + 1}-$endIndex of $total');
+        'Processing batch $batchNumber/$totalBatches: cards ${currentIndex + 1}-$endIndex of $total',
+      );
 
       final results = await Future.wait(
-        batch.map((factId) => _processOneCard(userId, factId)),
+        batch.map(
+          (factId) =>
+              _processOneCard(userId, factId, reanalyzeAssets: reanalyzeAssets),
+        ),
       );
 
       for (var i = 0; i < results.length; i++) {
@@ -179,15 +192,20 @@ Future<void> handleReprocessCardsImpl(
     );
 
     _logger.info(
-        'Reprocess cards task completed. Success: $successCount, Failed: $failCount, Total: $total');
+      'Reprocess cards task completed. Success: $successCount, Failed: $failCount, Total: $total',
+    );
   } catch (e, stack) {
     _logger.severe('Error in reprocess cards task: $e', e, stack);
     rethrowIfNonRetryable(e);
   }
 }
 
-/// Processes one card: extract content, ensure card exists, call card_agent. Returns whether it succeeded.
-Future<bool> _processOneCard(String userId, String factId) async {
+/// Processes one card: extract content, optionally refresh media analysis, ensure card exists, call card_agent. Returns whether it succeeded.
+Future<bool> _processOneCard(
+  String userId,
+  String factId, {
+  required bool reanalyzeAssets,
+}) async {
   FactContentResult? factInfo;
   try {
     final fileSystem = FileSystemService.instance;
@@ -200,14 +218,34 @@ Future<bool> _processOneCard(String userId, String factId) async {
 
     await _ensureCardExists(fileSystem, userId, factId, factInfo.datetime);
 
+    var assetAnalyses = factInfo.assetAnalyses;
+    if (reanalyzeAssets) {
+      final assetPaths = _extractAssetPaths(
+        fileSystem,
+        userId,
+        factInfo.content,
+      );
+      if (assetPaths.isNotEmpty) {
+        _logger.info('Re-analyzing ${assetPaths.length} asset(s) for $factId');
+        final refreshedAnalyses = await analyzeAssetsForFact(
+          userId: userId,
+          factId: factId,
+          assetPaths: assetPaths,
+        );
+        assetAnalyses = refreshedAnalyses.map((e) => e.toJson()).toList();
+      }
+    }
+
     await processWithCardAgent(
       userId: userId,
       factId: factId,
       contentText: factInfo.content,
-      assetAnalyses: factInfo.assetAnalyses,
+      assetAnalyses: assetAnalyses,
       inputDateTime: factInfo.datetime,
       dryRun: false,
     );
+
+    await renderAndPushCardUpdate(userId, factId, factInfo.content);
 
     return true;
   } catch (e, stack) {
@@ -216,6 +254,19 @@ Future<bool> _processOneCard(String userId, String factId) async {
   } finally {
     factInfo = null;
   }
+}
+
+List<String> _extractAssetPaths(
+  FileSystemService fileSystem,
+  String userId,
+  String content,
+) {
+  final assetsDir = fileSystem.getAssetsPath(userId);
+  return RegExp(r'fs://([^\s\)]+)').allMatches(content).map((m) {
+    final filename = m.group(1)!;
+    final absolutePath = '$assetsDir/$filename';
+    return fileSystem.toRelativePath(absolutePath);
+  }).toList();
 }
 
 /// Ensures the card exists; creates an initial card if not found.
@@ -242,14 +293,15 @@ Future<void> _ensureCardExists(
     timestamp: now.millisecondsSinceEpoch ~/ 1000,
     status: 'processing',
     tags: const [],
-    uiConfigs: [
-      UiConfig(templateId: 'classic_card', data: {}),
-    ],
+    uiConfigs: const [UiConfig(templateId: 'classic_card', data: {})],
   );
 
   try {
-    final success =
-        await fileSystem.safeWriteCardFile(userId, factId, initialCard);
+    final success = await fileSystem.safeWriteCardFile(
+      userId,
+      factId,
+      initialCard,
+    );
     if (success) {
       _logger.info('Created initial card for: $factId');
     } else {
@@ -284,8 +336,5 @@ Future<void> _saveProgress(
     'total': factIds.length,
   };
 
-  await LocalTaskExecutor.instance.updateTaskResult(
-    taskId,
-    jsonEncode(result),
-  );
+  await LocalTaskExecutor.instance.updateTaskResult(taskId, jsonEncode(result));
 }

--- a/lib/domain/models/llm_config.dart
+++ b/lib/domain/models/llm_config.dart
@@ -139,7 +139,7 @@ class LLMConfig {
       case typeBedrockClaude:
         return const {
           'us.anthropic.claude-opus-4-6-v1',
-          'us.anthropic.claude-sonnet-4-6'
+          'us.anthropic.claude-sonnet-4-6',
         };
       case typeGemini:
       case typeGeminiOauth:
@@ -153,7 +153,7 @@ class LLMConfig {
       case typeZhipu:
         return const {'glm-5v-turbo', 'glm-4.6v'};
       case typeMimo:
-        return const {'mimo-v2-pro'};
+        return const {'mimo-v2.5', 'mimo-v2-omni'};
       case typeOpenRouter:
         return const {
           'anthropic/claude-opus-4.6',
@@ -183,7 +183,7 @@ class LLMConfig {
           'gemini-3-flash-preview',
           'gemini-3.1-flash-lite-preview',
           'gemini-2.5-flash',
-          'gemini-2.5-pro'
+          'gemini-2.5-pro',
         ];
       case typeChatCompletion:
       case typeResponses:
@@ -235,14 +235,14 @@ class LLMConfig {
           'kimi-k2',
           'kimi-k2-thinking',
           'kimi-k2-thinking-turbo',
-          'kimi-k2-turbo-preview'
+          'kimi-k2-turbo-preview',
         ];
       case typeQwen:
         return const [
           'qwen3.5-plus',
           'qwen3-coder',
           'qwen3-235b-a22b',
-          'qwen-max'
+          'qwen-max',
         ];
       case typeSeed:
         return const ['doubao-seed-1-8-251228', 'doubao-1.5-pro-256k'];
@@ -261,8 +261,10 @@ class LLMConfig {
         return const ['qwen2.5:7b', 'llama3.1:8b', 'gemma3:12b'];
       case typeMimo:
         return const [
-          'mimo-v2-pro',
+          'mimo-v2.5',
           'mimo-v2-omni',
+          'mimo-v2.5-pro',
+          'mimo-v2-pro',
           'mimo-v2-flash',
         ];
       default:
@@ -296,6 +298,7 @@ class LLMConfig {
       case typeSeed:
       case typeZhipu:
       case typeMinimax:
+      case typeMimo:
       case typeOpenRouter:
       case typeOllama:
       case typeGemini:
@@ -314,7 +317,62 @@ class LLMConfig {
     final base = baseUrl.endsWith('/')
         ? baseUrl.substring(0, baseUrl.length - 1)
         : baseUrl;
+    if (type == typeClaude || type == typeMinimax || type == typeMimo) {
+      return base.endsWith('/v1') ? '$base/models' : '$base/v1/models';
+    }
     return '$base/models';
+  }
+
+  /// Whether the model is known to support image input.
+  ///
+  /// This is intentionally conservative: unknown models return false so UI can
+  /// warn before they are used for Media analysis.
+  static bool isKnownMultimodal(String type, String modelId) {
+    final id = modelId.trim().toLowerCase();
+    if (id.isEmpty) return false;
+
+    switch (type) {
+      case typeGemini:
+      case typeGeminiOauth:
+        return id.startsWith('gemini-');
+      case typeClaude:
+      case typeBedrockClaude:
+        return id.contains('claude-3') ||
+            id.contains('claude-sonnet') ||
+            id.contains('claude-opus') ||
+            id.contains('claude-haiku');
+      case typeChatCompletion:
+      case typeResponses:
+      case typeOpenAiOauth:
+        return id.contains('gpt-4o') ||
+            id.contains('gpt-4.1') ||
+            id.contains('gpt-5') ||
+            id.contains('o3');
+      case typeZhipu:
+        return id.contains('glm-') && id.contains('v');
+      case typeMimo:
+        return id == 'mimo-v2.5' || id == 'mimo-v2-omni' || id.contains('omni');
+      case typeQwen:
+      case typeSeed:
+      case typeMinimax:
+        return id.contains('vl') ||
+            id.contains('vision') ||
+            id.contains('omni');
+      case typeOpenRouter:
+        return id.contains('gemini') ||
+            id.contains('claude') ||
+            id.contains('gpt-4o') ||
+            id.contains('gpt-4.1') ||
+            id.contains('gpt-5') ||
+            id.contains('o3') ||
+            id.contains('qwen-vl') ||
+            id.contains('vision') ||
+            id.contains('mimo-v2.5') ||
+            id.contains('mimo-v2-omni') ||
+            (id.contains('glm-') && id.contains('v'));
+      default:
+        return false;
+    }
   }
 
   /// Default base URL for a given provider type.

--- a/lib/domain/models/llm_config.dart
+++ b/lib/domain/models/llm_config.dart
@@ -126,53 +126,6 @@ class LLMConfig {
   static bool isChatgptProModel(String modelId) =>
       chatgptProOnlyModels.contains(modelId);
 
-  /// Featured model IDs that get a "Recommended" badge, per provider type.
-  static Set<String> featuredModels(String type) {
-    switch (type) {
-      case typeChatCompletion:
-      case typeResponses:
-        return const {'gpt-5.4', 'o3', 'o1', 'gpt-5.2'};
-      case typeOpenAiOauth:
-        return const {'gpt-5.4', 'gpt-5.2'};
-      case typeClaude:
-        return const {'claude-opus-4-6', 'claude-sonnet-4-6'};
-      case typeBedrockClaude:
-        return const {
-          'us.anthropic.claude-opus-4-6-v1',
-          'us.anthropic.claude-sonnet-4-6',
-        };
-      case typeGemini:
-      case typeGeminiOauth:
-        return const {'gemini-3.1-pro-preview', 'gemini-3-flash-preview'};
-      case typeKimi:
-        return const {'kimi-k2.5'};
-      case typeQwen:
-        return const {'qwen3.5-plus'};
-      case typeSeed:
-        return const {'doubao-seed-2-0-pro-260215', 'doubao-seed-1-8-251228'};
-      case typeZhipu:
-        return const {'glm-5v-turbo', 'glm-4.6v'};
-      case typeMimo:
-        return const {'mimo-v2.5', 'mimo-v2-omni'};
-      case typeOpenRouter:
-        return const {
-          'anthropic/claude-opus-4.6',
-          'anthropic/claude-sonnet-4.6',
-          'google/gemini-3.1-pro-preview',
-          'openai/gpt-5.4',
-          'openai/gpt-5.2',
-          'openai/o3',
-          'qwen/qwen-plus',
-          'qwen/qwen-max',
-          'x-ai/grok-4',
-          'z-ai/glm-4.6v',
-          'z-ai/glm-5v-turbo',
-        };
-      default:
-        return const {};
-    }
-  }
-
   /// Recommended model IDs per provider type.
   static List<String> recommendedModels(String type) {
     switch (type) {

--- a/lib/domain/models/llm_config.dart
+++ b/lib/domain/models/llm_config.dart
@@ -126,6 +126,53 @@ class LLMConfig {
   static bool isChatgptProModel(String modelId) =>
       chatgptProOnlyModels.contains(modelId);
 
+  /// Featured model IDs that get a "Recommended" badge, per provider type.
+  static Set<String> featuredModels(String type) {
+    switch (type) {
+      case typeChatCompletion:
+      case typeResponses:
+        return const {'gpt-5.4', 'o3', 'o1', 'gpt-5.2'};
+      case typeOpenAiOauth:
+        return const {'gpt-5.4', 'gpt-5.2'};
+      case typeClaude:
+        return const {'claude-opus-4-6', 'claude-sonnet-4-6'};
+      case typeBedrockClaude:
+        return const {
+          'us.anthropic.claude-opus-4-6-v1',
+          'us.anthropic.claude-sonnet-4-6',
+        };
+      case typeGemini:
+      case typeGeminiOauth:
+        return const {'gemini-3.1-pro-preview', 'gemini-3-flash-preview'};
+      case typeKimi:
+        return const {'kimi-k2.5'};
+      case typeQwen:
+        return const {'qwen3.5-plus'};
+      case typeSeed:
+        return const {'doubao-seed-2-0-pro-260215', 'doubao-seed-1-8-251228'};
+      case typeZhipu:
+        return const {'glm-5v-turbo', 'glm-4.6v'};
+      case typeMimo:
+        return const {'mimo-v2-pro'};
+      case typeOpenRouter:
+        return const {
+          'anthropic/claude-opus-4.6',
+          'anthropic/claude-sonnet-4.6',
+          'google/gemini-3.1-pro-preview',
+          'openai/gpt-5.4',
+          'openai/gpt-5.2',
+          'openai/o3',
+          'qwen/qwen-plus',
+          'qwen/qwen-max',
+          'x-ai/grok-4',
+          'z-ai/glm-4.6v',
+          'z-ai/glm-5v-turbo',
+        };
+      default:
+        return const {};
+    }
+  }
+
   /// Recommended model IDs per provider type.
   static List<String> recommendedModels(String type) {
     switch (type) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -896,6 +896,12 @@
   "demoSkip": "Skip",
   "demoPrefillText": "Hello Memex! This is my first record 🎉",
 
+  "visionBadge": "Vision",
+  "notMultimodalHint": "Memex relies on multimodal model capabilities for media analysis. If your records contain images, please make sure the model you configured supports image input.",
+  "defaultModelPrefix": "Default",
+  "reanalyzeMediaAssets": "Re-analyze media assets",
+  "reanalyzeMediaAssetsDesc": "Refreshes media analysis files before regenerating cards.",
+
   "readOnlyMode": "Chat",
   "readOnlyBadge": "CHAT",
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -899,6 +899,7 @@
   "visionBadge": "Vision",
   "notMultimodalHint": "Memex relies on multimodal model capabilities for media analysis. If your records contain images, please make sure the model you configured supports image input.",
   "defaultModelPrefix": "Default",
+  "recommendedBadge": "Recommended",
   "reanalyzeMediaAssets": "Re-analyze media assets",
   "reanalyzeMediaAssetsDesc": "Refreshes media analysis files before regenerating cards.",
 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3668,6 +3668,12 @@ abstract class AppLocalizations {
   /// **'Default'**
   String get defaultModelPrefix;
 
+  /// No description provided for @recommendedBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'Recommended'**
+  String get recommendedBadge;
+
   /// No description provided for @reanalyzeMediaAssets.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3650,6 +3650,36 @@ abstract class AppLocalizations {
   /// **'Hello Memex! This is my first record 🎉'**
   String get demoPrefillText;
 
+  /// No description provided for @visionBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'Vision'**
+  String get visionBadge;
+
+  /// No description provided for @notMultimodalHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Memex relies on multimodal model capabilities for media analysis. If your records contain images, please make sure the model you configured supports image input.'**
+  String get notMultimodalHint;
+
+  /// No description provided for @defaultModelPrefix.
+  ///
+  /// In en, this message translates to:
+  /// **'Default'**
+  String get defaultModelPrefix;
+
+  /// No description provided for @reanalyzeMediaAssets.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-analyze media assets'**
+  String get reanalyzeMediaAssets;
+
+  /// No description provided for @reanalyzeMediaAssetsDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Refreshes media analysis files before regenerating cards.'**
+  String get reanalyzeMediaAssetsDesc;
+
   /// No description provided for @readOnlyMode.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2002,6 +2002,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get defaultModelPrefix => 'Default';
 
   @override
+  String get recommendedBadge => 'Recommended';
+
+  @override
   String get reanalyzeMediaAssets => 'Re-analyze media assets';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1992,6 +1992,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get demoPrefillText => 'Hello Memex! This is my first record 🎉';
 
   @override
+  String get visionBadge => 'Vision';
+
+  @override
+  String get notMultimodalHint =>
+      'Memex relies on multimodal model capabilities for media analysis. If your records contain images, please make sure the model you configured supports image input.';
+
+  @override
+  String get defaultModelPrefix => 'Default';
+
+  @override
+  String get reanalyzeMediaAssets => 'Re-analyze media assets';
+
+  @override
+  String get reanalyzeMediaAssetsDesc =>
+      'Refreshes media analysis files before regenerating cards.';
+
+  @override
   String get readOnlyMode => 'Chat';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1923,6 +1923,22 @@ class AppLocalizationsZh extends AppLocalizations {
   String get demoPrefillText => '你好 Memex！这是我的第一条记录 🎉';
 
   @override
+  String get visionBadge => '视觉';
+
+  @override
+  String get notMultimodalHint =>
+      'Memex依赖模型多模态能力用于媒体分析，如果您的记录内容包含图片，请确保您配置的模型支持图片输入。';
+
+  @override
+  String get defaultModelPrefix => '默认使用';
+
+  @override
+  String get reanalyzeMediaAssets => '重新分析图片/音频';
+
+  @override
+  String get reanalyzeMediaAssetsDesc => '会先刷新 Facts/assets 下的媒体分析，再重新生成卡片。';
+
+  @override
   String get readOnlyMode => '对话';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1933,6 +1933,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get defaultModelPrefix => '默认使用';
 
   @override
+  String get recommendedBadge => '推荐';
+
+  @override
   String get reanalyzeMediaAssets => '重新分析图片/音频';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -877,6 +877,7 @@
   "visionBadge": "视觉",
   "notMultimodalHint": "Memex依赖模型多模态能力用于媒体分析，如果您的记录内容包含图片，请确保您配置的模型支持图片输入。",
   "defaultModelPrefix": "默认使用",
+  "recommendedBadge": "推荐",
   "reanalyzeMediaAssets": "重新分析图片/音频",
   "reanalyzeMediaAssetsDesc": "会先刷新 Facts/assets 下的媒体分析，再重新生成卡片。",
 

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -874,6 +874,12 @@
   "demoSkip": "跳过",
   "demoPrefillText": "你好 Memex！这是我的第一条记录 🎉",
 
+  "visionBadge": "视觉",
+  "notMultimodalHint": "Memex依赖模型多模态能力用于媒体分析，如果您的记录内容包含图片，请确保您配置的模型支持图片输入。",
+  "defaultModelPrefix": "默认使用",
+  "reanalyzeMediaAssets": "重新分析图片/音频",
+  "reanalyzeMediaAssetsDesc": "会先刷新 Facts/assets 下的媒体分析，再重新生成卡片。",
+
   "readOnlyMode": "对话",
   "readOnlyBadge": "对话",
 

--- a/lib/ui/settings/widgets/agent_config_list_page.dart
+++ b/lib/ui/settings/widgets/agent_config_list_page.dart
@@ -56,7 +56,9 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
     } catch (e) {
       if (mounted) {
         ToastHelper.showError(
-            context, UserStorage.l10n.loadDataFailed(e.toString()));
+          context,
+          UserStorage.l10n.loadDataFailed(e.toString()),
+        );
         setState(() => _isLoading = false);
       }
     }
@@ -74,17 +76,46 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
     } catch (e) {
       if (mounted) {
         ToastHelper.showError(
-            context, UserStorage.l10n.saveConfigFailed(e.toString()));
+          context,
+          UserStorage.l10n.saveConfigFailed(e.toString()),
+        );
       }
     }
   }
 
   Future<void> _updateAgentModelConfig(
-      String agentId, String? llmConfigKey) async {
-    final newConfig = (_agentConfigs[agentId] ?? const AgentConfig())
-        .copyWith(llmConfigKey: llmConfigKey);
+    String agentId,
+    String? llmConfigKey,
+  ) async {
+    final newConfig = (_agentConfigs[agentId] ?? const AgentConfig()).copyWith(
+      llmConfigKey: llmConfigKey,
+    );
     await _saveAgentConfig(agentId, newConfig);
   }
+
+  bool get _isZh => UserStorage.l10n.localeName == 'zh';
+
+  String get _visionBadgeText => _isZh ? '视觉' : 'Vision';
+
+  String get _mediaModelWarning => _isZh
+      ? '媒体分析需要多模态模型。当前模型未标记为可读图，可能会忽略图片内容。'
+      : 'Media analysis needs a multimodal model. The current model is not marked as vision-capable and may ignore images.';
+
+  String get _defaultModelPrefix => _isZh ? '默认使用' : 'Default';
+
+  LLMConfig? _findConfig(String? key) {
+    if (key == null || key.isEmpty) return null;
+    for (final config in _llmConfigs) {
+      if (config.key == key) return config;
+    }
+    return null;
+  }
+
+  LLMConfig? _effectiveConfig(String? selectedKey) =>
+      _findConfig(selectedKey) ?? _findConfig(LLMConfig.defaultClientKey);
+
+  bool _isKnownMultimodalConfig(LLMConfig config) =>
+      LLMConfig.isKnownMultimodal(config.type, config.modelId);
 
   InputDecoration _dropdownDecoration() {
     return InputDecoration(
@@ -124,8 +155,10 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                     ),
                     TextButton(
                       onPressed: () => Navigator.pop(context, true),
-                      child: Text(l10n.resetButton,
-                          style: const TextStyle(color: Colors.red)),
+                      child: Text(
+                        l10n.resetButton,
+                        style: const TextStyle(color: Colors.red),
+                      ),
                     ),
                   ],
                 ),
@@ -139,8 +172,10 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                   if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                          content:
-                              Text(UserStorage.l10n.agentConfigurationsReset)),
+                        content: Text(
+                          UserStorage.l10n.agentConfigurationsReset,
+                        ),
+                      ),
                     );
                   }
                 } catch (e) {
@@ -148,8 +183,10 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                   if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                          content:
-                              Text(UserStorage.l10n.resetFailed(e.toString()))),
+                        content: Text(
+                          UserStorage.l10n.resetFailed(e.toString()),
+                        ),
+                      ),
                     );
                   }
                 }
@@ -167,8 +204,14 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                 final agentId = _agentIds[index];
                 final displayName =
                     AgentDefinitions.displayNames[agentId] ?? agentId;
-                final currentConfig = _agentConfigs[agentId] ?? const AgentConfig();
+                final currentConfig =
+                    _agentConfigs[agentId] ?? const AgentConfig();
                 final selectedKey = currentConfig.llmConfigKey;
+                final effectiveConfig = _effectiveConfig(selectedKey);
+                final showMediaWarning =
+                    agentId == AgentDefinitions.analyzeAssets &&
+                    effectiveConfig != null &&
+                    !_isKnownMultimodalConfig(effectiveConfig);
 
                 return Container(
                   margin: const EdgeInsets.only(bottom: 12),
@@ -203,9 +246,22 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                           color: AppColors.textTertiary,
                         ),
                       ),
+                      if (selectedKey == null && effectiveConfig != null) ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          '$_defaultModelPrefix: ${effectiveConfig.key} / ${effectiveConfig.modelId}',
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: AppColors.textTertiary,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
                       const SizedBox(height: 12),
                       DropdownButtonFormField<String>(
-                        key: ValueKey('agent-model-$agentId-${selectedKey ?? ''}'),
+                        key: ValueKey(
+                          'agent-model-$agentId-${selectedKey ?? ''}',
+                        ),
                         initialValue: selectedKey,
                         isExpanded: true,
                         decoration: _dropdownDecoration(),
@@ -214,13 +270,41 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                           ..._llmConfigs.map((config) {
                             return DropdownMenuItem<String>(
                               value: config.key,
-                              child: Text(
-                                config.key,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
-                                  fontSize: 14,
-                                  color: AppColors.textPrimary,
-                                ),
+                              child: Row(
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      '${config.key} / ${config.modelId}',
+                                      overflow: TextOverflow.ellipsis,
+                                      style: const TextStyle(
+                                        fontSize: 14,
+                                        color: AppColors.textPrimary,
+                                      ),
+                                    ),
+                                  ),
+                                  if (_isKnownMultimodalConfig(config))
+                                    Container(
+                                      margin: const EdgeInsets.only(left: 8),
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: Colors.green.withValues(
+                                          alpha: 0.1,
+                                        ),
+                                        borderRadius: BorderRadius.circular(4),
+                                      ),
+                                      child: Text(
+                                        _visionBadgeText,
+                                        style: const TextStyle(
+                                          fontSize: 10,
+                                          color: Colors.green,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                ],
                               ),
                             );
                           }),
@@ -231,6 +315,30 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                           }
                         },
                       ),
+                      if (showMediaWarning) ...[
+                        const SizedBox(height: 8),
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Icon(
+                              Icons.visibility_off_outlined,
+                              size: 15,
+                              color: Color(0xFFD97706),
+                            ),
+                            const SizedBox(width: 6),
+                            Expanded(
+                              child: Text(
+                                _mediaModelWarning,
+                                style: const TextStyle(
+                                  fontSize: 12,
+                                  color: Color(0xFFD97706),
+                                  height: 1.3,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
                     ],
                   ),
                 );

--- a/lib/ui/settings/widgets/agent_config_list_page.dart
+++ b/lib/ui/settings/widgets/agent_config_list_page.dart
@@ -93,15 +93,9 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
     await _saveAgentConfig(agentId, newConfig);
   }
 
-  bool get _isZh => UserStorage.l10n.localeName == 'zh';
+  String get _visionBadgeText => UserStorage.l10n.visionBadge;
 
-  String get _visionBadgeText => _isZh ? '视觉' : 'Vision';
-
-  String get _mediaModelWarning => _isZh
-      ? '媒体分析需要多模态模型。当前模型未标记为可读图，可能会忽略图片内容。'
-      : 'Media analysis needs a multimodal model. The current model is not marked as vision-capable and may ignore images.';
-
-  String get _defaultModelPrefix => _isZh ? '默认使用' : 'Default';
+  String get _defaultModelPrefix => UserStorage.l10n.defaultModelPrefix;
 
   LLMConfig? _findConfig(String? key) {
     if (key == null || key.isEmpty) return null;
@@ -208,10 +202,6 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                     _agentConfigs[agentId] ?? const AgentConfig();
                 final selectedKey = currentConfig.llmConfigKey;
                 final effectiveConfig = _effectiveConfig(selectedKey);
-                final showMediaWarning =
-                    agentId == AgentDefinitions.analyzeAssets &&
-                    effectiveConfig != null &&
-                    !_isKnownMultimodalConfig(effectiveConfig);
 
                 return Container(
                   margin: const EdgeInsets.only(bottom: 12),
@@ -315,30 +305,6 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                           }
                         },
                       ),
-                      if (showMediaWarning) ...[
-                        const SizedBox(height: 8),
-                        Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const Icon(
-                              Icons.visibility_off_outlined,
-                              size: 15,
-                              color: Color(0xFFD97706),
-                            ),
-                            const SizedBox(width: 6),
-                            Expanded(
-                              child: Text(
-                                _mediaModelWarning,
-                                style: const TextStyle(
-                                  fontSize: 12,
-                                  color: Color(0xFFD97706),
-                                  height: 1.3,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
                     ],
                   ),
                 );

--- a/lib/ui/settings/widgets/model_config_edit_page.dart
+++ b/lib/ui/settings/widgets/model_config_edit_page.dart
@@ -63,19 +63,25 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
     _apiKeyController = TextEditingController(text: config?.apiKey ?? '');
     _baseUrlController = TextEditingController(text: config?.baseUrl ?? '');
     _proxyUrlController = TextEditingController(text: config?.proxyUrl ?? '');
-    _temperatureController =
-        TextEditingController(text: config?.temperature?.toString() ?? '');
-    _maxTokensController =
-        TextEditingController(text: config?.maxTokens?.toString() ?? '');
+    _temperatureController = TextEditingController(
+      text: config?.temperature?.toString() ?? '',
+    );
+    _maxTokensController = TextEditingController(
+      text: config?.maxTokens?.toString() ?? '',
+    );
     _topPController = TextEditingController(
-        text: config?.topP?.toString() ?? ''); // Fixed line
+      text: config?.topP?.toString() ?? '',
+    ); // Fixed line
 
     _bedrockAccessKeyController = TextEditingController(
-        text: config?.extra['accessKeyId'] as String? ?? '');
+      text: config?.extra['accessKeyId'] as String? ?? '',
+    );
     _bedrockSecretKeyController = TextEditingController(
-        text: config?.extra['secretAccessKey'] as String? ?? '');
+      text: config?.extra['secretAccessKey'] as String? ?? '',
+    );
     _bedrockRegionController = TextEditingController(
-        text: config?.extra['region'] as String? ?? 'us-west-2');
+      text: config?.extra['region'] as String? ?? 'us-west-2',
+    );
 
     String extraJson = '{}';
     if (config != null && config.extra.isNotEmpty) {
@@ -106,7 +112,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
     }
 
     _animationController = AnimationController(
-        vsync: this, duration: const Duration(milliseconds: 800));
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
 
     _keyController.addListener(_checkChanges);
     _modelIdController.addListener(_checkChanges);
@@ -205,7 +213,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
             mounted) {
           _dismissAuthDialog();
           ToastHelper.showError(
-              context, UserStorage.l10n.authFailed('Authorization cancelled'));
+            context,
+            UserStorage.l10n.authFailed('Authorization cancelled'),
+          );
         }
       });
     }
@@ -264,12 +274,15 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                 children: [
                   const CircularProgressIndicator(),
                   const SizedBox(height: 16),
-                  Text(UserStorage.l10n.authorizing,
-                      style: const TextStyle(
-                          fontSize: 14,
-                          color: Colors.black87,
-                          decoration: TextDecoration.none,
-                          fontWeight: FontWeight.normal)),
+                  Text(
+                    UserStorage.l10n.authorizing,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      color: Colors.black87,
+                      decoration: TextDecoration.none,
+                      fontWeight: FontWeight.normal,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -291,7 +304,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
         _dismissAuthDialog();
         if (mounted) {
           ToastHelper.showError(
-              context, UserStorage.l10n.authFailed(error.toString()));
+            context,
+            UserStorage.l10n.authFailed(error.toString()),
+          );
         }
       },
     );
@@ -319,12 +334,15 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                 children: [
                   const CircularProgressIndicator(),
                   const SizedBox(height: 16),
-                  Text(UserStorage.l10n.authorizing,
-                      style: const TextStyle(
-                          fontSize: 14,
-                          color: Colors.black87,
-                          decoration: TextDecoration.none,
-                          fontWeight: FontWeight.normal)),
+                  Text(
+                    UserStorage.l10n.authorizing,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      color: Colors.black87,
+                      decoration: TextDecoration.none,
+                      fontWeight: FontWeight.normal,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -346,7 +364,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
         _dismissAuthDialog();
         if (mounted) {
           ToastHelper.showError(
-              context, UserStorage.l10n.authFailed(error.toString()));
+            context,
+            UserStorage.l10n.authFailed(error.toString()),
+          );
         }
       },
     );
@@ -388,8 +408,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
             child: ElevatedButton.icon(
               onPressed: _startOpenAiAuth,
               icon: const Icon(Icons.login),
-              label:
-                  Text(isAuthorized ? 'Re-authorize' : 'Authorize with OpenAI'),
+              label: Text(
+                isAuthorized ? 'Re-authorize' : 'Authorize with OpenAI',
+              ),
             ),
           ),
           if (isAuthorized)
@@ -451,8 +472,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
             child: ElevatedButton.icon(
               onPressed: _startGeminiAuth,
               icon: const Icon(Icons.login),
-              label:
-                  Text(isAuthorized ? 'Re-authorize' : 'Authorize with Google'),
+              label: Text(
+                isAuthorized ? 'Re-authorize' : 'Authorize with Google',
+              ),
             ),
           ),
           if (isAuthorized)
@@ -522,32 +544,38 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
       if (filtered.isEmpty) continue;
 
       // Group header
-      items.add(DropdownMenuItem<String>(
-        enabled: false,
-        value: '__header_${groupIndex}__',
-        child: Padding(
-          padding: EdgeInsets.only(top: groupIndex > 0 ? 4 : 0),
-          child: Text(
-            entry.key,
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: Colors.grey[500],
-              letterSpacing: 0.5,
+      items.add(
+        DropdownMenuItem<String>(
+          enabled: false,
+          value: '__header_${groupIndex}__',
+          child: Padding(
+            padding: EdgeInsets.only(top: groupIndex > 0 ? 4 : 0),
+            child: Text(
+              entry.key,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: Colors.grey[500],
+                letterSpacing: 0.5,
+              ),
             ),
           ),
         ),
-      ));
+      );
 
       for (final provider in filtered) {
-        items.add(DropdownMenuItem(
-          value: provider.type,
-          child: Padding(
-            padding: const EdgeInsets.only(left: 12),
-            child:
-                Text(provider.label, style: TextStyle(color: Colors.grey[800])),
+        items.add(
+          DropdownMenuItem(
+            value: provider.type,
+            child: Padding(
+              padding: const EdgeInsets.only(left: 12),
+              child: Text(
+                provider.label,
+                style: TextStyle(color: Colors.grey[800]),
+              ),
+            ),
           ),
-        ));
+        );
       }
       groupIndex++;
     }
@@ -567,11 +595,21 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
     final missingFeatured = featured.where((m) => !models.contains(m)).toList();
     final top = [
       ...missingFeatured,
-      ...models.where((m) => featured.contains(m))
+      ...models.where((m) => featured.contains(m)),
     ];
     final rest = models.where((m) => !featured.contains(m)).toList();
     return [...top, ...rest];
   }
+
+  bool _isKnownMultimodalModel(String modelId) =>
+      LLMConfig.isKnownMultimodal(_selectedType, modelId);
+
+  String get _visionBadgeText =>
+      UserStorage.l10n.localeName == 'zh' ? '视觉' : 'Vision';
+
+  String get _notMultimodalHint => UserStorage.l10n.localeName == 'zh'
+      ? '该模型未标记为多模态；如果用于媒体分析，可能无法读取图片。建议媒体分析使用 mimo-v2.5、mimo-v2-omni 或其他视觉模型。'
+      : 'This model is not marked as multimodal; Media analysis may not be able to read images. Use mimo-v2.5, mimo-v2-omni, or another vision-capable model.';
 
   /// Whether the model selector should be disabled (needs API key first).
   bool get _modelSelectorDisabled {
@@ -663,7 +701,11 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
     }
 
     // Check Key Uniqueness if new
-    if (widget.config == null && await _isKeyExists(_keyController.text)) {
+    final keyExists =
+        widget.config == null && await _isKeyExists(_keyController.text);
+    if (!mounted) return;
+
+    if (keyExists) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(UserStorage.l10n.keyAlreadyExists)),
       );
@@ -715,8 +757,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
 
     // Issue 3: Check LLM data sharing consent before saving a valid config
     if (newConfig.isValid) {
-      final hasConsent =
-          await UserStorage.hasLLMConsent(providerType: _selectedType);
+      final hasConsent = await UserStorage.hasLLMConsent(
+        providerType: _selectedType,
+      );
       if (!hasConsent && mounted) {
         final l10n = UserStorage.l10n;
         final providerName = _selectedType.isNotEmpty
@@ -786,8 +829,10 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            child: Text(UserStorage.l10n.resetButton,
-                style: const TextStyle(color: Colors.red)),
+            child: Text(
+              UserStorage.l10n.resetButton,
+              style: const TextStyle(color: Colors.red),
+            ),
           ),
         ],
       ),
@@ -797,8 +842,10 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
 
     final defaultKey = widget.config!.key;
     final defaultType = widget.config!.type;
-    final defaultLLMConfig =
-        LLMConfig.createDefaultConfig(defaultKey, defaultType);
+    final defaultLLMConfig = LLMConfig.createDefaultConfig(
+      defaultKey,
+      defaultType,
+    );
 
     setState(() {
       _modelIdController.text = defaultLLMConfig.modelId;
@@ -820,8 +867,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
       String extraJson = '{}';
       if (defaultLLMConfig.extra.isNotEmpty) {
         try {
-          extraJson = const JsonEncoder.withIndent('  ')
-              .convert(defaultLLMConfig.extra);
+          extraJson = const JsonEncoder.withIndent(
+            '  ',
+          ).convert(defaultLLMConfig.extra);
         } catch (e) {
           extraJson = '{}';
         }
@@ -853,8 +901,10 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            child: Text(UserStorage.l10n.discardButton,
-                style: const TextStyle(color: Colors.red)),
+            child: Text(
+              UserStorage.l10n.discardButton,
+              style: const TextStyle(color: Colors.red),
+            ),
           ),
         ],
       ),
@@ -879,9 +929,11 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
         appBar: AppBar(
           backgroundColor: AppColors.background,
           surfaceTintColor: AppColors.background,
-          title: Text(widget.config == null
-              ? UserStorage.l10n.addConfiguration
-              : UserStorage.l10n.editConfiguration),
+          title: Text(
+            widget.config == null
+                ? UserStorage.l10n.addConfiguration
+                : UserStorage.l10n.editConfiguration,
+          ),
           actions: [
             if (isDefault)
               IconButton(
@@ -897,8 +949,10 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                       ? 1.0 + (_animationController.value * 0.2)
                       : 1.0,
                   child: IconButton(
-                    icon: Icon(Icons.save,
-                        color: _hasChanges ? Colors.blue.shade700 : null),
+                    icon: Icon(
+                      Icons.save,
+                      color: _hasChanges ? Colors.blue.shade700 : null,
+                    ),
                     onPressed: _save,
                   ),
                 );
@@ -924,15 +978,21 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      const Icon(Icons.info_outline,
-                          size: 18, color: Color(0xFFD97706)),
+                      const Icon(
+                        Icons.info_outline,
+                        size: 18,
+                        color: Color(0xFFD97706),
+                      ),
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(
                           UserStorage.l10n.llmConsentDataShareNote(
-                              LLMConfig.providerDisplayName(_selectedType)),
+                            LLMConfig.providerDisplayName(_selectedType),
+                          ),
                           style: const TextStyle(
-                              fontSize: 13, color: Color(0xFF92400E)),
+                            fontSize: 13,
+                            color: Color(0xFF92400E),
+                          ),
                         ),
                       ),
                     ],
@@ -948,8 +1008,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                 ),
                 enabled: !isDefault, // Default keys cannot be changed
                 validator: (value) {
-                  if (value == null || value.isEmpty)
+                  if (value == null || value.isEmpty) {
                     return UserStorage.l10n.required;
+                  }
                   return null;
                 },
               ),
@@ -958,7 +1019,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
               // Type
               DropdownButtonFormField<String>(
                 isExpanded: true,
-                value: _selectedType.isEmpty ? null : _selectedType,
+                initialValue: _selectedType.isEmpty ? null : _selectedType,
                 hint: Text(UserStorage.l10n.select),
                 decoration: InputDecoration(
                   labelText: UserStorage.l10n.clientLabel,
@@ -989,8 +1050,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                     final recommended = _getRecommendedModels(value);
                     _modelIdController.text =
                         recommended.isNotEmpty ? recommended.first : '';
-                    _modelDropdownKey.currentState
-                        ?.setText(_modelIdController.text);
+                    _modelDropdownKey.currentState?.setText(
+                      _modelIdController.text,
+                    );
                     // Reset API Key
                     _apiKeyController.text = '';
 
@@ -1027,8 +1089,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                     border: const OutlineInputBorder(),
                   ),
                   validator: (value) {
-                    if (value == null || value.isEmpty)
+                    if (value == null || value.isEmpty) {
                       return UserStorage.l10n.required;
+                    }
                     return null;
                   },
                 ),
@@ -1064,9 +1127,11 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                     labelText: 'Secret Access Key',
                     border: const OutlineInputBorder(),
                     suffixIcon: IconButton(
-                      icon: Icon(_isObscureApiKey
-                          ? Icons.visibility
-                          : Icons.visibility_off),
+                      icon: Icon(
+                        _isObscureApiKey
+                            ? Icons.visibility
+                            : Icons.visibility_off,
+                      ),
                       onPressed: () =>
                           setState(() => _isObscureApiKey = !_isObscureApiKey),
                     ),
@@ -1098,9 +1163,11 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                     labelText: UserStorage.l10n.apiKeyLabel,
                     border: const OutlineInputBorder(),
                     suffixIcon: IconButton(
-                      icon: Icon(_isObscureApiKey
-                          ? Icons.visibility
-                          : Icons.visibility_off),
+                      icon: Icon(
+                        _isObscureApiKey
+                            ? Icons.visibility
+                            : Icons.visibility_off,
+                      ),
                       onPressed: () =>
                           setState(() => _isObscureApiKey = !_isObscureApiKey),
                     ),
@@ -1121,7 +1188,10 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                   child: Text(
                     UserStorage.l10n.enterApiKeyFirst,
                     style: TextStyle(
-                        fontSize: 12, color: Colors.orange[700], height: 1.3),
+                      fontSize: 12,
+                      color: Colors.orange[700],
+                      height: 1.3,
+                    ),
                   ),
                 ),
               AbsorbPointer(
@@ -1158,12 +1228,15 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                             final isPro =
                                 _selectedType == LLMConfig.typeOpenAiOauth &&
                                     _isProModel(option);
-                            final isFeatured =
-                                LLMConfig.featuredModels(_selectedType)
-                                    .contains(option);
+                            final isFeatured = LLMConfig.featuredModels(
+                              _selectedType,
+                            ).contains(option);
+                            final isVision = _isKnownMultimodalModel(option);
                             return Padding(
                               padding: const EdgeInsets.symmetric(
-                                  horizontal: 16, vertical: 12),
+                                horizontal: 16,
+                                vertical: 12,
+                              ),
                               child: Row(
                                 children: [
                                   Expanded(child: Text(option)),
@@ -1171,40 +1244,70 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                                     Container(
                                       margin: const EdgeInsets.only(left: 8),
                                       padding: const EdgeInsets.symmetric(
-                                          horizontal: 6, vertical: 2),
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
                                       decoration: BoxDecoration(
-                                        color: AppColors.primary
-                                            .withValues(alpha: 0.1),
+                                        color: AppColors.primary.withValues(
+                                          alpha: 0.1,
+                                        ),
                                         borderRadius: BorderRadius.circular(4),
                                       ),
                                       child: Text(
                                         UserStorage.l10n.localeName == 'zh'
                                             ? '推荐'
                                             : 'Recommended',
-                                        style: TextStyle(
-                                            fontSize: 10,
-                                            color: AppColors.primary,
-                                            fontWeight: FontWeight.w600),
+                                        style: const TextStyle(
+                                          fontSize: 10,
+                                          color: AppColors.primary,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                  if (isVision)
+                                    Container(
+                                      margin: const EdgeInsets.only(left: 8),
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: Colors.green.withValues(
+                                          alpha: 0.1,
+                                        ),
+                                        borderRadius: BorderRadius.circular(4),
+                                      ),
+                                      child: Text(
+                                        _visionBadgeText,
+                                        style: const TextStyle(
+                                          fontSize: 10,
+                                          color: Colors.green,
+                                          fontWeight: FontWeight.w600,
+                                        ),
                                       ),
                                     ),
                                   if (isPro)
                                     Container(
                                       margin: const EdgeInsets.only(left: 8),
                                       padding: const EdgeInsets.symmetric(
-                                          horizontal: 6, vertical: 2),
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
                                       decoration: BoxDecoration(
                                         color: const Color(0xFFFFF7ED),
                                         borderRadius: BorderRadius.circular(4),
                                         border: Border.all(
-                                            color: const Color(0xFFFBBF24),
-                                            width: 0.5),
+                                          color: const Color(0xFFFBBF24),
+                                          width: 0.5,
+                                        ),
                                       ),
                                       child: const Text(
                                         'Pro/Plus',
                                         style: TextStyle(
-                                            fontSize: 10,
-                                            color: Color(0xFFD97706),
-                                            fontWeight: FontWeight.w600),
+                                          fontSize: 10,
+                                          color: Color(0xFFD97706),
+                                          fontWeight: FontWeight.w600,
+                                        ),
                                       ),
                                     ),
                                 ],
@@ -1223,7 +1326,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                                     width: 20,
                                     height: 20,
                                     child: CircularProgressIndicator(
-                                        strokeWidth: 2))
+                                      strokeWidth: 2,
+                                    ),
+                                  )
                                 : const Icon(Icons.refresh),
                             tooltip: UserStorage.l10n.fetchModelsButton,
                             onPressed: _isFetchingModels ? null : _fetchModels,
@@ -1239,16 +1344,47 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                   padding: const EdgeInsets.only(top: 6, left: 4),
                   child: Row(
                     children: [
-                      const Icon(Icons.info_outline,
-                          size: 14, color: Color(0xFFD97706)),
+                      const Icon(
+                        Icons.info_outline,
+                        size: 14,
+                        color: Color(0xFFD97706),
+                      ),
                       const SizedBox(width: 4),
                       Expanded(
                         child: Text(
                           UserStorage.l10n.proModelHint,
                           style: const TextStyle(
-                              fontSize: 12,
-                              color: Color(0xFFD97706),
-                              height: 1.3),
+                            fontSize: 12,
+                            color: Color(0xFFD97706),
+                            height: 1.3,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              if (_selectedType.isNotEmpty &&
+                  _modelIdController.text.trim().isNotEmpty &&
+                  !_isKnownMultimodalModel(_modelIdController.text))
+                Padding(
+                  padding: const EdgeInsets.only(top: 6, left: 4),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Icon(
+                        Icons.visibility_off_outlined,
+                        size: 14,
+                        color: Color(0xFFD97706),
+                      ),
+                      const SizedBox(width: 4),
+                      Expanded(
+                        child: Text(
+                          _notMultimodalHint,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFFD97706),
+                            height: 1.3,
+                          ),
                         ),
                       ),
                     ],
@@ -1280,7 +1416,8 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                             border: const OutlineInputBorder(),
                           ),
                           keyboardType: const TextInputType.numberWithOptions(
-                              decimal: true),
+                            decimal: true,
+                          ),
                         ),
                       ),
                       const SizedBox(width: 16),
@@ -1292,7 +1429,8 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                             border: const OutlineInputBorder(),
                           ),
                           keyboardType: const TextInputType.numberWithOptions(
-                              decimal: true),
+                            decimal: true,
+                          ),
                         ),
                       ),
                     ],

--- a/lib/ui/settings/widgets/model_config_edit_page.dart
+++ b/lib/ui/settings/widgets/model_config_edit_page.dart
@@ -583,33 +583,18 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
   }
 
   /// Returns the model options to show: fetched models if available, else recommended.
-  /// Featured models are sorted to the top.
-  /// Missing featured models are prepended even if not in the fetched list.
   List<String> _modelOptions() {
-    final models = _fetchedModels.isNotEmpty
+    return _fetchedModels.isNotEmpty
         ? _fetchedModels
         : _getRecommendedModels(_selectedType);
-    final featured = LLMConfig.featuredModels(_selectedType);
-    if (featured.isEmpty) return models;
-    // Ensure all featured models appear, even if API didn't return them
-    final missingFeatured = featured.where((m) => !models.contains(m)).toList();
-    final top = [
-      ...missingFeatured,
-      ...models.where((m) => featured.contains(m)),
-    ];
-    final rest = models.where((m) => !featured.contains(m)).toList();
-    return [...top, ...rest];
   }
 
   bool _isKnownMultimodalModel(String modelId) =>
       LLMConfig.isKnownMultimodal(_selectedType, modelId);
 
-  String get _visionBadgeText =>
-      UserStorage.l10n.localeName == 'zh' ? '视觉' : 'Vision';
+  String get _visionBadgeText => UserStorage.l10n.visionBadge;
 
-  String get _notMultimodalHint => UserStorage.l10n.localeName == 'zh'
-      ? '该模型未标记为多模态；如果用于媒体分析，可能无法读取图片。建议媒体分析使用 mimo-v2.5、mimo-v2-omni 或其他视觉模型。'
-      : 'This model is not marked as multimodal; Media analysis may not be able to read images. Use mimo-v2.5, mimo-v2-omni, or another vision-capable model.';
+  String get _notMultimodalHint => UserStorage.l10n.notMultimodalHint;
 
   /// Whether the model selector should be disabled (needs API key first).
   bool get _modelSelectorDisabled {
@@ -1228,9 +1213,6 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                             final isPro =
                                 _selectedType == LLMConfig.typeOpenAiOauth &&
                                     _isProModel(option);
-                            final isFeatured = LLMConfig.featuredModels(
-                              _selectedType,
-                            ).contains(option);
                             final isVision = _isKnownMultimodalModel(option);
                             return Padding(
                               padding: const EdgeInsets.symmetric(
@@ -1240,30 +1222,6 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                               child: Row(
                                 children: [
                                   Expanded(child: Text(option)),
-                                  if (isFeatured)
-                                    Container(
-                                      margin: const EdgeInsets.only(left: 8),
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 6,
-                                        vertical: 2,
-                                      ),
-                                      decoration: BoxDecoration(
-                                        color: AppColors.primary.withValues(
-                                          alpha: 0.1,
-                                        ),
-                                        borderRadius: BorderRadius.circular(4),
-                                      ),
-                                      child: Text(
-                                        UserStorage.l10n.localeName == 'zh'
-                                            ? '推荐'
-                                            : 'Recommended',
-                                        style: const TextStyle(
-                                          fontSize: 10,
-                                          color: AppColors.primary,
-                                          fontWeight: FontWeight.w600,
-                                        ),
-                                      ),
-                                    ),
                                   if (isVision)
                                     Container(
                                       margin: const EdgeInsets.only(left: 8),
@@ -1367,27 +1325,14 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                   _modelIdController.text.trim().isNotEmpty &&
                   !_isKnownMultimodalModel(_modelIdController.text))
                 Padding(
-                  padding: const EdgeInsets.only(top: 6, left: 4),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Icon(
-                        Icons.visibility_off_outlined,
-                        size: 14,
-                        color: Color(0xFFD97706),
-                      ),
-                      const SizedBox(width: 4),
-                      Expanded(
-                        child: Text(
-                          _notMultimodalHint,
-                          style: const TextStyle(
-                            fontSize: 12,
-                            color: Color(0xFFD97706),
-                            height: 1.3,
-                          ),
-                        ),
-                      ),
-                    ],
+                  padding: const EdgeInsets.only(top: 6, left: 16),
+                  child: Text(
+                    _notMultimodalHint,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: Color(0xFFD97706),
+                      height: 1.3,
+                    ),
                   ),
                 ),
               const SizedBox(height: 24),

--- a/lib/ui/settings/widgets/model_config_edit_page.dart
+++ b/lib/ui/settings/widgets/model_config_edit_page.dart
@@ -583,10 +583,21 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
   }
 
   /// Returns the model options to show: fetched models if available, else recommended.
+  /// Featured models are sorted to the top.
+  /// Missing featured models are prepended even if not in the fetched list.
   List<String> _modelOptions() {
-    return _fetchedModels.isNotEmpty
+    final models = _fetchedModels.isNotEmpty
         ? _fetchedModels
         : _getRecommendedModels(_selectedType);
+    final featured = LLMConfig.featuredModels(_selectedType);
+    if (featured.isEmpty) return models;
+    final missingFeatured = featured.where((m) => !models.contains(m)).toList();
+    final top = [
+      ...missingFeatured,
+      ...models.where((m) => featured.contains(m)),
+    ];
+    final rest = models.where((m) => !featured.contains(m)).toList();
+    return [...top, ...rest];
   }
 
   bool _isKnownMultimodalModel(String modelId) =>
@@ -1213,6 +1224,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                             final isPro =
                                 _selectedType == LLMConfig.typeOpenAiOauth &&
                                     _isProModel(option);
+                            final isFeatured = LLMConfig.featuredModels(
+                              _selectedType,
+                            ).contains(option);
                             final isVision = _isKnownMultimodalModel(option);
                             return Padding(
                               padding: const EdgeInsets.symmetric(
@@ -1222,6 +1236,28 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                               child: Row(
                                 children: [
                                   Expanded(child: Text(option)),
+                                  if (isFeatured)
+                                    Container(
+                                      margin: const EdgeInsets.only(left: 8),
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: AppColors.primary.withValues(
+                                          alpha: 0.1,
+                                        ),
+                                        borderRadius: BorderRadius.circular(4),
+                                      ),
+                                      child: Text(
+                                        UserStorage.l10n.recommendedBadge,
+                                        style: const TextStyle(
+                                          fontSize: 10,
+                                          color: AppColors.primary,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
                                   if (isVision)
                                     Container(
                                       margin: const EdgeInsets.only(left: 8),

--- a/lib/ui/settings/widgets/model_config_list_page.dart
+++ b/lib/ui/settings/widgets/model_config_list_page.dart
@@ -55,6 +55,13 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
     }
   }
 
+  bool get _isZh => UserStorage.l10n.localeName == 'zh';
+
+  String get _visionBadgeText => _isZh ? '视觉' : 'Vision';
+
+  bool _isKnownMultimodalConfig(LLMConfig config) =>
+      LLMConfig.isKnownMultimodal(config.type, config.modelId);
+
   @override
   void initState() {
     super.initState();
@@ -99,9 +106,7 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
         builder: (context) => AlertDialog(
           backgroundColor: Colors.white,
           title: Text(l10n.cannotDeleteConfigurationTitle),
-          content: Text(
-            l10n.configUsedByAgentsMessage(usingAgents.join('\n')),
-          ),
+          content: Text(l10n.configUsedByAgentsMessage(usingAgents.join('\n'))),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context),
@@ -181,8 +186,10 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                     ),
                     TextButton(
                       onPressed: () => Navigator.pop(context, true),
-                      child: Text(l10n.resetButton,
-                          style: const TextStyle(color: Colors.red)),
+                      child: Text(
+                        l10n.resetButton,
+                        style: const TextStyle(color: Colors.red),
+                      ),
                     ),
                   ],
                 ),
@@ -196,8 +203,10 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                   if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                          content:
-                              Text(UserStorage.l10n.modelConfigurationsReset)),
+                        content: Text(
+                          UserStorage.l10n.modelConfigurationsReset,
+                        ),
+                      ),
                     );
                   }
                 } catch (e) {
@@ -205,8 +214,10 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                   if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                          content:
-                              Text(UserStorage.l10n.resetFailed(e.toString()))),
+                        content: Text(
+                          UserStorage.l10n.resetFailed(e.toString()),
+                        ),
+                      ),
                     );
                   }
                 }
@@ -216,7 +227,7 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
         ],
       ),
       body: _isLoading
-          ? Center(child: AgentLogoLoading())
+          ? const Center(child: AgentLogoLoading())
           : Column(
               children: [
                 Expanded(
@@ -239,8 +250,9 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                         confirmDismiss: (direction) async {
                           if (config.isDefault) return false;
 
-                          final usingAgents =
-                              await _getAgentsUsingConfig(config.key);
+                          final usingAgents = await _getAgentsUsingConfig(
+                            config.key,
+                          );
                           if (usingAgents.isNotEmpty) {
                             if (!context.mounted) return false;
                             final l10n = UserStorage.l10n;
@@ -248,11 +260,13 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                               context: context,
                               builder: (context) => AlertDialog(
                                 backgroundColor: Colors.white,
-                                title:
-                                    Text(l10n.cannotDeleteConfigurationTitle),
+                                title: Text(
+                                  l10n.cannotDeleteConfigurationTitle,
+                                ),
                                 content: Text(
                                   l10n.configUsedByAgentsMessage(
-                                      usingAgents.join('\n')),
+                                    usingAgents.join('\n'),
+                                  ),
                                 ),
                                 actions: [
                                   TextButton(
@@ -274,7 +288,8 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                               backgroundColor: Colors.white,
                               title: Text(l10n.deleteConfigurationTitle),
                               content: Text(
-                                  l10n.confirmDeleteConfigMessage(config.key)),
+                                l10n.confirmDeleteConfigMessage(config.key),
+                              ),
                               actions: [
                                 TextButton(
                                   onPressed: () =>
@@ -303,7 +318,8 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                                 child: Text(
                                   config.key,
                                   style: const TextStyle(
-                                      fontWeight: FontWeight.bold),
+                                    fontWeight: FontWeight.bold,
+                                  ),
                                   overflow: TextOverflow.ellipsis,
                                   maxLines: 1,
                                 ),
@@ -312,16 +328,46 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                                 Container(
                                   margin: const EdgeInsets.only(left: 8),
                                   padding: const EdgeInsets.symmetric(
-                                      horizontal: 6, vertical: 2),
+                                    horizontal: 6,
+                                    vertical: 2,
+                                  ),
                                   decoration: BoxDecoration(
-                                    color: Colors.blue.withOpacity(0.1),
+                                    color: Colors.blue.withValues(alpha: 0.1),
                                     borderRadius: BorderRadius.circular(4),
                                     border: Border.all(
-                                        color: Colors.blue.withOpacity(0.5)),
+                                      color: Colors.blue.withValues(alpha: 0.5),
+                                    ),
                                   ),
-                                  child: Text(UserStorage.l10n.defaultLabel,
-                                      style: const TextStyle(
-                                          fontSize: 10, color: Colors.blue)),
+                                  child: Text(
+                                    UserStorage.l10n.defaultLabel,
+                                    style: const TextStyle(
+                                      fontSize: 10,
+                                      color: Colors.blue,
+                                    ),
+                                  ),
+                                ),
+                              if (_isKnownMultimodalConfig(config))
+                                Container(
+                                  margin: const EdgeInsets.only(left: 8),
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 6,
+                                    vertical: 2,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: Colors.green.withValues(alpha: 0.1),
+                                    borderRadius: BorderRadius.circular(4),
+                                    border: Border.all(
+                                      color:
+                                          Colors.green.withValues(alpha: 0.5),
+                                    ),
+                                  ),
+                                  child: Text(
+                                    _visionBadgeText,
+                                    style: const TextStyle(
+                                      fontSize: 10,
+                                      color: Colors.green,
+                                    ),
+                                  ),
                                 ),
                             ],
                           ),
@@ -369,8 +415,10 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                             children: [
                               if (!config.isDefault)
                                 IconButton(
-                                  icon: const Icon(Icons.delete_outline,
-                                      color: Colors.grey),
+                                  icon: const Icon(
+                                    Icons.delete_outline,
+                                    color: Colors.grey,
+                                  ),
                                   onPressed: () => _deleteConfig(index),
                                 ),
                               const Icon(Icons.chevron_right),

--- a/lib/ui/settings/widgets/model_config_list_page.dart
+++ b/lib/ui/settings/widgets/model_config_list_page.dart
@@ -55,9 +55,7 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
     }
   }
 
-  bool get _isZh => UserStorage.l10n.localeName == 'zh';
-
-  String get _visionBadgeText => _isZh ? '视觉' : 'Vision';
+  String get _visionBadgeText => UserStorage.l10n.visionBadge;
 
   bool _isKnownMultimodalConfig(LLMConfig config) =>
       LLMConfig.isKnownMultimodal(config.type, config.modelId);

--- a/lib/ui/settings/widgets/personal_center_screen.dart
+++ b/lib/ui/settings/widgets/personal_center_screen.dart
@@ -63,7 +63,9 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
 
   Future<void> _changeAvatar() async {
     final picked = await showAvatarPicker(
-        context, _userAvatar ?? UserStorage.defaultAvatarSeed);
+      context,
+      _userAvatar ?? UserStorage.defaultAvatarSeed,
+    );
     if (picked != null && mounted) {
       await UserStorage.saveUserAvatar(picked);
       setState(() => _userAvatar = picked);
@@ -83,9 +85,7 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
           ),
           TextButton(
             onPressed: () => Navigator.of(context).pop(true),
-            style: TextButton.styleFrom(
-              foregroundColor: Colors.red,
-            ),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
             child: Text(UserStorage.l10n.confirm),
           ),
         ],
@@ -99,14 +99,18 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
         _memexRouter.resetForLogout();
         if (mounted) {
           ToastHelper.showSuccessWithKey(
-              _scaffoldMessengerKey, UserStorage.l10n.tokenCleared);
+            _scaffoldMessengerKey,
+            UserStorage.l10n.tokenCleared,
+          );
           // navigate to setup screen
           context.go(AppRoutes.userSetup);
         }
       } catch (e) {
         if (mounted) {
-          ToastHelper.showErrorWithKey(_scaffoldMessengerKey,
-              UserStorage.l10n.clearTokenFailed(e.toString()));
+          ToastHelper.showErrorWithKey(
+            _scaffoldMessengerKey,
+            UserStorage.l10n.clearTokenFailed(e.toString()),
+          );
         }
       }
     }
@@ -119,6 +123,7 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
     DateTime? dateFrom;
     DateTime? dateTo;
     int? limit;
+    var reanalyzeAssets = false;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -148,9 +153,11 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                         });
                       }
                     },
-                    child: Text(dateFrom == null
-                        ? UserStorage.l10n.select
-                        : '${dateFrom!.year}-${dateFrom!.month.toString().padLeft(2, '0')}-${dateFrom!.day.toString().padLeft(2, '0')}'),
+                    child: Text(
+                      dateFrom == null
+                          ? UserStorage.l10n.select
+                          : '${dateFrom!.year}-${dateFrom!.month.toString().padLeft(2, '0')}-${dateFrom!.day.toString().padLeft(2, '0')}',
+                    ),
                   ),
                 ),
                 ListTile(
@@ -169,9 +176,11 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                         });
                       }
                     },
-                    child: Text(dateTo == null
-                        ? UserStorage.l10n.select
-                        : '${dateTo!.year}-${dateTo!.month.toString().padLeft(2, '0')}-${dateTo!.day.toString().padLeft(2, '0')}'),
+                    child: Text(
+                      dateTo == null
+                          ? UserStorage.l10n.select
+                          : '${dateTo!.year}-${dateTo!.month.toString().padLeft(2, '0')}-${dateTo!.day.toString().padLeft(2, '0')}',
+                    ),
                   ),
                 ),
                 const SizedBox(height: 8),
@@ -183,6 +192,26 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                   keyboardType: TextInputType.number,
                   onChanged: (value) {
                     limit = int.tryParse(value);
+                  },
+                ),
+                const SizedBox(height: 8),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  value: reanalyzeAssets,
+                  title: Text(
+                    UserStorage.l10n.localeName == 'zh'
+                        ? '重新分析图片/音频'
+                        : 'Re-analyze media assets',
+                  ),
+                  subtitle: Text(
+                    UserStorage.l10n.localeName == 'zh'
+                        ? '会先刷新 Facts/assets 下的媒体分析，再重新生成卡片。'
+                        : 'Refreshes media analysis files before regenerating cards.',
+                  ),
+                  onChanged: (value) {
+                    setDialogState(() {
+                      reanalyzeAssets = value;
+                    });
                   },
                 ),
               ],
@@ -216,7 +245,9 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
             _isReprocessingCards = false;
           });
           ToastHelper.showErrorWithKey(
-              _scaffoldMessengerKey, UserStorage.l10n.userIdNotFound);
+            _scaffoldMessengerKey,
+            UserStorage.l10n.userIdNotFound,
+          );
         }
         return;
       }
@@ -234,6 +265,9 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
       final limitValue = limit;
       if (limitValue != null && limitValue > 0) {
         payload['limit'] = limitValue;
+      }
+      if (reanalyzeAssets) {
+        payload['reanalyze_assets'] = true;
       }
 
       // enqueue task
@@ -259,7 +293,9 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
           _isReprocessingCards = false;
         });
         ToastHelper.showErrorWithKey(
-            _scaffoldMessengerKey, UserStorage.l10n.createTaskFailed(e));
+          _scaffoldMessengerKey,
+          UserStorage.l10n.createTaskFailed(e),
+        );
       }
     }
   }
@@ -300,9 +336,11 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                         });
                       }
                     },
-                    child: Text(dateFrom == null
-                        ? UserStorage.l10n.select
-                        : '${dateFrom!.year}-${dateFrom!.month.toString().padLeft(2, '0')}-${dateFrom!.day.toString().padLeft(2, '0')}'),
+                    child: Text(
+                      dateFrom == null
+                          ? UserStorage.l10n.select
+                          : '${dateFrom!.year}-${dateFrom!.month.toString().padLeft(2, '0')}-${dateFrom!.day.toString().padLeft(2, '0')}',
+                    ),
                   ),
                 ),
                 ListTile(
@@ -321,9 +359,11 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                         });
                       }
                     },
-                    child: Text(dateTo == null
-                        ? UserStorage.l10n.select
-                        : '${dateTo!.year}-${dateTo!.month.toString().padLeft(2, '0')}-${dateTo!.day.toString().padLeft(2, '0')}'),
+                    child: Text(
+                      dateTo == null
+                          ? UserStorage.l10n.select
+                          : '${dateTo!.year}-${dateTo!.month.toString().padLeft(2, '0')}-${dateTo!.day.toString().padLeft(2, '0')}',
+                    ),
                   ),
                 ),
                 const SizedBox(height: 8),
@@ -368,7 +408,9 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
             _isReprocessingComments = false;
           });
           ToastHelper.showErrorWithKey(
-              _scaffoldMessengerKey, UserStorage.l10n.userIdNotFound);
+            _scaffoldMessengerKey,
+            UserStorage.l10n.userIdNotFound,
+          );
         }
         return;
       }
@@ -411,7 +453,9 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
           _isReprocessingComments = false;
         });
         ToastHelper.showErrorWithKey(
-            _scaffoldMessengerKey, UserStorage.l10n.createTaskFailed(e));
+          _scaffoldMessengerKey,
+          UserStorage.l10n.createTaskFailed(e),
+        );
       }
     }
   }
@@ -452,9 +496,11 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                         });
                       }
                     },
-                    child: Text(dateFrom == null
-                        ? UserStorage.l10n.select
-                        : '${dateFrom!.year}-${dateFrom!.month.toString().padLeft(2, '0')}-${dateFrom!.day.toString().padLeft(2, '0')}'),
+                    child: Text(
+                      dateFrom == null
+                          ? UserStorage.l10n.select
+                          : '${dateFrom!.year}-${dateFrom!.month.toString().padLeft(2, '0')}-${dateFrom!.day.toString().padLeft(2, '0')}',
+                    ),
                   ),
                 ),
                 ListTile(
@@ -473,9 +519,11 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                         });
                       }
                     },
-                    child: Text(dateTo == null
-                        ? UserStorage.l10n.select
-                        : '${dateTo!.year}-${dateTo!.month.toString().padLeft(2, '0')}-${dateTo!.day.toString().padLeft(2, '0')}'),
+                    child: Text(
+                      dateTo == null
+                          ? UserStorage.l10n.select
+                          : '${dateTo!.year}-${dateTo!.month.toString().padLeft(2, '0')}-${dateTo!.day.toString().padLeft(2, '0')}',
+                    ),
                   ),
                 ),
                 const SizedBox(height: 8),
@@ -520,7 +568,9 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
             _isReprocessingKnowledgeBase = false;
           });
           ToastHelper.showErrorWithKey(
-              _scaffoldMessengerKey, UserStorage.l10n.userIdNotFound);
+            _scaffoldMessengerKey,
+            UserStorage.l10n.userIdNotFound,
+          );
         }
         return;
       }
@@ -564,7 +614,9 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
           _isReprocessingKnowledgeBase = false;
         });
         ToastHelper.showErrorWithKey(
-            _scaffoldMessengerKey, UserStorage.l10n.createTaskFailed(e));
+          _scaffoldMessengerKey,
+          UserStorage.l10n.createTaskFailed(e),
+        );
       }
     }
   }
@@ -589,9 +641,7 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
           ),
           TextButton(
             onPressed: () => Navigator.of(context).pop(true),
-            style: TextButton.styleFrom(
-              foregroundColor: Colors.red,
-            ),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
             child: Text(UserStorage.l10n.confirmClear),
           ),
         ],
@@ -619,13 +669,17 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
 
       if (mounted) {
         ToastHelper.showSuccessWithKey(
-            _scaffoldMessengerKey, UserStorage.l10n.dataClearedSuccess);
+          _scaffoldMessengerKey,
+          UserStorage.l10n.dataClearedSuccess,
+        );
       }
     } catch (e, stack) {
       _logger.severe('Clear data failed: $e', e, stack);
       if (mounted) {
         ToastHelper.showErrorWithKey(
-            _scaffoldMessengerKey, UserStorage.l10n.clearDataFailed(e));
+          _scaffoldMessengerKey,
+          UserStorage.l10n.clearDataFailed(e),
+        );
       }
     } finally {
       if (mounted) {
@@ -717,11 +771,15 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                                     color: const Color(0xFF6366F1),
                                     shape: BoxShape.circle,
                                     border: Border.all(
-                                        color: const Color(0xFFF7F8FA),
-                                        width: 2),
+                                      color: const Color(0xFFF7F8FA),
+                                      width: 2,
+                                    ),
                                   ),
-                                  child: const Icon(Icons.edit,
-                                      size: 13, color: Colors.white),
+                                  child: const Icon(
+                                    Icons.edit,
+                                    size: 13,
+                                    color: Colors.white,
+                                  ),
                                 ),
                               ),
                             ],
@@ -897,7 +955,7 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
             border: Border.all(color: Colors.white),
             boxShadow: [
               BoxShadow(
-                color: const Color(0xFF64748B).withOpacity(0.08),
+                color: const Color(0xFF64748B).withValues(alpha: 0.08),
                 blurRadius: 16,
                 offset: const Offset(0, 4),
               ),
@@ -908,11 +966,7 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
               Stack(
                 clipBehavior: Clip.none,
                 children: [
-                  Icon(
-                    icon,
-                    color: const Color(0xFF6366F1),
-                    size: 24,
-                  ),
+                  Icon(icon, color: const Color(0xFF6366F1), size: 24),
                   if (showBadge)
                     Positioned(
                       right: -2,
@@ -945,15 +999,10 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                 const SizedBox(
                   width: 20,
                   height: 20,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                  ),
+                  child: CircularProgressIndicator(strokeWidth: 2),
                 )
               else
-                const Icon(
-                  Icons.chevron_right,
-                  color: Color(0xFFCBD5E1),
-                ),
+                const Icon(Icons.chevron_right, color: Color(0xFFCBD5E1)),
             ],
           ),
         ),

--- a/lib/ui/settings/widgets/personal_center_screen.dart
+++ b/lib/ui/settings/widgets/personal_center_screen.dart
@@ -199,14 +199,10 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                   contentPadding: EdgeInsets.zero,
                   value: reanalyzeAssets,
                   title: Text(
-                    UserStorage.l10n.localeName == 'zh'
-                        ? '重新分析图片/音频'
-                        : 'Re-analyze media assets',
+                    UserStorage.l10n.reanalyzeMediaAssets,
                   ),
                   subtitle: Text(
-                    UserStorage.l10n.localeName == 'zh'
-                        ? '会先刷新 Facts/assets 下的媒体分析，再重新生成卡片。'
-                        : 'Refreshes media analysis files before regenerating cards.',
+                    UserStorage.l10n.reanalyzeMediaAssetsDesc,
                   ),
                   onChanged: (value) {
                     setDialogState(() {

--- a/lib/ui/user_setup/widgets/setup_model_config_page.dart
+++ b/lib/ui/user_setup/widgets/setup_model_config_page.dart
@@ -423,10 +423,22 @@ class _SetupModelConfigPageState extends State<SetupModelConfigPage>
   List<String> _getRecommendedModels(String type) =>
       LLMConfig.recommendedModels(type);
 
+  /// Returns the model options to show: fetched models if available, else recommended.
+  /// Featured models are sorted to the top.
+  /// Missing featured models are prepended even if not in the fetched list.
   List<String> _modelOptions() {
-    return _fetchedModels.isNotEmpty
+    final models = _fetchedModels.isNotEmpty
         ? _fetchedModels
         : _getRecommendedModels(_selectedType);
+    final featured = LLMConfig.featuredModels(_selectedType);
+    if (featured.isEmpty) return models;
+    final missingFeatured = featured.where((m) => !models.contains(m)).toList();
+    final top = [
+      ...missingFeatured,
+      ...models.where((m) => featured.contains(m)),
+    ];
+    final rest = models.where((m) => !featured.contains(m)).toList();
+    return [...top, ...rest];
   }
 
   bool get _modelSelectorDisabled {
@@ -804,12 +816,34 @@ class _SetupModelConfigPageState extends State<SetupModelConfigPage>
                               final isPro =
                                   _selectedType == LLMConfig.typeOpenAiOauth &&
                                       _isProModel(option);
+                              final isFeatured =
+                                  LLMConfig.featuredModels(_selectedType)
+                                      .contains(option);
                               return Padding(
                                 padding: const EdgeInsets.symmetric(
                                     horizontal: 16, vertical: 12),
                                 child: Row(
                                   children: [
                                     Expanded(child: Text(option)),
+                                    if (isFeatured)
+                                      Container(
+                                        margin: const EdgeInsets.only(left: 8),
+                                        padding: const EdgeInsets.symmetric(
+                                            horizontal: 6, vertical: 2),
+                                        decoration: BoxDecoration(
+                                          color: AppColors.primary
+                                              .withValues(alpha: 0.1),
+                                          borderRadius:
+                                              BorderRadius.circular(4),
+                                        ),
+                                        child: Text(
+                                          UserStorage.l10n.recommendedBadge,
+                                          style: const TextStyle(
+                                              fontSize: 10,
+                                              color: AppColors.primary,
+                                              fontWeight: FontWeight.w600),
+                                        ),
+                                      ),
                                     if (isPro)
                                       Container(
                                         margin: const EdgeInsets.only(left: 8),

--- a/lib/ui/user_setup/widgets/setup_model_config_page.dart
+++ b/lib/ui/user_setup/widgets/setup_model_config_page.dart
@@ -424,19 +424,9 @@ class _SetupModelConfigPageState extends State<SetupModelConfigPage>
       LLMConfig.recommendedModels(type);
 
   List<String> _modelOptions() {
-    final models = _fetchedModels.isNotEmpty
+    return _fetchedModels.isNotEmpty
         ? _fetchedModels
         : _getRecommendedModels(_selectedType);
-    final featured = LLMConfig.featuredModels(_selectedType);
-    if (featured.isEmpty) return models;
-    // Ensure all featured models appear, even if API didn't return them
-    final missingFeatured = featured.where((m) => !models.contains(m)).toList();
-    final top = [
-      ...missingFeatured,
-      ...models.where((m) => featured.contains(m))
-    ];
-    final rest = models.where((m) => !featured.contains(m)).toList();
-    return [...top, ...rest];
   }
 
   bool get _modelSelectorDisabled {
@@ -814,36 +804,12 @@ class _SetupModelConfigPageState extends State<SetupModelConfigPage>
                               final isPro =
                                   _selectedType == LLMConfig.typeOpenAiOauth &&
                                       _isProModel(option);
-                              final isFeatured =
-                                  LLMConfig.featuredModels(_selectedType)
-                                      .contains(option);
                               return Padding(
                                 padding: const EdgeInsets.symmetric(
                                     horizontal: 16, vertical: 12),
                                 child: Row(
                                   children: [
                                     Expanded(child: Text(option)),
-                                    if (isFeatured)
-                                      Container(
-                                        margin: const EdgeInsets.only(left: 8),
-                                        padding: const EdgeInsets.symmetric(
-                                            horizontal: 6, vertical: 2),
-                                        decoration: BoxDecoration(
-                                          color: AppColors.primary
-                                              .withValues(alpha: 0.1),
-                                          borderRadius:
-                                              BorderRadius.circular(4),
-                                        ),
-                                        child: Text(
-                                          UserStorage.l10n.localeName == 'zh'
-                                              ? '推荐'
-                                              : 'Recommended',
-                                          style: TextStyle(
-                                              fontSize: 10,
-                                              color: AppColors.primary,
-                                              fontWeight: FontWeight.w600),
-                                        ),
-                                      ),
                                     if (isPro)
                                       Container(
                                         margin: const EdgeInsets.only(left: 8),


### PR DESCRIPTION
## 背景

图片内容被旧的媒体分析结果误识别后，`reprocess_cards_task` 只会复用已有的 `.analysis.txt`，即使切换到支持视觉的模型也不会重新读取图片语义，导致重新刷卡片仍然沿用错误描述。

## 变更

- 将媒体资产分析逻辑抽成 `analyzeAssetsForFact`，供正常入库流程和历史重处理流程复用。
- 为 `reprocess_cards_task` 增加 `reanalyze_assets` 参数；开启后会先刷新图片/音频分析文件，再重新生成卡片，并推送卡片更新事件。
- 在个人中心的“重新处理卡片”弹窗中增加“重新分析图片/音频”开关。
- 更新 MIMO 推荐模型，将 `mimo-v2.5`、`mimo-v2-omni` 标为推荐/视觉模型候选。
- 增加保守的多模态模型识别逻辑，在模型配置列表、模型选择器和媒体分析模型列表中展示“视觉”标记或非多模态提示。
- 修正 Anthropic 兼容提供方（Claude / MiniMax / MIMO）的模型列表请求：使用 `/v1/models` 与 `x-api-key` 请求头。

## 验证

- `dart analyze lib/data/services/task_handlers/analyze_assets_handler.dart lib/data/services/task_handlers/card_agent_handler.dart lib/data/services/task_handlers/reprocess_cards_handler.dart lib/domain/models/llm_config.dart lib/data/services/model_list_service.dart lib/ui/settings/widgets/agent_config_list_page.dart lib/ui/settings/widgets/model_config_edit_page.dart lib/ui/settings/widgets/model_config_list_page.dart lib/ui/settings/widgets/personal_center_screen.dart`
- `flutter test`

说明：全仓 `flutter analyze --no-pub` 仍会因仓库既有 warning/info 返回非 0，目前不是本 PR 引入的新问题。
