### PR TITLE
[codex] render AI markdown responses

### DIFF
--- a/lib/ui/character/widgets/persona_chat_screen.dart
+++ b/lib/ui/character/widgets/persona_chat_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:memex/agent/companion_agent/companion_agent.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/domain/models/character_model.dart';
@@ -416,15 +417,43 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
                   Flexible(
-                    child: Text(
-                      text,
-                      style: TextStyle(
-                        fontSize: 15,
-                        height: 1.5,
-                        color:
-                            isCharacter ? AppColors.textPrimary : Colors.white,
-                      ),
-                    ),
+                    child: isCharacter
+                        ? MarkdownBody(
+                            data: text,
+                            softLineBreak: true,
+                            styleSheet: MarkdownStyleSheet(
+                              p: const TextStyle(
+                                fontSize: 15,
+                                height: 1.5,
+                                color: AppColors.textPrimary,
+                              ),
+                              strong: const TextStyle(
+                                fontWeight: FontWeight.w700,
+                                color: AppColors.textPrimary,
+                              ),
+                              em: const TextStyle(fontStyle: FontStyle.italic),
+                              listBullet:
+                                  const TextStyle(color: AppColors.primary),
+                              code: const TextStyle(
+                                fontSize: 14,
+                                color: AppColors.textPrimary,
+                                backgroundColor: Color(0xFFF7F8FA),
+                                fontFamily: 'monospace',
+                              ),
+                              codeblockDecoration: BoxDecoration(
+                                color: const Color(0xFFF7F8FA),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                            ),
+                          )
+                        : Text(
+                            text,
+                            style: const TextStyle(
+                              fontSize: 15,
+                              height: 1.5,
+                              color: Colors.white,
+                            ),
+                          ),
                   ),
                   if (isStreaming) ...[
                     const SizedBox(width: 4),

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -750,10 +750,44 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                     .copyWith(topLeft: const Radius.circular(4)),
                 border: Border.all(color: const Color(0xFFF7F8FA)),
               ),
-              child: SelectableText(
-                item.text,
-                style: TextStyle(
-                    fontSize: 14, color: AppColors.textSecondary, height: 1.5),
+              child: MarkdownBody(
+                data: item.text,
+                selectable: true,
+                softLineBreak: true,
+                styleSheet: MarkdownStyleSheet(
+                  p: const TextStyle(
+                    fontSize: 14,
+                    color: AppColors.textSecondary,
+                    height: 1.5,
+                  ),
+                  strong: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.textPrimary,
+                  ),
+                  em: const TextStyle(fontStyle: FontStyle.italic),
+                  listBullet: const TextStyle(color: AppColors.primary),
+                  code: const TextStyle(
+                    fontSize: 13,
+                    color: AppColors.textPrimary,
+                    backgroundColor: Color(0xFFF7F8FA),
+                    fontFamily: 'monospace',
+                  ),
+                  codeblockDecoration: BoxDecoration(
+                    color: const Color(0xFFF7F8FA),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  blockquote: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontStyle: FontStyle.italic,
+                  ),
+                  blockquoteDecoration: BoxDecoration(
+                    color: const Color(0xFFF7F8FA),
+                    borderRadius: BorderRadius.circular(8),
+                    border: const Border(
+                      left: BorderSide(color: AppColors.primary, width: 3),
+                    ),
+                  ),
+                ),
               ),
             ),
           ],

--- a/lib/ui/insight/widgets/insight_detail_page.dart
+++ b/lib/ui/insight/widgets/insight_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:memex/data/repositories/memex_router.dart';
@@ -81,6 +82,32 @@ class _InsightDetailPageState extends State<InsightDetailPage> {
   // Get content
   String get _content {
     return _insightDetail?.content ?? '';
+  }
+
+  Widget _buildInsightMarkdown(String content, TextStyle style) {
+    return MarkdownBody(
+      data: content,
+      softLineBreak: true,
+      styleSheet: MarkdownStyleSheet(
+        p: style,
+        strong: style.copyWith(
+          fontWeight: FontWeight.w700,
+          color: const Color(0xFF1E293B),
+        ),
+        em: style.copyWith(fontStyle: FontStyle.italic),
+        listBullet: style.copyWith(color: const Color(0xFF5B6CFF)),
+        code: TextStyle(
+          fontSize: (style.fontSize ?? 14) - 1,
+          color: const Color(0xFF334155),
+          backgroundColor: const Color(0xFFF7F8FA),
+          fontFamily: 'monospace',
+        ),
+        codeblockDecoration: BoxDecoration(
+          color: const Color(0xFFF7F8FA),
+          borderRadius: BorderRadius.circular(8),
+        ),
+      ),
+    );
   }
 
   // Get related cards
@@ -217,14 +244,14 @@ class _InsightDetailPageState extends State<InsightDetailPage> {
                     ),
                     const SizedBox(width: 10),
                     Expanded(
-                      child: Text(
+                      child: _buildInsightMarkdown(
                         _content,
-                        style: GoogleFonts.inter(
+                        GoogleFonts.inter(
                           fontSize: 14,
                           fontWeight: FontWeight.w400,
                           color: const Color(0xFF4A5565),
                           height: 1.6,
-                          letterSpacing: -0.15,
+                          letterSpacing: 0,
                         ),
                       ),
                     ),
@@ -235,13 +262,13 @@ class _InsightDetailPageState extends State<InsightDetailPage> {
 
             const SizedBox(height: 32),
           ] else if (_content.isNotEmpty) ...[
-            Text(
+            _buildInsightMarkdown(
               _content,
-              style: const TextStyle(
+              const TextStyle(
                 fontSize: 17,
                 color: Color(0xFF334155), // Slate-700
                 height: 1.7,
-                letterSpacing: 0.2,
+                letterSpacing: 0,
               ),
             ),
             const SizedBox(height: 32),

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -2,6 +2,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/cupertino.dart';
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:memex/domain/models/card_model.dart';
@@ -1248,16 +1249,47 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                 ],
               ),
               const SizedBox(height: 4),
-              Text(
-                content,
-                style: const TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w400,
-                  color: Color(0xFF334155),
-                  height: 1.43,
-                  letterSpacing: 0,
+              if (isAuthor || isAi)
+                MarkdownBody(
+                  data: content,
+                  softLineBreak: true,
+                  styleSheet: MarkdownStyleSheet(
+                    p: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w400,
+                      color: Color(0xFF334155),
+                      height: 1.43,
+                      letterSpacing: 0,
+                    ),
+                    strong: const TextStyle(
+                      fontWeight: FontWeight.w700,
+                      color: Color(0xFF0A0A0A),
+                    ),
+                    em: const TextStyle(fontStyle: FontStyle.italic),
+                    listBullet: const TextStyle(color: Color(0xFF5B6CFF)),
+                    code: const TextStyle(
+                      fontSize: 13,
+                      color: Color(0xFF334155),
+                      backgroundColor: Color(0xFFF7F8FA),
+                      fontFamily: 'monospace',
+                    ),
+                    codeblockDecoration: BoxDecoration(
+                      color: const Color(0xFFF7F8FA),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                )
+              else
+                Text(
+                  content,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w400,
+                    color: Color(0xFF334155),
+                    height: 1.43,
+                    letterSpacing: 0,
+                  ),
                 ),
-              ),
               const SizedBox(height: 4),
               Row(
                 children: [


### PR DESCRIPTION
## 摘要
- 将 AI 助手回复改为 `MarkdownBody` 渲染，让 `**加粗**`、列表、代码和引用等 Markdown 语法正常显示。
- 保留 AI 助手回复的 `selectable: true`，不回退 #15 中新增的文本选择/复制能力。
- 同步检查并修复其他明确的 AI 长文本展示出口：角色聊天回复、卡片详情里的 insight/AI comment、Insight 详情正文。
- 为这些 AI 文本区域补充局部 Markdown 样式，尽量贴近原有字体、颜色和行高。

## 问题原因
这些位置此前使用 `Text` 或 `SelectableText` 直接展示模型返回内容，因此 Markdown 标记会被当作普通文本显示。#15 将 AI 助手消息从 `Text` 改成 `SelectableText` 是为了支持长按选中和复制；本 PR 在保留该能力的同时，把 AI 回复类内容切换为 Markdown 渲染。

## 范围说明
- 已修复：AI 助手回复、角色聊天里的 AI 角色回复、卡片详情里的 AI insight/comment、Insight 详情正文。
- 暂未改动：用户自己发送的消息、历史列表 preview、普通 Timeline raw content、标题和结构化卡片字段。这些更偏纯文本/摘要，直接 Markdown 化可能引入不必要的视觉变化。

## 验证
- `dart format --output=none --set-exit-if-changed lib/ui/character/widgets/persona_chat_screen.dart lib/ui/timeline/widgets/timeline_card_detail_screen.dart lib/ui/insight/widgets/insight_detail_page.dart`
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib/ui/chat/widgets/agent_chat_dialog.dart lib/ui/character/widgets/persona_chat_screen.dart lib/ui/timeline/widgets/timeline_card_detail_screen.dart lib/ui/insight/widgets/insight_detail_page.dart`
- `git diff --check`

## 备注
- 聚焦的 analyze 命令仍会报告相关文件中已有的 info/warning 级提示，例如 `withOpacity`、`const` 建议和既有未使用方法，但命令成功退出，没有新增 fatal warning 或 error。
