### PR TITLE
添加输入草稿保护

### DIFF
--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -1141,6 +1141,16 @@ class FileSystemService {
     return path.join(getWorkspacePath(userId), '_System');
   }
 
+  /// Drafts directory path (input draft files)
+  String getDraftsPath(String userId) {
+    return path.join(getSystemPath(userId), 'Drafts');
+  }
+
+  /// Active draft file path
+  String getActiveDraftPath(String userId) {
+    return path.join(getDraftsPath(userId), 'active.json');
+  }
+
   /// Templates directory path (card templates)
   String getTemplatesPath(String userId) {
     return path.join(getSystemPath(userId), 'Templates');

--- a/lib/data/services/input_draft_service.dart
+++ b/lib/data/services/input_draft_service.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/user_storage.dart';
+
+class InputDraft {
+  final String id;
+  final String text;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const InputDraft({
+    required this.id,
+    required this.text,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  bool get isEmpty => text.trim().isEmpty;
+
+  int get characterCount => text.runes.length;
+
+  Map<String, dynamic> toJson() => {
+        'version': 1,
+        'id': id,
+        'text': text,
+        'created_at': createdAt.toIso8601String(),
+        'updated_at': updatedAt.toIso8601String(),
+      };
+
+  factory InputDraft.fromJson(Map<String, dynamic> json) {
+    final now = DateTime.now();
+    return InputDraft(
+      id: json['id'] as String? ?? 'active',
+      text: json['text'] as String? ?? '',
+      createdAt: DateTime.tryParse(json['created_at'] as String? ?? '') ?? now,
+      updatedAt: DateTime.tryParse(json['updated_at'] as String? ?? '') ?? now,
+    );
+  }
+}
+
+class InputDraftService {
+  static final InputDraftService instance = InputDraftService._();
+
+  final _logger = getLogger('InputDraftService');
+
+  InputDraftService._();
+
+  Future<InputDraft?> loadActiveDraft() async {
+    try {
+      final file = await _activeDraftFile();
+      if (!await file.exists()) return null;
+
+      final content = await file.readAsString();
+      final json = jsonDecode(content) as Map<String, dynamic>;
+      final draft = InputDraft.fromJson(json);
+      return draft.isEmpty ? null : draft;
+    } catch (e, st) {
+      _logger.warning('Failed to load active input draft: $e', e, st);
+      return null;
+    }
+  }
+
+  Future<bool> hasActiveDraft() async {
+    final draft = await loadActiveDraft();
+    return draft != null && !draft.isEmpty;
+  }
+
+  Future<void> saveTextDraft(String text) async {
+    if (text.trim().isEmpty) {
+      await clearActiveDraft();
+      return;
+    }
+
+    try {
+      final previous = await loadActiveDraft();
+      final now = DateTime.now();
+      final draft = InputDraft(
+        id: previous?.id ?? 'active',
+        text: text,
+        createdAt: previous?.createdAt ?? now,
+        updatedAt: now,
+      );
+
+      final file = await _activeDraftFile();
+      await file.parent.create(recursive: true);
+
+      final tempFile = File('${file.path}.tmp');
+      await tempFile.writeAsString(jsonEncode(draft.toJson()), flush: true);
+      if (await file.exists()) {
+        await file.delete();
+      }
+      await tempFile.rename(file.path);
+    } catch (e, st) {
+      _logger.warning('Failed to save active input draft: $e', e, st);
+    }
+  }
+
+  Future<void> clearActiveDraft() async {
+    try {
+      final file = await _activeDraftFile();
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } catch (e, st) {
+      _logger.warning('Failed to clear active input draft: $e', e, st);
+    }
+  }
+
+  Future<File> _activeDraftFile() async {
+    final userId = await UserStorage.getUserId();
+    final dataRoot = await UserStorage.resolveDataRoot(userId);
+    return File(path.join(dataRoot, '_System', 'Drafts', 'active.json'));
+  }
+}

--- a/lib/data/services/input_draft_service.dart
+++ b/lib/data/services/input_draft_service.dart
@@ -1,10 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
-
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
+import 'package:memex/data/services/file_system_service.dart';
 
 class InputDraft {
   final String id;
@@ -112,7 +111,7 @@ class InputDraftService {
 
   Future<File> _activeDraftFile() async {
     final userId = await UserStorage.getUserId();
-    final dataRoot = await UserStorage.resolveDataRoot(userId);
-    return File(path.join(dataRoot, '_System', 'Drafts', 'active.json'));
+    final filePath = FileSystemService.instance.getActiveDraftPath(userId!);
+    return File(filePath);
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -135,6 +135,17 @@
   "selectFromAlbum": "Select from album",
   "takePhoto": "Take photo",
   "enterContentOrMediaHint": "Enter content, select image or record audio.",
+  "@inputDraftLabel": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "inputDraftLabel": "{count, plural, =1{Draft · 1 char} other{Draft · {count} chars}}",
+  "discardDraftTitle": "Discard this draft?",
+  "discardDraftMessage": "The draft content will be cleared.",
+  "discardDraftTooltip": "Discard draft",
   "tellAiWhatHappened": "Tell AI what happened...",
   "@recordingWithDuration": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -638,6 +638,30 @@ abstract class AppLocalizations {
   /// **'Enter content, select image or record audio.'**
   String get enterContentOrMediaHint;
 
+  /// No description provided for @inputDraftLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Draft · 1 char} other{Draft · {count} chars}}'**
+  String inputDraftLabel(num count);
+
+  /// No description provided for @discardDraftTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Discard this draft?'**
+  String get discardDraftTitle;
+
+  /// No description provided for @discardDraftMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'The draft content will be cleared.'**
+  String get discardDraftMessage;
+
+  /// No description provided for @discardDraftTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Discard draft'**
+  String get discardDraftTooltip;
+
   /// No description provided for @tellAiWhatHappened.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -307,6 +307,26 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enter content, select image or record audio.';
 
   @override
+  String inputDraftLabel(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Draft · $count chars',
+      one: 'Draft · 1 char',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get discardDraftTitle => 'Discard this draft?';
+
+  @override
+  String get discardDraftMessage => 'The draft content will be cleared.';
+
+  @override
+  String get discardDraftTooltip => 'Discard draft';
+
+  @override
   String get tellAiWhatHappened => 'Tell AI what happened...';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -298,6 +298,20 @@ class AppLocalizationsZh extends AppLocalizations {
   String get enterContentOrMediaHint => '请输入内容、选择图片或录制音频';
 
   @override
+  String inputDraftLabel(num count) {
+    return '草稿 · $count 字';
+  }
+
+  @override
+  String get discardDraftTitle => '丢弃这份草稿？';
+
+  @override
+  String get discardDraftMessage => '草稿内容会被清空。';
+
+  @override
+  String get discardDraftTooltip => '丢弃草稿';
+
+  @override
   String get tellAiWhatHappened => '告诉AI发生了什么...';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -135,6 +135,17 @@
   "selectFromAlbum": "从相册选择",
   "takePhoto": "拍照",
   "enterContentOrMediaHint": "请输入内容、选择图片或录制音频",
+  "@inputDraftLabel": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "inputDraftLabel": "草稿 · {count} 字",
+  "discardDraftTitle": "丢弃这份草稿？",
+  "discardDraftMessage": "草稿内容会被清空。",
+  "discardDraftTooltip": "丢弃草稿",
   "tellAiWhatHappened": "告诉AI发生了什么...",
   "@recordingWithDuration": {
     "placeholders": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1087,7 +1087,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
     if (item != null) {
       if (mounted) setState(() => _isRadialMenuOpen = false);
-      _handleInputSubmit(InputData(text: item.content));
+      unawaited(_handleInputSubmit(InputData(text: item.content)));
     } else if (hasRecording) {
       // Show calibrating state — keep menu open
       if (mounted) setState(() => _isQuickCalibrating = true);
@@ -1102,7 +1102,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         });
       }
       if (_quickTranscribedText.isNotEmpty) {
-        _handleInputSubmit(InputData(text: _quickTranscribedText));
+        unawaited(_handleInputSubmit(InputData(text: _quickTranscribedText)));
       } else if (_quickAudioPath != null) {
         final audioFile = File(_quickAudioPath!);
         String? audioHash;
@@ -1112,8 +1112,11 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
           audioHash =
               md5.convert(utf8.encode('audio_${fileName}_$length')).toString();
         }
-        _handleInputSubmit(
-            InputData(audioPath: _quickAudioPath, audioHash: audioHash));
+        unawaited(
+          _handleInputSubmit(
+            InputData(audioPath: _quickAudioPath, audioHash: audioHash),
+          ),
+        );
       }
       _quickTranscribedText = '';
       _quickAudioPath = null;
@@ -1173,7 +1176,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     }
   }
 
-  Future<void> _handleInputSubmit(InputData data) async {
+  Future<bool> _handleInputSubmit(InputData data) async {
     // During demo: advance tapSend → tapCard first, so the overlay
     // immediately shows a blocking scrim (cardReady is still false).
     DemoService.instance.tryAdvance(DemoStep.tapSend);
@@ -1233,6 +1236,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
       // Refresh auto-input count after manual input
       // since the manual input might have consumed items that were pending auto-publish.
+      return true;
     } catch (e) {
       // Hide loading on error
       if (mounted) context.read<TimelineViewModel>().setSubmitting(false);
@@ -1240,6 +1244,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       if (mounted) {
         ToastHelper.showError(context, e);
       }
+      return false;
     }
   }
 

--- a/lib/ui/main_screen/widgets/input_sheet.dart
+++ b/lib/ui/main_screen/widgets/input_sheet.dart
@@ -18,6 +18,7 @@ import 'package:memex/data/services/photo_suggestion_service.dart';
 import 'package:memex/data/services/whisper_service.dart';
 import 'package:memex/data/services/streaming_transcriber.dart';
 import 'package:memex/data/services/speech_transcription_service.dart';
+import 'package:memex/data/services/input_draft_service.dart';
 import 'package:memex/config/app_flavor.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/data/services/demo_service.dart';
@@ -54,7 +55,7 @@ class InputData {
 class InputSheet extends StatefulWidget {
   final bool isOpen;
   final VoidCallback onClose;
-  final Function(InputData data) onSubmit;
+  final Future<bool> Function(InputData data) onSubmit;
   final InputData? initialData;
   const InputSheet({
     super.key,
@@ -68,7 +69,8 @@ class InputSheet extends StatefulWidget {
   State<InputSheet> createState() => _InputSheetState();
 }
 
-class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
+class _InputSheetState extends State<InputSheet>
+    with TickerProviderStateMixin, WidgetsBindingObserver {
   late AnimationController _controller;
   late Animation<Offset> _slideAnimation;
   late Animation<double> _fadeAnimation;
@@ -93,9 +95,11 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
   final AudioPlayer _audioPlayer = AudioPlayer();
 
   final Logger _logger = getLogger('InputSheet');
+  final InputDraftService _draftService = InputDraftService.instance;
 
   StreamingTranscriber? _streamingTranscriber;
   StreamSubscription<Uint8List>? _audioStreamSub;
+  Timer? _draftSaveDebounce;
   // Accumulated PCM data for saving as WAV after recording stops
   final List<int> _pcmBuffer = [];
   // Text in the text field before recording started (to preserve user-typed text)
@@ -112,11 +116,15 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
 
   List<List<EnhancedPhoto>>? _autoClusters;
   bool _isLoadingAuto = false;
+  bool _isApplyingDraft = false;
+  bool _isRestoredDraft = false;
+  bool _isSubmitting = false;
   final Map<String, AssetEntity> _assetsMap = {}; // path -> AssetEntity
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
 
     _controller = AnimationController(
       duration: const Duration(milliseconds: 300),
@@ -126,18 +134,12 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
     _slideAnimation = Tween<Offset>(
       begin: const Offset(0, 1),
       end: Offset.zero,
-    ).animate(CurvedAnimation(
-      parent: _controller,
-      curve: Curves.easeOut,
-    ));
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
 
     _fadeAnimation = Tween<double>(
       begin: 0,
       end: 1,
-    ).animate(CurvedAnimation(
-      parent: _controller,
-      curve: Curves.easeOut,
-    ));
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
 
     if (widget.isOpen) {
       _controller.forward();
@@ -156,6 +158,14 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
         _isPlaying = false;
       });
     });
+
+    if (widget.isOpen) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && widget.isOpen) {
+          _prepareForOpen();
+        }
+      });
+    }
   }
 
   @override
@@ -165,9 +175,7 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
       if (widget.isOpen) {
         _logger.info('Opening InputSheet');
         _controller.forward();
-        _resetForm();
-        _applyInitialData(widget.initialData);
-        _fetchAutoClusters();
+        _prepareForOpen();
       } else {
         _controller.reverse();
       }
@@ -177,14 +185,60 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
       // Sheet already open but new share arrived: reload with shared data
       _logger.info('InputSheet already open, reloading with new shared data');
       _applyInitialData(widget.initialData);
+      _scheduleDraftSave();
     }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.paused ||
+        state == AppLifecycleState.detached) {
+      _flushDraft();
+    }
+  }
+
+  Future<void> _prepareForOpen() async {
+    if (widget.initialData != null && !widget.initialData!.isEmpty) {
+      _resetForm();
+      _applyInitialData(widget.initialData);
+      _scheduleDraftSave();
+    } else {
+      await _restoreDraft();
+    }
+    if (!mounted || !widget.isOpen) return;
+    _fetchAutoClusters();
+  }
+
+  Future<void> _restoreDraft() async {
+    _resetForm();
+    final draft = await _draftService.loadActiveDraft();
+    if (!mounted || !widget.isOpen) return;
+
+    if (draft == null) {
+      _setRestoredDraft(false);
+      return;
+    }
+
+    _isApplyingDraft = true;
+    _textController.text = draft.text;
+    _textController.selection = TextSelection.collapsed(
+      offset: _textController.text.length,
+    );
+    _isApplyingDraft = false;
+    _updateDetectedTags(draft.text);
+    _setRestoredDraft(true);
+    _scrollTextToBottom();
   }
 
   void _applyInitialData(InputData? data) {
     if (data == null) return;
 
     final text = data.text ?? '';
+    _isApplyingDraft = true;
     _textController.text = text;
+    _textController.selection = TextSelection.collapsed(offset: text.length);
+    _isApplyingDraft = false;
     _audioPlayer.stop();
 
     final regex = RegExp(r'#([^\s#]+)');
@@ -203,12 +257,16 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
       _autoClusters = null;
       _isLoadingAuto = false;
     });
+    _setRestoredDraft(false);
 
     _loadAudioDuration();
   }
 
   void _resetForm() {
+    _draftSaveDebounce?.cancel();
+    _isApplyingDraft = true;
     _textController.clear();
+    _isApplyingDraft = false;
     _audioPlayer.stop();
     setState(() {
       _selectedImages = [];
@@ -221,6 +279,8 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
       _detectedTags = [];
       _autoClusters = null;
       _isLoadingAuto = false;
+      _isRestoredDraft = false;
+      _isSubmitting = false;
     });
   }
 
@@ -282,6 +342,13 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
 
   void _onTextChanged() {
     final text = _textController.text;
+    _updateDetectedTags(text);
+    if (!_isApplyingDraft) {
+      _scheduleDraftSave();
+    }
+  }
+
+  void _updateDetectedTags(String text) {
     final regex = RegExp(r'#([^\s#]+)');
     final matches = regex.allMatches(text);
     final tags = matches.map((match) => match.group(1)!).toSet().toList();
@@ -292,8 +359,76 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
     }
   }
 
+  void _setRestoredDraft(bool isRestoredDraft) {
+    if (_isRestoredDraft == isRestoredDraft) return;
+    if (mounted) {
+      setState(() => _isRestoredDraft = isRestoredDraft);
+    } else {
+      _isRestoredDraft = isRestoredDraft;
+    }
+  }
+
+  void _scheduleDraftSave() {
+    _draftSaveDebounce?.cancel();
+    _draftSaveDebounce = Timer(const Duration(milliseconds: 400), () {
+      unawaited(_draftService.saveTextDraft(_textController.text));
+    });
+  }
+
+  Future<void> _flushDraft() async {
+    _draftSaveDebounce?.cancel();
+    if (!widget.isOpen && _textController.text.trim().isEmpty) return;
+    await _draftService.saveTextDraft(_textController.text);
+  }
+
+  Future<void> _handleClose() async {
+    await _flushDraft();
+    widget.onClose();
+  }
+
+  String get _draftLabel {
+    final count = _textController.text.trim().runes.length;
+    return UserStorage.l10n.inputDraftLabel(count);
+  }
+
+  Future<void> _handleDiscardDraft() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: Colors.white,
+        title: Text(UserStorage.l10n.discardDraftTitle),
+        content: Text(UserStorage.l10n.discardDraftMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(UserStorage.l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(
+              UserStorage.l10n.discardButton,
+              style: const TextStyle(color: AppColors.danger),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+    _draftSaveDebounce?.cancel();
+    await _draftService.clearActiveDraft();
+    if (!mounted) return;
+    _resetForm();
+    _setRestoredDraft(false);
+  }
+
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _draftSaveDebounce?.cancel();
+    if (widget.isOpen || _textController.text.trim().isNotEmpty) {
+      unawaited(_draftService.saveTextDraft(_textController.text));
+    }
     _audioStreamSub?.cancel();
     _streamingTranscriber?.dispose();
     _pcmBuffer.clear();
@@ -385,9 +520,9 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to pick image: $e')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to pick image: $e')));
       }
     }
   }
@@ -449,7 +584,8 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
         chunkCount++;
         if (chunkCount % 50 == 1) {
           _logger.info(
-              'Audio stream chunk #$chunkCount, size=${chunk.length} bytes');
+            'Audio stream chunk #$chunkCount, size=${chunk.length} bytes',
+          );
         }
         _pcmBuffer.addAll(chunk);
         _streamingTranscriber?.addAudioChunk(chunk);
@@ -476,8 +612,9 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
     Future.delayed(const Duration(seconds: 1), () {
       if (mounted && _isRecording) {
         setState(() {
-          _recordingDuration =
-              Duration(seconds: _recordingDuration.inSeconds + 1);
+          _recordingDuration = Duration(
+            seconds: _recordingDuration.inSeconds + 1,
+          );
         });
         // Auto-stop at 60 seconds
         if (_recordingDuration.inSeconds >= 60) {
@@ -512,8 +649,10 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
         final directory = await getTemporaryDirectory();
         final timestamp = DateTime.now().millisecondsSinceEpoch;
         final wavPath = '${directory.path}/audio_$timestamp.wav';
-        await SpeechTranscriptionService.instance
-            .savePcmAsWav(wavPath, Uint8List.fromList(_pcmBuffer));
+        await SpeechTranscriptionService.instance.savePcmAsWav(
+          wavPath,
+          Uint8List.fromList(_pcmBuffer),
+        );
         _pcmBuffer.clear();
 
         if (!useLocal) {
@@ -533,9 +672,9 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to stop recording: $e')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to stop recording: $e')));
       }
       if (mounted) {
         setState(() {
@@ -562,8 +701,9 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
       for (int i = 0; i < int16Data.length; i++) {
         samples[i] = int16Data[i] / 32768.0;
       }
-      final text =
-          await SpeechTranscriptionService.instance.transcribeSamples(samples);
+      final text = await SpeechTranscriptionService.instance.transcribeSamples(
+        samples,
+      );
       if (text != null && text.isNotEmpty && mounted) {
         final separator = _preRecordingText.isNotEmpty ? ' ' : '';
         setState(() {
@@ -683,9 +823,7 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
         });
         _scrollTextToBottom();
       } else {
-        messenger.showSnackBar(
-          SnackBar(content: Text(l10n.speechNoResult)),
-        );
+        messenger.showSnackBar(SnackBar(content: Text(l10n.speechNoResult)));
       }
     } catch (e) {
       _logger.severe('Pick audio file failed: $e');
@@ -693,9 +831,9 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
         Navigator.of(context).pop();
       }
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to process audio: $e')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to process audio: $e')));
       }
     }
   }
@@ -1021,7 +1159,7 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
   }
 
   Future<void> _handleSubmit() async {
-    if (!mounted) return;
+    if (!mounted || _isSubmitting) return;
     final trimmedText = _textController.text.trim().isEmpty
         ? null
         : _textController.text.trim();
@@ -1056,13 +1194,19 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
 
           _logger.info('Generating hash for image: $rawHashStr');
           await Future.delayed(Duration.zero);
-          imageHashes
-              .add(crypto.md5.convert(utf8.encode(rawHashStr)).toString());
+          imageHashes.add(
+            crypto.md5.convert(utf8.encode(rawHashStr)).toString(),
+          );
         } catch (e) {
-          imageHashes.add(crypto.md5
-              .convert(utf8.encode(
-                  'photo_${xFile.path}_${DateTime.now().millisecondsSinceEpoch}'))
-              .toString());
+          imageHashes.add(
+            crypto.md5
+                .convert(
+                  utf8.encode(
+                    'photo_${xFile.path}_${DateTime.now().millisecondsSinceEpoch}',
+                  ),
+                )
+                .toString(),
+          );
         }
       }
     }
@@ -1084,8 +1228,58 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
       return;
     }
 
-    widget.onSubmit(inputData);
-    _resetForm();
+    setState(() => _isSubmitting = true);
+    await _flushDraft();
+    final submitted = await widget.onSubmit(inputData);
+    if (!mounted) return;
+
+    if (submitted) {
+      await _draftService.clearActiveDraft();
+      if (!mounted) return;
+      _resetForm();
+      _setRestoredDraft(false);
+    } else {
+      setState(() => _isSubmitting = false);
+    }
+  }
+
+  Widget _buildDraftHeader() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 0, 16, 4),
+      child: Row(
+        children: [
+          Container(
+            width: 6,
+            height: 6,
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.7),
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              _draftLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: AppColors.textTertiary,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          IconButton(
+            tooltip: UserStorage.l10n.discardDraftTooltip,
+            onPressed: _handleDiscardDraft,
+            icon: const Icon(Icons.delete_outline),
+            color: AppColors.textTertiary,
+            iconSize: 20,
+            visualDensity: VisualDensity.compact,
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -1104,10 +1298,8 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
         FadeTransition(
           opacity: _fadeAnimation,
           child: GestureDetector(
-            onTap: widget.onClose,
-            child: Container(
-              color: Colors.black.withValues(alpha: 0.2),
-            ),
+            onTap: _handleClose,
+            child: Container(color: Colors.black.withValues(alpha: 0.2)),
           ),
         ),
         SlideTransition(
@@ -1127,8 +1319,10 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                       child: Container(
                         margin: const EdgeInsets.fromLTRB(20, 0, 20, 20),
                         constraints: BoxConstraints(
-                          maxHeight:
-                              cardMaxHeight.clamp(160.0, screenHeight * 0.7),
+                          maxHeight: cardMaxHeight.clamp(
+                            160.0,
+                            screenHeight * 0.7,
+                          ),
                         ),
                         decoration: BoxDecoration(
                           color: Colors.white,
@@ -1137,8 +1331,10 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                             BoxShadow(
                               color: Colors.black.withValues(alpha: 0.1),
                               blurRadius: 30,
-                              offset:
-                                  const Offset(0, 10), // Shadow below for float
+                              offset: const Offset(
+                                0,
+                                10,
+                              ), // Shadow below for float
                             ),
                           ],
                         ),
@@ -1146,11 +1342,18 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                           child: Column(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              const SizedBox(height: 12), // Removed handle
+                              const SizedBox(height: 8), // Removed handle
+                              if (_isRestoredDraft &&
+                                  _textController.text.trim().isNotEmpty)
+                                _buildDraftHeader(),
                               Flexible(
                                 child: SingleChildScrollView(
-                                  padding:
-                                      const EdgeInsets.fromLTRB(24, 0, 24, 24),
+                                  padding: const EdgeInsets.fromLTRB(
+                                    24,
+                                    0,
+                                    24,
+                                    24,
+                                  ),
                                   child: Column(
                                     crossAxisAlignment:
                                         CrossAxisAlignment.start,
@@ -1236,21 +1439,25 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                                             itemBuilder: (context, index) {
                                               return Padding(
                                                 padding: const EdgeInsets.only(
-                                                    right: 8),
+                                                  right: 8,
+                                                ),
                                                 child: Stack(
                                                   children: [
                                                     ClipRRect(
                                                       borderRadius:
                                                           BorderRadius.circular(
-                                                              12),
+                                                        12,
+                                                      ),
                                                       child: GestureDetector(
                                                         onTap: () =>
                                                             _showImagePreview(
-                                                                index),
-                                                        child: _assetsMap.containsKey(
-                                                                _selectedImages[
-                                                                        index]
-                                                                    .path)
+                                                          index,
+                                                        ),
+                                                        child: _assetsMap
+                                                                .containsKey(
+                                                          _selectedImages[index]
+                                                              .path,
+                                                        )
                                                             ? AssetEntityImage(
                                                                 _assetsMap[
                                                                     _selectedImages[
@@ -1265,15 +1472,18 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                                                                 thumbnailSize:
                                                                     const ThumbnailSize
                                                                         .square(
-                                                                        200),
+                                                                  200,
+                                                                ),
                                                                 thumbnailFormat:
                                                                     ThumbnailFormat
                                                                         .jpeg,
                                                               )
                                                             : Image.file(
-                                                                File(_selectedImages[
-                                                                        index]
-                                                                    .path),
+                                                                File(
+                                                                  _selectedImages[
+                                                                          index]
+                                                                      .path,
+                                                                ),
                                                                 width: 100,
                                                                 height: 100,
                                                                 fit: BoxFit
@@ -1290,7 +1500,9 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                                                         child: Container(
                                                           padding:
                                                               const EdgeInsets
-                                                                  .all(4),
+                                                                  .all(
+                                                            4,
+                                                          ),
                                                           decoration:
                                                               const BoxDecoration(
                                                             color:
@@ -1320,8 +1532,9 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                                           padding: const EdgeInsets.all(12),
                                           decoration: BoxDecoration(
                                             color: const Color(0xFFF8FAFC),
-                                            borderRadius:
-                                                BorderRadius.circular(12),
+                                            borderRadius: BorderRadius.circular(
+                                              12,
+                                            ),
                                           ),
                                           child: Row(
                                             children: [
@@ -1334,7 +1547,8 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                                                     color: Colors.white,
                                                     borderRadius:
                                                         BorderRadius.circular(
-                                                            18),
+                                                      18,
+                                                    ),
                                                   ),
                                                   child: Icon(
                                                     _isPlaying
@@ -1369,7 +1583,8 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                                                           ? UserStorage
                                                               .l10n.playing
                                                           : _formatDuration(
-                                                              _audioDuration),
+                                                              _audioDuration,
+                                                            ),
                                                       style: const TextStyle(
                                                         fontSize: 13,
                                                         color: AppColors
@@ -1382,8 +1597,9 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                                               GestureDetector(
                                                 onTap: _removeAudio,
                                                 child: Container(
-                                                  padding:
-                                                      const EdgeInsets.all(4),
+                                                  padding: const EdgeInsets.all(
+                                                    4,
+                                                  ),
                                                   decoration:
                                                       const BoxDecoration(
                                                     color: Colors.white,
@@ -1425,17 +1641,20 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                                                     children: [
                                                       if (_isRecording) ...[
                                                         _buildRipple(
-                                                            _pulseController
-                                                                .value,
-                                                            0.0),
+                                                          _pulseController
+                                                              .value,
+                                                          0.0,
+                                                        ),
                                                         _buildRipple(
-                                                            _pulseController
-                                                                .value,
-                                                            0.33),
+                                                          _pulseController
+                                                              .value,
+                                                          0.33,
+                                                        ),
                                                         _buildRipple(
-                                                            _pulseController
-                                                                .value,
-                                                            0.66),
+                                                          _pulseController
+                                                              .value,
+                                                          0.66,
+                                                        ),
                                                       ],
                                                       Container(
                                                         width: 48,
@@ -1449,13 +1668,17 @@ class _InputSheetState extends State<InputSheet> with TickerProviderStateMixin {
                                                                   ? AppColors
                                                                       .primary
                                                                       .withValues(
-                                                                          alpha:
-                                                                              0.08)
+                                                                      alpha:
+                                                                          0.08,
+                                                                    )
                                                                   : const Color(
-                                                                      0xFFF7F8FA),
+                                                                      0xFFF7F8FA,
+                                                                    ),
                                                           borderRadius:
                                                               BorderRadius
-                                                                  .circular(24),
+                                                                  .circular(
+                                                            24,
+                                                          ),
                                                         ),
                                                         child: Stack(
                                                           alignment:


### PR DESCRIPTION
## 背景

输入面板里输入文字后，如果用户不小心点到背景关闭面板，未提交内容会直接丢失。这个 PR 为文本输入增加本地草稿保护，降低误操作成本。

## 变更

- 新增 `InputDraftService`，将当前文本草稿保存到用户数据目录下的 `_System/Drafts/active.json`。
- 输入内容变更后 debounce 自动保存；关闭输入面板、应用切后台/失活、面板销毁时会 flush 当前草稿。
- 提交成功后清除草稿；提交失败时保留草稿，方便用户重新打开继续提交。
- 只有真正从已保存草稿恢复时，输入框顶部才展示“草稿 · 字数”和删除按钮；首次输入不展示草稿标识，首页不增加草稿入口。
- 补齐草稿相关英文/中文 ARB 文案，并重新生成 Flutter l10n 代码。

## 验证

- `flutter gen-l10n`
- `dart analyze lib/data/services/input_draft_service.dart lib/ui/main_screen/widgets/input_sheet.dart lib/main.dart`：通过，仅剩既有 info 级提示
- `flutter test`：13 个测试通过
- `git diff --check`：通过
- `flutter analyze`：仓库当前 analyzer baseline 仍有 404 条既有 issue，非本 PR 新增
