### PR TITLE
feat: comment section enhancements

### DIFF
--- a/lib/agent/comment_agent/comment_agent.dart
+++ b/lib/agent/comment_agent/comment_agent.dart
@@ -122,7 +122,7 @@ class CommentAgent {
         },
         systemCallback: createSystemCallback(userId));
 
-    _logger.info('PkmAgent created, userId: $userId, sessionId: $sessionId');
+    _logger.info('CommentAgent created, userId: $userId, sessionId: $sessionId');
     return agent;
   }
 

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -353,8 +353,15 @@ This skill acts as a virtual companion for the user, providing emotional support
 $identity
 </identity>
 
+# Multi-Character Interaction
+- Other characters may have already commented on this entry. Their comments are listed in the `<existing_comments>` section of the user message (if present).
+- If another character has already commented, you may reply to their comment using the `reply_to_id` parameter in `SaveComment`. This creates a natural conversation thread.
+- Do NOT repeat what other characters have already said. Bring your own unique perspective based on your persona.
+- You can agree with, build upon, or gently disagree with other characters' comments — just stay in character.
+
 # Tool Usage
 - `SaveComment` tool call must be included in your final message, as it marks the completion of current task.
+- When replying to another character's comment, use the `reply_to_id` parameter (the comment ID). The reply target's name will be resolved automatically.
 - **Memory Update**: After saving your comment, if you noticed something worth remembering about the user (a new interest, an emotional state, a life event, a preference), use `MemoryWrite` to save it. Keep memory entries concise and factual. Use labels like "user_mood", "user_interests", "user_life_events", "relationship_notes". Do NOT save trivial or transient information.
 - **Parallelism:** Execute multiple independent tool calls in parallel when feasible.
 Examples: 

--- a/lib/agent/skills/comment_agent/tools/comment_tools.dart
+++ b/lib/agent/skills/comment_agent/tools/comment_tools.dart
@@ -26,10 +26,15 @@ class CommentToolFactory {
             'type': 'string',
             'description': 'The content of your comment.'
           },
+          'reply_to_id': {
+            'type': 'string',
+            'description':
+                'Optional. The ID of the comment you are replying to. Leave empty for a top-level comment.'
+          },
         },
         'required': ['content']
       },
-      executable: (String content) async {
+      executable: (String content, String? reply_to_id) async {
         if (content.isEmpty) {
           return "Error: Comment content cannot be empty.";
         }
@@ -48,6 +53,7 @@ class CommentToolFactory {
                 isAi: true,
                 timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
                 characterId: characterId,
+                replyToId: reply_to_id,
               );
               return card.copyWith(comments: [...card.comments, newComment]);
             },

--- a/lib/data/repositories/card.dart
+++ b/lib/data/repositories/card.dart
@@ -176,6 +176,7 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
 
     // Read comments (from card file comments field if present)
     final comments = <Comment>[];
+    // First pass: build comments with character info
     for (final commentData in cardData.comments) {
       try {
         CharacterInfo? commentCharacter;
@@ -203,10 +204,41 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
           isAi: commentData.isAi,
           timestamp: commentData.timestamp,
           character: commentCharacter,
+          replyToId: commentData.replyToId,
         ));
       } catch (e) {
         _logger.warning('Failed to process comment: $e');
         continue;
+      }
+    }
+
+    // Second pass: resolve replyToName from the comment list
+    // Build a lookup: commentId -> display name
+    final commentNameMap = <String, String>{};
+    for (final c in comments) {
+      if (!c.isAi) {
+        // User comment — use the userId as display name
+        commentNameMap[c.id] = userId;
+      } else {
+        commentNameMap[c.id] = c.character?.name ?? 'AI';
+      }
+    }
+    // Resolve replyToName for each comment that has a replyToId
+    for (var i = 0; i < comments.length; i++) {
+      final c = comments[i];
+      if (c.replyToId != null && c.replyToName == null) {
+        final resolvedName = commentNameMap[c.replyToId];
+        if (resolvedName != null) {
+          comments[i] = Comment(
+            id: c.id,
+            content: c.content,
+            isAi: c.isAi,
+            timestamp: c.timestamp,
+            character: c.character,
+            replyToId: c.replyToId,
+            replyToName: resolvedName,
+          );
+        }
       }
     }
 

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -50,6 +50,7 @@ import 'package:memex/data/repositories/get_cards_by_ids.dart';
 import 'package:memex/data/repositories/get_calendar_data.dart';
 import 'package:memex/data/repositories/card.dart';
 import 'package:memex/data/repositories/post_comment.dart';
+import 'package:memex/data/services/comment_settings_service.dart';
 import 'package:memex/data/repositories/pin_insight.dart';
 import 'package:memex/data/repositories/character.dart';
 import 'package:memex/data/repositories/health.dart' as health_endpoint;
@@ -257,6 +258,7 @@ class MemexRouter {
             'card_id': p.cardId,
             'content': p.content,
             'comment_id': p.commentId,
+            if (p.replyToId != null) 'reply_to_id': p.replyToId,
           });
         },
       ),
@@ -521,7 +523,10 @@ class MemexRouter {
   }
 
   Future<Map<String, dynamic>> postComment(
-      String cardId, String content) async {
+    String cardId,
+    String content, {
+    String? replyToId,
+  }) async {
     await _ensureInitialized();
     _logger.info('LocalMode: postComment called: cardId=$cardId');
 
@@ -531,11 +536,28 @@ class MemexRouter {
         throw Exception('User not logged in, cannot submit comment');
       }
 
-      return await postCommentEndpoint(cardId, userId, content);
+      return await postCommentEndpoint(cardId, userId, content,
+          replyToId: replyToId);
     } catch (e) {
       _logger.severe('Failed to post comment for card $cardId: $e');
       rethrow;
     }
+  }
+
+  /// Load per-user comment settings.
+  Future<CommentSettings> getCommentSettings() async {
+    await _ensureInitialized();
+    final userId = await UserStorage.getUserId();
+    if (userId == null) return const CommentSettings();
+    return CommentSettingsService.load(userId);
+  }
+
+  /// Save per-user comment settings.
+  Future<void> saveCommentSettings(CommentSettings settings) async {
+    await _ensureInitialized();
+    final userId = await UserStorage.getUserId();
+    if (userId == null) return;
+    await CommentSettingsService.save(userId, settings);
   }
 
   Future<void> enqueueTask({

--- a/lib/data/repositories/post_comment.dart
+++ b/lib/data/repositories/post_comment.dart
@@ -20,14 +20,16 @@ final _fileSystemService = FileSystemService.instance;
 ///   cardId: card ID (fact_id)
 ///   userId: user ID
 ///   content: comment content
+///   replyToId: optional, ID of the comment being replied to
 ///
 /// Returns:
 ///   Map with user comment info (AI reply is async)
 Future<Map<String, dynamic>> postCommentEndpoint(
   String cardId,
   String userId,
-  String content,
-) async {
+  String content, {
+  String? replyToId,
+}) async {
   _logger.info(
       'PostCommentEndpoint: postComment called: cardId=$cardId, userId=$userId');
 
@@ -46,6 +48,7 @@ Future<Map<String, dynamic>> postCommentEndpoint(
         content: content,
         isAi: false,
         timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        replyToId: replyToId,
       );
       return card.copyWith(comments: [...card.comments, newComment]);
     });
@@ -82,6 +85,7 @@ Future<Map<String, dynamic>> postCommentEndpoint(
           cardId: cardId,
           content: content,
           commentId: commentId,
+          replyToId: replyToId,
         ),
       ),
     );
@@ -133,12 +137,14 @@ Future<void> processAICommentReply({
     final initialInsight = cardData.insight?.text;
 
     // 2. Character ID Fallback
+    // When no explicit characterId: pick the most recent AI commenter
+    // (the character most recently active in the conversation).
+    // Falls back to the insight character if no AI comments exist.
     if (characterId == null) {
-      for (final c in cardData.comments) {
+      for (final c in cardData.comments.reversed) {
         if (c.isAi && c.characterId != null) {
           characterId = c.characterId;
-          _logger
-              .info('Using character_id $characterId from existing comments');
+          _logger.info('Using most recent AI commenter $characterId');
           break;
         }
       }
@@ -179,10 +185,29 @@ Future<void> processAICommentReply({
     final client = resources.client;
     final modelConfig = resources.modelConfig;
 
-    // 6. Initialize and Run Agent
+    // 6. Build existing comments context for multi-character interaction
+    String existingCommentsContext = '';
+    if (cardData.comments.isNotEmpty) {
+      final buf = StringBuffer();
+      buf.writeln('\n<existing_comments>');
+      for (final c in cardData.comments) {
+        final author = c.isAi ? (c.characterId ?? 'AI') : 'User';
+        final replyInfo =
+            c.replyToId != null ? ' (replying to ${c.replyToId})' : '';
+        buf.writeln('- [$author] (id: ${c.id})$replyInfo: ${c.content}');
+      }
+      buf.writeln('</existing_comments>');
+      existingCommentsContext = buf.toString();
+    }
+
+    // 7. Initialize and Run Agent
+    final fullUserContent = existingCommentsContext.isNotEmpty
+        ? '$userContent\n$existingCommentsContext'
+        : userContent;
+
     try {
       await CommentAgent.runWithContent(
-        userContent,
+        fullUserContent,
         client: client,
         modelConfig: modelConfig,
         userId: userId,

--- a/lib/data/services/character_selection_service.dart
+++ b/lib/data/services/character_selection_service.dart
@@ -1,16 +1,23 @@
 import 'dart:math';
+import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/domain/models/character_model.dart';
 import 'package:memex/data/services/character_service.dart';
 import 'package:memex/utils/logger.dart';
 
-/// Selects the most appropriate character to comment on a given input,
-/// based on content-persona affinity rather than random selection.
+/// Selects characters to comment on a given input.
 ///
-/// Uses a lightweight keyword-matching approach (no LLM call) so it's
-/// fast enough to run in the task handler hot path.
+/// - [selectCharacter]: lightweight keyword-matching for single-character
+///   scenarios (reprocess, explicit triggers). No LLM call.
+/// - [selectMultipleCharacters]: LLM-based selection for multi-character
+///   interaction on new records. One short LLM call decides which characters
+///   should participate.
 class CharacterSelectionService {
   static final Logger _logger = getLogger('CharacterSelectionService');
+
+  // ---------------------------------------------------------------------------
+  // Single-character selection (keyword-based, no LLM) — original logic
+  // ---------------------------------------------------------------------------
 
   /// Select the best character for the given input content.
   /// Falls back to weighted-random if no clear winner.
@@ -19,8 +26,7 @@ class CharacterSelectionService {
     required String inputContent,
     required String factId,
   }) async {
-    final characters =
-        await CharacterService.instance.getAllCharacters(userId);
+    final characters = await CharacterService.instance.getAllCharacters(userId);
     final enabled = characters.where((c) => c.enabled).toList();
 
     if (enabled.isEmpty) return null;
@@ -45,8 +51,8 @@ class CharacterSelectionService {
       final winnerId =
           scores.entries.firstWhere((e) => e.value == maxScore).key;
       final winner = enabled.firstWhere((c) => c.id == winnerId);
-      _logger.info(
-          'Selected ${winner.name} (score: $maxScore) for fact $factId');
+      _logger
+          .info('Selected ${winner.name} (score: $maxScore) for fact $factId');
       return winner;
     }
 
@@ -122,21 +128,24 @@ class CharacterSelectionService {
 
     // Venting/frustration signals → bestie characters
     if (_matchesAny(lowerContent, _ventingSignals)) {
-      if (_matchesAny(charLower, ['bestie', 'venting', 'company', '闺蜜', '吐槽'])) {
+      if (_matchesAny(
+          charLower, ['bestie', 'venting', 'company', '闺蜜', '吐槽'])) {
         score += 4.0;
       }
     }
 
     // Reflective/philosophical signals → mentor characters
     if (_matchesAny(lowerContent, _reflectiveSignals)) {
-      if (_matchesAny(charLower, ['wisdom', 'mentor', 'validation', '导师', '智慧'])) {
+      if (_matchesAny(
+          charLower, ['wisdom', 'mentor', 'validation', '导师', '智慧'])) {
         score += 4.0;
       }
     }
 
     // Emotional/nostalgic signals → poetic characters
     if (_matchesAny(lowerContent, _emotionalSignals)) {
-      if (_matchesAny(charLower, ['beauty', 'nostalgia', 'distant', '诗意', '月光'])) {
+      if (_matchesAny(
+          charLower, ['beauty', 'nostalgia', 'distant', '诗意', '月光'])) {
         score += 4.0;
       }
     }
@@ -179,37 +188,267 @@ class CharacterSelectionService {
   // --- Signal word lists ---
 
   static const _healthSignals = [
-    'tired', 'exhausted', 'sick', 'headache', 'sleep', 'insomnia',
-    'hospital', 'doctor', 'medicine', 'pain', 'fever', 'cold',
-    '累', '困', '生病', '头疼', '失眠', '医院', '吃药', '发烧', '感冒',
-    '加班', '熬夜', '疲惫', '身体',
+    'tired',
+    'exhausted',
+    'sick',
+    'headache',
+    'sleep',
+    'insomnia',
+    'hospital',
+    'doctor',
+    'medicine',
+    'pain',
+    'fever',
+    'cold',
+    '累',
+    '困',
+    '生病',
+    '头疼',
+    '失眠',
+    '医院',
+    '吃药',
+    '发烧',
+    '感冒',
+    '加班',
+    '熬夜',
+    '疲惫',
+    '身体',
   ];
 
   static const _ventingSignals = [
-    'angry', 'annoyed', 'frustrated', 'hate', 'ugh', 'wtf', 'unfair',
-    'stupid', 'ridiculous', 'done with', 'fed up', 'pissed',
-    '烦', '气死', '无语', '崩溃', '受不了', '讨厌', '垃圾', '傻逼',
-    '操', '吐了', '服了', '离谱',
+    'angry',
+    'annoyed',
+    'frustrated',
+    'hate',
+    'ugh',
+    'wtf',
+    'unfair',
+    'stupid',
+    'ridiculous',
+    'done with',
+    'fed up',
+    'pissed',
+    '烦',
+    '气死',
+    '无语',
+    '崩溃',
+    '受不了',
+    '讨厌',
+    '垃圾',
+    '傻逼',
+    '操',
+    '吐了',
+    '服了',
+    '离谱',
   ];
 
   static const _reflectiveSignals = [
-    'thinking about', 'wondering', 'realize', 'perspective', 'growth',
-    'decision', 'career', 'future', 'meaning', 'purpose', 'goal',
-    '思考', '反思', '成长', '方向', '意义', '目标', '选择', '人生',
-    '职业', '未来',
+    'thinking about',
+    'wondering',
+    'realize',
+    'perspective',
+    'growth',
+    'decision',
+    'career',
+    'future',
+    'meaning',
+    'purpose',
+    'goal',
+    '思考',
+    '反思',
+    '成长',
+    '方向',
+    '意义',
+    '目标',
+    '选择',
+    '人生',
+    '职业',
+    '未来',
   ];
 
   static const _emotionalSignals = [
-    'miss', 'remember', 'nostalgia', 'rain', 'sunset', 'music',
-    'lonely', 'quiet', 'dream', 'memory', 'beautiful', 'melancholy',
-    '想念', '回忆', '孤独', '安静', '梦', '月亮', '雨', '夕阳',
-    '音乐', '美', '忧伤', '感慨',
+    'miss',
+    'remember',
+    'nostalgia',
+    'rain',
+    'sunset',
+    'music',
+    'lonely',
+    'quiet',
+    'dream',
+    'memory',
+    'beautiful',
+    'melancholy',
+    '想念',
+    '回忆',
+    '孤独',
+    '安静',
+    '梦',
+    '月亮',
+    '雨',
+    '夕阳',
+    '音乐',
+    '美',
+    '忧伤',
+    '感慨',
   ];
 
   static const _stopWords = {
-    'the', 'and', 'for', 'that', 'this', 'with', 'from', 'about',
-    'into', 'like', 'just', 'only', 'also', 'more', 'than', 'when',
-    'will', 'what', 'which', 'their', 'them', 'they', 'have', 'been',
-    'focus', 'ignore', 'unless', 'based', 'user',
+    'the',
+    'and',
+    'for',
+    'that',
+    'this',
+    'with',
+    'from',
+    'about',
+    'into',
+    'like',
+    'just',
+    'only',
+    'also',
+    'more',
+    'than',
+    'when',
+    'will',
+    'what',
+    'which',
+    'their',
+    'them',
+    'they',
+    'have',
+    'been',
+    'focus',
+    'ignore',
+    'unless',
+    'based',
+    'user',
   };
+
+  // ---------------------------------------------------------------------------
+  // Multi-character selection (LLM-based)
+  // ---------------------------------------------------------------------------
+
+  /// Use an LLM call to decide which characters should comment on this input.
+  /// Returns 1–N characters. Falls back to primary companion on failure.
+  static Future<List<CharacterModel>> selectMultipleCharacters({
+    required String userId,
+    required String inputContent,
+    required String factId,
+    required LLMClient client,
+    required ModelConfig modelConfig,
+    int maxCharacters = 3,
+  }) async {
+    final characters = await CharacterService.instance.getAllCharacters(userId);
+    final enabled = characters.where((c) => c.enabled).toList();
+
+    if (enabled.isEmpty) return [];
+    if (enabled.length == 1) return [enabled.first];
+
+    // Try LLM-based selection
+    try {
+      final selected = await _llmSelectCharacters(
+        client: client,
+        modelConfig: modelConfig,
+        characters: enabled,
+        inputContent: inputContent,
+        maxCharacters: maxCharacters,
+      );
+      if (selected.isNotEmpty) {
+        _logger.info(
+            'LLM selected ${selected.length} characters for fact $factId: '
+            '${selected.map((c) => c.name).join(', ')}');
+        return selected;
+      }
+    } catch (e) {
+      _logger.warning('LLM character selection failed, falling back: $e');
+    }
+
+    // Fallback: pick the primary companion, or the first enabled character
+    final primary = enabled.where((c) => c.isPrimaryCompanion).toList();
+    if (primary.isNotEmpty) return [primary.first];
+    return [enabled.first];
+  }
+
+  /// One-shot LLM call to pick which characters should respond.
+  static Future<List<CharacterModel>> _llmSelectCharacters({
+    required LLMClient client,
+    required ModelConfig modelConfig,
+    required List<CharacterModel> characters,
+    required String inputContent,
+    int maxCharacters = 3,
+  }) async {
+    // Build a concise character list for the prompt
+    final charDescriptions = StringBuffer();
+    for (final c in characters) {
+      final tags = c.tags.isNotEmpty ? ' [${c.tags.join(', ')}]' : '';
+      final interest = c.interestFilter != null && c.interestFilter!.isNotEmpty
+          ? ' — ${c.interestFilter}'
+          : '';
+      charDescriptions
+          .writeln('- id: "${c.id}", name: "${c.name}"$tags$interest');
+    }
+
+    final truncatedInput = inputContent.length > 500
+        ? '${inputContent.substring(0, 500)}...'
+        : inputContent;
+
+    final prompt = 'Pick which characters should comment on this user entry.\n'
+        'Pick at most $maxCharacters characters whose personality or interests naturally fit the content.\n\n'
+        'Characters:\n$charDescriptions\n'
+        'User entry:\n"$truncatedInput"\n\n'
+        'Reply with ONLY their IDs separated by commas, e.g. id1,id2. No explanation.';
+
+    final selectionConfig = ModelConfig(
+      model: modelConfig.model,
+      maxTokens: 100,
+      extra: modelConfig.extra,
+    );
+
+    final response = await client.generate(
+      [
+        SystemMessage(
+            'You are a character routing assistant. Reply with only comma-separated IDs.'),
+        UserMessage([TextPart(prompt)]),
+      ],
+      modelConfig: selectionConfig,
+    );
+
+    // Extract the text response
+    final text = response.textOutput;
+    if (text == null || text.isEmpty) return [];
+
+    // Parse comma-separated IDs
+    final ids = _parseIdList(text);
+    if (ids.isEmpty) return [];
+
+    // Map IDs back to character models, preserving order
+    final selected = <CharacterModel>[];
+    for (final id in ids) {
+      final match = characters.where((c) => c.id == id);
+      if (match.isNotEmpty && !selected.contains(match.first)) {
+        selected.add(match.first);
+      }
+    }
+
+    return selected.take(maxCharacters).toList();
+  }
+
+  /// Parse comma-separated IDs from LLM output.
+  /// Tolerant of whitespace, quotes, and markdown fences.
+  static List<String> _parseIdList(String text) {
+    var cleaned = text.trim();
+    // Strip markdown code fences if present
+    cleaned = cleaned.replaceAll(RegExp(r'^```\w*\n?'), '');
+    cleaned = cleaned.replaceAll(RegExp(r'\n?```$'), '');
+    cleaned = cleaned.trim();
+    // Strip surrounding brackets/quotes if the model wrapped them
+    cleaned = cleaned.replaceAll(RegExp(r'[\[\]"' ']'), '');
+    // Split by comma, trim each, drop empties
+    return cleaned
+        .split(',')
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .toList();
+  }
 }

--- a/lib/data/services/comment_settings_service.dart
+++ b/lib/data/services/comment_settings_service.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/utils/logger.dart';
+
+/// Per-user comment settings stored in `_UserSettings/comment_settings.yaml`.
+///
+/// Fields:
+/// - `show_insight_text` (bool, default true): show insight as pinned comment
+/// - `enable_character_comment` (bool, default true): auto-generate character comments
+/// - `max_comment_characters` (int, default 1): max characters that comment per record
+///
+/// When `max_comment_characters` == 1, the original single-character selection
+/// is used (keyword-based, no LLM call). When > 1, an LLM call decides which
+/// characters participate.
+class CommentSettings {
+  final bool showInsightText;
+  final bool enableCharacterComment;
+  final int maxCommentCharacters;
+
+  const CommentSettings({
+    this.showInsightText = true,
+    this.enableCharacterComment = true,
+    this.maxCommentCharacters = 1,
+  });
+
+  factory CommentSettings.fromYaml(Map yaml) {
+    return CommentSettings(
+      showInsightText: yaml['show_insight_text'] as bool? ?? true,
+      enableCharacterComment: yaml['enable_character_comment'] as bool? ?? true,
+      maxCommentCharacters: yaml['max_comment_characters'] as int? ?? 1,
+    );
+  }
+
+  String toYaml() {
+    return 'show_insight_text: $showInsightText\n'
+        'enable_character_comment: $enableCharacterComment\n'
+        'max_comment_characters: $maxCommentCharacters\n';
+  }
+
+  CommentSettings copyWith({
+    bool? showInsightText,
+    bool? enableCharacterComment,
+    int? maxCommentCharacters,
+  }) {
+    return CommentSettings(
+      showInsightText: showInsightText ?? this.showInsightText,
+      enableCharacterComment:
+          enableCharacterComment ?? this.enableCharacterComment,
+      maxCommentCharacters: maxCommentCharacters ?? this.maxCommentCharacters,
+    );
+  }
+}
+
+/// Service for reading/writing per-user comment settings.
+/// Path is defined in [FileSystemService.getCommentSettingsPath].
+class CommentSettingsService {
+  static final _logger = getLogger('CommentSettingsService');
+
+  /// Load comment settings for a user. Returns defaults if file doesn't exist.
+  static Future<CommentSettings> load(String userId) async {
+    try {
+      final filePath =
+          FileSystemService.instance.getCommentSettingsPath(userId);
+      final file = File(filePath);
+      if (!await file.exists()) return const CommentSettings();
+
+      final content = await file.readAsString();
+      if (content.trim().isEmpty) return const CommentSettings();
+
+      final yaml = loadYaml(content);
+      if (yaml is YamlMap) {
+        return CommentSettings.fromYaml(yaml);
+      }
+      return const CommentSettings();
+    } catch (e) {
+      _logger.warning('Failed to load comment settings: $e');
+      return const CommentSettings();
+    }
+  }
+
+  /// Save comment settings for a user.
+  static Future<void> save(String userId, CommentSettings settings) async {
+    try {
+      final filePath =
+          FileSystemService.instance.getCommentSettingsPath(userId);
+      final dir = Directory(path.dirname(filePath));
+      if (!await dir.exists()) {
+        await dir.create(recursive: true);
+      }
+      await File(filePath).writeAsString(settings.toYaml());
+    } catch (e) {
+      _logger.warning('Failed to save comment settings: $e');
+    }
+  }
+}

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -979,6 +979,11 @@ class FileSystemService {
     return path.join(getUserSettingsPath(userId), 'profile.md');
   }
 
+  /// Comment settings file path
+  String getCommentSettingsPath(String userId) {
+    return path.join(getUserSettingsPath(userId), 'comment_settings.yaml');
+  }
+
   /// Add user custom location (lat, lng, name).
   Future<bool> addUserLocation(
       String userId, double lat, double lng, String name) async {

--- a/lib/data/services/task_handlers/comment_agent_handler.dart
+++ b/lib/data/services/task_handlers/comment_agent_handler.dart
@@ -3,6 +3,8 @@ import 'package:memex/agent/prompts.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/data/repositories/post_comment.dart';
 import 'package:memex/data/services/character_selection_service.dart';
+import 'package:memex/data/services/comment_settings_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/task_handlers/llm_error_utils.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
@@ -12,7 +14,6 @@ final _logger = Logger('CommentAgentHandler');
 
 Future<void> handleCommentAgentImpl(
     String userId, Map<String, dynamic> payload, TaskContext context) async {
-  // Stage 4: Comment Agent (Selection Phase)
   final factId = payload['fact_id'] as String;
   final combinedText = payload['combined_text'] as String;
 
@@ -20,6 +21,16 @@ Future<void> handleCommentAgentImpl(
       .info("Running Comment Agent selection for fact $factId, user $userId");
 
   try {
+    // Load per-user comment settings
+    final settings = await CommentSettingsService.load(userId);
+
+    // Check if character comments are enabled
+    if (!settings.enableCharacterComment) {
+      _logger.info(
+          'Character comments disabled — skipping comment agent for $factId');
+      return;
+    }
+
     // Skip if LLM is not configured.
     final llmConfig = await UserStorage.getAgentLLMConfig(
       AgentDefinitions.commentAgent,
@@ -36,13 +47,26 @@ Future<void> handleCommentAgentImpl(
       combinedText: combinedText,
     );
 
-    // 1. Character Selection
-    // If character_id is explicitly provided in payload, use it.
-    // Otherwise, select one.
+    // If character_id is explicitly provided in payload, use it (single character).
     String? selectedCharId = payload['character_id'] as String?;
 
-    if (selectedCharId == null) {
-      // Smart character selection based on content affinity
+    if (selectedCharId != null) {
+      // Explicit character — single comment
+      _logger.info("Using explicitly provided character $selectedCharId");
+      await processAICommentReply(
+        cardId: factId,
+        userId: userId,
+        userContent: Prompts.commentAgentInitialCommentPrompt,
+        characterId: selectedCharId,
+        rawInputContent: combinedText,
+      );
+      return;
+    }
+
+    final maxChars = settings.maxCommentCharacters;
+
+    if (maxChars <= 1) {
+      // Single-character mode: keyword-based selection (no LLM call)
       final selectedChar = await CharacterSelectionService.selectCharacter(
         userId: userId,
         inputContent: combinedText,
@@ -54,19 +78,50 @@ Future<void> handleCommentAgentImpl(
         return;
       }
 
-      selectedCharId = selectedChar.id;
       _logger.info(
-          "Selected character ${selectedChar.name} ($selectedCharId) for comment");
-    }
+          "Selected character ${selectedChar.name} (${selectedChar.id}) for comment");
+      await processAICommentReply(
+        cardId: factId,
+        userId: userId,
+        userContent: Prompts.commentAgentInitialCommentPrompt,
+        characterId: selectedChar.id,
+        rawInputContent: combinedText,
+      );
+    } else {
+      // Multi-character mode: LLM-based selection
+      final resources = await UserStorage.getAgentLLMResources(
+        AgentDefinitions.commentAgent,
+        defaultClientKey: LLMConfig.defaultClientKey,
+      );
 
-    // 2. Process (Async / Await here since we are in a worker)
-    await processAICommentReply(
-      cardId: factId,
-      userId: userId,
-      userContent: Prompts.commentAgentInitialCommentPrompt,
-      characterId: selectedCharId,
-      rawInputContent: combinedText,
-    );
+      final selectedChars =
+          await CharacterSelectionService.selectMultipleCharacters(
+        userId: userId,
+        inputContent: combinedText,
+        factId: factId,
+        client: resources.client,
+        modelConfig: resources.modelConfig,
+        maxCharacters: maxChars,
+      );
+
+      if (selectedChars.isEmpty) {
+        _logger.info("No enabled characters, skipping comment agent");
+        return;
+      }
+
+      // Process characters sequentially so later characters can see earlier comments
+      for (final char in selectedChars) {
+        _logger.info(
+            "Processing comment from character ${char.name} (${char.id})");
+        await processAICommentReply(
+          cardId: factId,
+          userId: userId,
+          userContent: Prompts.commentAgentInitialCommentPrompt,
+          characterId: char.id,
+          rawInputContent: combinedText,
+        );
+      }
+    }
   } catch (e, stack) {
     _logger.severe("CommentAgentHandler failed: $e", e, stack);
     rethrowIfNonRetryable(e);
@@ -79,15 +134,38 @@ Future<void> handleProcessAiReplyImpl(
   final cardId = payload['card_id'] as String;
   final content = payload['content'] as String;
   final commentId = payload['comment_id'] as String?;
+  final replyToId = payload['reply_to_id'] as String?;
 
   _logger.info(
       'HandleProcessAiReply: Processing AI reply for card $cardId, user $userId');
+
+  // If the user replied to a specific comment, resolve the target character
+  String? targetCharacterId;
+  if (replyToId != null) {
+    try {
+      final cardData =
+          await FileSystemService.instance.readCardFile(userId, cardId);
+      if (cardData != null) {
+        for (final c in cardData.comments) {
+          if (c.id == replyToId && c.isAi && c.characterId != null) {
+            targetCharacterId = c.characterId;
+            _logger.info(
+                'User replied to comment $replyToId, routing to character $targetCharacterId');
+            break;
+          }
+        }
+      }
+    } catch (e) {
+      _logger.warning('Failed to resolve reply target character: $e');
+    }
+  }
 
   await processAICommentReply(
     cardId: cardId,
     userId: userId,
     userContent: content,
     userCommentId: commentId,
+    characterId: targetCharacterId,
     withMemoryManagement: true,
   );
 }

--- a/lib/domain/models/card_detail_model.dart
+++ b/lib/domain/models/card_detail_model.dart
@@ -32,7 +32,7 @@ class CardDetailModel {
 
   factory CardDetailModel.fromJson(Map<String, dynamic> json) {
     final location = json['location'] as Map<String, dynamic>?;
-    
+
     List<UiConfig> configs = [];
     if (json['ui_configs'] != null) {
       configs = (json['ui_configs'] as List)
@@ -141,6 +141,8 @@ class Comment {
   final bool isAi;
   final int timestamp;
   final CharacterInfo? character;
+  final String? replyToId;
+  final String? replyToName;
 
   Comment({
     required this.id,
@@ -148,6 +150,8 @@ class Comment {
     required this.isAi,
     required this.timestamp,
     this.character,
+    this.replyToId,
+    this.replyToName,
   });
 
   factory Comment.fromJson(Map<String, dynamic> json) {
@@ -159,6 +163,8 @@ class Comment {
       character: json['character'] != null
           ? CharacterInfo.fromJson(json['character'] as Map<String, dynamic>)
           : null,
+      replyToId: json['reply_to_id'] as String?,
+      replyToName: json['reply_to_name'] as String?,
     );
   }
 }
@@ -353,4 +359,3 @@ class AgentStats {
     };
   }
 }
-

--- a/lib/domain/models/card_model.dart
+++ b/lib/domain/models/card_model.dart
@@ -235,6 +235,7 @@ class CardComment {
   final bool isAi;
   final int timestamp;
   final String? characterId;
+  final String? replyToId;
 
   const CardComment({
     required this.id,
@@ -242,6 +243,7 @@ class CardComment {
     required this.isAi,
     required this.timestamp,
     this.characterId,
+    this.replyToId,
   });
 
   factory CardComment.fromJson(Map<String, dynamic> json) {
@@ -252,6 +254,7 @@ class CardComment {
       isAi: json['is_ai'] as bool? ?? false,
       timestamp: json['timestamp'] as int? ?? 0,
       characterId: charId?.toString(),
+      replyToId: json['reply_to_id'] as String?,
     );
   }
 
@@ -263,6 +266,7 @@ class CardComment {
       'timestamp': timestamp,
     };
     if (characterId != null) m['character_id'] = characterId;
+    if (replyToId != null) m['reply_to_id'] = replyToId;
     return m;
   }
 }

--- a/lib/domain/models/system_event.dart
+++ b/lib/domain/models/system_event.dart
@@ -66,16 +66,19 @@ class CardCommentPostedPayload {
     required this.cardId,
     required this.content,
     required this.commentId,
+    this.replyToId,
   });
 
   final String cardId;
   final String content;
   final String commentId;
+  final String? replyToId;
 
   Map<String, dynamic> toJson() => {
         'card_id': cardId,
         'content': content,
         'comment_id': commentId,
+        if (replyToId != null) 'reply_to_id': replyToId,
       };
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -938,5 +938,20 @@
 
   "chatModeLabel": "Agent",
 
-  "switchCompanion": "Switch companion"
+  "switchCompanion": "Switch companion",
+
+  "showInsightTextTitle": "Show Memex insight comment",
+  "showInsightTextDesc": "Whether to show the Memex insight as a pinned comment in the card detail comment section.",
+  "enableCharacterCommentTitle": "Character auto-comment",
+  "enableCharacterCommentDesc": "Characters automatically comment on new records.",
+  "maxCommentCharactersTitle": "Max commenting characters",
+  "maxCommentCharactersDesc": "How many characters can comment on each record.",
+  "replyTo": "Reply to {name}",
+  "@replyTo": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3817,6 +3817,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Switch companion'**
   String get switchCompanion;
+
+  /// No description provided for @showInsightTextTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Memex insight comment'**
+  String get showInsightTextTitle;
+
+  /// No description provided for @showInsightTextDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Whether to show the Memex insight as a pinned comment in the card detail comment section.'**
+  String get showInsightTextDesc;
+
+  /// No description provided for @enableCharacterCommentTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Character auto-comment'**
+  String get enableCharacterCommentTitle;
+
+  /// No description provided for @enableCharacterCommentDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Characters automatically comment on new records.'**
+  String get enableCharacterCommentDesc;
+
+  /// No description provided for @maxCommentCharactersTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Max commenting characters'**
+  String get maxCommentCharactersTitle;
+
+  /// No description provided for @maxCommentCharactersDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'How many characters can comment on each record.'**
+  String get maxCommentCharactersDesc;
+
+  /// No description provided for @replyTo.
+  ///
+  /// In en, this message translates to:
+  /// **'Reply to {name}'**
+  String replyTo(String name);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2086,4 +2086,30 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get switchCompanion => 'Switch companion';
+
+  @override
+  String get showInsightTextTitle => 'Show Memex insight comment';
+
+  @override
+  String get showInsightTextDesc =>
+      'Whether to show the Memex insight as a pinned comment in the card detail comment section.';
+
+  @override
+  String get enableCharacterCommentTitle => 'Character auto-comment';
+
+  @override
+  String get enableCharacterCommentDesc =>
+      'Characters automatically comment on new records.';
+
+  @override
+  String get maxCommentCharactersTitle => 'Max commenting characters';
+
+  @override
+  String get maxCommentCharactersDesc =>
+      'How many characters can comment on each record.';
+
+  @override
+  String replyTo(String name) {
+    return 'Reply to $name';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2010,4 +2010,27 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get switchCompanion => '切换角色';
+
+  @override
+  String get showInsightTextTitle => '显示 Memex 洞察评论';
+
+  @override
+  String get showInsightTextDesc => '是否在卡片详情的评论区显示 Memex 洞察评论。';
+
+  @override
+  String get enableCharacterCommentTitle => '角色自动评论';
+
+  @override
+  String get enableCharacterCommentDesc => '角色自动对新记录发表评论。';
+
+  @override
+  String get maxCommentCharactersTitle => '最大评论角色数';
+
+  @override
+  String get maxCommentCharactersDesc => '每条记录最多几个角色参与评论。';
+
+  @override
+  String replyTo(String name) {
+    return '回复 $name';
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -916,5 +916,20 @@
 
   "chatModeLabel": "智能体",
 
-  "switchCompanion": "切换角色"
+  "switchCompanion": "切换角色",
+
+  "showInsightTextTitle": "显示 Memex 洞察评论",
+  "showInsightTextDesc": "是否在卡片详情的评论区显示 Memex 洞察评论。",
+  "enableCharacterCommentTitle": "角色自动评论",
+  "enableCharacterCommentDesc": "角色自动对新记录发表评论。",
+  "maxCommentCharactersTitle": "最大评论角色数",
+  "maxCommentCharactersDesc": "每条记录最多几个角色参与评论。",
+  "replyTo": "回复 {name}",
+  "@replyTo": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/ui/character/widgets/character_config_screen.dart
+++ b/lib/ui/character/widgets/character_config_screen.dart
@@ -119,9 +119,9 @@ class _CharacterConfigScreenState extends State<CharacterConfigScreen> {
         return Scaffold(
           backgroundColor: const Color(0xFFF7F8FA),
           appBar: AppBar(
-            title: const Text(
-              'Configure AI character',
-              style: TextStyle(
+            title: Text(
+              UserStorage.l10n.configureAiCharacter,
+              style: const TextStyle(
                 fontSize: 18,
                 fontWeight: FontWeight.w600,
                 color: AppColors.textPrimary,

--- a/lib/ui/settings/widgets/settings_page.dart
+++ b/lib/ui/settings/widgets/settings_page.dart
@@ -9,6 +9,9 @@ import 'package:memex/db/app_database.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/data/services/comment_settings_service.dart'
+    show CommentSettings;
+import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/main.dart' show rootShellKey;
 
 class SettingsPage extends StatefulWidget {
@@ -21,6 +24,7 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   String _currentLang = 'en';
   bool _useLocalSpeechToText = true;
+  CommentSettings _commentSettings = const CommentSettings();
 
   @override
   void initState() {
@@ -31,10 +35,12 @@ class _SettingsPageState extends State<SettingsPage> {
   Future<void> _loadSettings() async {
     final locale = await UserStorage.getLocale();
     final useLocalSpeechToText = await UserStorage.getUseLocalSpeechToText();
+    final commentSettings = await MemexRouter().getCommentSettings();
     if (mounted) {
       setState(() {
         _currentLang = locale.languageCode == 'zh' ? 'zh' : 'en';
         _useLocalSpeechToText = useLocalSpeechToText;
+        _commentSettings = commentSettings;
       });
     }
   }
@@ -53,6 +59,30 @@ class _SettingsPageState extends State<SettingsPage> {
     await UserStorage.setUseLocalSpeechToText(value);
     if (mounted) {
       setState(() => _useLocalSpeechToText = value);
+    }
+  }
+
+  Future<void> _updateShowInsightText(bool value) async {
+    final updated = _commentSettings.copyWith(showInsightText: value);
+    await MemexRouter().saveCommentSettings(updated);
+    if (mounted) {
+      setState(() => _commentSettings = updated);
+    }
+  }
+
+  Future<void> _updateEnableCharacterComment(bool value) async {
+    final updated = _commentSettings.copyWith(enableCharacterComment: value);
+    await MemexRouter().saveCommentSettings(updated);
+    if (mounted) {
+      setState(() => _commentSettings = updated);
+    }
+  }
+
+  Future<void> _updateMaxCommentCharacters(int value) async {
+    final updated = _commentSettings.copyWith(maxCommentCharacters: value);
+    await MemexRouter().saveCommentSettings(updated);
+    if (mounted) {
+      setState(() => _commentSettings = updated);
     }
   }
 
@@ -165,6 +195,169 @@ class _SettingsPageState extends State<SettingsPage> {
               onChanged: _updateUseLocalSpeechToText,
             ),
           ),
+          const SizedBox(height: 16),
+          // Show Insight Text toggle
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.textSecondary.withValues(alpha: 0.08),
+                  blurRadius: 16,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              secondary: Icon(Icons.lightbulb_outline,
+                  color: AppColors.primary, size: 22),
+              title: Text(
+                UserStorage.l10n.showInsightTextTitle,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.textPrimary,
+                ),
+              ),
+              subtitle: Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: Text(
+                  UserStorage.l10n.showInsightTextDesc,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Colors.grey[600],
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              value: _commentSettings.showInsightText,
+              onChanged: _updateShowInsightText,
+            ),
+          ),
+          const SizedBox(height: 16),
+          // Enable Character Comment toggle
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.textSecondary.withValues(alpha: 0.08),
+                  blurRadius: 16,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              secondary: Icon(Icons.chat_bubble_outline,
+                  color: AppColors.primary, size: 22),
+              title: Text(
+                UserStorage.l10n.enableCharacterCommentTitle,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.textPrimary,
+                ),
+              ),
+              subtitle: Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: Text(
+                  UserStorage.l10n.enableCharacterCommentDesc,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Colors.grey[600],
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              value: _commentSettings.enableCharacterComment,
+              onChanged: _updateEnableCharacterComment,
+            ),
+          ),
+          // Max comment characters slider (only visible when comments are enabled)
+          if (_commentSettings.enableCharacterComment) ...[
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: AppColors.textSecondary.withValues(alpha: 0.08),
+                    blurRadius: 16,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Icon(Icons.groups_outlined,
+                          color: AppColors.primary, size: 22),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              UserStorage.l10n.maxCommentCharactersTitle,
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w500,
+                                color: AppColors.textPrimary,
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              UserStorage.l10n.maxCommentCharactersDesc,
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: Colors.grey[600],
+                                height: 1.4,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: AppColors.primary.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          '${_commentSettings.maxCommentCharacters}',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.primary,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Slider(
+                    value: _commentSettings.maxCommentCharacters.toDouble(),
+                    min: 1,
+                    max: 5,
+                    divisions: 4,
+                    activeColor: AppColors.primary,
+                    onChanged: (v) => _updateMaxCommentCharacters(v.round()),
+                  ),
+                ],
+              ),
+            ),
+          ],
           // Data Storage (iOS only — Android has no storage options to choose)
           if (Platform.isIOS) ...[
             const SizedBox(height: 16),

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -27,7 +27,9 @@ import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
 import 'package:memex/ui/core/cards/style/timeline_theme.dart';
+import 'package:memex/ui/core/themes/design_system.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
+import 'package:memex/ui/character/widgets/persona_chat_screen.dart';
 import 'package:memex/utils/share_service.dart';
 import 'package:memex/ui/core/cards/native_card_factory.dart';
 
@@ -56,6 +58,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   String _userName = 'User';
   String? _userAvatar;
   double? _firstImageAspectRatio;
+  bool _showInsightText = true;
+  String? _replyToCommentId;
+  String? _replyToCommentName;
 
   @override
   void initState() {
@@ -69,10 +74,12 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   Future<void> _loadUserInfo() async {
     final name = await UserStorage.getUserId();
     final avatar = await UserStorage.getUserAvatar();
+    final settings = await _memexRouter.getCommentSettings();
     if (mounted) {
       setState(() {
         _userName = name ?? 'User';
         _userAvatar = avatar;
+        _showInsightText = settings.showInsightText;
       });
     }
   }
@@ -723,6 +730,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   }
 
   void _showInputModal(String cardId) {
+    final replyId = _replyToCommentId;
+    final replyName = _replyToCommentName;
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -736,6 +745,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
           color: Colors.white,
           child: _CommentInputWidget(
             cardId: cardId,
+            replyToId: replyId,
+            replyToName: replyName,
             onCommentPosted: () {
               Navigator.pop(context);
               _fetchDetail();
@@ -744,7 +755,15 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
           ),
         ),
       ),
-    );
+    ).whenComplete(() {
+      // Clear reply state when modal is dismissed
+      if (mounted) {
+        setState(() {
+          _replyToCommentId = null;
+          _replyToCommentName = null;
+        });
+      }
+    });
   }
 
   @override
@@ -1138,8 +1157,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   Widget _buildCommentsList(CardDetailModel detail) {
     final List<Widget> commentWidgets = [];
 
-    // Add Insight as the first "Pinned" comment/description
-    if (detail.insight.character != null) {
+    // Add Insight as the first "Pinned" comment/description (if enabled)
+    if (_showInsightText && detail.insight.character != null) {
       commentWidgets.add(
         _buildSingleComment(
           characterId: detail.insight.characterId,
@@ -1152,18 +1171,53 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       );
     }
 
+    // Build a lookup map for comment names (for reply chain display)
+    final commentNameMap = <String, String>{};
+    // Add insight character as a possible reply target
+    if (detail.insight.character != null) {
+      commentNameMap['insight'] = detail.insight.character!.name;
+    }
+    for (var comment in detail.insight.comments) {
+      final isUser = !comment.isAi;
+      final name = isUser ? _userName : (comment.character?.name ?? 'AI');
+      commentNameMap[comment.id] = name;
+    }
+
     // Add other comments
     for (var comment in detail.insight.comments) {
       final isUser = !comment.isAi;
+      final commentName =
+          isUser ? _userName : (comment.character?.name ?? 'AI');
       commentWidgets.add(
-        _buildSingleComment(
-          characterId: isUser ? 'user' : comment.character?.id,
-          avatar: isUser ? _userAvatar : comment.character?.avatar,
-          name: isUser ? _userName : (comment.character?.name ?? 'AI'),
-          content: comment.content,
-          time: DateFormat('MM-dd').format(
-              DateTime.fromMillisecondsSinceEpoch(comment.timestamp * 1000)),
-          isAi: comment.isAi,
+        Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: () {
+              // Tap a comment to reply to it
+              setState(() {
+                _replyToCommentId = comment.id;
+                _replyToCommentName = commentName;
+              });
+              _showInputModal(detail.id);
+            },
+            borderRadius: BorderRadius.circular(8),
+            splashColor: AppColors.primary.withValues(alpha: 0.06),
+            highlightColor: AppColors.primary.withValues(alpha: 0.03),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 2),
+              child: _buildSingleComment(
+                characterId: isUser ? 'user' : comment.character?.id,
+                avatar: isUser ? _userAvatar : comment.character?.avatar,
+                name: commentName,
+                content: comment.content,
+                time: DateFormat('MM-dd').format(
+                    DateTime.fromMillisecondsSinceEpoch(
+                        comment.timestamp * 1000)),
+                isAi: comment.isAi,
+                replyToName: comment.replyToName,
+              ),
+            ),
+          ),
         ),
       );
     }
@@ -1184,6 +1238,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     required String time,
     bool isAuthor = false,
     bool isAi = false,
+    String? replyToName,
   }) {
     // Determine avatar widget:
     // - characterId "0" or null = Memex system → use logo
@@ -1225,27 +1280,54 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       );
     }
 
+    // Wrap avatar with tap-to-chat for AI characters
+    final bool isCharacterAvatar = !isUserComment &&
+        !isMemexSystem &&
+        characterId != null &&
+        characterId != '0';
+    final tappableAvatar = isCharacterAvatar
+        ? GestureDetector(
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => PersonaChatScreen(characterId: characterId),
+                ),
+              );
+            },
+            child: avatarWidget,
+          )
+        : avatarWidget;
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        avatarWidget,
+        tappableAvatar,
         const SizedBox(width: 12),
         Expanded(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
+              // Name row with optional reply chain indicator
+              Wrap(
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: 0,
                 children: [
-                  Text(
-                    name,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                      color: Color(0xFF0A0A0A),
-                      letterSpacing: -0.15,
-                      height: 1.25,
+                  Text(name, style: AppTextStyles.commentName),
+                  if (replyToName != null) ...[
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 6),
+                      child: Icon(Icons.subdirectory_arrow_right_rounded,
+                          size: 14, color: AppColors.textTertiary),
                     ),
-                  ),
+                    Text(
+                      replyToName,
+                      style: AppTextStyles.commentName.copyWith(
+                        color: AppColors.primary,
+                        fontSize: 15,
+                      ),
+                    ),
+                  ],
                 ],
               ),
               const SizedBox(height: 4),
@@ -1254,61 +1336,32 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                   data: content,
                   softLineBreak: true,
                   styleSheet: MarkdownStyleSheet(
-                    p: const TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w400,
-                      color: Color(0xFF334155),
-                      height: 1.43,
-                      letterSpacing: 0,
-                    ),
-                    strong: const TextStyle(
+                    p: AppTextStyles.commentContent,
+                    strong: AppTextStyles.commentContent.copyWith(
                       fontWeight: FontWeight.w700,
-                      color: Color(0xFF0A0A0A),
+                      color: AppColors.textPrimary,
                     ),
                     em: const TextStyle(fontStyle: FontStyle.italic),
-                    listBullet: const TextStyle(color: Color(0xFF5B6CFF)),
-                    code: const TextStyle(
+                    listBullet: const TextStyle(color: AppColors.primary),
+                    code: TextStyle(
                       fontSize: 13,
-                      color: Color(0xFF334155),
-                      backgroundColor: Color(0xFFF7F8FA),
+                      color: AppColors.textSecondary,
+                      backgroundColor: AppColors.background,
                       fontFamily: 'monospace',
                     ),
                     codeblockDecoration: BoxDecoration(
-                      color: const Color(0xFFF7F8FA),
+                      color: AppColors.background,
                       borderRadius: BorderRadius.circular(8),
                     ),
                   ),
                 )
               else
-                Text(
-                  content,
-                  style: const TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w400,
-                    color: Color(0xFF334155),
-                    height: 1.43,
-                    letterSpacing: 0,
-                  ),
-                ),
-              const SizedBox(height: 4),
-              Row(
-                children: [
-                  Text(
-                    time,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w400,
-                      color: Color(0xFF94A3B8),
-                      height: 1.43,
-                      letterSpacing: -0.15,
-                    ),
-                  ),
-                ],
-              ),
+                Text(content, style: AppTextStyles.commentContent),
+              const SizedBox(height: 6),
+              Text(time, style: AppTextStyles.commentDate),
             ],
           ),
         ),
-        // Like button removed
       ],
     );
   }
@@ -1321,9 +1374,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       child: Container(
         padding: const EdgeInsets.fromLTRB(
             16, 8, 16, 32), // Safe area handled by bottom padding
-        decoration: const BoxDecoration(
-          color: Colors.white,
-          border: Border(top: BorderSide(color: Color(0xFFE2E8F0))),
+        decoration: BoxDecoration(
+          color: AppColors.cardBackground,
+          border: Border(
+              top: BorderSide(
+                  color: AppColors.textTertiary.withValues(alpha: 0.2))),
         ),
         child: Row(
           children: [
@@ -1334,18 +1389,18 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                   height: 36,
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   decoration: BoxDecoration(
-                    color: const Color(0xFFF7F8FA),
+                    color: AppColors.background,
                     borderRadius: BorderRadius.circular(18),
                   ),
                   child: Row(
                     children: [
-                      const Icon(Icons.edit_outlined,
-                          size: 16, color: Color(0xFF94A3B8)),
+                      Icon(Icons.edit_outlined,
+                          size: 16, color: AppColors.textTertiary),
                       const SizedBox(width: 8),
                       Text(
                         UserStorage.l10n.saySomething,
-                        style: const TextStyle(
-                            fontSize: 14, color: Color(0xFF94A3B8)),
+                        style: TextStyle(
+                            fontSize: 14, color: AppColors.textTertiary),
                       ),
                     ],
                   ),
@@ -1849,11 +1904,15 @@ class _CommentInputWidget extends StatefulWidget {
   final String cardId;
   final VoidCallback onCommentPosted;
   final bool autofocus;
+  final String? replyToId;
+  final String? replyToName;
 
   const _CommentInputWidget({
     required this.cardId,
     required this.onCommentPosted,
     this.autofocus = false,
+    this.replyToId,
+    this.replyToName,
   });
 
   @override
@@ -1880,7 +1939,11 @@ class _CommentInputWidgetState extends State<_CommentInputWidget> {
 
     try {
       final memexRouter = MemexRouter();
-      await memexRouter.postComment(widget.cardId, content);
+      await memexRouter.postComment(
+        widget.cardId,
+        content,
+        replyToId: widget.replyToId,
+      );
 
       _controller.clear();
       widget.onCommentPosted();
@@ -1903,56 +1966,99 @@ class _CommentInputWidgetState extends State<_CommentInputWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: const Color(0xFFF7F8FA),
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: TextField(
-              controller: _controller,
-              autofocus: widget.autofocus,
-              decoration: InputDecoration(
-                hintText: UserStorage.l10n.saySomething,
-                border: InputBorder.none,
-                contentPadding:
-                    EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                hintStyle: TextStyle(
-                  color: Color(0xFF94A3B8),
-                  fontSize: 14,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Reply-to banner (WeChat-style)
+        if (widget.replyToName != null)
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.06),
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(12)),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.reply_rounded, size: 16, color: AppColors.primary),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    UserStorage.l10n.replyTo(widget.replyToName!),
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.primary,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
-              ),
-              style: const TextStyle(
-                fontSize: 14,
-                color: Color(0xFF1E293B),
-              ),
-              maxLines: null,
-              textInputAction: TextInputAction.send,
-              onSubmitted: (_) => _postComment(),
+              ],
             ),
           ),
-          IconButton(
-            icon: _isPosting
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      valueColor:
-                          AlwaysStoppedAnimation<Color>(Color(0xFF6366F1)),
-                    ),
-                  )
-                : const Icon(
-                    Icons.send,
-                    color: Color(0xFF6366F1),
-                    size: 20,
+        // Input field
+        Container(
+          decoration: BoxDecoration(
+            color: AppColors.background,
+            borderRadius:
+                BorderRadius.circular(widget.replyToName != null ? 0 : 20),
+            border: widget.replyToName != null
+                ? null
+                : Border.all(
+                    color: AppColors.primary.withValues(alpha: 0.0),
+                    width: 1.5,
                   ),
-            onPressed: _isPosting ? null : _postComment,
           ),
-        ],
-      ),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  autofocus: widget.autofocus,
+                  decoration: InputDecoration(
+                    hintText: widget.replyToName != null
+                        ? UserStorage.l10n.replyTo(widget.replyToName!)
+                        : UserStorage.l10n.saySomething,
+                    border: InputBorder.none,
+                    contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 12),
+                    hintStyle: TextStyle(
+                      color: AppColors.textTertiary,
+                      fontSize: 14,
+                    ),
+                  ),
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: AppColors.textPrimary,
+                  ),
+                  maxLines: null,
+                  textInputAction: TextInputAction.send,
+                  onSubmitted: (_) => _postComment(),
+                ),
+              ),
+              IconButton(
+                icon: _isPosting
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor:
+                              AlwaysStoppedAnimation<Color>(AppColors.primary),
+                        ),
+                      )
+                    : Icon(
+                        Icons.send_rounded,
+                        color: AppColors.primary,
+                        size: 20,
+                      ),
+                onPressed: _isPosting ? null : _postComment,
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
Closes #27

## Summary

Comment section enhancements: insight/comment toggles, multi-character interaction, reply chains, and per-user settings.

## Changes

**Settings & Storage**
- Per-user comment settings stored in `_UserSettings/comment_settings.yaml` (not SharedPreferences)
- Three settings: show Memex insight comment, enable character auto-comment, max commenting characters (1–5)
- Settings UI with toggles and slider, wired through MemexRouter

**Multi-character commenting**
- When max characters > 1, an LLM call selects which characters should respond based on content affinity
- When max characters = 1, original keyword-based single-character selection (no extra LLM call)
- Characters comment sequentially so later ones see earlier comments

**Reply chains**
- `CardComment.replyToId` persisted in card YAML; `replyToName` resolved at query time
- Threaded display in comment section (name → replied-to name)
- Tap a comment to reply to it; reply-to banner shown in input
- User replies routed to the correct character

**Comment context**
- Existing comments injected into CommentAgent prompt as `<existing_comments>` block
- Includes reply relationships so agents understand the conversation thread

**UI polish**
- Comment section uses design system tokens (AppTextStyles, AppColors)
- InkWell tap feedback on comments
- Tap character avatar to open PersonaChatScreen
- Fix hardcoded 'Configure AI character' string → l10n

## Not changed

- Insight data generation pipeline (unaffected by display toggle)
- Existing single-character comment behavior when max = 1
