### PR TITLE
fix: 卡片详情页洞察/评论更新后自动刷新

### DIFF
--- a/lib/agent/skills/manage_pkm/pkm_skill.dart
+++ b/lib/agent/skills/manage_pkm/pkm_skill.dart
@@ -2,6 +2,7 @@ import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/agent/prompts.dart';
 import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
 
@@ -89,6 +90,11 @@ class PkmSkill extends Skill {
               stopFlag: stopFlag,
             );
           }
+
+          // Notify detail page to refresh after insight update
+          EventBusService.instance.emitEvent(CardDetailUpdatedMessage(
+            cardId: fact_id,
+          ));
 
           return AgentToolResult(
             content: TextPart(Prompts.pkmAgentUpdateCardInsightSuccess(

--- a/lib/data/services/task_handlers/card_agent_handler.dart
+++ b/lib/data/services/task_handlers/card_agent_handler.dart
@@ -76,10 +76,10 @@ Future<void> processWithCardAgent({
 
     final userMessageContent =
         Prompts.cardAgentUserMessagePromptForPublishNewContent(
-          publishTime,
-          factId,
-          enhancedFactContent,
-        );
+      publishTime,
+      factId,
+      enhancedFactContent,
+    );
 
     // 4. Run Agent
     await CardAgent.runWithContent(
@@ -159,12 +159,12 @@ Future<void> handleCardAgentImpl(
         combinedText: combinedText,
       );
       try {
-        final analysisResult = await LocalTaskExecutor.instance
-            .getTaskResultByBizId(
-              userId,
-              'handle_analyze_assets',
-              taskContext.bizId!,
-            );
+        final analysisResult =
+            await LocalTaskExecutor.instance.getTaskResultByBizId(
+          userId,
+          'handle_analyze_assets',
+          taskContext.bizId!,
+        );
 
         if (analysisResult != null &&
             analysisResult.containsKey('asset_analyses')) {
@@ -212,8 +212,7 @@ Future<void> renderAndPushCardUpdate(
   }
 
   final tags = cardData?.tags ?? <String>[];
-  final cardForRender =
-      cardData ??
+  final cardForRender = cardData ??
       CardData(
         factId: factId,
         timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:ui' as ui;
 import 'package:flutter/cupertino.dart';
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -23,6 +22,7 @@ import 'package:memex/ui/timeline/widgets/timeline/asset_header_gallery.dart';
 import 'package:memex/ui/core/widgets/local_image.dart';
 
 import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
+import 'package:memex/data/services/event_bus_service.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
@@ -52,9 +52,6 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   bool _isLoading = true;
   String? _errorMessage;
   late final MemexRouter _memexRouter;
-  Timer? _pollingTimer;
-  static const Duration _pollingInterval =
-      Duration(seconds: 5); // poll every 5s
   String _userName = 'User';
   String? _userAvatar;
   double? _firstImageAspectRatio;
@@ -67,8 +64,23 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     super.initState();
     _memexRouter = MemexRouter();
     _fetchDetail();
-    _startPollingIfNeeded();
     _loadUserInfo();
+    _setupEventBus();
+  }
+
+  void _setupEventBus() {
+    EventBusService.instance.addHandler(
+      EventBusMessageType.cardDetailUpdated,
+      _handleCardDetailUpdated,
+    );
+  }
+
+  void _handleCardDetailUpdated(EventBusMessage message) {
+    if (message is CardDetailUpdatedMessage &&
+        message.cardId == widget.cardId &&
+        mounted) {
+      _fetchDetail();
+    }
   }
 
   Future<void> _loadUserInfo() async {
@@ -99,7 +111,10 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
 
   @override
   void dispose() {
-    _stopPolling();
+    EventBusService.instance.removeHandler(
+      EventBusMessageType.cardDetailUpdated,
+      _handleCardDetailUpdated,
+    );
     super.dispose();
   }
 
@@ -129,48 +144,6 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       setState(() {
         _isLoading = false;
       });
-    }
-    // check polling status after setState
-    _startPollingIfNeeded();
-  }
-
-  /// Check if there is a pending comment (last comment is user, no follow-up AI reply yet)
-  bool get _hasPendingComment {
-    if (_detail == null) return false;
-    final comments = _detail!.insight.comments;
-    if (comments.isEmpty) return false;
-
-    // check if last comment is from user
-    final lastComment = comments.last;
-    return !lastComment.isAi;
-  }
-
-  void _startPollingIfNeeded() {
-    if (_hasPendingComment && _pollingTimer == null) {
-      _startPolling();
-    } else if (!_hasPendingComment && _pollingTimer != null) {
-      _stopPolling();
-    }
-  }
-
-  void _startPolling() {
-    if (_pollingTimer != null) {
-      return;
-    }
-
-    _pollingTimer = Timer.periodic(_pollingInterval, (timer) {
-      if (!mounted) {
-        timer.cancel();
-        return;
-      }
-      _fetchDetail();
-    });
-  }
-
-  void _stopPolling() {
-    if (_pollingTimer != null) {
-      _pollingTimer?.cancel();
-      _pollingTimer = null;
     }
   }
 


### PR DESCRIPTION
Closes #31

## 改动

卡片详情页在洞察产生或评论更新后自动刷新，替代原有的轮询机制。

### 变更点

- **详情页**：监听 `CardDetailUpdatedMessage` 事件，匹配当前 cardId 后自动刷新；移除 5 秒轮询
- **PkmSkill**：`update_timeline_card_insight` 工具写入 insight 成功后发送 `CardDetailUpdatedMessage`
- comment agent 的 `processAICommentReply` 已在发送该事件，无需改动

### 测试

- 进入卡片详情页，等待 PKM agent 产生洞察，页面应自动刷新显示
- 进入卡片详情页，等待 comment agent 生成初始评论，页面应自动刷新显示
- 在详情页手动发评论，AI 回复后页面应自动刷新（原轮询场景）