### PR TITLE
修正模型使用统计中的缓存命中率计算

### DIFF
--- a/lib/agent/agent_controller.util.dart
+++ b/lib/agent/agent_controller.util.dart
@@ -41,6 +41,7 @@ void addAgentLogger(AgentController controller) {
         handlerName: null,
         usage: event.response.usage!,
         model: event.response.model,
+        client: event.agent.client,
       );
     },
   );

--- a/lib/data/model/chat_events.dart
+++ b/lib/data/model/chat_events.dart
@@ -37,6 +37,7 @@ class ChatTokenUsageEvent extends ChatEvent {
   final int promptTokens;
   final int completionTokens;
   final int cachedTokens;
+  final int cacheBaseTokens;
   final int totalTokens;
   final double estimatedCost;
 
@@ -44,6 +45,7 @@ class ChatTokenUsageEvent extends ChatEvent {
     required this.promptTokens,
     required this.completionTokens,
     required this.cachedTokens,
+    required this.cacheBaseTokens,
     required this.totalTokens,
     required this.estimatedCost,
   });

--- a/lib/data/model/chat_events.dart
+++ b/lib/data/model/chat_events.dart
@@ -37,17 +37,23 @@ class ChatTokenUsageEvent extends ChatEvent {
   final int promptTokens;
   final int completionTokens;
   final int cachedTokens;
-  final int cacheBaseTokens;
   final int totalTokens;
   final double estimatedCost;
+
+  /// Normalized denominator for cache rate, computed per-call then summed.
+  final int effectivePromptTokens;
+
+  /// Numerator for cache rate (excludes unknown-semantics calls).
+  final int cachedTokensForRate;
 
   ChatTokenUsageEvent({
     required this.promptTokens,
     required this.completionTokens,
     required this.cachedTokens,
-    required this.cacheBaseTokens,
     required this.totalTokens,
     required this.estimatedCost,
+    this.effectivePromptTokens = 0,
+    this.cachedTokensForRate = 0,
   });
 }
 

--- a/lib/data/repositories/card.dart
+++ b/lib/data/repositories/card.dart
@@ -8,6 +8,7 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/llm_call_record_service.dart';
 import 'package:memex/data/services/character_service.dart';
 import 'package:memex/data/services/card_renderer.dart';
+import 'package:memex/utils/token_usage_utils.dart';
 
 final _logger = getLogger('CardDetailEndpoint');
 final _fileSystemService = FileSystemService.instance;
@@ -280,8 +281,8 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
           },
         };
 
-        double _calculateCost(
-            String model, int prompt, int completion, int cached, int thought) {
+        double _calculateCost(String model, int prompt, int completion,
+            int cached, int thought, bool? cachedTokensIncludedInPrompt) {
           // Find matching model pricing
           Map<String, double>? prices;
           for (final key in _pricing.keys) {
@@ -296,8 +297,12 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
 
           if (prices == null) return 0.0;
 
-          // Input cost: (prompt - cached) * input_price + cached * cached_price
-          final effectivePrompt = (prompt - cached) > 0 ? (prompt - cached) : 0;
+          // Input cost: uncached prompt * input_price + cached * cached_price.
+          final effectivePrompt = TokenUsageUtils.nonCachedPromptTokensOrNull(
+                  promptTokens: prompt,
+                  cachedTokens: cached,
+                  cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt) ??
+              prompt;
           final inputCost = (effectivePrompt * prices['input']!) +
               (cached * prices['cached']!);
 
@@ -316,6 +321,8 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
         int totalPromptTokens = 0;
         int totalCompletionTokens = 0;
         int totalCachedTokens = 0;
+        int totalCacheBaseTokens = 0;
+        int totalCacheUnknownTokens = 0;
         int totalThoughtTokens = 0;
         int totalTokens = 0;
         double totalCost = 0.0;
@@ -329,14 +336,29 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
           final tokens = usage['total_tokens'] as int? ?? 0;
           final agentName = call['agent_name'] as String;
           final model = call['model'] as String? ?? '';
+          final cachedTokensIncludedInPrompt =
+              TokenUsageUtils.cachedTokensIncludedInPrompt(
+            originalUsage: usage['original_usage'],
+            recordedValue: usage['cache_tokens_included_in_prompt'],
+          );
+          final cacheBaseTokens = (usage['cache_base_tokens'] as int?) ??
+              TokenUsageUtils.effectivePromptTokensOrNull(
+                promptTokens: promptTokens,
+                cachedTokens: cachedTokens,
+                cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
+              );
+          final cacheUnknownTokens =
+              cacheBaseTokens == null && cachedTokens > 0 ? cachedTokens : 0;
 
           final cost = _calculateCost(model, promptTokens, completionTokens,
-              cachedTokens, thoughtTokens);
+              cachedTokens, thoughtTokens, cachedTokensIncludedInPrompt);
 
           totalCalls++;
           totalPromptTokens += promptTokens;
           totalCompletionTokens += completionTokens;
           totalCachedTokens += cachedTokens;
+          totalCacheBaseTokens += cacheBaseTokens ?? 0;
+          totalCacheUnknownTokens += cacheUnknownTokens;
           totalThoughtTokens += thoughtTokens;
           totalTokens += tokens;
           totalCost += cost;
@@ -347,6 +369,8 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
               promptTokens: 0,
               completionTokens: 0,
               cachedTokens: 0,
+              cacheBaseTokens: 0,
+              cacheUnknownTokens: 0,
               thoughtTokens: 0,
               totalTokens: 0,
               totalCost: 0.0,
@@ -358,6 +382,9 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
             promptTokens: agentStat.promptTokens + promptTokens,
             completionTokens: agentStat.completionTokens + completionTokens,
             cachedTokens: agentStat.cachedTokens + cachedTokens,
+            cacheBaseTokens: agentStat.cacheBaseTokens + (cacheBaseTokens ?? 0),
+            cacheUnknownTokens:
+                agentStat.cacheUnknownTokens + cacheUnknownTokens,
             thoughtTokens: agentStat.thoughtTokens + thoughtTokens,
             totalTokens: agentStat.totalTokens + tokens,
             totalCost: agentStat.totalCost + cost,
@@ -369,6 +396,8 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
           totalPromptTokens: totalPromptTokens,
           totalCompletionTokens: totalCompletionTokens,
           totalCachedTokens: totalCachedTokens,
+          totalCacheBaseTokens: totalCacheBaseTokens,
+          totalCacheUnknownTokens: totalCacheUnknownTokens,
           totalThoughtTokens: totalThoughtTokens,
           totalTokens: totalTokens,
           totalCost: totalCost,

--- a/lib/data/repositories/card.dart
+++ b/lib/data/repositories/card.dart
@@ -253,76 +253,14 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
       );
 
       if (record != null) {
-        final _pricing = {
-          'gemini-3-flash-preview': {
-            'input': 0.0000005,
-            'cached': 0.00000005,
-            'output': 0.000003,
-          },
-          'gemini-2.5-flash': {
-            'input': 0.0000003,
-            'cached': 0.00000003,
-            'output': 0.0000025,
-          },
-          'gemini-3.1-pro-preview': {
-            'input': 0.000002,
-            'cached': 0.0000002,
-            'output': 0.000012,
-          },
-          'gemini-3-pro-preview': {
-            'input': 0.000002,
-            'cached': 0.0000002,
-            'output': 0.000012,
-          },
-          'gpt-4o': {
-            'input': 0.0000025,
-            'cached': 0.00000125,
-            'output': 0.00001,
-          },
-        };
-
-        double _calculateCost(String model, int prompt, int completion,
-            int cached, int thought, bool? cachedTokensIncludedInPrompt) {
-          // Find matching model pricing
-          Map<String, double>? prices;
-          for (final key in _pricing.keys) {
-            if (model.toLowerCase().contains(key)) {
-              prices = _pricing[key];
-              break;
-            }
-          }
-
-          // Default to gpt-4o if not found
-          prices ??= _pricing['gpt-4o'];
-
-          if (prices == null) return 0.0;
-
-          // Input cost: uncached prompt * input_price + cached * cached_price.
-          final effectivePrompt = TokenUsageUtils.nonCachedPromptTokensOrNull(
-                  promptTokens: prompt,
-                  cachedTokens: cached,
-                  cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt) ??
-              prompt;
-          final inputCost = (effectivePrompt * prices['input']!) +
-              (cached * prices['cached']!);
-
-          // Output cost: (completion + thought) * output_price
-          final outputCost = model.startsWith(
-                  'ep-') // todo: responses API completion includes thought
-              ? completion * prices['output']!
-              : (completion + thought) * prices['output']!;
-
-          return inputCost + outputCost;
-        }
-
         final calls = record['calls'] as List? ?? [];
-        final agentStats = <String, AgentStats>{};
+        final agentTokens = <String, AgentStats>{};
         int totalCalls = 0;
         int totalPromptTokens = 0;
         int totalCompletionTokens = 0;
         int totalCachedTokens = 0;
-        int totalCacheBaseTokens = 0;
-        int totalCacheUnknownTokens = 0;
+        int totalEffectivePromptTokens = 0;
+        int totalCachedForRate = 0;
         int totalThoughtTokens = 0;
         int totalTokens = 0;
         double totalCost = 0.0;
@@ -336,58 +274,46 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
           final tokens = usage['total_tokens'] as int? ?? 0;
           final agentName = call['agent_name'] as String;
           final model = call['model'] as String? ?? '';
-          final cachedTokensIncludedInPrompt =
-              TokenUsageUtils.cachedTokensIncludedInPrompt(
-            originalUsage: usage['original_usage'],
-            recordedValue: usage['cache_tokens_included_in_prompt'],
-          );
-          final cacheBaseTokens = (usage['cache_base_tokens'] as int?) ??
-              TokenUsageUtils.effectivePromptTokensOrNull(
-                promptTokens: promptTokens,
-                cachedTokens: cachedTokens,
-                cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
-              );
-          final cacheUnknownTokens =
-              cacheBaseTokens == null && cachedTokens > 0 ? cachedTokens : 0;
+          final sem = TokenUsageUtils.resolveFromUsageRecord(usage);
+          final effPrompt = TokenUsageUtils.effectivePromptTokensOrNull(
+              promptTokens: promptTokens,
+              cachedTokens: cachedTokens,
+              cachedTokensIncludedInPrompt: sem);
 
-          final cost = _calculateCost(model, promptTokens, completionTokens,
-              cachedTokens, thoughtTokens, cachedTokensIncludedInPrompt);
+          final cost = TokenUsageUtils.calculateCost(
+              model: model,
+              promptTokens: promptTokens,
+              completionTokens: completionTokens,
+              cachedTokens: cachedTokens,
+              thoughtTokens: thoughtTokens,
+              cachedTokensIncludedInPrompt: sem)['total']!;
 
           totalCalls++;
           totalPromptTokens += promptTokens;
           totalCompletionTokens += completionTokens;
           totalCachedTokens += cachedTokens;
-          totalCacheBaseTokens += cacheBaseTokens ?? 0;
-          totalCacheUnknownTokens += cacheUnknownTokens;
+          if (effPrompt != null) {
+            totalEffectivePromptTokens += effPrompt;
+            totalCachedForRate += cachedTokens;
+          }
           totalThoughtTokens += thoughtTokens;
           totalTokens += tokens;
           totalCost += cost;
 
-          if (!agentStats.containsKey(agentName)) {
-            agentStats[agentName] = AgentStats(
-              calls: 0,
-              promptTokens: 0,
-              completionTokens: 0,
-              cachedTokens: 0,
-              cacheBaseTokens: 0,
-              cacheUnknownTokens: 0,
-              thoughtTokens: 0,
-              totalTokens: 0,
-              totalCost: 0.0,
-            );
-          }
-          final agentStat = agentStats[agentName]!;
-          agentStats[agentName] = AgentStats(
-            calls: agentStat.calls + 1,
-            promptTokens: agentStat.promptTokens + promptTokens,
-            completionTokens: agentStat.completionTokens + completionTokens,
-            cachedTokens: agentStat.cachedTokens + cachedTokens,
-            cacheBaseTokens: agentStat.cacheBaseTokens + (cacheBaseTokens ?? 0),
-            cacheUnknownTokens:
-                agentStat.cacheUnknownTokens + cacheUnknownTokens,
-            thoughtTokens: agentStat.thoughtTokens + thoughtTokens,
-            totalTokens: agentStat.totalTokens + tokens,
-            totalCost: agentStat.totalCost + cost,
+          // Per-agent accumulation
+          final prev = agentTokens[agentName];
+          agentTokens[agentName] = AgentStats(
+            calls: (prev?.calls ?? 0) + 1,
+            promptTokens: (prev?.promptTokens ?? 0) + promptTokens,
+            completionTokens: (prev?.completionTokens ?? 0) + completionTokens,
+            cachedTokens: (prev?.cachedTokens ?? 0) + cachedTokens,
+            effectivePromptTokens:
+                (prev?.effectivePromptTokens ?? 0) + (effPrompt ?? 0),
+            cachedTokensForRate: (prev?.cachedTokensForRate ?? 0) +
+                (effPrompt != null ? cachedTokens : 0),
+            thoughtTokens: (prev?.thoughtTokens ?? 0) + thoughtTokens,
+            totalTokens: (prev?.totalTokens ?? 0) + tokens,
+            totalCost: (prev?.totalCost ?? 0) + cost,
           );
         }
 
@@ -396,12 +322,12 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
           totalPromptTokens: totalPromptTokens,
           totalCompletionTokens: totalCompletionTokens,
           totalCachedTokens: totalCachedTokens,
-          totalCacheBaseTokens: totalCacheBaseTokens,
-          totalCacheUnknownTokens: totalCacheUnknownTokens,
+          totalEffectivePromptTokens: totalEffectivePromptTokens,
+          totalCachedTokensForRate: totalCachedForRate,
           totalThoughtTokens: totalThoughtTokens,
           totalTokens: totalTokens,
           totalCost: totalCost,
-          byAgent: agentStats,
+          byAgent: agentTokens,
         );
       }
     } catch (e) {

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -15,6 +15,7 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/utils/user_storage.dart';
+import 'package:memex/utils/token_usage_utils.dart';
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 import 'package:yaml/yaml.dart';
@@ -61,9 +62,13 @@ class ChatService {
     // 1. Session Management
     try {
       if (finalSessionId.isEmpty) {
-        finalSessionId = await _createSession(userId, agentName, [
-          {'type': 'text', 'text': message}
-        ], isQuickQuery: isQuickQuery);
+        finalSessionId = await _createSession(
+            userId,
+            agentName,
+            [
+              {'type': 'text', 'text': message}
+            ],
+            isQuickQuery: isQuickQuery);
       }
 
       // Notify UI of the active session ID immediately
@@ -343,27 +348,40 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
       int totalPrompt = 0;
       int totalCompletion = 0;
       int totalCached = 0;
+      int totalCacheBase = 0;
       int totalTokens = 0;
       double totalCost = 0.0;
 
       for (final msg in event.modelMessages) {
         final u = msg.usage;
-        if (u == null)
+        if (u == null) {
           continue; // Just in case, but lint says it's not null. Actually if lint says it CANT be null, then I don't need check.
+        }
         // Wait, if lint says "Left operand cant be null", it means msg.usage is NOT null.
         // So I can just use it.
 
         final p = u.promptTokens;
         final c = u.completionTokens;
         final ca = u.cachedToken;
+        final cachedTokensIncludedInPrompt =
+            TokenUsageUtils.cachedTokensIncludedInPrompt(
+          client: event.agent.client,
+          originalUsage: u.originalUsage,
+        );
+        final cacheBase = TokenUsageUtils.effectivePromptTokensOrNull(
+            promptTokens: p,
+            cachedTokens: ca,
+            cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
 
         totalPrompt += p;
         totalCompletion += c;
         totalCached += ca;
+        totalCacheBase += cacheBase ?? 0;
         totalTokens += u.totalTokens;
 
         // Calculate cost
-        final cost = _calculateCost(msg.model, p, c, ca, u.thoughtToken);
+        final cost = _calculateCost(
+            msg.model, p, c, ca, u.thoughtToken, cachedTokensIncludedInPrompt);
         totalCost += cost['total']!;
       }
 
@@ -393,6 +411,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
         'prompt_tokens': totalPrompt,
         'completion_tokens': totalCompletion,
         'cached_tokens': totalCached,
+        'cache_base_tokens': totalCacheBase,
         'total_tokens': totalTokens,
         'total_cost': totalCost
       });
@@ -403,6 +422,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
           promptTokens: sessionTotalUsage['prompt_tokens'] as int? ?? 0,
           completionTokens: sessionTotalUsage['completion_tokens'] as int? ?? 0,
           cachedTokens: sessionTotalUsage['cached_tokens'] as int? ?? 0,
+          cacheBaseTokens: sessionTotalUsage['cache_base_tokens'] as int? ?? 0,
           totalTokens: sessionTotalUsage['total_tokens'] as int? ?? 0,
           estimatedCost: sessionTotalUsage['total_cost'] as double? ?? 0.0,
         ));
@@ -412,6 +432,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
           promptTokens: totalPrompt,
           completionTokens: totalCompletion,
           cachedTokens: totalCached,
+          cacheBaseTokens: totalCacheBase,
           totalTokens: totalTokens,
           estimatedCost: totalCost,
         ));
@@ -526,13 +547,16 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
     },
   };
 
-  Map<String, double> _calculateCost(
-      String model, int prompt, int completion, int cached, int thought) {
+  Map<String, double> _calculateCost(String model, int prompt, int completion,
+      int cached, int thought, bool? cachedTokensIncludedInPrompt) {
     // Default to gemini-1.5-flash pricing if unknown
     final prices = _pricing[model] ?? _pricing['gemini-3-flash-preview']!;
 
-    // Effective prompt tokens = total prompt - cached tokens
-    final effectivePrompt = (prompt - cached).clamp(0, prompt);
+    final effectivePrompt = TokenUsageUtils.nonCachedPromptTokensOrNull(
+            promptTokens: prompt,
+            cachedTokens: cached,
+            cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt) ??
+        prompt;
 
     final inputCost =
         (effectivePrompt * prices['input']!) + (cached * prices['cached']!);
@@ -640,6 +664,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
                 'prompt_tokens': 0,
                 'completion_tokens': 0,
                 'cached_tokens': 0,
+                'cache_base_tokens': 0,
                 'total_tokens': 0,
                 'total_cost': 0.0,
               };
@@ -651,6 +676,8 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
             (usage['completion_tokens'] as int? ?? 0),
         'cached_tokens': (currentTotal['cached_tokens'] as int? ?? 0) +
             (usage['cached_tokens'] as int? ?? 0),
+        'cache_base_tokens': (currentTotal['cache_base_tokens'] as int? ?? 0) +
+            (usage['cache_base_tokens'] as int? ?? 0),
         'total_tokens': (currentTotal['total_tokens'] as int? ?? 0) +
             (usage['total_tokens'] as int? ?? 0),
         'total_cost': (currentTotal['total_cost'] as double? ?? 0.0) +

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -348,41 +348,50 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
       int totalPrompt = 0;
       int totalCompletion = 0;
       int totalCached = 0;
-      int totalCacheBase = 0;
+      int totalEffectivePrompt = 0;
+      int totalCachedForRate = 0;
       int totalTokens = 0;
       double totalCost = 0.0;
+      // Within a single agent turn all calls share the same client.
+      bool? turnCacheSemantics;
 
       for (final msg in event.modelMessages) {
         final u = msg.usage;
         if (u == null) {
-          continue; // Just in case, but lint says it's not null. Actually if lint says it CANT be null, then I don't need check.
+          continue;
         }
-        // Wait, if lint says "Left operand cant be null", it means msg.usage is NOT null.
-        // So I can just use it.
 
         final p = u.promptTokens;
         final c = u.completionTokens;
         final ca = u.cachedToken;
-        final cachedTokensIncludedInPrompt =
-            TokenUsageUtils.cachedTokensIncludedInPrompt(
+        final sem = TokenUsageUtils.cachedTokensIncludedInPrompt(
           client: event.agent.client,
           originalUsage: u.originalUsage,
         );
-        final cacheBase = TokenUsageUtils.effectivePromptTokensOrNull(
+        turnCacheSemantics ??= sem;
+        final effP = TokenUsageUtils.effectivePromptTokensOrNull(
             promptTokens: p,
             cachedTokens: ca,
-            cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
+            cachedTokensIncludedInPrompt: sem);
 
         totalPrompt += p;
         totalCompletion += c;
         totalCached += ca;
-        totalCacheBase += cacheBase ?? 0;
+        if (effP != null) {
+          totalEffectivePrompt += effP;
+          totalCachedForRate += ca;
+        }
         totalTokens += u.totalTokens;
 
         // Calculate cost
-        final cost = _calculateCost(
-            msg.model, p, c, ca, u.thoughtToken, cachedTokensIncludedInPrompt);
-        totalCost += cost['total']!;
+        final cost = TokenUsageUtils.calculateCost(
+            model: msg.model,
+            promptTokens: p,
+            completionTokens: c,
+            cachedTokens: ca,
+            thoughtTokens: u.thoughtToken,
+            cachedTokensIncludedInPrompt: sem)['total']!;
+        totalCost += cost;
       }
 
       if (event.error != null) {
@@ -411,7 +420,8 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
         'prompt_tokens': totalPrompt,
         'completion_tokens': totalCompletion,
         'cached_tokens': totalCached,
-        'cache_base_tokens': totalCacheBase,
+        if (turnCacheSemantics != null)
+          'cache_tokens_included_in_prompt': turnCacheSemantics,
         'total_tokens': totalTokens,
         'total_cost': totalCost
       });
@@ -422,7 +432,8 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
           promptTokens: sessionTotalUsage['prompt_tokens'] as int? ?? 0,
           completionTokens: sessionTotalUsage['completion_tokens'] as int? ?? 0,
           cachedTokens: sessionTotalUsage['cached_tokens'] as int? ?? 0,
-          cacheBaseTokens: sessionTotalUsage['cache_base_tokens'] as int? ?? 0,
+          effectivePromptTokens: totalEffectivePrompt,
+          cachedTokensForRate: totalCachedForRate,
           totalTokens: sessionTotalUsage['total_tokens'] as int? ?? 0,
           estimatedCost: sessionTotalUsage['total_cost'] as double? ?? 0.0,
         ));
@@ -432,7 +443,8 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
           promptTokens: totalPrompt,
           completionTokens: totalCompletion,
           cachedTokens: totalCached,
-          cacheBaseTokens: totalCacheBase,
+          effectivePromptTokens: totalEffectivePrompt,
+          cachedTokensForRate: totalCachedForRate,
           totalTokens: totalTokens,
           estimatedCost: totalCost,
         ));
@@ -517,59 +529,6 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
       stream.add(ChatToolResultEvent(event.result.name, resultPreview,
           isError: event.result.isError));
     });
-  }
-
-  static const _pricing = {
-    'gemini-3-flash-preview': {
-      'input': 0.0000005,
-      'cached': 0.00000005,
-      'output': 0.000003,
-    },
-    'gemini-2.5-flash': {
-      'input': 0.0000003,
-      'cached': 0.00000003,
-      'output': 0.0000025,
-    },
-    'gemini-3.1-pro-preview': {
-      'input': 0.000002,
-      'cached': 0.0000002,
-      'output': 0.000012,
-    },
-    'gemini-3-pro-preview': {
-      'input': 0.000002,
-      'cached': 0.0000002,
-      'output': 0.000012,
-    },
-    'gpt-4o': {
-      'input': 0.0000025,
-      'cached': 0.00000125,
-      'output': 0.00001,
-    },
-  };
-
-  Map<String, double> _calculateCost(String model, int prompt, int completion,
-      int cached, int thought, bool? cachedTokensIncludedInPrompt) {
-    // Default to gemini-1.5-flash pricing if unknown
-    final prices = _pricing[model] ?? _pricing['gemini-3-flash-preview']!;
-
-    final effectivePrompt = TokenUsageUtils.nonCachedPromptTokensOrNull(
-            promptTokens: prompt,
-            cachedTokens: cached,
-            cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt) ??
-        prompt;
-
-    final inputCost =
-        (effectivePrompt * prices['input']!) + (cached * prices['cached']!);
-    final outputCost = model.startsWith(
-            'ep-') // todo: responses API completion includes thought
-        ? completion * prices['output']!
-        : (completion + thought) * prices['output']!;
-
-    return {
-      'input': inputCost,
-      'output': outputCost,
-      'total': inputCost + outputCost,
-    };
   }
 
   // --- Session Helpers (Recreated from chat.dart to be independent) ---
@@ -664,7 +623,6 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
                 'prompt_tokens': 0,
                 'completion_tokens': 0,
                 'cached_tokens': 0,
-                'cache_base_tokens': 0,
                 'total_tokens': 0,
                 'total_cost': 0.0,
               };
@@ -676,8 +634,6 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
             (usage['completion_tokens'] as int? ?? 0),
         'cached_tokens': (currentTotal['cached_tokens'] as int? ?? 0) +
             (usage['cached_tokens'] as int? ?? 0),
-        'cache_base_tokens': (currentTotal['cache_base_tokens'] as int? ?? 0) +
-            (usage['cache_base_tokens'] as int? ?? 0),
         'total_tokens': (currentTotal['total_tokens'] as int? ?? 0) +
             (usage['total_tokens'] as int? ?? 0),
         'total_cost': (currentTotal['total_cost'] as double? ?? 0.0) +

--- a/lib/data/services/llm_call_record_service.dart
+++ b/lib/data/services/llm_call_record_service.dart
@@ -7,6 +7,7 @@ import 'package:synchronized/synchronized.dart';
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:uuid/uuid.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/token_usage_utils.dart';
 import 'file_system_service.dart';
 import 'base_file_service.dart';
 
@@ -137,6 +138,7 @@ class LLMCallRecordService {
     String? handlerName,
     required ModelUsage usage,
     required String model,
+    Object? client,
     Map<String, dynamic>? metadata,
   }) async {
     return _lock.synchronized(() async {
@@ -165,6 +167,16 @@ class LLMCallRecordService {
 
         // Append the new call to the record.
         final callId = _uuid.v4();
+        final cachedTokensIncludedInPrompt =
+            TokenUsageUtils.cachedTokensIncludedInPrompt(
+          client: client,
+          originalUsage: usage.originalUsage,
+        );
+        final cacheBaseTokens = TokenUsageUtils.effectivePromptTokensOrNull(
+          promptTokens: usage.promptTokens,
+          cachedTokens: usage.cachedToken,
+          cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
+        );
         final call = {
           'call_id': callId,
           'agent_name': agentName,
@@ -177,6 +189,9 @@ class LLMCallRecordService {
             'total_tokens': usage.totalTokens,
             if (usage.model != null) 'model': usage.model,
             'cached_tokens': usage.cachedToken,
+            if (cachedTokensIncludedInPrompt != null)
+              'cache_tokens_included_in_prompt': cachedTokensIncludedInPrompt,
+            if (cacheBaseTokens != null) 'cache_base_tokens': cacheBaseTokens,
             'thought_tokens': usage.thoughtToken,
             if (usage.originalUsage != null)
               'original_usage': usage.originalUsage,
@@ -316,6 +331,8 @@ class LLMCallRecordService {
     int totalPromptTokens = 0;
     int totalCompletionTokens = 0;
     int totalCachedTokens = 0;
+    int totalCacheBaseTokens = 0;
+    int totalCacheUnknownTokens = 0;
     int totalThoughtTokens = 0;
     int totalTokens = 0;
 
@@ -329,6 +346,18 @@ class LLMCallRecordService {
         final promptTokens = usage['prompt_tokens'] as int? ?? 0;
         final completionTokens = usage['completion_tokens'] as int? ?? 0;
         final cachedTokens = usage['cached_tokens'] as int? ?? 0;
+        final cachedTokensIncludedInPrompt =
+            TokenUsageUtils.cachedTokensIncludedInPrompt(
+          originalUsage: usage['original_usage'],
+          recordedValue: usage['cache_tokens_included_in_prompt'],
+        );
+        final cacheBaseTokens = (usage['cache_base_tokens'] as int?) ??
+            TokenUsageUtils.effectivePromptTokensOrNull(
+                promptTokens: promptTokens,
+                cachedTokens: cachedTokens,
+                cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
+        final cacheUnknownTokens =
+            cacheBaseTokens == null && cachedTokens > 0 ? cachedTokens : 0;
         final thoughtTokens = usage['thought_tokens'] as int? ?? 0;
         final tokens = usage['total_tokens'] as int? ?? 0;
         final agentName = call['agent_name'] as String;
@@ -346,6 +375,8 @@ class LLMCallRecordService {
             'prompt_tokens': 0,
             'completion_tokens': 0,
             'cached_tokens': 0,
+            'cache_base_tokens': 0,
+            'cache_unknown_tokens': 0,
             'thought_tokens': 0,
             'total_tokens': 0,
           };
@@ -358,6 +389,10 @@ class LLMCallRecordService {
             (dayStat['completion_tokens'] as int) + completionTokens;
         dayStat['cached_tokens'] =
             (dayStat['cached_tokens'] as int) + cachedTokens;
+        dayStat['cache_base_tokens'] =
+            (dayStat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
+        dayStat['cache_unknown_tokens'] =
+            (dayStat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
         dayStat['thought_tokens'] =
             (dayStat['thought_tokens'] as int) + thoughtTokens;
         dayStat['total_tokens'] = (dayStat['total_tokens'] as int) + tokens;
@@ -371,6 +406,8 @@ class LLMCallRecordService {
             'prompt_tokens': 0,
             'completion_tokens': 0,
             'cached_tokens': 0,
+            'cache_base_tokens': 0,
+            'cache_unknown_tokens': 0,
             'thought_tokens': 0,
             'total_tokens': 0,
           };
@@ -383,6 +420,10 @@ class LLMCallRecordService {
             (monthStat['completion_tokens'] as int) + completionTokens;
         monthStat['cached_tokens'] =
             (monthStat['cached_tokens'] as int) + cachedTokens;
+        monthStat['cache_base_tokens'] =
+            (monthStat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
+        monthStat['cache_unknown_tokens'] =
+            (monthStat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
         monthStat['thought_tokens'] =
             (monthStat['thought_tokens'] as int) + thoughtTokens;
         monthStat['total_tokens'] = (monthStat['total_tokens'] as int) + tokens;
@@ -394,6 +435,8 @@ class LLMCallRecordService {
             'prompt_tokens': 0,
             'completion_tokens': 0,
             'cached_tokens': 0,
+            'cache_base_tokens': 0,
+            'cache_unknown_tokens': 0,
             'thought_tokens': 0,
             'total_tokens': 0,
           };
@@ -406,6 +449,10 @@ class LLMCallRecordService {
             (sceneStat['completion_tokens'] as int) + completionTokens;
         sceneStat['cached_tokens'] =
             (sceneStat['cached_tokens'] as int) + cachedTokens;
+        sceneStat['cache_base_tokens'] =
+            (sceneStat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
+        sceneStat['cache_unknown_tokens'] =
+            (sceneStat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
         sceneStat['thought_tokens'] =
             (sceneStat['thought_tokens'] as int) + thoughtTokens;
         sceneStat['total_tokens'] = (sceneStat['total_tokens'] as int) + tokens;
@@ -417,6 +464,8 @@ class LLMCallRecordService {
             'prompt_tokens': 0,
             'completion_tokens': 0,
             'cached_tokens': 0,
+            'cache_base_tokens': 0,
+            'cache_unknown_tokens': 0,
             'thought_tokens': 0,
             'total_tokens': 0,
           };
@@ -429,6 +478,10 @@ class LLMCallRecordService {
             (aggAgentStat['completion_tokens'] as int) + completionTokens;
         aggAgentStat['cached_tokens'] =
             (aggAgentStat['cached_tokens'] as int) + cachedTokens;
+        aggAgentStat['cache_base_tokens'] =
+            (aggAgentStat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
+        aggAgentStat['cache_unknown_tokens'] =
+            (aggAgentStat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
         aggAgentStat['thought_tokens'] =
             (aggAgentStat['thought_tokens'] as int) + thoughtTokens;
         aggAgentStat['total_tokens'] =
@@ -439,6 +492,8 @@ class LLMCallRecordService {
         totalPromptTokens += promptTokens;
         totalCompletionTokens += completionTokens;
         totalCachedTokens += cachedTokens;
+        totalCacheBaseTokens += cacheBaseTokens ?? 0;
+        totalCacheUnknownTokens += cacheUnknownTokens;
         totalThoughtTokens += thoughtTokens;
         totalTokens += tokens;
       }
@@ -450,6 +505,8 @@ class LLMCallRecordService {
         'prompt_tokens': totalPromptTokens,
         'completion_tokens': totalCompletionTokens,
         'cached_tokens': totalCachedTokens,
+        'cache_base_tokens': totalCacheBaseTokens,
+        'cache_unknown_tokens': totalCacheUnknownTokens,
         'thought_tokens': totalThoughtTokens,
         'total_tokens': totalTokens,
       },
@@ -460,4 +517,3 @@ class LLMCallRecordService {
     };
   }
 }
-

--- a/lib/data/services/llm_call_record_service.dart
+++ b/lib/data/services/llm_call_record_service.dart
@@ -20,7 +20,7 @@ class LLMCallRecordService {
   final BaseFileService _baseService = BaseFileService();
   final Logger _logger = getLogger('LLMCallRecordService');
   final _lock = Lock();
-  final _uuid = Uuid();
+  final _uuid = const Uuid();
 
   static LLMCallRecordService? _instance;
   static LLMCallRecordService get instance {
@@ -96,6 +96,7 @@ class LLMCallRecordService {
     String? handlerName,
     required ModelMessage message,
     required AgentState state,
+    Object? client,
   }) async {
     if (message.usage == null) {
       return; // No usage data, skip recording
@@ -117,6 +118,7 @@ class LLMCallRecordService {
       handlerName: handlerName,
       usage: message.usage!,
       model: message.model,
+      client: client,
     );
   }
 
@@ -165,18 +167,15 @@ class LLMCallRecordService {
           record = _createEmptyRecord(scene, sceneId);
         }
 
-        // Append the new call to the record.
-        final callId = _uuid.v4();
+        // Resolve cache semantics from client + original usage.
         final cachedTokensIncludedInPrompt =
             TokenUsageUtils.cachedTokensIncludedInPrompt(
           client: client,
           originalUsage: usage.originalUsage,
         );
-        final cacheBaseTokens = TokenUsageUtils.effectivePromptTokensOrNull(
-          promptTokens: usage.promptTokens,
-          cachedTokens: usage.cachedToken,
-          cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
-        );
+
+        // Append the new call to the record.
+        final callId = _uuid.v4();
         final call = {
           'call_id': callId,
           'agent_name': agentName,
@@ -191,7 +190,6 @@ class LLMCallRecordService {
             'cached_tokens': usage.cachedToken,
             if (cachedTokensIncludedInPrompt != null)
               'cache_tokens_included_in_prompt': cachedTokensIncludedInPrompt,
-            if (cacheBaseTokens != null) 'cache_base_tokens': cacheBaseTokens,
             'thought_tokens': usage.thoughtToken,
             if (usage.originalUsage != null)
               'original_usage': usage.originalUsage,
@@ -331,8 +329,8 @@ class LLMCallRecordService {
     int totalPromptTokens = 0;
     int totalCompletionTokens = 0;
     int totalCachedTokens = 0;
-    int totalCacheBaseTokens = 0;
-    int totalCacheUnknownTokens = 0;
+    int totalEffectivePromptTokens = 0;
+    int totalCachedForRate = 0;
     int totalThoughtTokens = 0;
     int totalTokens = 0;
 
@@ -346,18 +344,11 @@ class LLMCallRecordService {
         final promptTokens = usage['prompt_tokens'] as int? ?? 0;
         final completionTokens = usage['completion_tokens'] as int? ?? 0;
         final cachedTokens = usage['cached_tokens'] as int? ?? 0;
-        final cachedTokensIncludedInPrompt =
-            TokenUsageUtils.cachedTokensIncludedInPrompt(
-          originalUsage: usage['original_usage'],
-          recordedValue: usage['cache_tokens_included_in_prompt'],
-        );
-        final cacheBaseTokens = (usage['cache_base_tokens'] as int?) ??
-            TokenUsageUtils.effectivePromptTokensOrNull(
-                promptTokens: promptTokens,
-                cachedTokens: cachedTokens,
-                cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
-        final cacheUnknownTokens =
-            cacheBaseTokens == null && cachedTokens > 0 ? cachedTokens : 0;
+        final sem = TokenUsageUtils.resolveFromUsageRecord(usage);
+        final effPrompt = TokenUsageUtils.effectivePromptTokensOrNull(
+            promptTokens: promptTokens,
+            cachedTokens: cachedTokens,
+            cachedTokensIncludedInPrompt: sem);
         final thoughtTokens = usage['thought_tokens'] as int? ?? 0;
         final tokens = usage['total_tokens'] as int? ?? 0;
         final agentName = call['agent_name'] as String;
@@ -366,134 +357,65 @@ class LLMCallRecordService {
             ? DateTime.fromMicrosecondsSinceEpoch(timestamp)
             : DateTime.fromMicrosecondsSinceEpoch(record['created_at'] as int);
 
+        // Helper to create empty stat bucket.
+        Map<String, dynamic> emptyStat() => {
+              'calls': 0,
+              'prompt_tokens': 0,
+              'completion_tokens': 0,
+              'cached_tokens': 0,
+              'effective_prompt_tokens': 0,
+              'cached_tokens_for_rate': 0,
+              'thought_tokens': 0,
+              'total_tokens': 0,
+            };
+
+        // Helper to accumulate into a stat bucket.
+        void accumulate(Map<String, dynamic> stat) {
+          stat['calls'] = (stat['calls'] as int) + 1;
+          stat['prompt_tokens'] = (stat['prompt_tokens'] as int) + promptTokens;
+          stat['completion_tokens'] =
+              (stat['completion_tokens'] as int) + completionTokens;
+          stat['cached_tokens'] = (stat['cached_tokens'] as int) + cachedTokens;
+          if (effPrompt != null) {
+            stat['effective_prompt_tokens'] =
+                (stat['effective_prompt_tokens'] as int) + effPrompt;
+            stat['cached_tokens_for_rate'] =
+                (stat['cached_tokens_for_rate'] as int) + cachedTokens;
+          }
+          stat['thought_tokens'] =
+              (stat['thought_tokens'] as int) + thoughtTokens;
+          stat['total_tokens'] = (stat['total_tokens'] as int) + tokens;
+        }
+
         // Aggregate by day.
         final dayKey =
             '${callCreatedAt.year}-${callCreatedAt.month.toString().padLeft(2, '0')}-${callCreatedAt.day.toString().padLeft(2, '0')}';
-        if (!dailyStats.containsKey(dayKey)) {
-          dailyStats[dayKey] = {
-            'calls': 0,
-            'prompt_tokens': 0,
-            'completion_tokens': 0,
-            'cached_tokens': 0,
-            'cache_base_tokens': 0,
-            'cache_unknown_tokens': 0,
-            'thought_tokens': 0,
-            'total_tokens': 0,
-          };
-        }
-        final dayStat = dailyStats[dayKey]!;
-        dayStat['calls'] = (dayStat['calls'] as int) + 1;
-        dayStat['prompt_tokens'] =
-            (dayStat['prompt_tokens'] as int) + promptTokens;
-        dayStat['completion_tokens'] =
-            (dayStat['completion_tokens'] as int) + completionTokens;
-        dayStat['cached_tokens'] =
-            (dayStat['cached_tokens'] as int) + cachedTokens;
-        dayStat['cache_base_tokens'] =
-            (dayStat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
-        dayStat['cache_unknown_tokens'] =
-            (dayStat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
-        dayStat['thought_tokens'] =
-            (dayStat['thought_tokens'] as int) + thoughtTokens;
-        dayStat['total_tokens'] = (dayStat['total_tokens'] as int) + tokens;
+        dailyStats.putIfAbsent(dayKey, emptyStat);
+        accumulate(dailyStats[dayKey]!);
 
         // Aggregate by month.
         final monthKey =
             '${callCreatedAt.year}-${callCreatedAt.month.toString().padLeft(2, '0')}';
-        if (!monthlyStats.containsKey(monthKey)) {
-          monthlyStats[monthKey] = {
-            'calls': 0,
-            'prompt_tokens': 0,
-            'completion_tokens': 0,
-            'cached_tokens': 0,
-            'cache_base_tokens': 0,
-            'cache_unknown_tokens': 0,
-            'thought_tokens': 0,
-            'total_tokens': 0,
-          };
-        }
-        final monthStat = monthlyStats[monthKey]!;
-        monthStat['calls'] = (monthStat['calls'] as int) + 1;
-        monthStat['prompt_tokens'] =
-            (monthStat['prompt_tokens'] as int) + promptTokens;
-        monthStat['completion_tokens'] =
-            (monthStat['completion_tokens'] as int) + completionTokens;
-        monthStat['cached_tokens'] =
-            (monthStat['cached_tokens'] as int) + cachedTokens;
-        monthStat['cache_base_tokens'] =
-            (monthStat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
-        monthStat['cache_unknown_tokens'] =
-            (monthStat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
-        monthStat['thought_tokens'] =
-            (monthStat['thought_tokens'] as int) + thoughtTokens;
-        monthStat['total_tokens'] = (monthStat['total_tokens'] as int) + tokens;
+        monthlyStats.putIfAbsent(monthKey, emptyStat);
+        accumulate(monthlyStats[monthKey]!);
 
         // Aggregate by scene.
-        if (!sceneStats.containsKey(sceneType)) {
-          sceneStats[sceneType] = {
-            'calls': 0,
-            'prompt_tokens': 0,
-            'completion_tokens': 0,
-            'cached_tokens': 0,
-            'cache_base_tokens': 0,
-            'cache_unknown_tokens': 0,
-            'thought_tokens': 0,
-            'total_tokens': 0,
-          };
-        }
-        final sceneStat = sceneStats[sceneType]!;
-        sceneStat['calls'] = (sceneStat['calls'] as int) + 1;
-        sceneStat['prompt_tokens'] =
-            (sceneStat['prompt_tokens'] as int) + promptTokens;
-        sceneStat['completion_tokens'] =
-            (sceneStat['completion_tokens'] as int) + completionTokens;
-        sceneStat['cached_tokens'] =
-            (sceneStat['cached_tokens'] as int) + cachedTokens;
-        sceneStat['cache_base_tokens'] =
-            (sceneStat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
-        sceneStat['cache_unknown_tokens'] =
-            (sceneStat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
-        sceneStat['thought_tokens'] =
-            (sceneStat['thought_tokens'] as int) + thoughtTokens;
-        sceneStat['total_tokens'] = (sceneStat['total_tokens'] as int) + tokens;
+        sceneStats.putIfAbsent(sceneType, emptyStat);
+        accumulate(sceneStats[sceneType]!);
 
         // Aggregate by agent.
-        if (!agentStats.containsKey(agentName)) {
-          agentStats[agentName] = {
-            'calls': 0,
-            'prompt_tokens': 0,
-            'completion_tokens': 0,
-            'cached_tokens': 0,
-            'cache_base_tokens': 0,
-            'cache_unknown_tokens': 0,
-            'thought_tokens': 0,
-            'total_tokens': 0,
-          };
-        }
-        final aggAgentStat = agentStats[agentName]!;
-        aggAgentStat['calls'] = (aggAgentStat['calls'] as int) + 1;
-        aggAgentStat['prompt_tokens'] =
-            (aggAgentStat['prompt_tokens'] as int) + promptTokens;
-        aggAgentStat['completion_tokens'] =
-            (aggAgentStat['completion_tokens'] as int) + completionTokens;
-        aggAgentStat['cached_tokens'] =
-            (aggAgentStat['cached_tokens'] as int) + cachedTokens;
-        aggAgentStat['cache_base_tokens'] =
-            (aggAgentStat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
-        aggAgentStat['cache_unknown_tokens'] =
-            (aggAgentStat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
-        aggAgentStat['thought_tokens'] =
-            (aggAgentStat['thought_tokens'] as int) + thoughtTokens;
-        aggAgentStat['total_tokens'] =
-            (aggAgentStat['total_tokens'] as int) + tokens;
+        agentStats.putIfAbsent(agentName, emptyStat);
+        accumulate(agentStats[agentName]!);
 
         // Totals.
         totalCalls++;
         totalPromptTokens += promptTokens;
         totalCompletionTokens += completionTokens;
         totalCachedTokens += cachedTokens;
-        totalCacheBaseTokens += cacheBaseTokens ?? 0;
-        totalCacheUnknownTokens += cacheUnknownTokens;
+        if (effPrompt != null) {
+          totalEffectivePromptTokens += effPrompt;
+          totalCachedForRate += cachedTokens;
+        }
         totalThoughtTokens += thoughtTokens;
         totalTokens += tokens;
       }
@@ -505,8 +427,8 @@ class LLMCallRecordService {
         'prompt_tokens': totalPromptTokens,
         'completion_tokens': totalCompletionTokens,
         'cached_tokens': totalCachedTokens,
-        'cache_base_tokens': totalCacheBaseTokens,
-        'cache_unknown_tokens': totalCacheUnknownTokens,
+        'effective_prompt_tokens': totalEffectivePromptTokens,
+        'cached_tokens_for_rate': totalCachedForRate,
         'thought_tokens': totalThoughtTokens,
         'total_tokens': totalTokens,
       },

--- a/lib/data/services/task_handlers/analyze_assets_handler.dart
+++ b/lib/data/services/task_handlers/analyze_assets_handler.dart
@@ -376,6 +376,7 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
           handlerName: 'analyze_assets_handler',
           usage: toolUsage,
           model: toolModel,
+          client: client,
           metadata: {
             'asset_path': assetPath,
             'asset_index': index + 1,

--- a/lib/domain/models/card_detail_model.dart
+++ b/lib/domain/models/card_detail_model.dart
@@ -266,6 +266,8 @@ class LLMStats {
   final int totalPromptTokens;
   final int totalCompletionTokens;
   final int totalCachedTokens;
+  final int totalCacheBaseTokens;
+  final int totalCacheUnknownTokens;
   final int totalThoughtTokens;
   final int totalTokens;
   final double totalCost;
@@ -276,6 +278,8 @@ class LLMStats {
     required this.totalPromptTokens,
     required this.totalCompletionTokens,
     required this.totalCachedTokens,
+    this.totalCacheBaseTokens = 0,
+    this.totalCacheUnknownTokens = 0,
     required this.totalThoughtTokens,
     required this.totalTokens,
     this.totalCost = 0.0,
@@ -294,6 +298,8 @@ class LLMStats {
       totalPromptTokens: json['total_prompt_tokens'] as int? ?? 0,
       totalCompletionTokens: json['total_completion_tokens'] as int? ?? 0,
       totalCachedTokens: json['total_cached_tokens'] as int? ?? 0,
+      totalCacheBaseTokens: json['total_cache_base_tokens'] as int? ?? 0,
+      totalCacheUnknownTokens: json['total_cache_unknown_tokens'] as int? ?? 0,
       totalThoughtTokens: json['total_thought_tokens'] as int? ?? 0,
       totalTokens: json['total_tokens'] as int? ?? 0,
       totalCost: (json['total_cost'] as num?)?.toDouble() ?? 0.0,
@@ -307,6 +313,8 @@ class LLMStats {
       'total_prompt_tokens': totalPromptTokens,
       'total_completion_tokens': totalCompletionTokens,
       'total_cached_tokens': totalCachedTokens,
+      'total_cache_base_tokens': totalCacheBaseTokens,
+      'total_cache_unknown_tokens': totalCacheUnknownTokens,
       'total_thought_tokens': totalThoughtTokens,
       'total_tokens': totalTokens,
       'total_cost': totalCost,
@@ -321,6 +329,8 @@ class AgentStats {
   final int promptTokens;
   final int completionTokens;
   final int cachedTokens;
+  final int cacheBaseTokens;
+  final int cacheUnknownTokens;
   final int thoughtTokens;
   final int totalTokens;
   final double totalCost;
@@ -330,6 +340,8 @@ class AgentStats {
     required this.promptTokens,
     required this.completionTokens,
     required this.cachedTokens,
+    this.cacheBaseTokens = 0,
+    this.cacheUnknownTokens = 0,
     required this.thoughtTokens,
     required this.totalTokens,
     this.totalCost = 0.0,
@@ -341,6 +353,8 @@ class AgentStats {
       promptTokens: json['prompt_tokens'] as int? ?? 0,
       completionTokens: json['completion_tokens'] as int? ?? 0,
       cachedTokens: json['cached_tokens'] as int? ?? 0,
+      cacheBaseTokens: json['cache_base_tokens'] as int? ?? 0,
+      cacheUnknownTokens: json['cache_unknown_tokens'] as int? ?? 0,
       thoughtTokens: json['thought_tokens'] as int? ?? 0,
       totalTokens: json['total_tokens'] as int? ?? 0,
       totalCost: (json['total_cost'] as num?)?.toDouble() ?? 0.0,
@@ -353,6 +367,8 @@ class AgentStats {
       'prompt_tokens': promptTokens,
       'completion_tokens': completionTokens,
       'cached_tokens': cachedTokens,
+      'cache_base_tokens': cacheBaseTokens,
+      'cache_unknown_tokens': cacheUnknownTokens,
       'thought_tokens': thoughtTokens,
       'total_tokens': totalTokens,
       'total_cost': totalCost,

--- a/lib/domain/models/card_detail_model.dart
+++ b/lib/domain/models/card_detail_model.dart
@@ -266,24 +266,30 @@ class LLMStats {
   final int totalPromptTokens;
   final int totalCompletionTokens;
   final int totalCachedTokens;
-  final int totalCacheBaseTokens;
-  final int totalCacheUnknownTokens;
   final int totalThoughtTokens;
   final int totalTokens;
   final double totalCost;
   final Map<String, AgentStats> byAgent;
+
+  /// Normalized denominator for cache rate: sum of per-call effectivePromptTokens.
+  /// Each call's effective prompt is computed from its own cachedTokensIncludedInPrompt.
+  /// Calls with unknown semantics are excluded.
+  final int totalEffectivePromptTokens;
+
+  /// Numerator for cache rate: cached tokens from calls with known semantics only.
+  final int totalCachedTokensForRate;
 
   LLMStats({
     required this.totalCalls,
     required this.totalPromptTokens,
     required this.totalCompletionTokens,
     required this.totalCachedTokens,
-    this.totalCacheBaseTokens = 0,
-    this.totalCacheUnknownTokens = 0,
     required this.totalThoughtTokens,
     required this.totalTokens,
     this.totalCost = 0.0,
     required this.byAgent,
+    this.totalEffectivePromptTokens = 0,
+    this.totalCachedTokensForRate = 0,
   });
 
   factory LLMStats.fromJson(Map<String, dynamic> json) {
@@ -298,12 +304,14 @@ class LLMStats {
       totalPromptTokens: json['total_prompt_tokens'] as int? ?? 0,
       totalCompletionTokens: json['total_completion_tokens'] as int? ?? 0,
       totalCachedTokens: json['total_cached_tokens'] as int? ?? 0,
-      totalCacheBaseTokens: json['total_cache_base_tokens'] as int? ?? 0,
-      totalCacheUnknownTokens: json['total_cache_unknown_tokens'] as int? ?? 0,
       totalThoughtTokens: json['total_thought_tokens'] as int? ?? 0,
       totalTokens: json['total_tokens'] as int? ?? 0,
       totalCost: (json['total_cost'] as num?)?.toDouble() ?? 0.0,
       byAgent: byAgent,
+      totalEffectivePromptTokens:
+          json['total_effective_prompt_tokens'] as int? ?? 0,
+      totalCachedTokensForRate:
+          json['total_cached_tokens_for_rate'] as int? ?? 0,
     );
   }
 
@@ -313,12 +321,12 @@ class LLMStats {
       'total_prompt_tokens': totalPromptTokens,
       'total_completion_tokens': totalCompletionTokens,
       'total_cached_tokens': totalCachedTokens,
-      'total_cache_base_tokens': totalCacheBaseTokens,
-      'total_cache_unknown_tokens': totalCacheUnknownTokens,
       'total_thought_tokens': totalThoughtTokens,
       'total_tokens': totalTokens,
       'total_cost': totalCost,
       'by_agent': byAgent.map((key, value) => MapEntry(key, value.toJson())),
+      'total_effective_prompt_tokens': totalEffectivePromptTokens,
+      'total_cached_tokens_for_rate': totalCachedTokensForRate,
     };
   }
 }
@@ -329,22 +337,26 @@ class AgentStats {
   final int promptTokens;
   final int completionTokens;
   final int cachedTokens;
-  final int cacheBaseTokens;
-  final int cacheUnknownTokens;
   final int thoughtTokens;
   final int totalTokens;
   final double totalCost;
+
+  /// Normalized denominator for cache rate.
+  final int effectivePromptTokens;
+
+  /// Numerator for cache rate (excludes unknown-semantics calls).
+  final int cachedTokensForRate;
 
   AgentStats({
     required this.calls,
     required this.promptTokens,
     required this.completionTokens,
     required this.cachedTokens,
-    this.cacheBaseTokens = 0,
-    this.cacheUnknownTokens = 0,
     required this.thoughtTokens,
     required this.totalTokens,
     this.totalCost = 0.0,
+    this.effectivePromptTokens = 0,
+    this.cachedTokensForRate = 0,
   });
 
   factory AgentStats.fromJson(Map<String, dynamic> json) {
@@ -353,11 +365,11 @@ class AgentStats {
       promptTokens: json['prompt_tokens'] as int? ?? 0,
       completionTokens: json['completion_tokens'] as int? ?? 0,
       cachedTokens: json['cached_tokens'] as int? ?? 0,
-      cacheBaseTokens: json['cache_base_tokens'] as int? ?? 0,
-      cacheUnknownTokens: json['cache_unknown_tokens'] as int? ?? 0,
       thoughtTokens: json['thought_tokens'] as int? ?? 0,
       totalTokens: json['total_tokens'] as int? ?? 0,
       totalCost: (json['total_cost'] as num?)?.toDouble() ?? 0.0,
+      effectivePromptTokens: json['effective_prompt_tokens'] as int? ?? 0,
+      cachedTokensForRate: json['cached_tokens_for_rate'] as int? ?? 0,
     );
   }
 
@@ -367,11 +379,11 @@ class AgentStats {
       'prompt_tokens': promptTokens,
       'completion_tokens': completionTokens,
       'cached_tokens': cachedTokens,
-      'cache_base_tokens': cacheBaseTokens,
-      'cache_unknown_tokens': cacheUnknownTokens,
       'thought_tokens': thoughtTokens,
       'total_tokens': totalTokens,
       'total_cost': totalCost,
+      'effective_prompt_tokens': effectivePromptTokens,
+      'cached_tokens_for_rate': cachedTokensForRate,
     };
   }
 }

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -11,6 +11,7 @@ import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:go_router/go_router.dart';
 import 'package:memex/routing/routes.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/utils/token_usage_utils.dart';
 
 // --- Display Models ---
 
@@ -190,6 +191,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           promptTokens: usage['prompt_tokens'] as int? ?? 0,
           completionTokens: usage['completion_tokens'] as int? ?? 0,
           cachedTokens: usage['cached_tokens'] as int? ?? 0,
+          cacheBaseTokens: (usage['cache_base_tokens'] as int?) ??
+              (usage['prompt_tokens'] as int? ?? 0),
           totalTokens: usage['total_tokens'] as int? ?? 0,
           estimatedCost: usage['total_cost'] as double? ?? 0.0,
         );
@@ -882,11 +885,10 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     if (_lastTokenUsage == null) return const SizedBox.shrink();
     final item = _lastTokenUsage!;
 
-    String cacheRate = '0.0%';
-    if (item.promptTokens > 0) {
-      final rate = (item.cachedTokens / item.promptTokens) * 100;
-      cacheRate = '${rate.toStringAsFixed(1)}%';
-    }
+    final cacheRate = TokenUsageUtils.formatCacheRate(
+        promptTokens: item.cacheBaseTokens,
+        cachedTokens: item.cachedTokens,
+        cachedTokensIncludedInPrompt: true);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -187,12 +187,32 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       ChatTokenUsageEvent? restoredUsage;
       if (sessionData['total_usage'] != null) {
         final usage = sessionData['total_usage'] as Map<String, dynamic>;
+        final prompt = usage['prompt_tokens'] as int? ?? 0;
+        final cached = usage['cached_tokens'] as int? ?? 0;
+        // Recompute effectivePromptTokens from per-message usage.
+        int effPrompt = 0;
+        int cachedForRate = 0;
+        for (final msg in messagesData) {
+          final msgUsage = msg['usage'] as Map<String, dynamic>?;
+          if (msgUsage == null) continue;
+          final mp = msgUsage['prompt_tokens'] as int? ?? 0;
+          final mc = msgUsage['cached_tokens'] as int? ?? 0;
+          final sem = TokenUsageUtils.resolveFromUsageRecord(msgUsage);
+          final eff = TokenUsageUtils.effectivePromptTokensOrNull(
+              promptTokens: mp,
+              cachedTokens: mc,
+              cachedTokensIncludedInPrompt: sem);
+          if (eff != null) {
+            effPrompt += eff;
+            cachedForRate += mc;
+          }
+        }
         restoredUsage = ChatTokenUsageEvent(
-          promptTokens: usage['prompt_tokens'] as int? ?? 0,
+          promptTokens: prompt,
           completionTokens: usage['completion_tokens'] as int? ?? 0,
-          cachedTokens: usage['cached_tokens'] as int? ?? 0,
-          cacheBaseTokens: (usage['cache_base_tokens'] as int?) ??
-              (usage['prompt_tokens'] as int? ?? 0),
+          cachedTokens: cached,
+          effectivePromptTokens: effPrompt,
+          cachedTokensForRate: cachedForRate,
           totalTokens: usage['total_tokens'] as int? ?? 0,
           estimatedCost: usage['total_cost'] as double? ?? 0.0,
         );
@@ -885,10 +905,9 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     if (_lastTokenUsage == null) return const SizedBox.shrink();
     final item = _lastTokenUsage!;
 
-    final cacheRate = TokenUsageUtils.formatCacheRate(
-        promptTokens: item.cacheBaseTokens,
-        cachedTokens: item.cachedTokens,
-        cachedTokensIncludedInPrompt: true);
+    final cacheRate = TokenUsageUtils.formatCacheRateFromAggregated(
+        effectivePromptTokens: item.effectivePromptTokens,
+        cachedTokens: item.cachedTokensForRate);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/lib/ui/settings/widgets/model_stats_page.dart
+++ b/lib/ui/settings/widgets/model_stats_page.dart
@@ -4,6 +4,7 @@ import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/utils/token_usage_utils.dart';
 
 class ModelStatsPage extends StatefulWidget {
   const ModelStatsPage({super.key});
@@ -124,8 +125,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
     },
   };
 
-  Map<String, double> _calculateCost(
-      String model, int prompt, int completion, int cached, int thought) {
+  Map<String, double> _calculateCost(String model, int prompt, int completion,
+      int cached, int thought, bool? cachedTokensIncludedInPrompt) {
     // Find matching model pricing
     Map<String, double>? prices;
     for (final key in _pricing.keys) {
@@ -142,8 +143,12 @@ class _ModelStatsPageState extends State<ModelStatsPage>
       return {'input': 0.0, 'output': 0.0, 'total': 0.0};
     }
 
-    // Input cost: (prompt - cached) * input_price + cached * cached_price
-    final effectivePrompt = (prompt - cached) > 0 ? (prompt - cached) : 0;
+    // Input cost: uncached prompt * input_price + cached * cached_price.
+    final effectivePrompt = TokenUsageUtils.nonCachedPromptTokensOrNull(
+            promptTokens: prompt,
+            cachedTokens: cached,
+            cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt) ??
+        prompt;
     final inputCost =
         (effectivePrompt * prices['input']!) + (cached * prices['cached']!);
 
@@ -180,6 +185,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
     int totalPromptTokens = 0;
     int totalCompletionTokens = 0;
     int totalCachedTokens = 0;
+    int totalCacheBaseTokens = 0;
+    int totalCacheUnknownTokens = 0;
     int totalThoughtTokens = 0;
     int totalTokens = 0;
     double totalEstimatedCost = 0.0;
@@ -192,18 +199,30 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         final promptTokens = usage['prompt_tokens'] as int? ?? 0;
         final completionTokens = usage['completion_tokens'] as int? ?? 0;
         final cachedTokens = usage['cached_tokens'] as int? ?? 0;
+        final model = call['model'] as String? ?? '';
+        final cachedTokensIncludedInPrompt =
+            TokenUsageUtils.cachedTokensIncludedInPrompt(
+          originalUsage: usage['original_usage'],
+          recordedValue: usage['cache_tokens_included_in_prompt'],
+        );
+        final cacheBaseTokens = (usage['cache_base_tokens'] as int?) ??
+            TokenUsageUtils.effectivePromptTokensOrNull(
+                promptTokens: promptTokens,
+                cachedTokens: cachedTokens,
+                cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
+        final cacheUnknownTokens =
+            cacheBaseTokens == null && cachedTokens > 0 ? cachedTokens : 0;
         final thoughtTokens = usage['thought_tokens'] as int? ?? 0;
         final tokens = usage['total_tokens'] as int? ?? 0;
         final agentName = call['agent_name'] as String;
-        final model = call['model'] as String? ?? '';
 
         final timestamp = call['timestamp'] as int?;
         final callCreatedAt = timestamp != null
             ? DateTime.fromMicrosecondsSinceEpoch(timestamp)
             : DateTime.fromMicrosecondsSinceEpoch(record['created_at'] as int);
 
-        final costs = _calculateCost(
-            model, promptTokens, completionTokens, cachedTokens, thoughtTokens);
+        final costs = _calculateCost(model, promptTokens, completionTokens,
+            cachedTokens, thoughtTokens, cachedTokensIncludedInPrompt);
         final cost = costs['total']!;
 
         // Helper to update stats map
@@ -215,6 +234,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
               'prompt_tokens': 0,
               'completion_tokens': 0,
               'cached_tokens': 0,
+              'cache_base_tokens': 0,
+              'cache_unknown_tokens': 0,
               'thought_tokens': 0,
               'total_tokens': 0,
               'total_cost': 0.0,
@@ -226,6 +247,10 @@ class _ModelStatsPageState extends State<ModelStatsPage>
           stat['completion_tokens'] =
               (stat['completion_tokens'] as int) + completionTokens;
           stat['cached_tokens'] = (stat['cached_tokens'] as int) + cachedTokens;
+          stat['cache_base_tokens'] =
+              (stat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
+          stat['cache_unknown_tokens'] =
+              (stat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
           stat['thought_tokens'] =
               (stat['thought_tokens'] as int) + thoughtTokens;
           stat['total_tokens'] = (stat['total_tokens'] as int) + tokens;
@@ -244,6 +269,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         totalPromptTokens += promptTokens;
         totalCompletionTokens += completionTokens;
         totalCachedTokens += cachedTokens;
+        totalCacheBaseTokens += cacheBaseTokens ?? 0;
+        totalCacheUnknownTokens += cacheUnknownTokens;
         totalThoughtTokens += thoughtTokens;
         totalTokens += tokens;
         totalEstimatedCost += cost;
@@ -256,6 +283,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         'prompt_tokens': totalPromptTokens,
         'completion_tokens': totalCompletionTokens,
         'cached_tokens': totalCachedTokens,
+        'cache_base_tokens': totalCacheBaseTokens,
+        'cache_unknown_tokens': totalCacheUnknownTokens,
         'thought_tokens': totalThoughtTokens,
         'total_tokens': totalTokens,
         'total_cost': totalEstimatedCost,
@@ -344,7 +373,9 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         _buildStatCard(
             'Cache Rate',
             _calculateCacheRate(total['cached_tokens'] as int? ?? 0,
-                total['prompt_tokens'] as int? ?? 0),
+                total['cache_base_tokens'] as int? ?? 0,
+                unknownCachedTokens:
+                    total['cache_unknown_tokens'] as int? ?? 0),
             Colors.teal),
         const SizedBox(height: 12),
         Row(
@@ -386,10 +417,13 @@ class _ModelStatsPageState extends State<ModelStatsPage>
     );
   }
 
-  String _calculateCacheRate(int cached, int prompt) {
-    if (prompt == 0) return '0.0%';
-    final rate = (cached / prompt) * 100;
-    return '${rate.toStringAsFixed(1)}%';
+  String _calculateCacheRate(int cached, int prompt,
+      {int unknownCachedTokens = 0}) {
+    if (unknownCachedTokens > 0) return 'N/A';
+    return TokenUsageUtils.formatCacheRate(
+        promptTokens: prompt,
+        cachedTokens: cached,
+        cachedTokensIncludedInPrompt: true);
   }
 
   Widget _buildListTab(String key, String label) {
@@ -409,8 +443,9 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         final itemData = data[itemKey] as Map<String, dynamic>;
 
         final cached = itemData['cached_tokens'] as int? ?? 0;
-        final prompt = itemData['prompt_tokens'] as int? ?? 0;
-        final cacheRate = _calculateCacheRate(cached, prompt);
+        final cacheBase = itemData['cache_base_tokens'] as int? ?? 0;
+        final cacheRate = _calculateCacheRate(cached, cacheBase,
+            unknownCachedTokens: itemData['cache_unknown_tokens'] as int? ?? 0);
         final cost = itemData['total_cost'] as double? ?? 0.0;
 
         return Card(
@@ -507,6 +542,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         int recPrompt = 0;
         int recCompletion = 0;
         int recCached = 0;
+        int recCacheBase = 0;
+        int recCacheUnknown = 0;
         int recThought = 0;
         int recTotal = 0;
         double recCost = 0.0;
@@ -516,22 +553,37 @@ class _ModelStatsPageState extends State<ModelStatsPage>
           final p = usage['prompt_tokens'] as int? ?? 0;
           final c = usage['completion_tokens'] as int? ?? 0;
           final ca = usage['cached_tokens'] as int? ?? 0;
+          final model = call['model'] as String? ?? '';
+          final cachedTokensIncludedInPrompt =
+              TokenUsageUtils.cachedTokensIncludedInPrompt(
+            originalUsage: usage['original_usage'],
+            recordedValue: usage['cache_tokens_included_in_prompt'],
+          );
+          final cacheBase = (usage['cache_base_tokens'] as int?) ??
+              TokenUsageUtils.effectivePromptTokensOrNull(
+                  promptTokens: p,
+                  cachedTokens: ca,
+                  cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
+          final cacheUnknown = cacheBase == null && ca > 0 ? ca : 0;
           final t = usage['thought_tokens'] as int? ?? 0;
           recPrompt += p;
           recCompletion += c;
           recCached += ca;
+          recCacheBase += cacheBase ?? 0;
+          recCacheUnknown += cacheUnknown;
           recThought += t;
           recTotal += usage['total_tokens'] as int? ?? 0;
 
-          final model = call['model'] as String? ?? '';
-          final costs = _calculateCost(model, p, c, ca, t);
+          final costs =
+              _calculateCost(model, p, c, ca, t, cachedTokensIncludedInPrompt);
           recCost += costs['total']!;
         }
 
         final timestamp =
             DateTime.fromMicrosecondsSinceEpoch(record['created_at'] as int);
         final timeStr = DateFormat('yyyy-MM-dd HH:mm:ss').format(timestamp);
-        final cacheRate = _calculateCacheRate(recCached, recPrompt);
+        final cacheRate = _calculateCacheRate(recCached, recCacheBase,
+            unknownCachedTokens: recCacheUnknown);
 
         return Card(
           elevation: 1,
@@ -677,11 +729,25 @@ class _ModelStatsPageState extends State<ModelStatsPage>
                       final cached = usage['cached_tokens'] as int? ?? 0;
                       final thought = usage['thought_tokens'] as int? ?? 0;
                       final total = usage['total_tokens'] as int? ?? 0;
-                      final cacheRate = _calculateCacheRate(cached, prompt);
 
                       final model = call['model'] as String? ?? '';
-                      final costs = _calculateCost(
-                          model, prompt, completion, cached, thought);
+                      final cachedTokensIncludedInPrompt =
+                          TokenUsageUtils.cachedTokensIncludedInPrompt(
+                        originalUsage: usage['original_usage'],
+                        recordedValue: usage['cache_tokens_included_in_prompt'],
+                      );
+                      final cacheBase = (usage['cache_base_tokens'] as int?) ??
+                          TokenUsageUtils.effectivePromptTokensOrNull(
+                              promptTokens: prompt,
+                              cachedTokens: cached,
+                              cachedTokensIncludedInPrompt:
+                                  cachedTokensIncludedInPrompt);
+                      final cacheRate = cacheBase == null && cached > 0
+                          ? 'N/A'
+                          : _calculateCacheRate(cached, cacheBase ?? 0);
+
+                      final costs = _calculateCost(model, prompt, completion,
+                          cached, thought, cachedTokensIncludedInPrompt);
                       final totalCost = costs['total']!;
                       final inputCost = costs['input']!;
                       final outputCost = costs['output']!;
@@ -826,7 +892,19 @@ class _ModelStatsPageState extends State<ModelStatsPage>
     final usage = call['usage'] as Map<String, dynamic>;
     final prompt = usage['prompt_tokens'] as int? ?? 0;
     final cached = usage['cached_tokens'] as int? ?? 0;
-    final cacheRate = _calculateCacheRate(cached, prompt);
+    final cachedTokensIncludedInPrompt =
+        TokenUsageUtils.cachedTokensIncludedInPrompt(
+      originalUsage: usage['original_usage'],
+      recordedValue: usage['cache_tokens_included_in_prompt'],
+    );
+    final cacheBase = (usage['cache_base_tokens'] as int?) ??
+        TokenUsageUtils.effectivePromptTokensOrNull(
+            promptTokens: prompt,
+            cachedTokens: cached,
+            cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
+    final cacheRate = cacheBase == null && cached > 0
+        ? 'N/A'
+        : _calculateCacheRate(cached, cacheBase ?? 0);
 
     showDialog(
       context: context,

--- a/lib/ui/settings/widgets/model_stats_page.dart
+++ b/lib/ui/settings/widgets/model_stats_page.dart
@@ -96,76 +96,6 @@ class _ModelStatsPageState extends State<ModelStatsPage>
     }
   }
 
-  // Pricing configuration (per token)
-  static const _pricing = {
-    'gemini-3-flash-preview': {
-      'input': 0.0000005,
-      'cached': 0.00000005,
-      'output': 0.000003,
-    },
-    'gemini-2.5-flash': {
-      'input': 0.0000003,
-      'cached': 0.00000003,
-      'output': 0.0000025,
-    },
-    'gemini-3.1-pro-preview': {
-      'input': 0.000002,
-      'cached': 0.0000002,
-      'output': 0.000012,
-    },
-    'gemini-3-pro-preview': {
-      'input': 0.000002,
-      'cached': 0.0000002,
-      'output': 0.000012,
-    },
-    'gpt-4o': {
-      'input': 0.0000025,
-      'cached': 0.00000125,
-      'output': 0.00001,
-    },
-  };
-
-  Map<String, double> _calculateCost(String model, int prompt, int completion,
-      int cached, int thought, bool? cachedTokensIncludedInPrompt) {
-    // Find matching model pricing
-    Map<String, double>? prices;
-    for (final key in _pricing.keys) {
-      if (model.toLowerCase().contains(key)) {
-        prices = _pricing[key];
-        break;
-      }
-    }
-
-    // Default to gpt-4o if not found
-    prices ??= _pricing['gpt-4o'];
-
-    if (prices == null) {
-      return {'input': 0.0, 'output': 0.0, 'total': 0.0};
-    }
-
-    // Input cost: uncached prompt * input_price + cached * cached_price.
-    final effectivePrompt = TokenUsageUtils.nonCachedPromptTokensOrNull(
-            promptTokens: prompt,
-            cachedTokens: cached,
-            cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt) ??
-        prompt;
-    final inputCost =
-        (effectivePrompt * prices['input']!) + (cached * prices['cached']!);
-
-    // Output cost: (completion + thought) * output_price
-    // Thought tokens are usually part of the output billing
-    final outputCost = model.startsWith(
-            'ep-') // todo: responses API completion includes thought
-        ? completion * prices['output']!
-        : (completion + thought) * prices['output']!;
-
-    return {
-      'input': inputCost,
-      'output': outputCost,
-      'total': inputCost + outputCost,
-    };
-  }
-
   String _formatCost(double cost) {
     if (cost == 0) return '';
     return '(\$${cost.toStringAsFixed(5)})';
@@ -178,15 +108,14 @@ class _ModelStatsPageState extends State<ModelStatsPage>
   /// Aggregate records into the format expected by the UI
   Map<String, dynamic> _aggregateRecords(List<Map<String, dynamic>> records) {
     final dailyStats = <String, Map<String, dynamic>>{};
-    // final monthlyStats = <String, Map<String, dynamic>>{}; // Removed
     final agentStats = <String, Map<String, dynamic>>{};
 
     int totalCalls = 0;
     int totalPromptTokens = 0;
     int totalCompletionTokens = 0;
     int totalCachedTokens = 0;
-    int totalCacheBaseTokens = 0;
-    int totalCacheUnknownTokens = 0;
+    int totalEffectivePromptTokens = 0;
+    int totalCachedForRate = 0;
     int totalThoughtTokens = 0;
     int totalTokens = 0;
     double totalEstimatedCost = 0.0;
@@ -200,18 +129,11 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         final completionTokens = usage['completion_tokens'] as int? ?? 0;
         final cachedTokens = usage['cached_tokens'] as int? ?? 0;
         final model = call['model'] as String? ?? '';
-        final cachedTokensIncludedInPrompt =
-            TokenUsageUtils.cachedTokensIncludedInPrompt(
-          originalUsage: usage['original_usage'],
-          recordedValue: usage['cache_tokens_included_in_prompt'],
-        );
-        final cacheBaseTokens = (usage['cache_base_tokens'] as int?) ??
-            TokenUsageUtils.effectivePromptTokensOrNull(
-                promptTokens: promptTokens,
-                cachedTokens: cachedTokens,
-                cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
-        final cacheUnknownTokens =
-            cacheBaseTokens == null && cachedTokens > 0 ? cachedTokens : 0;
+        final sem = TokenUsageUtils.resolveFromUsageRecord(usage);
+        final effPrompt = TokenUsageUtils.effectivePromptTokensOrNull(
+            promptTokens: promptTokens,
+            cachedTokens: cachedTokens,
+            cachedTokensIncludedInPrompt: sem);
         final thoughtTokens = usage['thought_tokens'] as int? ?? 0;
         final tokens = usage['total_tokens'] as int? ?? 0;
         final agentName = call['agent_name'] as String;
@@ -221,8 +143,13 @@ class _ModelStatsPageState extends State<ModelStatsPage>
             ? DateTime.fromMicrosecondsSinceEpoch(timestamp)
             : DateTime.fromMicrosecondsSinceEpoch(record['created_at'] as int);
 
-        final costs = _calculateCost(model, promptTokens, completionTokens,
-            cachedTokens, thoughtTokens, cachedTokensIncludedInPrompt);
+        final costs = TokenUsageUtils.calculateCost(
+            model: model,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            cachedTokens: cachedTokens,
+            thoughtTokens: thoughtTokens,
+            cachedTokensIncludedInPrompt: sem);
         final cost = costs['total']!;
 
         // Helper to update stats map
@@ -234,8 +161,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
               'prompt_tokens': 0,
               'completion_tokens': 0,
               'cached_tokens': 0,
-              'cache_base_tokens': 0,
-              'cache_unknown_tokens': 0,
+              'effective_prompt_tokens': 0,
+              'cached_tokens_for_rate': 0,
               'thought_tokens': 0,
               'total_tokens': 0,
               'total_cost': 0.0,
@@ -247,10 +174,12 @@ class _ModelStatsPageState extends State<ModelStatsPage>
           stat['completion_tokens'] =
               (stat['completion_tokens'] as int) + completionTokens;
           stat['cached_tokens'] = (stat['cached_tokens'] as int) + cachedTokens;
-          stat['cache_base_tokens'] =
-              (stat['cache_base_tokens'] as int) + (cacheBaseTokens ?? 0);
-          stat['cache_unknown_tokens'] =
-              (stat['cache_unknown_tokens'] as int) + cacheUnknownTokens;
+          if (effPrompt != null) {
+            stat['effective_prompt_tokens'] =
+                (stat['effective_prompt_tokens'] as int) + effPrompt;
+            stat['cached_tokens_for_rate'] =
+                (stat['cached_tokens_for_rate'] as int) + cachedTokens;
+          }
           stat['thought_tokens'] =
               (stat['thought_tokens'] as int) + thoughtTokens;
           stat['total_tokens'] = (stat['total_tokens'] as int) + tokens;
@@ -269,8 +198,10 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         totalPromptTokens += promptTokens;
         totalCompletionTokens += completionTokens;
         totalCachedTokens += cachedTokens;
-        totalCacheBaseTokens += cacheBaseTokens ?? 0;
-        totalCacheUnknownTokens += cacheUnknownTokens;
+        if (effPrompt != null) {
+          totalEffectivePromptTokens += effPrompt;
+          totalCachedForRate += cachedTokens;
+        }
         totalThoughtTokens += thoughtTokens;
         totalTokens += tokens;
         totalEstimatedCost += cost;
@@ -283,8 +214,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         'prompt_tokens': totalPromptTokens,
         'completion_tokens': totalCompletionTokens,
         'cached_tokens': totalCachedTokens,
-        'cache_base_tokens': totalCacheBaseTokens,
-        'cache_unknown_tokens': totalCacheUnknownTokens,
+        'effective_prompt_tokens': totalEffectivePromptTokens,
+        'cached_tokens_for_rate': totalCachedForRate,
         'thought_tokens': totalThoughtTokens,
         'total_tokens': totalTokens,
         'total_cost': totalEstimatedCost,
@@ -372,10 +303,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         const SizedBox(height: 12),
         _buildStatCard(
             'Cache Rate',
-            _calculateCacheRate(total['cached_tokens'] as int? ?? 0,
-                total['cache_base_tokens'] as int? ?? 0,
-                unknownCachedTokens:
-                    total['cache_unknown_tokens'] as int? ?? 0),
+            _calculateCacheRate(total['cached_tokens_for_rate'] as int? ?? 0,
+                total['effective_prompt_tokens'] as int? ?? 0),
             Colors.teal),
         const SizedBox(height: 12),
         Row(
@@ -417,13 +346,9 @@ class _ModelStatsPageState extends State<ModelStatsPage>
     );
   }
 
-  String _calculateCacheRate(int cached, int prompt,
-      {int unknownCachedTokens = 0}) {
-    if (unknownCachedTokens > 0) return 'N/A';
-    return TokenUsageUtils.formatCacheRate(
-        promptTokens: prompt,
-        cachedTokens: cached,
-        cachedTokensIncludedInPrompt: true);
+  String _calculateCacheRate(int cached, int effectivePrompt) {
+    return TokenUsageUtils.formatCacheRateFromAggregated(
+        effectivePromptTokens: effectivePrompt, cachedTokens: cached);
   }
 
   Widget _buildListTab(String key, String label) {
@@ -442,10 +367,9 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         final itemKey = keys[index];
         final itemData = data[itemKey] as Map<String, dynamic>;
 
-        final cached = itemData['cached_tokens'] as int? ?? 0;
-        final cacheBase = itemData['cache_base_tokens'] as int? ?? 0;
-        final cacheRate = _calculateCacheRate(cached, cacheBase,
-            unknownCachedTokens: itemData['cache_unknown_tokens'] as int? ?? 0);
+        final cached = itemData['cached_tokens_for_rate'] as int? ?? 0;
+        final effPrompt = itemData['effective_prompt_tokens'] as int? ?? 0;
+        final cacheRate = _calculateCacheRate(cached, effPrompt);
         final cost = itemData['total_cost'] as double? ?? 0.0;
 
         return Card(
@@ -542,8 +466,8 @@ class _ModelStatsPageState extends State<ModelStatsPage>
         int recPrompt = 0;
         int recCompletion = 0;
         int recCached = 0;
-        int recCacheBase = 0;
-        int recCacheUnknown = 0;
+        int recEffectivePrompt = 0;
+        int recCachedForRate = 0;
         int recThought = 0;
         int recTotal = 0;
         double recCost = 0.0;
@@ -554,36 +478,37 @@ class _ModelStatsPageState extends State<ModelStatsPage>
           final c = usage['completion_tokens'] as int? ?? 0;
           final ca = usage['cached_tokens'] as int? ?? 0;
           final model = call['model'] as String? ?? '';
-          final cachedTokensIncludedInPrompt =
-              TokenUsageUtils.cachedTokensIncludedInPrompt(
-            originalUsage: usage['original_usage'],
-            recordedValue: usage['cache_tokens_included_in_prompt'],
-          );
-          final cacheBase = (usage['cache_base_tokens'] as int?) ??
-              TokenUsageUtils.effectivePromptTokensOrNull(
-                  promptTokens: p,
-                  cachedTokens: ca,
-                  cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
-          final cacheUnknown = cacheBase == null && ca > 0 ? ca : 0;
+          final sem = TokenUsageUtils.resolveFromUsageRecord(usage);
+          final effP = TokenUsageUtils.effectivePromptTokensOrNull(
+              promptTokens: p,
+              cachedTokens: ca,
+              cachedTokensIncludedInPrompt: sem);
           final t = usage['thought_tokens'] as int? ?? 0;
           recPrompt += p;
           recCompletion += c;
           recCached += ca;
-          recCacheBase += cacheBase ?? 0;
-          recCacheUnknown += cacheUnknown;
+          if (effP != null) {
+            recEffectivePrompt += effP;
+            recCachedForRate += ca;
+          }
           recThought += t;
           recTotal += usage['total_tokens'] as int? ?? 0;
 
-          final costs =
-              _calculateCost(model, p, c, ca, t, cachedTokensIncludedInPrompt);
+          final costs = TokenUsageUtils.calculateCost(
+              model: model,
+              promptTokens: p,
+              completionTokens: c,
+              cachedTokens: ca,
+              thoughtTokens: t,
+              cachedTokensIncludedInPrompt: sem);
           recCost += costs['total']!;
         }
 
         final timestamp =
             DateTime.fromMicrosecondsSinceEpoch(record['created_at'] as int);
         final timeStr = DateFormat('yyyy-MM-dd HH:mm:ss').format(timestamp);
-        final cacheRate = _calculateCacheRate(recCached, recCacheBase,
-            unknownCachedTokens: recCacheUnknown);
+        final cacheRate =
+            _calculateCacheRate(recCachedForRate, recEffectivePrompt);
 
         return Card(
           elevation: 1,
@@ -731,23 +656,22 @@ class _ModelStatsPageState extends State<ModelStatsPage>
                       final total = usage['total_tokens'] as int? ?? 0;
 
                       final model = call['model'] as String? ?? '';
-                      final cachedTokensIncludedInPrompt =
-                          TokenUsageUtils.cachedTokensIncludedInPrompt(
-                        originalUsage: usage['original_usage'],
-                        recordedValue: usage['cache_tokens_included_in_prompt'],
-                      );
-                      final cacheBase = (usage['cache_base_tokens'] as int?) ??
-                          TokenUsageUtils.effectivePromptTokensOrNull(
-                              promptTokens: prompt,
-                              cachedTokens: cached,
-                              cachedTokensIncludedInPrompt:
-                                  cachedTokensIncludedInPrompt);
-                      final cacheRate = cacheBase == null && cached > 0
-                          ? 'N/A'
-                          : _calculateCacheRate(cached, cacheBase ?? 0);
+                      final sem = TokenUsageUtils.resolveFromUsageRecord(usage);
+                      final effP = TokenUsageUtils.effectivePromptTokensOrNull(
+                          promptTokens: prompt,
+                          cachedTokens: cached,
+                          cachedTokensIncludedInPrompt: sem);
+                      final cacheRate = effP != null
+                          ? _calculateCacheRate(cached, effP)
+                          : '0.0%';
 
-                      final costs = _calculateCost(model, prompt, completion,
-                          cached, thought, cachedTokensIncludedInPrompt);
+                      final costs = TokenUsageUtils.calculateCost(
+                          model: model,
+                          promptTokens: prompt,
+                          completionTokens: completion,
+                          cachedTokens: cached,
+                          thoughtTokens: thought,
+                          cachedTokensIncludedInPrompt: sem);
                       final totalCost = costs['total']!;
                       final inputCost = costs['input']!;
                       final outputCost = costs['output']!;
@@ -892,19 +816,12 @@ class _ModelStatsPageState extends State<ModelStatsPage>
     final usage = call['usage'] as Map<String, dynamic>;
     final prompt = usage['prompt_tokens'] as int? ?? 0;
     final cached = usage['cached_tokens'] as int? ?? 0;
-    final cachedTokensIncludedInPrompt =
-        TokenUsageUtils.cachedTokensIncludedInPrompt(
-      originalUsage: usage['original_usage'],
-      recordedValue: usage['cache_tokens_included_in_prompt'],
-    );
-    final cacheBase = (usage['cache_base_tokens'] as int?) ??
-        TokenUsageUtils.effectivePromptTokensOrNull(
-            promptTokens: prompt,
-            cachedTokens: cached,
-            cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt);
-    final cacheRate = cacheBase == null && cached > 0
-        ? 'N/A'
-        : _calculateCacheRate(cached, cacheBase ?? 0);
+    final sem = TokenUsageUtils.resolveFromUsageRecord(usage);
+    final effP = TokenUsageUtils.effectivePromptTokensOrNull(
+        promptTokens: prompt,
+        cachedTokens: cached,
+        cachedTokensIncludedInPrompt: sem);
+    final cacheRate = effP != null ? _calculateCacheRate(cached, effP) : '0.0%';
 
     showDialog(
       context: context,

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -32,6 +32,7 @@ import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/character/widgets/persona_chat_screen.dart';
 import 'package:memex/utils/share_service.dart';
 import 'package:memex/ui/core/cards/native_card_factory.dart';
+import 'package:memex/utils/token_usage_utils.dart';
 
 /// Timeline card detail screen - plays full card detail
 class TimelineCardDetailScreen extends StatefulWidget {
@@ -413,6 +414,13 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                 ...stats.byAgent.entries.map((entry) {
                   final agentName = entry.key;
                   final agentStat = entry.value;
+                  final cacheRate = agentStat.cacheUnknownTokens > 0
+                      ? 'N/A'
+                      : TokenUsageUtils.formatCacheRate(
+                          promptTokens: agentStat.cacheBaseTokens,
+                          cachedTokens: agentStat.cachedTokens,
+                          cachedTokensIncludedInPrompt: true,
+                        );
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 12),
                     child: _buildStatSection(
@@ -429,6 +437,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                             -2, // Special flag for cost
                       },
                       cost: agentStat.totalCost,
+                      cacheRate: cacheRate,
                     ),
                   );
                 }),
@@ -447,11 +456,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   }
 
   Widget _buildStatSection(String title, Map<String, int> stats,
-      {double? cost}) {
-    // Extract values for calculation
-    final prompt = stats['Prompt Tokens'] ?? 0;
-    final cached = stats['Cached Tokens'] ?? 0;
-
+      {double? cost, String? cacheRate}) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -466,12 +471,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
         ...stats.entries.map((entry) {
           String valueStr;
           if (entry.key == 'Cache Rate') {
-            if (prompt == 0) {
-              valueStr = '0.0%';
-            } else {
-              final rate = (cached / prompt) * 100;
-              valueStr = '${rate.toStringAsFixed(1)}%';
-            }
+            valueStr = cacheRate ?? 'N/A';
           } else if (entry.key == UserStorage.l10n.estimatedCost) {
             valueStr = _formatCost(cost ?? 0.0);
           } else {

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -399,7 +399,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                     'Total Tokens': stats.totalTokens,
                     UserStorage.l10n.estimatedCost: -2, // Special flag for cost
                   },
-                  cost: stats.totalCost),
+                  cost: stats.totalCost,
+                  cacheRate: TokenUsageUtils.formatCacheRateFromAggregated(
+                    effectivePromptTokens: stats.totalEffectivePromptTokens,
+                    cachedTokens: stats.totalCachedTokensForRate,
+                  )),
               const SizedBox(height: 16),
               // by Agent
               if (stats.byAgent.isNotEmpty) ...[
@@ -414,13 +418,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                 ...stats.byAgent.entries.map((entry) {
                   final agentName = entry.key;
                   final agentStat = entry.value;
-                  final cacheRate = agentStat.cacheUnknownTokens > 0
-                      ? 'N/A'
-                      : TokenUsageUtils.formatCacheRate(
-                          promptTokens: agentStat.cacheBaseTokens,
-                          cachedTokens: agentStat.cachedTokens,
-                          cachedTokensIncludedInPrompt: true,
-                        );
+                  final cacheRate =
+                      TokenUsageUtils.formatCacheRateFromAggregated(
+                    effectivePromptTokens: agentStat.effectivePromptTokens,
+                    cachedTokens: agentStat.cachedTokensForRate,
+                  );
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 12),
                     child: _buildStatSection(

--- a/lib/utils/token_usage_utils.dart
+++ b/lib/utils/token_usage_utils.dart
@@ -1,0 +1,187 @@
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:memex/llm_client/codex_responses_client.dart';
+import 'package:memex/llm_client/gemini_oauth_client.dart';
+
+class TokenUsageUtils {
+  const TokenUsageUtils._();
+
+  static int _nonNegative(int value) => value < 0 ? 0 : value;
+
+  static bool? _asBool(Object? value) {
+    if (value is bool) return value;
+    return null;
+  }
+
+  /// Resolves whether [cachedTokens] are already included in the prompt/input
+  /// token count reported by the provider.
+  ///
+  /// This intentionally does not infer from token values or model names. The
+  /// answer must come from persisted semantics, the raw provider usage object,
+  /// or the concrete client adapter that produced the usage.
+  static bool? cachedTokensIncludedInPrompt({
+    Object? client,
+    dynamic originalUsage,
+    Object? recordedValue,
+  }) {
+    final recorded = _asBool(recordedValue);
+    if (recorded != null) return recorded;
+
+    final usage = originalUsage is Map ? originalUsage : null;
+    if (usage != null) {
+      if (usage.containsKey('cache_read_input_tokens') ||
+          usage.containsKey('cache_creation_input_tokens')) {
+        return false;
+      }
+      if (usage.containsKey('prompt_tokens_details') ||
+          usage.containsKey('input_tokens_details') ||
+          usage.containsKey('cachedContentTokenCount')) {
+        return true;
+      }
+    }
+
+    if (client == null) return null;
+    return cachedTokensIncludedInPromptForClient(client);
+  }
+
+  static bool? cachedTokensIncludedInPromptForClient(Object client) {
+    if (client is ClaudeClient || client is BedrockClaudeClient) {
+      return false;
+    }
+    if (client is GeminiClient ||
+        client is GeminiOAuthClient ||
+        client is OpenAIClient ||
+        client is ResponsesClient ||
+        client is CodexResponsesClient) {
+      return true;
+    }
+
+    return null;
+  }
+
+  /// Returns the total input-token denominator for cache-rate display.
+  static int effectivePromptTokens({
+    required int promptTokens,
+    required int cachedTokens,
+    required bool cachedTokensIncludedInPrompt,
+  }) {
+    final prompt = _nonNegative(promptTokens);
+    final cached = _nonNegative(cachedTokens);
+
+    if (cachedTokensIncludedInPrompt) return prompt;
+    return prompt + cached;
+  }
+
+  /// Returns prompt tokens billed at the normal input-token price.
+  static int nonCachedPromptTokens({
+    required int promptTokens,
+    required int cachedTokens,
+    required bool cachedTokensIncludedInPrompt,
+  }) {
+    final prompt = _nonNegative(promptTokens);
+    final cached = _nonNegative(cachedTokens);
+
+    if (cachedTokensIncludedInPrompt) {
+      final nonCached = prompt - cached;
+      return nonCached > 0 ? nonCached : 0;
+    }
+    return prompt;
+  }
+
+  static int? effectivePromptTokensOrNull({
+    required int promptTokens,
+    required int cachedTokens,
+    required bool? cachedTokensIncludedInPrompt,
+  }) {
+    final prompt = _nonNegative(promptTokens);
+    final cached = _nonNegative(cachedTokens);
+    if (cached == 0) return prompt;
+    if (cachedTokensIncludedInPrompt == null) return null;
+
+    return effectivePromptTokens(
+      promptTokens: prompt,
+      cachedTokens: cached,
+      cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
+    );
+  }
+
+  static int? nonCachedPromptTokensOrNull({
+    required int promptTokens,
+    required int cachedTokens,
+    required bool? cachedTokensIncludedInPrompt,
+  }) {
+    final prompt = _nonNegative(promptTokens);
+    final cached = _nonNegative(cachedTokens);
+    if (cached == 0) return prompt;
+    if (cachedTokensIncludedInPrompt == null) return null;
+
+    return nonCachedPromptTokens(
+      promptTokens: prompt,
+      cachedTokens: cached,
+      cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
+    );
+  }
+
+  static double cacheRate({
+    required int promptTokens,
+    required int cachedTokens,
+    required bool cachedTokensIncludedInPrompt,
+  }) {
+    final cached = _nonNegative(cachedTokens);
+    if (cached == 0) return 0.0;
+
+    final denominator = effectivePromptTokens(
+      promptTokens: promptTokens,
+      cachedTokens: cached,
+      cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
+    );
+    if (denominator == 0) return 0.0;
+
+    return ((cached / denominator) * 100).clamp(0.0, 100.0).toDouble();
+  }
+
+  static double? cacheRateOrNull({
+    required int promptTokens,
+    required int cachedTokens,
+    required bool? cachedTokensIncludedInPrompt,
+  }) {
+    final cached = _nonNegative(cachedTokens);
+    if (cached == 0) return 0.0;
+    if (cachedTokensIncludedInPrompt == null) return null;
+
+    return cacheRate(
+      promptTokens: promptTokens,
+      cachedTokens: cachedTokens,
+      cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
+    );
+  }
+
+  static String formatCacheRate({
+    required int promptTokens,
+    required int cachedTokens,
+    required bool cachedTokensIncludedInPrompt,
+    int fractionDigits = 1,
+  }) {
+    final rate = cacheRate(
+      promptTokens: promptTokens,
+      cachedTokens: cachedTokens,
+      cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
+    );
+    return '${rate.toStringAsFixed(fractionDigits)}%';
+  }
+
+  static String formatCacheRateOrUnavailable({
+    required int promptTokens,
+    required int cachedTokens,
+    required bool? cachedTokensIncludedInPrompt,
+    int fractionDigits = 1,
+    String unavailableLabel = 'N/A',
+  }) {
+    final rate = cacheRateOrNull(
+      promptTokens: promptTokens,
+      cachedTokens: cachedTokens,
+      cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
+    );
+    if (rate == null) return unavailableLabel;
+    return '${rate.toStringAsFixed(fractionDigits)}%';
+  }
+}

--- a/lib/utils/token_usage_utils.dart
+++ b/lib/utils/token_usage_utils.dart
@@ -58,7 +58,19 @@ class TokenUsageUtils {
     return null;
   }
 
+  /// Resolves [cachedTokensIncludedInPrompt] from a persisted usage record.
+  static bool? resolveFromUsageRecord(Map<String, dynamic> usage) {
+    return cachedTokensIncludedInPrompt(
+      originalUsage: usage['original_usage'],
+      recordedValue: usage['cache_tokens_included_in_prompt'],
+    );
+  }
+
   /// Returns the total input-token denominator for cache-rate display.
+  ///
+  /// When [cachedTokensIncludedInPrompt] is true (OpenAI/Gemini), prompt
+  /// already contains cached, so the denominator is just prompt.
+  /// When false (Claude), cached is separate, so denominator = prompt + cached.
   static int effectivePromptTokens({
     required int promptTokens,
     required int cachedTokens,
@@ -121,6 +133,23 @@ class TokenUsageUtils {
     );
   }
 
+  /// Computes cache rate from pre-normalized effective prompt tokens.
+  ///
+  /// [effectivePromptTokens] is the denominator (total input tokens including
+  /// cached), already normalized per-call before aggregation.
+  /// [cachedTokens] is the numerator.
+  static String formatCacheRateFromAggregated({
+    required int effectivePromptTokens,
+    required int cachedTokens,
+    int fractionDigits = 1,
+  }) {
+    final cached = _nonNegative(cachedTokens);
+    final denom = _nonNegative(effectivePromptTokens);
+    if (cached == 0 || denom == 0) return '0.0%';
+    final rate = ((cached / denom) * 100).clamp(0.0, 100.0);
+    return '${rate.toStringAsFixed(fractionDigits)}%';
+  }
+
   static double cacheRate({
     required int promptTokens,
     required int cachedTokens,
@@ -137,22 +166,6 @@ class TokenUsageUtils {
     if (denominator == 0) return 0.0;
 
     return ((cached / denominator) * 100).clamp(0.0, 100.0).toDouble();
-  }
-
-  static double? cacheRateOrNull({
-    required int promptTokens,
-    required int cachedTokens,
-    required bool? cachedTokensIncludedInPrompt,
-  }) {
-    final cached = _nonNegative(cachedTokens);
-    if (cached == 0) return 0.0;
-    if (cachedTokensIncludedInPrompt == null) return null;
-
-    return cacheRate(
-      promptTokens: promptTokens,
-      cachedTokens: cachedTokens,
-      cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
-    );
   }
 
   static String formatCacheRate({
@@ -176,12 +189,91 @@ class TokenUsageUtils {
     int fractionDigits = 1,
     String unavailableLabel = 'N/A',
   }) {
-    final rate = cacheRateOrNull(
+    final cached = _nonNegative(cachedTokens);
+    if (cached == 0) return '0.0%';
+    if (cachedTokensIncludedInPrompt == null) return unavailableLabel;
+    final rate = cacheRate(
       promptTokens: promptTokens,
       cachedTokens: cachedTokens,
       cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt,
     );
-    if (rate == null) return unavailableLabel;
     return '${rate.toStringAsFixed(fractionDigits)}%';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cost estimation
+  // ---------------------------------------------------------------------------
+
+  static const _pricing = {
+    'gemini-3-flash-preview': {
+      'input': 0.0000005,
+      'cached': 0.00000005,
+      'output': 0.000003,
+    },
+    'gemini-2.5-flash': {
+      'input': 0.0000003,
+      'cached': 0.00000003,
+      'output': 0.0000025,
+    },
+    'gemini-3.1-pro-preview': {
+      'input': 0.000002,
+      'cached': 0.0000002,
+      'output': 0.000012,
+    },
+    'gemini-3-pro-preview': {
+      'input': 0.000002,
+      'cached': 0.0000002,
+      'output': 0.000012,
+    },
+    'gpt-4o': {
+      'input': 0.0000025,
+      'cached': 0.00000125,
+      'output': 0.00001,
+    },
+  };
+
+  /// Estimates the cost of a single LLM call.
+  ///
+  /// Returns a map with 'input', 'output', and 'total' cost values.
+  static Map<String, double> calculateCost({
+    required String model,
+    required int promptTokens,
+    required int completionTokens,
+    required int cachedTokens,
+    required int thoughtTokens,
+    required bool? cachedTokensIncludedInPrompt,
+  }) {
+    // Find matching model pricing via substring match.
+    Map<String, double>? prices;
+    final modelLower = model.toLowerCase();
+    for (final key in _pricing.keys) {
+      if (modelLower.contains(key)) {
+        prices = _pricing[key];
+        break;
+      }
+    }
+    prices ??= _pricing['gpt-4o'];
+    if (prices == null) {
+      return {'input': 0.0, 'output': 0.0, 'total': 0.0};
+    }
+
+    final uncached = nonCachedPromptTokensOrNull(
+            promptTokens: promptTokens,
+            cachedTokens: cachedTokens,
+            cachedTokensIncludedInPrompt: cachedTokensIncludedInPrompt) ??
+        promptTokens;
+    final inputCost =
+        (uncached * prices['input']!) + (cachedTokens * prices['cached']!);
+
+    // todo: responses API completion includes thought
+    final outputCost = model.startsWith('ep-')
+        ? completionTokens * prices['output']!
+        : (completionTokens + thoughtTokens) * prices['output']!;
+
+    return {
+      'input': inputCost,
+      'output': outputCost,
+      'total': inputCost + outputCost,
+    };
   }
 }

--- a/test/utils/token_usage_utils_test.dart
+++ b/test/utils/token_usage_utils_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:memex/llm_client/codex_responses_client.dart';
+import 'package:memex/utils/token_usage_utils.dart';
+
+void main() {
+  group('TokenUsageUtils', () {
+    test(
+      'uses prompt tokens as denominator when cached tokens are included',
+      () {
+        expect(
+          TokenUsageUtils.effectivePromptTokens(
+            promptTokens: 1000,
+            cachedTokens: 250,
+            cachedTokensIncludedInPrompt: true,
+          ),
+          1000,
+        );
+        expect(
+          TokenUsageUtils.nonCachedPromptTokens(
+            promptTokens: 1000,
+            cachedTokens: 250,
+            cachedTokensIncludedInPrompt: true,
+          ),
+          750,
+        );
+        expect(
+          TokenUsageUtils.cacheRate(
+            promptTokens: 1000,
+            cachedTokens: 250,
+            cachedTokensIncludedInPrompt: true,
+          ),
+          closeTo(25.0, 0.001),
+        );
+      },
+    );
+
+    test(
+      'adds cached tokens to denominator when provider returns them separately',
+      () {
+        expect(
+          TokenUsageUtils.effectivePromptTokens(
+            promptTokens: 200,
+            cachedTokens: 800,
+            cachedTokensIncludedInPrompt: false,
+          ),
+          1000,
+        );
+        expect(
+          TokenUsageUtils.nonCachedPromptTokens(
+            promptTokens: 200,
+            cachedTokens: 800,
+            cachedTokensIncludedInPrompt: false,
+          ),
+          200,
+        );
+        expect(
+          TokenUsageUtils.cacheRate(
+            promptTokens: 200,
+            cachedTokens: 800,
+            cachedTokensIncludedInPrompt: false,
+          ),
+          closeTo(80.0, 0.001),
+        );
+      },
+    );
+
+    test('does not infer provider semantics from token magnitude', () {
+      expect(
+        TokenUsageUtils.effectivePromptTokens(
+          promptTokens: 1000,
+          cachedTokens: 250,
+          cachedTokensIncludedInPrompt: false,
+        ),
+        1250,
+      );
+      expect(
+        TokenUsageUtils.nonCachedPromptTokens(
+          promptTokens: 1000,
+          cachedTokens: 250,
+          cachedTokensIncludedInPrompt: false,
+        ),
+        1000,
+      );
+      expect(
+        TokenUsageUtils.cacheRate(
+          promptTokens: 1000,
+          cachedTokens: 250,
+          cachedTokensIncludedInPrompt: false,
+        ),
+        closeTo(20.0, 0.001),
+      );
+    });
+
+    test('detects known provider cache token semantics from usage shape', () {
+      expect(
+        TokenUsageUtils.cachedTokensIncludedInPrompt(
+          originalUsage: {
+            'prompt_tokens_details': {'cached_tokens': 100},
+          },
+        ),
+        isTrue,
+      );
+      expect(
+        TokenUsageUtils.cachedTokensIncludedInPrompt(
+          originalUsage: {'cache_read_input_tokens': 100},
+        ),
+        isFalse,
+      );
+      expect(
+        TokenUsageUtils.cachedTokensIncludedInPrompt(
+          originalUsage: {'cache_creation_input_tokens': 100},
+        ),
+        isFalse,
+      );
+      expect(
+        TokenUsageUtils.cachedTokensIncludedInPrompt(
+          originalUsage: {
+            'input_tokens_details': {'cached_tokens': 100},
+          },
+        ),
+        isTrue,
+      );
+      expect(
+        TokenUsageUtils.cachedTokensIncludedInPrompt(
+          originalUsage: {'cachedContentTokenCount': 100},
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns null when cache token semantics cannot be proven', () {
+      expect(
+        TokenUsageUtils.cachedTokensIncludedInPrompt(),
+        isNull,
+      );
+    });
+
+    test('detects cache token semantics from concrete client adapters', () {
+      expect(
+        TokenUsageUtils.cachedTokensIncludedInPrompt(
+          client: ClaudeClient(apiKey: 'test-key'),
+        ),
+        isFalse,
+      );
+      expect(
+        TokenUsageUtils.cachedTokensIncludedInPrompt(
+          client: ResponsesClient(apiKey: 'test-key'),
+        ),
+        isTrue,
+      );
+      expect(
+        TokenUsageUtils.cachedTokensIncludedInPrompt(
+          client: CodexResponsesClient(accessToken: 'test-token'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('formats cache rate without exceeding 100 percent', () {
+      expect(
+        TokenUsageUtils.formatCacheRate(
+          promptTokens: 0,
+          cachedTokens: 500,
+          cachedTokensIncludedInPrompt: false,
+        ),
+        '100.0%',
+      );
+      expect(
+        TokenUsageUtils.formatCacheRate(
+          promptTokens: 0,
+          cachedTokens: 0,
+          cachedTokensIncludedInPrompt: false,
+        ),
+        '0.0%',
+      );
+    });
+
+    test('returns unavailable cache rate when cache semantics are unknown', () {
+      expect(
+        TokenUsageUtils.effectivePromptTokensOrNull(
+          promptTokens: 100,
+          cachedTokens: 50,
+          cachedTokensIncludedInPrompt: null,
+        ),
+        isNull,
+      );
+      expect(
+        TokenUsageUtils.formatCacheRateOrUnavailable(
+          promptTokens: 100,
+          cachedTokens: 50,
+          cachedTokensIncludedInPrompt: null,
+        ),
+        'N/A',
+      );
+      expect(
+        TokenUsageUtils.formatCacheRateOrUnavailable(
+          promptTokens: 100,
+          cachedTokens: 0,
+          cachedTokensIncludedInPrompt: null,
+        ),
+        '0.0%',
+      );
+    });
+  });
+}

--- a/test/utils/token_usage_utils_test.dart
+++ b/test/utils/token_usage_utils_test.dart
@@ -202,5 +202,87 @@ void main() {
         '0.0%',
       );
     });
+
+    test('resolveFromUsageRecord reads persisted semantics', () {
+      expect(
+        TokenUsageUtils.resolveFromUsageRecord({
+          'cache_tokens_included_in_prompt': true,
+        }),
+        isTrue,
+      );
+      expect(
+        TokenUsageUtils.resolveFromUsageRecord({
+          'original_usage': {'cache_read_input_tokens': 100},
+        }),
+        isFalse,
+      );
+      expect(
+        TokenUsageUtils.resolveFromUsageRecord({}),
+        isNull,
+      );
+    });
+
+    test('formatCacheRateFromAggregated computes from pre-normalized values',
+        () {
+      // 250 cached out of 1000 effective prompt = 25%
+      expect(
+        TokenUsageUtils.formatCacheRateFromAggregated(
+          effectivePromptTokens: 1000,
+          cachedTokens: 250,
+        ),
+        '25.0%',
+      );
+      // zero cached
+      expect(
+        TokenUsageUtils.formatCacheRateFromAggregated(
+          effectivePromptTokens: 1000,
+          cachedTokens: 0,
+        ),
+        '0.0%',
+      );
+      // zero denominator
+      expect(
+        TokenUsageUtils.formatCacheRateFromAggregated(
+          effectivePromptTokens: 0,
+          cachedTokens: 0,
+        ),
+        '0.0%',
+      );
+    });
+
+    test('calculateCost estimates token cost with known pricing', () {
+      // gemini-2.5-flash: input=0.0000003, cached=0.00000003, output=0.0000025
+      final costs = TokenUsageUtils.calculateCost(
+        model: 'gemini-2.5-flash-preview-05-20',
+        promptTokens: 1000,
+        completionTokens: 200,
+        cachedTokens: 300,
+        thoughtTokens: 50,
+        cachedTokensIncludedInPrompt: true,
+      );
+      // nonCached = 1000 - 300 = 700
+      // inputCost = 700 * 0.0000003 + 300 * 0.00000003
+      final expectedInput = 700 * 0.0000003 + 300 * 0.00000003;
+      // outputCost = (200 + 50) * 0.0000025
+      final expectedOutput = 250 * 0.0000025;
+      expect(costs['input'], closeTo(expectedInput, 1e-10));
+      expect(costs['output'], closeTo(expectedOutput, 1e-10));
+      expect(costs['total'], closeTo(expectedInput + expectedOutput, 1e-10));
+    });
+
+    test('calculateCost falls back to gpt-4o for unknown models', () {
+      final costs = TokenUsageUtils.calculateCost(
+        model: 'unknown-model-xyz',
+        promptTokens: 100,
+        completionTokens: 50,
+        cachedTokens: 0,
+        thoughtTokens: 0,
+        cachedTokensIncludedInPrompt: true,
+      );
+      // gpt-4o: input=0.0000025, output=0.00001
+      final expectedInput = 100 * 0.0000025;
+      final expectedOutput = 50 * 0.00001;
+      expect(costs['total'], closeTo(expectedInput + expectedOutput, 1e-10));
+    });
   });
 }


### PR DESCRIPTION
## 变更说明

- 新增统一的 Token 使用统计工具，明确区分“cached tokens 是否已包含在 prompt/input tokens 中”的 provider 口径。
- 去掉按 token 大小和模型名推断缓存语义的启发式逻辑；新记录从原始 usage 字段或具体 LLM client adapter 推导并持久化 `cache_tokens_included_in_prompt` / `cache_base_tokens`。
- 对无法证明语义的历史记录不再强行显示百分比，cache rate 显示为 `N/A`，避免给出看似精确但可能错误的数据。
- 修正 Debugging 模型使用统计页、卡片详情、聊天浮层以及成本估算中的缓存 token 分母和非缓存 prompt token 计算。
- 增加单元测试覆盖 OpenAI / Responses / Gemini / Anthropic 口径、未知语义、cached tokens 大于 prompt tokens、prompt 为 0 等边界场景。

## API 口径核对

- OpenAI Chat/Responses：`cached_tokens` 是 prompt/input tokens 的子集，分母使用 prompt/input tokens。
- Gemini：`cachedContentTokenCount` 是 prompt tokens 中来自缓存内容的部分，分母使用 prompt tokens。
- Anthropic/Claude：`cache_read_input_tokens` / `cache_creation_input_tokens` 与 `input_tokens` 分开返回，分母使用 `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`。

## 验证

- `flutter test`
- `flutter test test/utils/token_usage_utils_test.dart`
- `git diff --check`
- `dart analyze` 目标文件：无新增类型错误；仍有项目既有 warning/info（如未使用的 `_showLLMStats`、`withOpacity` deprecated 等）。