### PR TITLE
feat: 支持详情页长图分享

### DIFF
--- a/.github/i18n_issue_body.md
+++ b/.github/i18n_issue_body.md
@@ -1,0 +1,66 @@
+## Problem
+
+Memex 目前仅支持 **English** (`en`) 和 **简体中文** (`zh`)。作为一款面向全球用户的个人生活记录应用，仅两种语言限制了大量潜在用户的使用体验——尤其是一款需要处理日常自然语言输入的 app。
+
+## Proposed solution
+
+新增以下语言的本地化支持：
+
+| # | Locale | Language | 使用人数 |
+|---|--------|----------|----------|
+| 1 | `ko` | 한국어 (Korean) | ~80M+ |
+| 2 | `ja` | 日本語 (Japanese) | ~125M+ |
+| 3 | `zh-Hant` | 繁體中文 (Traditional Chinese) | ~50M+（台湾、香港、澳门） |
+| 4 | `es` | Español (Spanish) | ~500M+ |
+| 5 | `hi` | हिन्दी (Hindi) | ~600M+ |
+| 6 | `ar` | العربية (Arabic) | ~400M+ |
+| 7 | `pt` | Português (Portuguese) | ~260M+ |
+| 8 | `fr` | Français (French) | ~280M+ |
+| 9 | `ru` | Русский (Russian) | ~250M+ |
+| 10 | `de` | Deutsch (German) | ~100M+ |
+| 11 | `id` | Bahasa Indonesia | ~270M+ |
+| 12 | `th` | ไทย (Thai) | ~70M+ |
+| 13 | `vi` | Tiếng Việt (Vietnamese) | ~85M+ |
+
+## Scope of work
+
+当前代码库有两层本地化机制，每种新语言都需要同时覆盖：
+
+### 1. ARB 文件（短 UI 字符串）
+- `lib/l10n/app_en.arb` — 约 250+ 翻译 key（按钮、标签、toast、状态消息等）
+- 每种新语言需要对应的 `app_<locale>.arb` 文件
+
+### 2. `AppLocalizationsExt`（多行长文本）
+- `lib/l10n/app_localizations_ext.dart` — mixin，约 20 个长文本属性（agent prompt、onboarding 文案、OAuth 消息、默认角色、分享文案等）
+- 每种新语言需要 `app_localizations_ext_<locale>.dart` + 在 `lookupAppLocalizationsExt()` 中注册
+
+### 3. 配置更新
+- `l10n.yaml` — 无需改动（自动发现 ARB 文件）
+- `app_localizations.dart` — `supportedLocales` 列表（`flutter gen-l10n` 自动生成）
+- `ios/Runner/Info.plist` — 添加 locale 到 `CFBundleLocalizations`
+- `android/app/src/main/res/` — 添加 `values-<locale>/strings.xml`（app 名称、快捷方式等 Android 专属字符串）
+
+### 4. RTL 支持（Arabic）
+- 验证所有布局在 `TextDirection.rtl` 下正常工作
+- 检查 `Directionality` widget 使用、padding/margin 不对称、图标镜像等
+
+### 5. Agent prompt 本地化
+- Agent 系统 prompt 和语言指令已有本地化模式（`AppLocalizationsExt` 中的 `*LanguageInstruction` 属性）
+- 新语言需要对应的 prompt 翻译，且需保证翻译质量不影响 LLM 交互效果
+
+## Implementation approach
+
+1. **机器翻译打底 + 人工审校** — 先用机器翻译生成 ARB 骨架文件，再由母语者审校，尤其是 agent prompt 部分（措辞直接影响 LLM 输出质量）
+2. **社区贡献模式** — ARB 骨架就位后，为每种语言标记 `help wanted` + `good first issue`，方便母语者通过 PR 贡献翻译
+3. **CI 校验** — 添加 lint 步骤，检查所有 ARB 文件的 key 集合一致（不遗漏翻译）
+
+## Checklist
+
+- [ ] 为 13 种新语言创建 ARB 骨架文件
+- [ ] 为 13 种新语言创建 `AppLocalizationsExt` 实现
+- [ ] 更新 `lookupAppLocalizationsExt()` switch 语句
+- [ ] 添加 iOS `Info.plist` locale 条目
+- [ ] 添加 Android `values-<locale>/strings.xml` 文件
+- [ ] 验证 Arabic RTL 布局
+- [ ] 添加 missing-key CI lint
+- [ ] 各语言母语者审校

--- a/lib/l10n/app_localizations_ext.dart
+++ b/lib/l10n/app_localizations_ext.dart
@@ -44,6 +44,8 @@ mixin AppLocalizationsExt on AppLocalizations {
   String get shareNow;
   String get sharedFromMemex;
   String get appTagline;
+  String get shareDetailStyle;
+  String get shareCardStyle;
 
   /// Default built-in characters (used to seed `Characters/*.yaml`).
   List<Map<String, dynamic>> get defaultCharacters;

--- a/lib/l10n/app_localizations_ext_en.dart
+++ b/lib/l10n/app_localizations_ext_en.dart
@@ -200,4 +200,10 @@ class AppLocalizationsExtEn extends AppLocalizationsEn
 
   @override
   String get appTagline => 'Record the Spark, Architect the Soul';
+
+  @override
+  String get shareDetailStyle => 'Detail Style';
+
+  @override
+  String get shareCardStyle => 'Card Style';
 }

--- a/lib/l10n/app_localizations_ext_zh.dart
+++ b/lib/l10n/app_localizations_ext_zh.dart
@@ -198,4 +198,10 @@ class AppLocalizationsExtZh extends AppLocalizationsZh
 
   @override
   String get appTagline => '记录微光，构筑灵魂';
+
+  @override
+  String get shareDetailStyle => '详情样式';
+
+  @override
+  String get shareCardStyle => '卡片样式';
 }

--- a/lib/ui/core/widgets/share_preview_dialog.dart
+++ b/lib/ui/core/widgets/share_preview_dialog.dart
@@ -10,11 +10,20 @@ class SharePreviewDialog extends StatelessWidget {
   final VoidCallback onShare;
   final VoidCallback onCancel;
 
+  /// Callback to toggle between card style and detail style.
+  /// If null, the toggle button is hidden.
+  final VoidCallback? onToggleStyle;
+
+  /// Whether the current preview is in detail (long image) style.
+  final bool isDetailStyle;
+
   const SharePreviewDialog({
     super.key,
     required this.imageBytes,
     required this.onShare,
     required this.onCancel,
+    this.onToggleStyle,
+    this.isDetailStyle = false,
   });
 
   @override
@@ -96,6 +105,20 @@ class SharePreviewDialog extends StatelessWidget {
                     label: l10n.cancel,
                     isPrimary: false,
                   ),
+                  if (onToggleStyle != null) ...[
+                    const SizedBox(width: 24),
+                    _buildButton(
+                      onTap: onToggleStyle!,
+                      icon: isDetailStyle
+                          ? Icons.crop_square_rounded
+                          : Icons.article_outlined,
+                      label: isDetailStyle
+                          ? l10n.shareCardStyle
+                          : l10n.shareDetailStyle,
+                      isPrimary: false,
+                      isAccent: true,
+                    ),
+                  ],
                   const SizedBox(width: 24),
                   _buildButton(
                     onTap: onShare,
@@ -117,20 +140,23 @@ class SharePreviewDialog extends StatelessWidget {
     required IconData icon,
     required String label,
     required bool isPrimary,
+    bool isAccent = false,
   }) {
     return GestureDetector(
       onTap: onTap,
       child: Column(
         children: [
           Container(
-            width: 64,
-            height: 64,
+            width: 56,
+            height: 56,
             decoration: BoxDecoration(
               shape: BoxShape.circle,
               color: isPrimary
                   ? Colors.white
-                  : Colors.white.withValues(alpha: 0.15),
-              border: isPrimary
+                  : isAccent
+                      ? AppColors.primary.withValues(alpha: 0.25)
+                      : Colors.white.withValues(alpha: 0.15),
+              border: isPrimary || isAccent
                   ? null
                   : Border.all(
                       color: Colors.white.withValues(alpha: 0.3), width: 1.5),
@@ -146,8 +172,12 @@ class SharePreviewDialog extends StatelessWidget {
             ),
             child: Icon(
               icon,
-              color: isPrimary ? AppColors.primary : Colors.white,
-              size: 28,
+              color: isPrimary
+                  ? AppColors.primary
+                  : isAccent
+                      ? Colors.white
+                      : Colors.white,
+              size: 24,
             ),
           ),
           const SizedBox(height: 10),
@@ -155,7 +185,7 @@ class SharePreviewDialog extends StatelessWidget {
             label,
             style: TextStyle(
               color: Colors.white.withValues(alpha: 0.9),
-              fontSize: 13,
+              fontSize: 12,
               fontWeight: FontWeight.w600,
             ),
           ),

--- a/lib/ui/insight/widgets/insight_detail_page.dart
+++ b/lib/ui/insight/widgets/insight_detail_page.dart
@@ -146,7 +146,134 @@ class _InsightDetailPageState extends State<InsightDetailPage> {
       ),
     );
 
-    await ShareService.shareWidgetAsPoster(context, shareWidget);
+    // Build detail-style widget mirroring the insight detail page layout
+    final detailWidget = _buildShareDetailWidget();
+
+    await ShareService.shareWidgetAsPoster(
+      context,
+      shareWidget,
+      detailContent: detailWidget,
+    );
+  }
+
+  /// Builds a long-form detail widget for the "detail style" share image.
+  /// Mirrors the insight detail page layout: native widget card → insight
+  /// comment → related cards.
+  Widget _buildShareDetailWidget() {
+    return Container(
+      width: 400,
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 20),
+      color: const Color(0xFFF7F8FA),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 1. Native widget card (detail view)
+          if (_insightDetail?.widgetType == 'native' &&
+              _insightDetail?.widgetTemplate != null &&
+              _insightDetail?.widgetData != null) ...[
+            NativeWidgetFactory.buildDetail(
+                  _insightDetail!.widgetTemplate!,
+                  _insightDetail!.widgetData!,
+                ) ??
+                const SizedBox.shrink(),
+
+            // 2. Insight comment below card (same as detail page)
+            if (_content.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF7F8FA),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Padding(
+                      padding: EdgeInsets.only(top: 1),
+                      child: Icon(
+                        Icons.auto_awesome,
+                        size: 16,
+                        color: Color(0xFF5B6CFF),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        _content,
+                        style: GoogleFonts.inter(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w400,
+                          color: const Color(0xFF4A5565),
+                          height: 1.6,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+
+            const SizedBox(height: 32),
+          ] else if (_content.isNotEmpty) ...[
+            // Fallback: plain text content
+            Text(
+              _content,
+              style: const TextStyle(
+                fontSize: 17,
+                color: Color(0xFF334155),
+                height: 1.7,
+                letterSpacing: 0,
+              ),
+            ),
+            const SizedBox(height: 32),
+          ],
+
+          // 3. Related cards section (same as detail page)
+          if (_relatedCards.isNotEmpty) ...[
+            Text(
+              UserStorage.l10n.relatedRecordsCount(_relatedCards.length),
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: Color(0xFF0A0A0A),
+              ),
+            ),
+            const SizedBox(height: 16),
+            ..._relatedCards.map((card) {
+              final displayConfigs = card.uiConfigs;
+              if (displayConfigs.isEmpty) {
+                return const SizedBox.shrink();
+              }
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: displayConfigs.map((config) {
+                    if (config.templateId == 'legacy_html') {
+                      return const SizedBox.shrink();
+                    }
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 8.0),
+                      child: NativeCardFactory.build(
+                        status: card.status,
+                        templateId: config.templateId,
+                        data: config.data,
+                        title: card.title ?? '',
+                        tags: card.tags,
+                      ),
+                    );
+                  }).toList(),
+                ),
+              );
+            }),
+          ],
+        ],
+      ),
+    );
   }
 
   @override

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -699,7 +699,362 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       ),
     );
 
-    await ShareService.shareWidgetAsPoster(context, shareWidget);
+    // Build detail-style widget (long image with full content, images, comments)
+    final detailWidget = _buildShareDetailWidget(_detail!);
+
+    await ShareService.shareWidgetAsPoster(
+      context,
+      shareWidget,
+      detailContent: detailWidget,
+    );
+  }
+
+  /// Builds a long-form detail widget for the "detail style" share image.
+  /// Mirrors the real detail page layout: images → title → content+tags →
+  /// date/location → related memories → comments (insight as first comment).
+  Widget _buildShareDetailWidget(CardDetailModel detail) {
+    final imageAssets = detail.assets.where((a) => a.isImage).toList();
+
+    return Container(
+      width: 400,
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 20),
+      color: Colors.white,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 1. Images (same as header media)
+          if (imageAssets.isNotEmpty) ...[
+            for (final asset in imageAssets) ...[
+              ClipRRect(
+                borderRadius: BorderRadius.circular(20),
+                child: LocalImage(
+                  url: asset.url,
+                  fit: BoxFit.cover,
+                  width: double.infinity,
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
+          ],
+
+          const SizedBox(height: 4),
+
+          // 2. Title (same style as detail page)
+          if (detail.title.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Text(
+                detail.title,
+                style: const TextStyle(
+                  fontFamily: 'PingFang SC',
+                  fontSize: 24,
+                  fontWeight: FontWeight.w600,
+                  color: Color(0xFF334155),
+                  height: 1.375,
+                  letterSpacing: -0.45,
+                ),
+              ),
+            ),
+
+          // 3. Content with inline tags (same as detail page)
+          if (detail.rawContent.isNotEmpty || detail.tags.isNotEmpty)
+            Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(
+                    text: detail.rawContent,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      color: Color(0xFF334155),
+                      height: 1.6,
+                    ),
+                  ),
+                  if (detail.rawContent.isNotEmpty && detail.tags.isNotEmpty)
+                    const TextSpan(text: ' '),
+                  ...detail.tags.map((tag) {
+                    return TextSpan(
+                      text: '#$tag',
+                      style: const TextStyle(
+                        fontSize: 16,
+                        color: Color(0xFF6366F1),
+                        fontWeight: FontWeight.w400,
+                        height: 1.25,
+                        letterSpacing: 0,
+                      ),
+                    );
+                  }).expand((span) => [span, const TextSpan(text: ' ')]),
+                ],
+              ),
+            ),
+
+          const SizedBox(height: 16),
+
+          // 4. Date and Location (same as detail page)
+          Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Text(
+                DateFormat('MM-dd').format(detail.timestamp),
+                style: const TextStyle(
+                  fontSize: 13,
+                  color: Color(0xFF94A3B8),
+                ),
+              ),
+              if (detail.address.isNotEmpty && detail.address != 'Unknown') ...[
+                const SizedBox(width: 6),
+                Text(
+                  detail.address,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    color: Color(0xFF94A3B8),
+                  ),
+                ),
+              ],
+            ],
+          ),
+
+          const SizedBox(height: 24),
+          const Divider(height: 1, color: Color(0xFFE2E8F0)),
+          const SizedBox(height: 16),
+
+          // 5. Related Memories (same as detail page)
+          if (detail.insight.relatedCards.isNotEmpty) ...[
+            _buildShareRelatedMemories(detail.insight.relatedCards),
+            const SizedBox(height: 24),
+          ],
+
+          // 6. Comments — insight as first comment, then other comments
+          //    (mirrors _buildCommentsList logic)
+          _buildShareCommentsList(detail),
+        ],
+      ),
+    );
+  }
+
+  /// Builds the related memories section for the share detail widget.
+  /// Compact vertical list for the long image (horizontal carousel doesn't
+  /// work well in a static off-screen capture).
+  Widget _buildShareRelatedMemories(List<RelatedCard> cards) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Section Header (same as detail page)
+        Row(
+          children: [
+            Container(
+              width: 4,
+              height: 16,
+              decoration: BoxDecoration(
+                color: TimelineTheme.colors.primary,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              UserStorage.l10n.relatedMemories,
+              style: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w500,
+                color: Color(0xFF4A5565),
+                letterSpacing: -0.15,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        // Render related cards as compact list items
+        ...cards.take(5).map((card) {
+          final hasImage = card.assets.isNotEmpty && card.assets.first.isImage;
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 10),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (hasImage) ...[
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: SizedBox(
+                      width: 44,
+                      height: 44,
+                      child: LocalImage(
+                        url: card.assets.first.url,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                ],
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        card.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                          color: Color(0xFF334155),
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        card.date,
+                        style: const TextStyle(
+                          fontSize: 11,
+                          color: Color(0xFF94A3B8),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  /// Builds the comments list for the share detail widget.
+  /// Insight is rendered as the first "pinned" comment (same as detail page).
+  Widget _buildShareCommentsList(CardDetailModel detail) {
+    final List<Widget> commentWidgets = [];
+
+    // Insight as first comment (same as _buildCommentsList)
+    if (_showInsightText && detail.insight.character != null) {
+      commentWidgets.add(
+        _buildShareSingleComment(
+          characterId: detail.insight.characterId,
+          avatar: detail.insight.character!.avatar,
+          name: detail.insight.character!.name,
+          content: detail.insight.text,
+          time: DateFormat('MM-dd').format(detail.timestamp),
+          isAuthor: true,
+        ),
+      );
+    }
+
+    // Other comments
+    for (var comment in detail.insight.comments) {
+      final isUser = !comment.isAi;
+      final commentName =
+          isUser ? _userName : (comment.character?.name ?? 'AI');
+      commentWidgets.add(
+        _buildShareSingleComment(
+          characterId: isUser ? 'user' : comment.character?.id,
+          avatar: isUser ? _userAvatar : comment.character?.avatar,
+          name: commentName,
+          content: comment.content,
+          time: DateFormat('MM-dd').format(
+            DateTime.fromMillisecondsSinceEpoch(comment.timestamp * 1000),
+          ),
+          isAi: comment.isAi,
+          replyToName: comment.replyToName,
+        ),
+      );
+    }
+
+    return Column(
+      children: commentWidgets
+          .map((w) =>
+              Padding(padding: const EdgeInsets.only(bottom: 24), child: w))
+          .toList(),
+    );
+  }
+
+  /// Builds a single comment for the share detail widget.
+  /// Static version of _buildSingleComment (no tap handlers, no navigation).
+  Widget _buildShareSingleComment({
+    String? characterId,
+    String? avatar,
+    required String name,
+    required String content,
+    required String time,
+    bool isAuthor = false,
+    bool isAi = false,
+    String? replyToName,
+  }) {
+    // Avatar logic — same as _buildSingleComment
+    Widget avatarWidget;
+    final isMemexSystem = (characterId == null || characterId == '0') && !isAi;
+    final isUserComment = characterId == 'user';
+
+    if (isUserComment) {
+      avatarWidget = DiceBearAvatar(
+        seed: (avatar != null && avatar.isNotEmpty) ? avatar : name,
+        size: 36,
+        backgroundColor: const Color(0xFFEEF2FF),
+      );
+    } else if (isMemexSystem || (characterId == null || characterId == '0')) {
+      avatarWidget = CircleAvatar(
+        radius: 18,
+        backgroundColor: Colors.white,
+        child: ClipOval(
+          child: Image.asset(
+            'assets/icon.png',
+            width: 36,
+            height: 36,
+            fit: BoxFit.cover,
+          ),
+        ),
+      );
+    } else {
+      final seed =
+          (avatar != null && avatar.isNotEmpty) ? avatar : 'companion_$name';
+      avatarWidget = DiceBearAvatar(
+        seed: seed,
+        size: 36,
+        backgroundColor: const Color(0xFFEEF2FF),
+      );
+    }
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        avatarWidget,
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Name row with optional reply chain indicator
+              Wrap(
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: 0,
+                children: [
+                  Text(name, style: AppTextStyles.commentName),
+                  if (replyToName != null) ...[
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 6),
+                      child: Icon(Icons.subdirectory_arrow_right_rounded,
+                          size: 14, color: AppColors.textTertiary),
+                    ),
+                    Text(
+                      replyToName,
+                      style: AppTextStyles.commentName.copyWith(
+                        color: AppColors.primary,
+                        fontSize: 15,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+              const SizedBox(height: 4),
+              // Use plain Text for share (MarkdownBody may not render well offscreen)
+              Text(
+                content,
+                style: AppTextStyles.commentContent,
+              ),
+              const SizedBox(height: 6),
+              Text(time, style: AppTextStyles.commentDate),
+            ],
+          ),
+        ),
+      ],
+    );
   }
 
   void _showInputModal(String cardId) {

--- a/lib/utils/share_service.dart
+++ b/lib/utils/share_service.dart
@@ -10,9 +10,106 @@ import 'package:memex/utils/user_storage.dart';
 
 class ShareService {
   /// Captures a widget as a poster image and shows a preview dialog before sharing.
-  static Future<void> shareWidgetAsPoster(BuildContext context, Widget content) async {
-    // 1. Assemble share poster with decorator
-    final poster = Theme(
+  ///
+  /// If [detailContent] is provided, the user can toggle between card style
+  /// and detail (long image) style in the preview dialog.
+  static Future<void> shareWidgetAsPoster(
+    BuildContext context,
+    Widget content, {
+    Widget? detailContent,
+  }) async {
+    final cardBytes = await _captureWidget(context, content);
+    if (!context.mounted) return;
+
+    Uint8List? detailBytes;
+    bool isDetailStyle = false;
+    Uint8List currentBytes = cardBytes;
+
+    await showDialog(
+      context: context,
+      barrierColor: Colors.black.withValues(alpha: 0.2),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => SharePreviewDialog(
+          imageBytes: currentBytes,
+          isDetailStyle: isDetailStyle,
+          onCancel: () => Navigator.of(ctx).pop(),
+          onToggleStyle: detailContent != null
+              ? () async {
+                  if (!isDetailStyle) {
+                    // Switch to detail style — capture on first toggle
+                    if (detailBytes == null) {
+                      // Show a brief loading indicator
+                      setDialogState(() {});
+                      detailBytes = await _captureLongWidget(
+                        ctx,
+                        detailContent,
+                      );
+                    }
+                    if (detailBytes != null) {
+                      setDialogState(() {
+                        isDetailStyle = true;
+                        currentBytes = detailBytes!;
+                      });
+                    }
+                  } else {
+                    // Switch back to card style
+                    setDialogState(() {
+                      isDetailStyle = false;
+                      currentBytes = cardBytes;
+                    });
+                  }
+                }
+              : null,
+          onShare: () async {
+            Navigator.of(ctx).pop();
+            await _performShare(currentBytes);
+          },
+        ),
+      ),
+    );
+  }
+
+  /// Capture a normal-sized widget (fits in viewport).
+  static Future<Uint8List> _captureWidget(
+    BuildContext context,
+    Widget content,
+  ) async {
+    final poster =
+        _wrapForCapture(context, SharePosterDecorator(content: content));
+    final screenshotController = ScreenshotController();
+    final pixelRatio = MediaQuery.of(context).devicePixelRatio;
+    return screenshotController.captureFromWidget(
+      poster,
+      context: context,
+      delay: const Duration(milliseconds: 100),
+      pixelRatio: pixelRatio,
+    );
+  }
+
+  /// Capture a long widget that may exceed viewport height.
+  /// Uses [captureFromLongWidget] for off-screen rendering.
+  static Future<Uint8List> _captureLongWidget(
+    BuildContext context,
+    Widget content,
+  ) async {
+    final poster =
+        _wrapForCapture(context, SharePosterDecorator(content: content));
+    final screenshotController = ScreenshotController();
+    final pixelRatio = MediaQuery.of(context).devicePixelRatio;
+    return screenshotController.captureFromLongWidget(
+      poster,
+      context: context,
+      delay: const Duration(milliseconds: 200),
+      constraints: BoxConstraints(
+        maxWidth: MediaQuery.of(context).size.width,
+      ),
+      pixelRatio: pixelRatio,
+    );
+  }
+
+  /// Wraps a widget with the necessary context providers for off-screen capture.
+  static Widget _wrapForCapture(BuildContext context, Widget child) {
+    return Theme(
       data: Theme.of(context),
       child: Directionality(
         textDirection: Directionality.of(context),
@@ -20,33 +117,9 @@ class ShareService {
           data: MediaQuery.of(context),
           child: Material(
             color: Colors.transparent,
-            child: SharePosterDecorator(content: content),
+            child: child,
           ),
         ),
-      ),
-    );
-    
-    // 2. Render to image
-    final screenshotController = ScreenshotController();
-    final Uint8List imageBytes = await screenshotController.captureFromWidget(
-      poster,
-      context: context,
-      delay: const Duration(milliseconds: 100),
-    );
-
-    if (!context.mounted) return;
-
-    // 3. Show preview confirmation dialog
-    showDialog(
-      context: context,
-      barrierColor: Colors.black.withValues(alpha: 0.2),
-      builder: (ctx) => SharePreviewDialog(
-        imageBytes: imageBytes,
-        onCancel: () => Navigator.of(ctx).pop(),
-        onShare: () async {
-          Navigator.of(ctx).pop();
-          await _performShare(imageBytes);
-        },
       ),
     );
   }
@@ -54,9 +127,11 @@ class ShareService {
   /// Internal method to perform the actual sharing.
   static Future<void> _performShare(Uint8List imageBytes) async {
     final tempDir = await getTemporaryDirectory();
-    final file = File('${tempDir.path}/memex_share_${DateTime.now().millisecondsSinceEpoch}.png');
+    final file = File(
+        '${tempDir.path}/memex_share_${DateTime.now().millisecondsSinceEpoch}.png');
     await file.writeAsBytes(imageBytes);
 
-    await Share.shareXFiles([XFile(file.path)], text: UserStorage.l10n.sharedFromMemex);
+    await Share.shareXFiles([XFile(file.path)],
+        text: UserStorage.l10n.sharedFromMemex);
   }
 }


### PR DESCRIPTION
Closes #38

## 改动概述

在卡片详情页和洞察详情页的分享功能中，新增「详情样式」长图分享模式，同时修复分享图片模糊问题。

## 改动文件

| 文件 | 改动 |
|------|------|
| `lib/l10n/app_localizations_ext.dart` | 新增 `shareDetailStyle` / `shareCardStyle` 字段定义 |
| `lib/l10n/app_localizations_ext_zh.dart` | 中文翻译：详情样式 / 卡片样式 |
| `lib/l10n/app_localizations_ext_en.dart` | 英文翻译：Detail Style / Card Style |
| `lib/ui/core/widgets/share_preview_dialog.dart` | 新增中间切换按钮（可选参数，向后兼容） |
| `lib/utils/share_service.dart` | 支持双模式分享 + pixelRatio 高清渲染 |
| `lib/ui/timeline/widgets/timeline_card_detail_screen.dart` | 卡片详情长图构建（镜像详情页布局） |
| `lib/ui/insight/widgets/insight_detail_page.dart` | 洞察详情长图构建（镜像详情页布局） |

## 测试

- `flutter analyze` 全项目通过，无新增 error/warning
- 新增参数均为可选，不影响现有调用
- 长图渲染为懒加载，不影响正常浏览性能
- 无新增依赖