### PR TITLE
[codex] Add digest timeline card template

### DIFF
--- a/lib/agent/card_agent/rule_based_card_matcher.dart
+++ b/lib/agent/card_agent/rule_based_card_matcher.dart
@@ -9,7 +9,8 @@ final _logger = Logger('RuleBasedCardMatcher');
 ///   1. 1 image  → snapshot
 ///   2. 2+ images → gallery
 ///   3. URL-only text → link
-///   4. Everything else → snippet
+///   4. Long mixed text → digest
+///   5. Everything else → snippet
 CardData applyRuleBasedTemplate({
   required CardData card,
   required String combinedText,
@@ -21,7 +22,8 @@ CardData applyRuleBasedTemplate({
   final templateId = _matchTemplate(pureText: pureText, imageUrls: imageUrls);
 
   _logger.info(
-      'Rule-based match: templateId=$templateId, images=${imageUrls.length}, textLen=${pureText.length}');
+    'Rule-based match: templateId=$templateId, images=${imageUrls.length}, textLen=${pureText.length}',
+  );
 
   final data = _buildData(
     templateId: templateId,
@@ -38,12 +40,15 @@ CardData applyRuleBasedTemplate({
   );
 }
 
-String _matchTemplate(
-    {required String pureText, required List<String> imageUrls}) {
+String _matchTemplate({
+  required String pureText,
+  required List<String> imageUrls,
+}) {
   if (imageUrls.isNotEmpty) {
     return imageUrls.length == 1 ? 'snapshot' : 'gallery';
   }
   if (_isUrlOnly(pureText)) return 'link';
+  if (_looksLikeMixedLongText(pureText)) return 'digest';
   return 'snippet';
 }
 
@@ -74,14 +79,122 @@ Map<String, dynamic> _buildData({
     case 'link':
       final url = _urlRe.firstMatch(pureText)?.group(0) ?? pureText;
       final rest = pureText.replaceAll(_urlRe, '').trim();
-      return {
-        'url': url,
-        if (rest.isNotEmpty) 'title': rest,
-      };
+      return {'url': url, if (rest.isNotEmpty) 'title': rest};
+    case 'digest':
+      return _buildDigestData(pureText);
     case 'snippet':
     default:
       return {'text': pureText.isNotEmpty ? pureText : '…', 'style': 'default'};
   }
+}
+
+Map<String, dynamic> _buildDigestData(String pureText) {
+  final parts = _splitThoughts(pureText);
+  final groups = <String, List<String>>{};
+
+  for (final part in parts) {
+    final type = _classifyDigestPart(part);
+    groups.putIfAbsent(type, () => []).add(part);
+  }
+
+  final sections = <Map<String, dynamic>>[];
+  for (final entry in groups.entries) {
+    final items = entry.value.take(4).toList();
+    if (items.isEmpty) continue;
+    sections.add({
+      'type': entry.key,
+      'title': _digestSectionTitle(entry.key),
+      'items': items,
+    });
+  }
+
+  if (sections.isEmpty && pureText.trim().isNotEmpty) {
+    sections.add({
+      'type': 'note',
+      'title': 'Notes',
+      'items': parts.take(4).toList(),
+    });
+  }
+
+  return {
+    'summary': _shorten(pureText.replaceAll(RegExp(r'\s+'), ' '), 140),
+    'sections': sections,
+  };
+}
+
+List<String> _splitThoughts(String text) {
+  final byLine = text
+      .split(RegExp(r'\n+'))
+      .map((e) => e.trim())
+      .where((e) => e.isNotEmpty)
+      .toList();
+  if (byLine.length > 1) return byLine.take(12).toList();
+
+  return text
+      .split(RegExp(r'[。！？.!?；;]\s*'))
+      .map((e) => e.trim())
+      .where((e) => e.isNotEmpty)
+      .take(12)
+      .toList();
+}
+
+String _classifyDigestPart(String text) {
+  final lower = text.toLowerCase();
+  if (RegExp(r'(todo|to do|待办|要做|需要|得|must|need|finish|完成)').hasMatch(lower)) {
+    return 'todo';
+  }
+  if (RegExp(
+    r'(meeting|schedule|calendar|会议|日程|约|明天|后天|下周|周[一二三四五六日天]|星期|[0-2]?\d[:：][0-5]\d)',
+  ).hasMatch(lower)) {
+    return 'schedule';
+  }
+  if (RegExp(
+    r'(mood|feel|feeling|stress|anxious|happy|sad|tired|心情|感觉|焦虑|开心|难受|累|压力)',
+  ).hasMatch(lower)) {
+    return 'mood';
+  }
+  if (RegExp(
+    r'(project|prd|roadmap|milestone|deadline|review|项目|需求|版本|迭代|评审)',
+  ).hasMatch(lower)) {
+    return 'project';
+  }
+  if (RegExp(r'(idea|thought|maybe|灵感|想法|想到|也许|或许)').hasMatch(lower)) {
+    return 'idea';
+  }
+  return 'note';
+}
+
+String _digestSectionTitle(String type) {
+  switch (type) {
+    case 'todo':
+      return 'Todos';
+    case 'schedule':
+      return 'Schedule';
+    case 'mood':
+      return 'Mood';
+    case 'project':
+      return 'Project';
+    case 'idea':
+      return 'Ideas';
+    default:
+      return 'Notes';
+  }
+}
+
+String _shorten(String text, int maxLength) {
+  if (text.length <= maxLength) return text;
+  return '${text.substring(0, maxLength - 3)}...';
+}
+
+bool _looksLikeMixedLongText(String pureText) {
+  if (pureText.length < 280 && _splitThoughts(pureText).length < 4) {
+    return false;
+  }
+
+  final types = _splitThoughts(
+    pureText,
+  ).map(_classifyDigestPart).where((type) => type != 'note').toSet();
+  return types.length >= 2;
 }
 
 String _extractPureText(String combinedText) {

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -44,10 +44,13 @@ The user may upload various types of assets (images, audio, PDF, Excel, PPT, Wor
 $templatesSection
 
 # Template Selection Guidelines (Critical)
-- **Single Template**: Adhere to a single template unless the input consists of distinct and unrelated topics.
+- **Simple Inputs**: Use a single specific template when the raw input has one clear semantic purpose.
+- **Digest for Mixed Inputs**: If the raw input is long, messy, or contains multiple semantic domains (for example project discussion + thoughts + mood + schedule + todos), use `digest` as the first overview template instead of collapsing everything into `snippet` or `article`.
+- **Actionable Extraction**: When a mixed input contains clear todos, schedules, or emotional states, pair the `digest` overview with the most specific follow-up templates such as `task`, `event`, or `mood`. The `digest` should summarize and group; the specific templates should carry actionable or trackable data.
 - **Substance Over Form**: Analyze the *semantics and core intent* of the input. DO NOT consider the input format (text/audio/image) in your selection process.
 Example: An image of a receipt should use the `transaction` template, not a generic image template.
 - **Specificity**: If multiple templates are available for one piece of semantic, only choose the most specific one.
+- **No Plain Text Dumping**: For complex long-form inputs, do not put the entire raw text into a single `snippet` or `article` unless the input is truly a coherent article/note. Extract concise, structured sections instead.
 - **Strict Adherence**: ONLY use the `template_id`s listed in "Available Templates".
 
 # Title Guidelines

--- a/lib/agent/skills/manage_timeline_card/timeline_templates.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_templates.dart
@@ -8,11 +8,13 @@ void _reqStr(Map<String, dynamic> data, String key, [String? templateId]) {
   final v = data[key];
   if (v == null) {
     throw ArgumentError(
-        'Template${templateId != null ? " $templateId" : ""}: required field "$key" is missing.');
+      'Template${templateId != null ? " $templateId" : ""}: required field "$key" is missing.',
+    );
   }
   if (v is! String) {
     throw ArgumentError(
-        'Template${templateId != null ? " $templateId" : ""}: "$key" must be String, got ${v.runtimeType}.');
+      'Template${templateId != null ? " $templateId" : ""}: "$key" must be String, got ${v.runtimeType}.',
+    );
   }
   if (v.trim().isEmpty &&
       (key == 'url' ||
@@ -22,7 +24,8 @@ void _reqStr(Map<String, dynamic> data, String key, [String? templateId]) {
           key == 'image_url' ||
           key == 'video_url')) {
     throw ArgumentError(
-        'Template${templateId != null ? " $templateId" : ""}: "$key" must not be empty.');
+      'Template${templateId != null ? " $templateId" : ""}: "$key" must not be empty.',
+    );
   }
 }
 
@@ -30,11 +33,13 @@ void _reqNum(Map<String, dynamic> data, String key, [String? templateId]) {
   final v = data[key];
   if (v == null) {
     throw ArgumentError(
-        'Template${templateId != null ? " $templateId" : ""}: required field "$key" is missing.');
+      'Template${templateId != null ? " $templateId" : ""}: required field "$key" is missing.',
+    );
   }
   if (v is! num) {
     throw ArgumentError(
-        'Template${templateId != null ? " $templateId" : ""}: "$key" must be Number, got ${v.runtimeType}.');
+      'Template${templateId != null ? " $templateId" : ""}: "$key" must be Number, got ${v.runtimeType}.',
+    );
   }
 }
 
@@ -42,14 +47,16 @@ void _reqInt(Map<String, dynamic> data, String key, [String? templateId]) {
   final v = data[key];
   if (v == null) {
     throw ArgumentError(
-        'Template${templateId != null ? " $templateId" : ""}: required field "$key" is missing.');
+      'Template${templateId != null ? " $templateId" : ""}: required field "$key" is missing.',
+    );
   }
   if (v is! int) {
     if (v is num && v.toInt() == v) {
       return; // allow double that is whole number
     }
     throw ArgumentError(
-        'Template${templateId != null ? " $templateId" : ""}: "$key" must be int, got ${v.runtimeType}.');
+      'Template${templateId != null ? " $templateId" : ""}: "$key" must be int, got ${v.runtimeType}.',
+    );
   }
 }
 
@@ -57,11 +64,27 @@ void _reqList(Map<String, dynamic> data, String key, [String? templateId]) {
   final v = data[key];
   if (v == null) {
     throw ArgumentError(
-        'Template${templateId != null ? " $templateId" : ""}: required field "$key" is missing.');
+      'Template${templateId != null ? " $templateId" : ""}: required field "$key" is missing.',
+    );
   }
   if (v is! List) {
     throw ArgumentError(
-        'Template${templateId != null ? " $templateId" : ""}: "$key" must be List, got ${v.runtimeType}.');
+      'Template${templateId != null ? " $templateId" : ""}: "$key" must be List, got ${v.runtimeType}.',
+    );
+  }
+}
+
+void _reqNonEmptyStr(
+  Map<String, dynamic> data,
+  String key, [
+  String? templateId,
+]) {
+  _reqStr(data, key, templateId);
+  final v = data[key] as String;
+  if (v.trim().isEmpty) {
+    throw ArgumentError(
+      'Template${templateId != null ? " $templateId" : ""}: "$key" must not be empty.',
+    );
   }
 }
 
@@ -69,7 +92,8 @@ void _optStr(Map<String, dynamic> data, String key) {
   final v = data[key];
   if (v != null && v is! String) {
     throw ArgumentError(
-        'Optional "$key" must be String if present, got ${v.runtimeType}.');
+      'Optional "$key" must be String if present, got ${v.runtimeType}.',
+    );
   }
 }
 
@@ -77,7 +101,8 @@ void _optNum(Map<String, dynamic> data, String key) {
   final v = data[key];
   if (v != null && v is! num) {
     throw ArgumentError(
-        'Optional "$key" must be Number if present, got ${v.runtimeType}.');
+      'Optional "$key" must be Number if present, got ${v.runtimeType}.',
+    );
   }
 }
 
@@ -85,7 +110,8 @@ void _optBool(Map<String, dynamic> data, String key) {
   final v = data[key];
   if (v != null && v is! bool) {
     throw ArgumentError(
-        'Optional "$key" must be Boolean if present, got ${v.runtimeType}.');
+      'Optional "$key" must be Boolean if present, got ${v.runtimeType}.',
+    );
   }
 }
 
@@ -126,12 +152,14 @@ void validateTemplateData(String templateId, Map<String, dynamic> data) {
       _optStr(data, 'location');
       if (data['items'] != null) {
         final itemsList = data['items'];
-        if (itemsList is! List)
+        if (itemsList is! List) {
           throw ArgumentError('Template $t: "items" must be List.');
+        }
         for (var i = 0; i < itemsList.length; i++) {
           final item = itemsList[i];
-          if (item is! Map)
+          if (item is! Map) {
             throw ArgumentError('Template $t: items[$i] must be Map.');
+          }
           final m = Map<String, dynamic>.from(item);
           _reqStr(m, 'name', t);
           _reqStr(m, 'amount', t);
@@ -144,8 +172,9 @@ void validateTemplateData(String templateId, Map<String, dynamic> data) {
       final items = data['items'];
       for (var i = 0; i < items.length; i++) {
         final item = items[i];
-        if (item is! Map)
+        if (item is! Map) {
           throw ArgumentError('Template $t: items[$i] must be Map.');
+        }
         final m = Map<String, dynamic>.from(item);
         _reqStr(m, 'title', t);
         _reqNum(m, 'value', t);
@@ -165,7 +194,8 @@ void validateTemplateData(String templateId, Map<String, dynamic> data) {
       final moodVal = data['mood_name'] ?? data['mood'];
       if (moodVal == null) {
         throw ArgumentError(
-            'Template $t: required "mood_name" or "mood" is missing.');
+          'Template $t: required "mood_name" or "mood" is missing.',
+        );
       }
       if (moodVal is! String) {
         throw ArgumentError('Template $t: mood_name/mood must be String.');
@@ -197,12 +227,14 @@ void validateTemplateData(String templateId, Map<String, dynamic> data) {
       _optStr(data, 'due_date');
       if (data['subtasks'] != null) {
         final subtasksList = data['subtasks'];
-        if (subtasksList is! List)
+        if (subtasksList is! List) {
           throw ArgumentError('Template $t: "subtasks" must be List.');
+        }
         for (var i = 0; i < subtasksList.length; i++) {
           final item = subtasksList[i];
-          if (item is! Map)
+          if (item is! Map) {
             throw ArgumentError('Template $t: subtasks[$i] must be Map.');
+          }
           final m = Map<String, dynamic>.from(item);
           _reqStr(m, 'title', t);
           _optBool(m, 'completed');
@@ -213,8 +245,9 @@ void validateTemplateData(String templateId, Map<String, dynamic> data) {
       _reqStr(data, 'habit_name', t);
       _reqNum(data, 'streak', t);
       if (data['history'] != null) {
-        if (data['history'] is! List)
+        if (data['history'] is! List) {
           throw ArgumentError('Template $t: "history" must be List.');
+        }
       }
       break;
     case 'procedure':
@@ -232,16 +265,49 @@ void validateTemplateData(String templateId, Map<String, dynamic> data) {
       _optStr(data, 'title');
       _optStr(data, 'icon');
       if (data['details'] != null) {
-        if (data['details'] is! List)
+        if (data['details'] is! List) {
           throw ArgumentError('Template $t: "details" must be List.');
+        }
+      }
+      break;
+    case 'digest':
+      _reqNonEmptyStr(data, 'summary', t);
+      _reqList(data, 'sections', t);
+      final sections = data['sections'];
+      if (sections.isEmpty) {
+        throw ArgumentError('Template $t: "sections" must not be empty.');
+      }
+      for (var i = 0; i < sections.length; i++) {
+        final section = sections[i];
+        if (section is! Map) {
+          throw ArgumentError('Template $t: sections[$i] must be Map.');
+        }
+        final m = Map<String, dynamic>.from(section);
+        _reqNonEmptyStr(m, 'type', t);
+        _reqNonEmptyStr(m, 'title', t);
+        _reqList(m, 'items', t);
+        final items = m['items'];
+        if (items.isEmpty) {
+          throw ArgumentError(
+            'Template $t: sections[$i].items must not be empty.',
+          );
+        }
+        for (var j = 0; j < items.length; j++) {
+          if (items[j] is! String || (items[j] as String).trim().isEmpty) {
+            throw ArgumentError(
+              'Template $t: sections[$i].items[$j] must be a non-empty String.',
+            );
+          }
+        }
       }
       break;
     case 'snippet':
       _reqStr(data, 'text', t);
       _optStr(data, 'style');
       if (data['tags'] != null) {
-        if (data['tags'] is! List)
+        if (data['tags'] is! List) {
           throw ArgumentError('Template $t: "tags" must be List.');
+        }
       }
       break;
     case 'article':
@@ -255,8 +321,9 @@ void validateTemplateData(String templateId, Map<String, dynamic> data) {
       final messagesList = data['messages'];
       for (var i = 0; i < messagesList.length; i++) {
         final msg = messagesList[i];
-        if (msg is! Map)
+        if (msg is! Map) {
           throw ArgumentError('Template $t: messages[$i] must be Map.');
+        }
         final m = Map<String, dynamic>.from(msg);
         _reqStr(m, 'text', t);
         _optStr(m, 'sender');
@@ -284,7 +351,8 @@ void validateTemplateData(String templateId, Map<String, dynamic> data) {
       break;
     default:
       throw ArgumentError(
-          'Unknown template_id: "$templateId". Allowed: ${allowedTemplateIds.join(", ")}.');
+        'Unknown template_id: "$templateId". Allowed: ${allowedTemplateIds.join(", ")}.',
+      );
   }
 }
 
@@ -297,21 +365,25 @@ void validateUiConfig(Map<String, dynamic> config) {
   final tid = config['template_id'];
   if (tid is! String || tid.isEmpty) {
     throw ArgumentError(
-        'ui_configs entry "template_id" must be a non-empty String.');
+      'ui_configs entry "template_id" must be a non-empty String.',
+    );
   }
   final templateId = tid;
   if (!allowedTemplateIds.contains(templateId)) {
     throw ArgumentError(
-        'template_id "$templateId" is not allowed. Allowed: ${allowedTemplateIds.join(", ")}.');
+      'template_id "$templateId" is not allowed. Allowed: ${allowedTemplateIds.join(", ")}.',
+    );
   }
   if (!config.containsKey('data')) {
     throw ArgumentError(
-        'ui_configs entry for template "$templateId" missing "data".');
+      'ui_configs entry for template "$templateId" missing "data".',
+    );
   }
   final data = config['data'];
   if (data is! Map) {
     throw ArgumentError(
-        'ui_configs entry for template "$templateId": "data" must be an object (Map).');
+      'ui_configs entry for template "$templateId": "data" must be an object (Map).',
+    );
   }
   validateTemplateData(templateId, Map<String, dynamic>.from(data));
 }
@@ -324,7 +396,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `url` (String, required): Link address.
 - `title` (String, optional): Link title (defaults to card title).
 - `domain` (String, optional): Domain name, automatically extracted from URL if not provided.
-'''
+''',
   },
   {
     'template_id': 'person',
@@ -334,7 +406,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `image_url` (String, optional): Avatar link.
 - `relation` (String, optional): Relationship, e.g., "Colleague", "Friend".
 - `status` (String, optional): Status, e.g., "Online", "Busy", "Away".
-'''
+''',
   },
   {
     'template_id': 'place',
@@ -345,7 +417,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `address` (String, optional): Detailed address.
 - `latitude` or `lat` (Number, optional): Latitude (WGS-84 coordinate system).
 - `longitude` or `lng` (Number, optional): Longitude (WGS-84 coordinate system). If coordinates are provided, a map preview will be displayed.
-'''
+''',
   },
   {
     'template_id': 'spec_sheet',
@@ -356,7 +428,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `image_url` (String, optional): Image.
 - `subtitle` (String, optional): Subtitle.
 - `specs` (Map<String, dynamic>, optional): Specification key-value pairs, e.g., {"Brand": "Apple", "Model": "iPhone 15"}.
-'''
+''',
   },
   {
     'template_id': 'transaction',
@@ -368,7 +440,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `items` (List<Map>, optional): Transaction detail list, each item contains:
   - `name` (String, required): Item name.
   - `amount` (String, required): Item price, must include currency unit, e.g., "¥20.00", "\$10.99".
-'''
+''',
   },
   {
     'template_id': 'metric',
@@ -382,7 +454,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
   - `label` (String, optional): Label description.
   - `trend` (String, optional): Trend, options: "up", "down", "neutral".
   - `color` (String, optional): Color theme, options: "indigo", "emerald", "orange".
-'''
+''',
   },
   {
     'template_id': 'rating',
@@ -392,7 +464,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `score` (Number, required): Rating value.
 - `max_score` (Number, optional): Maximum score, defaults to 5.0.
 - `comment` (String, optional): Review text.
-'''
+''',
   },
   {
     'template_id': 'mood',
@@ -402,7 +474,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `intensity` (Number, optional): Intensity (1-10), defaults to 5.
 - `color_hex` (String, required): Color hex value.
 - `trigger` (String, optional): Trigger reason.
-'''
+''',
   },
   {
     'template_id': 'progress',
@@ -412,7 +484,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `total` (Number, required): Total value.
 - `unit` (String, optional): Unit, defaults to "%".
 - `label` (String, optional): Label description (defaults to card title).
-'''
+''',
   },
   {
     'template_id': 'event',
@@ -422,7 +494,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `start_time` (String, required): Start time (ISO8601 format string).
 - `end_time` (String, optional): End time.
 - `location` (String, optional): Location.
-'''
+''',
   },
   {
     'template_id': 'duration',
@@ -430,7 +502,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
     'data_structure': '''
 - `title` (String, optional): Title (defaults to card title).
 - `elapsed` (int, required): Duration in seconds.
-'''
+''',
   },
   {
     'template_id': 'task',
@@ -443,7 +515,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
   - `completed` (Boolean, optional): Whether completed.
 - `priority` (String, optional): Priority, e.g., "high".
 - `due_date` (String, optional): Due date.
-'''
+''',
   },
   {
     'template_id': 'routine',
@@ -452,7 +524,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `habit_name` (String, required): Habit name.
 - `streak` (Number, required): Consecutive days.
 - `history` (List<Boolean>, optional): Completion records for the last 7 days, defaults to 7 false values.
-'''
+''',
   },
   {
     'template_id': 'procedure',
@@ -460,7 +532,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
     'data_structure': '''
 - `title` (String, optional): Procedure title (defaults to card title).
 - `steps` (List<String>, required): Step list, in order.
-'''
+''',
   },
   {
     'template_id': 'compact',
@@ -471,7 +543,19 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `icon` (String, optional): Valid flutter icon key (e.g. Icons.home) suitable for this information.
 - `details` (List<String>, optional): Supplementary information list, e.g., ["200ml", "10:00"].
 - `color` (String, required): Color hex value (e.g., "#EF4444").
-'''
+''',
+  },
+  {
+    'template_id': 'digest',
+    'use_case':
+        'Mixed, long, or messy raw inputs that contain multiple semantic domains such as project updates, thoughts, emotions, schedules, and todos. Use as an overview card, not as a replacement for specific action cards.',
+    'data_structure': '''
+- `summary` (String, required): One concise synthesis of the whole input.
+- `sections` (List<Map>, required): Structured semantic sections. Use 2-6 sections when possible. Each section contains:
+  - `type` (String, required): One of "project", "thought", "mood", "schedule", "todo", "decision", "idea", "health", "finance", "relationship", "note", "other".
+  - `title` (String, required): Short section title.
+  - `items` (List<String>, required): Key extracted points for this section. Keep each item short and faithful to the raw input.
+''',
   },
   {
     'template_id': 'snippet',
@@ -480,7 +564,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `text` (String, required): Text content (Markdown supported).
 - `style` (String, optional): Style, options: "default", "mono", "handwritten".
 - `tags` (List<String>, optional): Tag list.
-'''
+''',
   },
   {
     'template_id': 'article',
@@ -489,7 +573,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `title` (String, optional): Article title (defaults to card title).
 - `body` (String, required): Body content (Markdown supported).
 - `image_url` (String, optional): Cover image.
-'''
+''',
   },
   {
     'template_id': 'conversation',
@@ -500,7 +584,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
   - `text` (String, required): Message content.
   - `sender` (String, optional): Sender name.
   - `isMe` (Boolean, optional): Whether sent by me.
-'''
+''',
   },
   {
     'template_id': 'quote',
@@ -509,7 +593,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `content` (String, required): Quote content.
 - `author` (String, optional): Author.
 - `source` (String, optional): Source/origin.
-'''
+''',
   },
   {
     'template_id': 'snapshot',
@@ -518,7 +602,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `image_url` (String, required): Image link.
 - `caption` (String, optional): Image caption (defaults to card title).
 - `location` (String, optional): Shooting location.
-'''
+''',
   },
   {
     'template_id': 'gallery',
@@ -526,7 +610,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
     'data_structure': '''
 - `image_urls` (List<String>, required): Image link list.
 - `title` (String, optional): Title (defaults to card title).
-'''
+''',
   },
   {
     'template_id': 'video',
@@ -535,6 +619,6 @@ final List<Map<String, dynamic>> timelineTemplates = [
 - `video_url` (String, required): Video link.
 - `title` (String, optional): Video title (defaults to card title).
 - `duration` (String, optional): Video duration.
-'''
+''',
   },
 ];

--- a/lib/data/services/card_renderer.dart
+++ b/lib/data/services/card_renderer.dart
@@ -42,6 +42,7 @@ const Set<String> _nativeCardTemplates = {
   'article',
   'conversation',
   'quote',
+  'digest',
   // Visual
   'snapshot',
   'gallery',
@@ -308,4 +309,3 @@ Future<Map<String, dynamic>> extractAssetsAndRawText(
     'rawText': rawText,
   };
 }
-

--- a/lib/ui/core/cards/native_card_factory.dart
+++ b/lib/ui/core/cards/native_card_factory.dart
@@ -7,6 +7,7 @@ import 'package:memex/ui/core/cards/templates/textual/compact_card.dart';
 import 'package:memex/ui/core/cards/templates/textual/snippet_card.dart';
 import 'package:memex/ui/core/cards/templates/textual/article_card.dart';
 import 'package:memex/ui/core/cards/templates/textual/conversation_card.dart';
+import 'package:memex/ui/core/cards/templates/textual/digest_card.dart';
 import 'package:memex/ui/core/cards/templates/textual/insight_summary_card.dart';
 import 'package:memex/ui/core/cards/templates/textual/quote_card.dart';
 import 'package:memex/ui/core/cards/templates/visual/snapshot_card.dart';
@@ -197,6 +198,8 @@ class NativeCardFactory {
           data: mergedData,
           onTap: onTap,
         );
+      case 'digest':
+        return DigestCard(data: mergedData, onTap: onTap);
       case 'insight_summary':
         return InsightSummaryCard(
           data: mergedData,

--- a/lib/ui/core/cards/templates/textual/digest_card.dart
+++ b/lib/ui/core/cards/templates/textual/digest_card.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import 'package:memex/ui/core/cards/ui/glass_card.dart';
+
+class DigestCard extends StatelessWidget {
+  final Map<String, dynamic> data;
+  final VoidCallback? onTap;
+
+  const DigestCard({super.key, required this.data, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final title = (data['title'] as String?)?.trim() ?? '';
+    final summary = (data['summary'] as String?)?.trim() ?? '';
+    final sections = _parseSections(data['sections']);
+
+    return GlassCard(
+      onTap: onTap,
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 34,
+                height: 34,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFEEF2FF),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: const Icon(
+                  Icons.dashboard_customize_outlined,
+                  size: 19,
+                  color: Color(0xFF4F46E5),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (title.isNotEmpty)
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                          height: 1.25,
+                          color: Color(0xFF0A0A0A),
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    if (summary.isNotEmpty) ...[
+                      if (title.isNotEmpty) const SizedBox(height: 6),
+                      Text(
+                        summary,
+                        style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w400,
+                          height: 1.45,
+                          color: Color(0xFF4A5565),
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (sections.isNotEmpty) ...[
+            const SizedBox(height: 18),
+            ...sections.asMap().entries.map((entry) {
+              final index = entry.key;
+              final section = entry.value;
+              final isLast = index == sections.length - 1;
+              return Padding(
+                padding: EdgeInsets.only(bottom: isLast ? 0 : 16),
+                child: _DigestSectionView(section: section),
+              );
+            }),
+          ],
+        ],
+      ),
+    );
+  }
+
+  List<_DigestSection> _parseSections(dynamic raw) {
+    if (raw is! List) return const [];
+    final sections = <_DigestSection>[];
+    for (final item in raw) {
+      if (item is! Map) continue;
+      final map = Map<String, dynamic>.from(item);
+      final type = (map['type'] as String?)?.trim().toLowerCase() ?? 'note';
+      final title = (map['title'] as String?)?.trim() ?? '';
+      final rawItems = map['items'];
+      final items = rawItems is List
+          ? rawItems
+              .map((e) => e.toString().trim())
+              .where((e) => e.isNotEmpty)
+              .toList()
+          : <String>[];
+      if (title.isEmpty || items.isEmpty) continue;
+      sections.add(_DigestSection(type: type, title: title, items: items));
+    }
+    return sections;
+  }
+}
+
+class _DigestSectionView extends StatelessWidget {
+  final _DigestSection section;
+
+  const _DigestSectionView({required this.section});
+
+  @override
+  Widget build(BuildContext context) {
+    final style = _DigestStyle.fromType(section.type);
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Column(
+          children: [
+            Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: style.background,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(style.icon, size: 16, color: style.color),
+            ),
+          ],
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Flexible(
+                    child: Text(
+                      section.title,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        height: 1.25,
+                        color: Color(0xFF111827),
+                        letterSpacing: 0,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    width: 6,
+                    height: 6,
+                    decoration: BoxDecoration(
+                      color: style.color,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 7),
+              ...section.items.take(4).map(
+                    (item) => Padding(
+                      padding: const EdgeInsets.only(bottom: 5),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            width: 4,
+                            height: 4,
+                            margin: const EdgeInsets.only(top: 8, right: 8),
+                            decoration: const BoxDecoration(
+                              color: Color(0xFFCBD5E1),
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                          Expanded(
+                            child: Text(
+                              item,
+                              style: const TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w400,
+                                height: 1.45,
+                                color: Color(0xFF4A5565),
+                                letterSpacing: 0,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              if (section.items.length > 4)
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(
+                    '+${section.items.length - 4}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: style.color,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DigestSection {
+  final String type;
+  final String title;
+  final List<String> items;
+
+  const _DigestSection({
+    required this.type,
+    required this.title,
+    required this.items,
+  });
+}
+
+class _DigestStyle {
+  final IconData icon;
+  final Color color;
+  final Color background;
+
+  const _DigestStyle({
+    required this.icon,
+    required this.color,
+    required this.background,
+  });
+
+  factory _DigestStyle.fromType(String type) {
+    switch (type) {
+      case 'project':
+        return const _DigestStyle(
+          icon: Icons.work_outline_rounded,
+          color: Color(0xFF4F46E5),
+          background: Color(0xFFEEF2FF),
+        );
+      case 'todo':
+      case 'task':
+        return const _DigestStyle(
+          icon: Icons.check_circle_outline_rounded,
+          color: Color(0xFF059669),
+          background: Color(0xFFE6F7EF),
+        );
+      case 'schedule':
+      case 'event':
+        return const _DigestStyle(
+          icon: Icons.event_outlined,
+          color: Color(0xFF2563EB),
+          background: Color(0xFFEFF6FF),
+        );
+      case 'mood':
+      case 'emotion':
+        return const _DigestStyle(
+          icon: Icons.sentiment_satisfied_alt_rounded,
+          color: Color(0xFFE11D48),
+          background: Color(0xFFFFEEF3),
+        );
+      case 'idea':
+        return const _DigestStyle(
+          icon: Icons.lightbulb_outline_rounded,
+          color: Color(0xFFD97706),
+          background: Color(0xFFFFF7E6),
+        );
+      case 'decision':
+        return const _DigestStyle(
+          icon: Icons.alt_route_rounded,
+          color: Color(0xFF0891B2),
+          background: Color(0xFFE6F8FB),
+        );
+      case 'health':
+        return const _DigestStyle(
+          icon: Icons.favorite_border_rounded,
+          color: Color(0xFF16A34A),
+          background: Color(0xFFECFDF3),
+        );
+      case 'finance':
+        return const _DigestStyle(
+          icon: Icons.payments_outlined,
+          color: Color(0xFF0F766E),
+          background: Color(0xFFE6FFFA),
+        );
+      case 'relationship':
+        return const _DigestStyle(
+          icon: Icons.people_outline_rounded,
+          color: Color(0xFFDB2777),
+          background: Color(0xFFFDF2F8),
+        );
+      case 'thought':
+        return const _DigestStyle(
+          icon: Icons.psychology_alt_outlined,
+          color: Color(0xFF7C3AED),
+          background: Color(0xFFF5F3FF),
+        );
+      case 'note':
+      case 'other':
+      default:
+        return const _DigestStyle(
+          icon: Icons.notes_rounded,
+          color: Color(0xFF64748B),
+          background: Color(0xFFF1F5F9),
+        );
+    }
+  }
+}

--- a/lib/ui/timeline/widgets/timeline_template_gallery_page.dart
+++ b/lib/ui/timeline/widgets/timeline_template_gallery_page.dart
@@ -90,6 +90,75 @@ class TimelineTemplateGalleryPage extends StatelessWidget {
           ),
           _buildSection(
             context,
+            isZh ? 'Digest Card (复杂记录整理)' : 'Digest Card (Mixed record digest)',
+            'digest',
+            isZh
+                ? {
+                    'summary': '今天的记录同时涉及项目延期、情绪压力、后续会议和几个待办，适合先做总览再拆出行动项。',
+                    'sections': [
+                      {
+                        'type': 'project',
+                        'title': '项目进展',
+                        'items': ['和 A 讨论了延期风险', 'PRD 需要重新整理优先级'],
+                      },
+                      {
+                        'type': 'mood',
+                        'title': '情绪状态',
+                        'items': ['对延期有些焦虑', '担心评审时信息不够聚焦'],
+                      },
+                      {
+                        'type': 'schedule',
+                        'title': '日程',
+                        'items': ['下周三约 B 开一次产品评审会'],
+                      },
+                      {
+                        'type': 'todo',
+                        'title': '待办',
+                        'items': ['今晚整理 PRD', '补一页风险说明'],
+                      },
+                    ],
+                  }
+                : {
+                    'summary':
+                        'This record mixes a project delay, emotional pressure, a follow-up meeting, and a few action items, so it works best as a structured overview.',
+                    'sections': [
+                      {
+                        'type': 'project',
+                        'title': 'Project update',
+                        'items': [
+                          'Discussed delay risks with Alex',
+                          'The PRD needs a priority pass',
+                        ],
+                      },
+                      {
+                        'type': 'mood',
+                        'title': 'Mood',
+                        'items': [
+                          'A little anxious about the delay',
+                          'Worried the review may feel unfocused',
+                        ],
+                      },
+                      {
+                        'type': 'schedule',
+                        'title': 'Schedule',
+                        'items': [
+                          'Set up a product review with Blair next Wednesday',
+                        ],
+                      },
+                      {
+                        'type': 'todo',
+                        'title': 'Todos',
+                        'items': [
+                          'Clean up the PRD tonight',
+                          'Add one risk slide',
+                        ],
+                      },
+                    ],
+                  },
+            title: isZh ? '复杂项目记录' : 'Mixed project note',
+          ),
+          _buildSection(
+            context,
             isZh
                 ? '4. Conversation Card (对话)'
                 : '4. Conversation Card (Conversation)',

--- a/test/agent/skills/manage_timeline_card/timeline_templates_test.dart
+++ b/test/agent/skills/manage_timeline_card/timeline_templates_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/card_agent/rule_based_card_matcher.dart';
+import 'package:memex/agent/skills/manage_timeline_card/timeline_templates.dart';
+import 'package:memex/domain/models/card_model.dart';
+
+void main() {
+  group('timeline template validation', () {
+    test('accepts valid digest config', () {
+      expect(
+        () => validateUiConfig({
+          'template_id': 'digest',
+          'data': {
+            'summary': 'Mixed project note with mood, schedule, and todos.',
+            'sections': [
+              {
+                'type': 'project',
+                'title': 'Project',
+                'items': ['Discussed launch risk with the team'],
+              },
+              {
+                'type': 'todo',
+                'title': 'Todos',
+                'items': ['Revise the PRD tonight'],
+              },
+            ],
+          },
+        }),
+        returnsNormally,
+      );
+    });
+
+    test('rejects digest without sections', () {
+      expect(
+        () => validateUiConfig({
+          'template_id': 'digest',
+          'data': {'summary': 'A mixed note.', 'sections': []},
+        }),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('rule-based card matcher', () {
+    test('uses digest for long mixed text when LLM is unavailable', () {
+      const card = CardData(
+        factId: '2026/05/05.md#ts_1',
+        timestamp: 0,
+        status: 'processing',
+        tags: [],
+        uiConfigs: [],
+      );
+
+      final result = applyRuleBasedTemplate(
+        card: card,
+        combinedText: '''
+Project: discussed the PRD delay and launch risk with Alex.
+Mood: I feel anxious because the review may be unfocused.
+Schedule: set up a product review next Wednesday at 14:00.
+Todo: revise the PRD tonight and add one risk slide.
+Idea: maybe split the launch into a smaller first milestone.
+''',
+        imageUrls: const [],
+        audioUrl: null,
+      );
+
+      expect(result.uiConfigs.single.templateId, 'digest');
+      expect(result.uiConfigs.single.data['sections'], isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes #41

## Summary
- add the `digest` timeline template, schema validation, and CardAgent prompt guidance for long mixed inputs
- add a native `DigestCard` renderer plus factory, renderer, and template gallery registration
- add a no-LLM rule-based fallback that turns long mixed text into grouped digest sections without affecting the normal LLM path
- cover digest validation and fallback selection with focused tests

## Validation
- `flutter test test/agent/skills/manage_timeline_card/timeline_templates_test.dart`
- `dart analyze lib/agent/card_agent/rule_based_card_matcher.dart lib/agent/skills/manage_timeline_card/timeline_templates.dart lib/ui/core/cards/templates/textual/digest_card.dart lib/ui/core/cards/native_card_factory.dart lib/data/services/card_renderer.dart test/agent/skills/manage_timeline_card/timeline_templates_test.dart`
- `git diff --cached --check`

## Notes
- The rule-based digest matcher only runs when the Card Agent has no valid LLM config; with a working LLM provider, the existing CardAgent path remains authoritative.
- Full repo `flutter analyze` still reports existing unrelated analyzer noise, so this PR uses targeted analysis for the changed surface.
