### PR TITLE
修复 Agent 上下文中的本地时间锚点

### DIFF
--- a/lib/agent/comment_agent/comment_agent.dart
+++ b/lib/agent/comment_agent/comment_agent.dart
@@ -12,7 +12,7 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/file_operation_service.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:logging/logging.dart';
-import 'package:intl/intl.dart';
+import 'package:memex/utils/time_context.dart';
 
 class CommentAgent {
   static final Logger _logger = getLogger('CommentAgent');
@@ -26,6 +26,8 @@ class CommentAgent {
     String? pkmContext,
     required String rawInputContent,
     String? initialInsight,
+    DateTime? currentTime,
+    DateTime? entryTime,
     bool withMemoryManagement = false,
   }) async {
     final fileService = FileSystemService.instance;
@@ -58,7 +60,8 @@ class CommentAgent {
     // 3. Find PKM Context if not provided
     if (pkmContext == null || pkmContext.isEmpty) {
       pkmContext = await _findPkmContext(
-          userId, workingDirectory, pkmPath, factId, fileOpService);
+          userId, workingDirectory, pkmPath, factId, fileOpService,
+          baseTime: entryTime ?? currentTime ?? DateTime.now());
     }
 
     // 4. Create Skill
@@ -92,6 +95,7 @@ class CommentAgent {
       factId: factId,
       rawInputContent: rawInputContent,
       initialInsight: initialInsight,
+      entryTime: entryTime,
       pkmContext: pkmContext,
       workingDirectory: workingDirectory,
       pkmStructure: pkmStructure,
@@ -138,8 +142,10 @@ class CommentAgent {
     required String rawInputContent,
     String? initialInsight,
     DateTime? currentTime,
+    DateTime? entryTime,
     bool withMemoryManagement = false,
   }) async {
+    final effectiveCurrentTime = currentTime ?? DateTime.now();
     final agent = await _createAgent(
       client: client,
       modelConfig: modelConfig,
@@ -149,13 +155,12 @@ class CommentAgent {
       pkmContext: pkmContext,
       rawInputContent: rawInputContent,
       initialInsight: initialInsight,
+      currentTime: effectiveCurrentTime,
+      entryTime: entryTime,
       withMemoryManagement: withMemoryManagement,
     );
     final state = agent.state;
-    final timeStr =
-        DateFormat("yyyy-MM-dd HH:mm:ss").format(currentTime ?? DateTime.now());
-    final systemReminder =
-        "<system-reminder>\nCurrent Time: $timeStr\n</system-reminder>\n\n";
+    final systemReminder = buildCurrentTimeReminder(effectiveCurrentTime);
     final fullUserContent = "$systemReminder$userContent";
     final userMessage = UserMessage([TextPart(fullUserContent)]);
 
@@ -201,7 +206,7 @@ class CommentAgent {
   /// Falls back to recent daily facts if the specific fact_id isn't in PKM yet.
   static Future<String> _findPkmContext(String userId, String workingDirectory,
       String pkmPath, String factId, FileOperationService fileOpService,
-      {int contextLines = 10}) async {
+      {required DateTime baseTime, int contextLines = 10}) async {
     final buffer = StringBuffer();
 
     // 1. Try to find the specific fact_id in PKM
@@ -229,7 +234,7 @@ class CommentAgent {
     // This gives the character awareness of what the user has been up to lately
     try {
       final recentContext = await _getRecentFactsContext(
-          userId, workingDirectory, fileOpService);
+          userId, workingDirectory, fileOpService, baseTime);
       if (recentContext.isNotEmpty) {
         buffer.writeln("\n## Recent User Activity (last few days):");
         buffer.writeln(recentContext);
@@ -245,9 +250,10 @@ class CommentAgent {
   /// Read the most recent daily fact files to give the character
   /// awareness of the user's recent life context.
   static Future<String> _getRecentFactsContext(String userId,
-      String workingDirectory, FileOperationService fileOpService) async {
+      String workingDirectory, FileOperationService fileOpService,
+      DateTime baseTime) async {
     final fileSystem = FileSystemService.instance;
-    final now = DateTime.now();
+    final now = baseTime.toLocal();
     final buffer = StringBuffer();
     var totalChars = 0;
     const maxChars = 3000; // Keep it concise

--- a/lib/agent/common_tools.dart
+++ b/lib/agent/common_tools.dart
@@ -4,6 +4,7 @@ import 'package:memex/utils/date_util.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/file_operation_service.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
 import 'dart:io';
 
 final getCurrentTimeTool = Tool(
@@ -24,7 +25,7 @@ final getCurrentTimeTool = Tool(
     final year = thursday.year;
 
     final weekId = '${year}_W${isoWeekNumber(now)}';
-    return "Current time: ${now.toIso8601String()}, Current WeekId: $weekId";
+    return "Current Local Time: ${formatLocalDateTimeWithZone(now)}, Current WeekId: $weekId";
   },
 );
 

--- a/lib/agent/companion_agent/companion_agent.dart
+++ b/lib/agent/companion_agent/companion_agent.dart
@@ -5,8 +5,8 @@ import 'package:memex/agent/companion_agent/companion_memory.dart';
 import 'package:memex/data/services/character_service.dart';
 import 'package:memex/domain/models/character_model.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/utils/user_storage.dart';
-import 'package:intl/intl.dart';
 
 /// Lightweight companion agent for 1-on-1 emotional chat.
 ///
@@ -25,6 +25,7 @@ class CompanionAgent {
     required String userId,
     required String characterId,
     required String userMessage,
+    DateTime? userMessageTime,
     List<LLMMessage> history = const [],
   }) async* {
     // 1. Load all context layers
@@ -49,10 +50,13 @@ class CompanionAgent {
         emotionalState, relationship, recentFacts, characterMemory);
 
     // 3. Assemble messages
+    final timedUserMessage = userMessageTime == null
+        ? userMessage
+        : '${buildMessageTimePrefix(userMessageTime)}$userMessage';
     final messages = <LLMMessage>[
       SystemMessage(systemPrompt),
       ...history,
-      UserMessage([TextPart(userMessage)]),
+      UserMessage([TextPart(timedUserMessage)]),
     ];
 
     // 4. Stream LLM response
@@ -117,7 +121,7 @@ class CompanionAgent {
     String recentFacts,
     String characterMemory,
   ) {
-    final now = DateFormat('yyyy-MM-dd HH:mm').format(DateTime.now());
+    final now = formatLocalDateTimeWithZone(DateTime.now());
     final lang = UserStorage.l10n.commentLanguageInstruction;
 
     final buffer = StringBuffer();

--- a/lib/agent/insight_agent/knowledge_insight_agent.dart
+++ b/lib/agent/insight_agent/knowledge_insight_agent.dart
@@ -17,6 +17,7 @@ import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/utils/user_storage.dart';
 
 final _logger = getLogger('KnowledgeInsightAgent');
@@ -181,8 +182,7 @@ class KnowledgeInsightAgent {
 
         final messages = [
           UserMessage([
-            TextPart(
-                "<system-reminder>current time is ${DateFormat("yyyy-MM-dd HH:mm:ss").format(DateTime.now())}.</system-reminder>"),
+            TextPart(buildCurrentTimeReminder(DateTime.now())),
             TextPart(inputMessage),
           ])
         ];

--- a/lib/agent/memory/memory_management.dart
+++ b/lib/agent/memory/memory_management.dart
@@ -6,6 +6,7 @@ import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:path/path.dart' as p;
 
@@ -223,7 +224,7 @@ Task: Synthesize "Short-term Memories" into a cohesive "User Profile".
 Goal: **Summarize and compress** information to build a high-fidelity persona. Do NOT create a daily log.
 
 ## Context Data:
-Current System Time: ${currentTime.toIso8601String()}
+Current Local Time: ${formatLocalDateTimeWithZone(currentTime)}
 
 ## Current Profile (Markdown):
 ${archived.isEmpty ? '(Empty - Initialize new)' : archived}

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -332,6 +332,7 @@ Usage:
     String factId,
     String identity,
     String userRawInput,
+    String entryLocalTime,
     String initialInsight,
     String relatedKnowledge,
     String instruction,
@@ -368,6 +369,7 @@ Examples:
   - After generating your comment, call `SaveComment` and `MemoryWrite` in parallel if you have something to remember.
 
 # User Raw Input (Fact ID: $factId)
+Entry Local Time: $entryLocalTime
 <user_raw_input>
 $userRawInput
 </user_raw_input>

--- a/lib/agent/skills/comment_agent/comment_agent_skill.dart
+++ b/lib/agent/skills/comment_agent/comment_agent_skill.dart
@@ -5,6 +5,7 @@ import 'package:memex/agent/security/file_permission_manager.dart';
 import 'package:memex/domain/models/character_model.dart';
 import 'package:memex/agent/skills/comment_agent/tools/comment_tools.dart';
 import 'package:memex/agent/skills/comment_agent/tools/memory_tools.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/utils/user_storage.dart';
 
 /// Skill for Comment Agent - generates warm, empathetic comments for user's private tree hole entries
@@ -15,6 +16,7 @@ class CommentAgentSkill extends Skill {
     required String rawInputContent,
     String? initialInsight,
     String? pkmContext,
+    DateTime? entryTime,
     required String workingDirectory,
     required String pkmStructure,
     required String userId,
@@ -29,6 +31,7 @@ class CommentAgentSkill extends Skill {
             rawInputContent: rawInputContent,
             initialInsight: initialInsight,
             pkmContext: pkmContext,
+            entryTime: entryTime,
           ),
           tools: _buildTools(
             userId: userId,
@@ -45,6 +48,7 @@ class CommentAgentSkill extends Skill {
     required String rawInputContent,
     String? initialInsight,
     String? pkmContext,
+    DateTime? entryTime,
   }) {
     StringBuffer personaBuffer = StringBuffer();
     if (character != null) {
@@ -72,6 +76,7 @@ class CommentAgentSkill extends Skill {
       factId,
       persona,
       rawInputContent,
+      entryTime == null ? 'Unknown' : formatLocalDateTimeWithZone(entryTime),
       initialInsight ?? '',
       pkmContext ?? '',
       UserStorage.l10n.commentLanguageInstruction,

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -254,12 +254,13 @@ class MemexRouter {
         taskType: 'process_ai_reply',
         payloadBuilder: (_, event) {
           final p = event.payload as CardCommentPostedPayload;
-          return Future.value({
-            'card_id': p.cardId,
-            'content': p.content,
-            'comment_id': p.commentId,
-            if (p.replyToId != null) 'reply_to_id': p.replyToId,
-          });
+            return Future.value({
+              'card_id': p.cardId,
+              'content': p.content,
+              'comment_id': p.commentId,
+              if (p.createdAtTs != null) 'created_at_ts': p.createdAtTs,
+              if (p.replyToId != null) 'reply_to_id': p.replyToId,
+            });
         },
       ),
     );

--- a/lib/data/repositories/post_comment.dart
+++ b/lib/data/repositories/post_comment.dart
@@ -10,6 +10,7 @@ import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/global_event_bus.dart';
 import 'package:memex/domain/models/system_event.dart';
+import 'package:memex/utils/time_context.dart';
 
 final _logger = Logger('PostCommentEndpoint');
 final _fileSystemService = FileSystemService.instance;
@@ -42,12 +43,13 @@ Future<Map<String, dynamic>> postCommentEndpoint(
 
     // Save user comment to card (persist immediately)
     final commentId = const Uuid().v4();
+    final commentTimestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     await _fileSystemService.updateCardFile(userId, cardId, (card) {
       final newComment = CardComment(
         id: commentId,
         content: content,
         isAi: false,
-        timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        timestamp: commentTimestamp,
         replyToId: replyToId,
       );
       return card.copyWith(comments: [...card.comments, newComment]);
@@ -85,6 +87,7 @@ Future<Map<String, dynamic>> postCommentEndpoint(
           cardId: cardId,
           content: content,
           commentId: commentId,
+          createdAtTs: commentTimestamp,
           replyToId: replyToId,
         ),
       ),
@@ -169,6 +172,7 @@ Future<void> processAICommentReply({
     // Build asset info string
 
     final assetAnalyses = factContent?.assetAnalyses;
+    final entryDateTime = factContent?.datetime;
     // Build asset info string
     final assetInfo = formatAssetAnalysis(assetAnalyses);
     contentToUse = contentToUse + assetInfo;
@@ -194,7 +198,11 @@ Future<void> processAICommentReply({
         final author = c.isAi ? (c.characterId ?? 'AI') : 'User';
         final replyInfo =
             c.replyToId != null ? ' (replying to ${c.replyToId})' : '';
-        buf.writeln('- [$author] (id: ${c.id})$replyInfo: ${c.content}');
+        final commentTime = formatLocalDateTimeWithZone(
+          DateTime.fromMillisecondsSinceEpoch(c.timestamp * 1000),
+        );
+        buf.writeln(
+            '- [$author] (id: ${c.id}, time: $commentTime)$replyInfo: ${c.content}');
       }
       buf.writeln('</existing_comments>');
       existingCommentsContext = buf.toString();
@@ -215,7 +223,8 @@ Future<void> processAICommentReply({
         rawInputContent: contentToUse,
         initialInsight: initialInsight,
         characterId: characterId,
-        currentTime: inputDateTime,
+        currentTime: inputDateTime ?? DateTime.now(),
+        entryTime: entryDateTime,
         withMemoryManagement: withMemoryManagement,
       );
     } catch (e) {

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
-import 'package:intl/intl.dart' show DateFormat;
 import 'package:logging/logging.dart';
 import 'package:memex/agent/memex_skill_host_agent/memex_skill_host_agent.dart';
 import 'package:memex/agent/pure_skill_host_agent/pure_skill_host_agent.dart';
@@ -13,6 +12,7 @@ import 'package:memex/domain/models/custom_agent_config.dart';
 import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/utils/token_usage_utils.dart';
@@ -299,8 +299,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
     }
 
     userMessages.add(UserMessage([
-      TextPart(
-          "<system-reminder>current time is ${DateFormat("yyyy-MM-dd HH:mm:ss").format(DateTime.now())}</system-reminder>."),
+      TextPart(buildCurrentTimeReminder(DateTime.now())),
       TextPart(message),
     ]));
 

--- a/lib/data/services/custom_agent_config_service.dart
+++ b/lib/data/services/custom_agent_config_service.dart
@@ -10,6 +10,7 @@ import 'package:memex/data/services/task_handlers/llm_error_utils.dart';
 import 'package:memex/domain/models/custom_agent_config.dart';
 import 'package:memex/domain/models/system_event.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
 
 /// Escape XML special characters in text content.
 String _xmlEscape(String text) {
@@ -117,8 +118,8 @@ String defaultEventToXml(SystemEvent event) {
 }
 
 /// Compact serializer for user_input_submitted events.
-/// Keeps only fact_id and combined_text — media assets are already sent as
-/// multimodal parts, and timestamps / markdown_entry are internal bookkeeping.
+/// Keeps the raw input plus its original local timestamp. Media assets are
+/// already sent as multimodal parts, and markdown_entry is internal bookkeeping.
 String _userInputCompactXml(SystemEvent event) {
   final buf = StringBuffer();
   buf.writeln(
@@ -128,7 +129,12 @@ String _userInputCompactXml(SystemEvent event) {
 
   final payload = event.payload;
   if (payload is UserInputSubmittedPayload) {
+    final inputTime = dateTimeFromUnixSeconds(payload.createdAtTs);
     buf.writeln('  <fact_id>${_xmlEscape(payload.factId)}</fact_id>');
+    buf.writeln(
+        '  <input_local_time>${_xmlEscape(formatLocalDateTimeWithZone(inputTime))}</input_local_time>');
+    buf.writeln(
+        '  <input_unix_seconds>${payload.createdAtTs}</input_unix_seconds>');
     buf.writeln(
         '  <combined_text>${_xmlEscape(payload.combinedText)}</combined_text>');
   } else {

--- a/lib/data/services/memory_sync_service.dart
+++ b/lib/data/services/memory_sync_service.dart
@@ -7,6 +7,7 @@ import 'package:memex/data/services/agent_activity_service.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:path/path.dart' as path;
 
@@ -101,7 +102,7 @@ class MemorySyncService {
           contentBuffer.writeln("<user_fact>");
           contentBuffer.writeln('ID: $factId');
           contentBuffer.writeln(
-              "Published Time: ${factInfo.datetime.toIso8601String()}");
+              "Published Time: ${formatLocalDateTimeWithZone(factInfo.datetime)}");
 
           // Explicitly label the user's original text input
           contentBuffer.writeln('User Original Content:');

--- a/lib/data/services/persona_chat_service.dart
+++ b/lib/data/services/persona_chat_service.dart
@@ -21,20 +21,21 @@ class PersonaChatService {
         .get();
   }
 
-  Future<int> addUserMessage(String characterId, String content) async {
+  Future<int> addUserMessage(String characterId, String content,
+      {DateTime? timestamp}) async {
     return _db.into(_db.personaChatMessages).insert(
           PersonaChatMessagesCompanion.insert(
             characterId: characterId,
             isFromCharacter: false,
             content: content,
             isRead: const Value(true),
-            timestamp: DateTime.now(),
+            timestamp: timestamp ?? DateTime.now(),
           ),
         );
   }
 
   Future<int> addCharacterMessage(String characterId, String content,
-      {String? factId, bool isRead = false}) async {
+      {String? factId, bool isRead = false, DateTime? timestamp}) async {
     return _db.into(_db.personaChatMessages).insert(
           PersonaChatMessagesCompanion.insert(
             characterId: characterId,
@@ -42,7 +43,7 @@ class PersonaChatService {
             content: content,
             factId: Value(factId),
             isRead: Value(isRead),
-            timestamp: DateTime.now(),
+            timestamp: timestamp ?? DateTime.now(),
           ),
         );
   }

--- a/lib/data/services/task_handlers/card_agent_handler.dart
+++ b/lib/data/services/task_handlers/card_agent_handler.dart
@@ -15,6 +15,7 @@ import 'package:memex/agent/agent_utils.dart';
 import 'package:memex/domain/models/card_detail_model.dart';
 import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/data/services/task_handlers/llm_error_utils.dart';
+import 'package:memex/utils/time_context.dart';
 
 final Logger _logger = getLogger('CardAgentHandler');
 
@@ -72,7 +73,8 @@ Future<void> processWithCardAgent({
     // 3. (Client initialized above)
     final client = resources.client;
 
-    final publishTime = inputDateTime.toString().substring(0, 19);
+    final publishTime =
+        formatLocalDateTimeWithZone(inputDateTime ?? DateTime.now());
 
     final userMessageContent =
         Prompts.cardAgentUserMessagePromptForPublishNewContent(
@@ -144,11 +146,7 @@ Future<void> handleCardAgentImpl(
     // 1. Parse Payload
     final factId = payload['fact_id'] as String;
     final combinedText = payload['combined_text'] as String;
-    final createdAtTs = (payload['created_at_ts'] as num?)?.toInt();
-
-    final inputDateTime = createdAtTs != null
-        ? DateTime.fromMillisecondsSinceEpoch(createdAtTs * 1000)
-        : DateTime.now();
+    final inputDateTime = dateTimeFromUnixSeconds(payload['created_at_ts']);
 
     // 2. Retrieve asset analyses (Stage 1 result)
     List<Map<String, dynamic>>? assetAnalyses;

--- a/lib/data/services/task_handlers/comment_agent_handler.dart
+++ b/lib/data/services/task_handlers/comment_agent_handler.dart
@@ -9,6 +9,7 @@ import 'package:memex/data/services/task_handlers/llm_error_utils.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/domain/models/llm_config.dart';
+import 'package:memex/utils/time_context.dart';
 
 final _logger = Logger('CommentAgentHandler');
 
@@ -16,6 +17,7 @@ Future<void> handleCommentAgentImpl(
     String userId, Map<String, dynamic> payload, TaskContext context) async {
   final factId = payload['fact_id'] as String;
   final combinedText = payload['combined_text'] as String;
+  final inputDateTime = tryParseUnixSeconds(payload['created_at_ts']);
 
   _logger
       .info("Running Comment Agent selection for fact $factId, user $userId");
@@ -59,6 +61,7 @@ Future<void> handleCommentAgentImpl(
         userContent: Prompts.commentAgentInitialCommentPrompt,
         characterId: selectedCharId,
         rawInputContent: combinedText,
+        inputDateTime: inputDateTime,
       );
       return;
     }
@@ -86,6 +89,7 @@ Future<void> handleCommentAgentImpl(
         userContent: Prompts.commentAgentInitialCommentPrompt,
         characterId: selectedChar.id,
         rawInputContent: combinedText,
+        inputDateTime: inputDateTime,
       );
     } else {
       // Multi-character mode: LLM-based selection
@@ -119,6 +123,7 @@ Future<void> handleCommentAgentImpl(
           userContent: Prompts.commentAgentInitialCommentPrompt,
           characterId: char.id,
           rawInputContent: combinedText,
+          inputDateTime: inputDateTime,
         );
       }
     }
@@ -135,6 +140,7 @@ Future<void> handleProcessAiReplyImpl(
   final content = payload['content'] as String;
   final commentId = payload['comment_id'] as String?;
   final replyToId = payload['reply_to_id'] as String?;
+  final inputDateTime = tryParseUnixSeconds(payload['created_at_ts']);
 
   _logger.info(
       'HandleProcessAiReply: Processing AI reply for card $cardId, user $userId');
@@ -166,6 +172,7 @@ Future<void> handleProcessAiReplyImpl(
     userContent: content,
     userCommentId: commentId,
     characterId: targetCharacterId,
+    inputDateTime: inputDateTime,
     withMemoryManagement: true,
   );
 }

--- a/lib/data/services/task_handlers/pkm_agent_handler.dart
+++ b/lib/data/services/task_handlers/pkm_agent_handler.dart
@@ -9,6 +9,7 @@ import 'package:memex/data/services/memory_sync_service.dart';
 import 'package:memex/data/services/task_handlers/llm_error_utils.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
 
 final Logger _logger = getLogger('PkmAgentHandler');
 
@@ -53,7 +54,7 @@ Future<void> processWithPkmAgent({
     // Build asset info string
     final assetInfo = formatAssetAnalysis(assetAnalyses);
 
-    final currentTime = dateTime.toString().substring(0, 19);
+    final currentTime = formatLocalDateTimeWithZone(dateTime);
 
     // 3. (Client initialized above)
 
@@ -92,14 +93,11 @@ Future<void> handlePkmAgentImpl(
     // 1. Parse Payload
     final factId = payload['fact_id'] as String;
     final combinedText = payload['combined_text'] as String;
-    final createdAtTs = (payload['created_at_ts'] as num?)?.toInt();
 
     // Check for dry_run flag in payload, default to false
     final dryRun = payload['dry_run'] as bool? ?? false;
 
-    final inputDateTime = createdAtTs != null
-        ? DateTime.fromMillisecondsSinceEpoch(createdAtTs * 1000)
-        : DateTime.now();
+    final inputDateTime = dateTimeFromUnixSeconds(payload['created_at_ts']);
 
     // 2. Retrieve asset analyses (Stage 1 result)
     List<Map<String, dynamic>>? assetAnalyses;

--- a/lib/domain/models/system_event.dart
+++ b/lib/domain/models/system_event.dart
@@ -66,18 +66,21 @@ class CardCommentPostedPayload {
     required this.cardId,
     required this.content,
     required this.commentId,
+    this.createdAtTs,
     this.replyToId,
   });
 
   final String cardId;
   final String content;
   final String commentId;
+  final int? createdAtTs;
   final String? replyToId;
 
   Map<String, dynamic> toJson() => {
         'card_id': cardId,
         'content': content,
         'comment_id': commentId,
+        if (createdAtTs != null) 'created_at_ts': createdAtTs,
         if (replyToId != null) 'reply_to_id': replyToId,
       };
 }

--- a/lib/ui/character/widgets/persona_chat_screen.dart
+++ b/lib/ui/character/widgets/persona_chat_screen.dart
@@ -11,6 +11,7 @@ import 'package:memex/data/services/character_service.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/ui/core/widgets/back_button.dart';
 import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:intl/intl.dart';
@@ -40,6 +41,18 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
   final List<LLMMessage> _llmHistory = [];
   static const int _maxHistoryMessages = 30;
 
+  String _withMessageTime(DateTime timestamp, String content) {
+    return '${buildMessageTimePrefix(timestamp)}$content';
+  }
+
+  LLMMessage _historyMessageFor(PersonaChatMessage msg) {
+    final content = _withMessageTime(msg.timestamp, msg.content);
+    if (msg.isFromCharacter) {
+      return ModelMessage(model: 'history', textOutput: content);
+    }
+    return UserMessage([TextPart(content)]);
+  }
+
   String get _avatarSeed {
     if (_character?.avatar != null && _character!.avatar!.isNotEmpty) {
       return _character!.avatar!;
@@ -67,12 +80,7 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
     _llmHistory.clear();
     final reversed = messages.reversed.toList();
     for (final msg in reversed) {
-      if (msg.isFromCharacter) {
-        _llmHistory
-            .add(ModelMessage(model: 'history', textOutput: msg.content));
-      } else {
-        _llmHistory.add(UserMessage([TextPart(msg.content)]));
-      }
+      _llmHistory.add(_historyMessageFor(msg));
     }
     // Trim to max
     if (_llmHistory.length > _maxHistoryMessages) {
@@ -125,11 +133,15 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
 
     _textController.clear();
 
+    final userMessageTime = DateTime.now();
+
     // Persist user message
-    await _chatService.addUserMessage(_currentCharacterId, text);
+    await _chatService.addUserMessage(_currentCharacterId, text,
+        timestamp: userMessageTime);
 
     // Add to LLM history
-    _llmHistory.add(UserMessage([TextPart(text)]));
+    _llmHistory.add(
+        UserMessage([TextPart(_withMessageTime(userMessageTime, text))]));
 
     // Reload messages to show user's message
     final messages = await _chatService.getMessages(_currentCharacterId);
@@ -164,6 +176,7 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
         userId: userId,
         characterId: _currentCharacterId,
         userMessage: text,
+        userMessageTime: userMessageTime,
         history: historyToSend,
       )) {
         buffer.write(chunk);
@@ -176,13 +189,16 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
       // Persist character response
       final fullResponse = buffer.toString().trim();
       if (fullResponse.isNotEmpty) {
+        final responseTime = DateTime.now();
         await _chatService.addCharacterMessage(
           _currentCharacterId,
           fullResponse,
           isRead: true, // User is looking at it
+          timestamp: responseTime,
         );
-        _llmHistory
-            .add(ModelMessage(model: 'companion', textOutput: fullResponse));
+        _llmHistory.add(ModelMessage(
+            model: 'companion',
+            textOutput: _withMessageTime(responseTime, fullResponse)));
       }
 
       // Reload messages

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -16,6 +16,7 @@ import 'package:flutter/services.dart';
 import 'package:memex/domain/models/card_detail_model.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/utils/toast_helper.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:memex/ui/timeline/widgets/timeline/asset_header_gallery.dart';
@@ -153,8 +154,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
 
     final contextString = StringBuffer();
     contextString.writeln('Card Fact ID: ${_detail!.id}');
-    contextString
-        .writeln('Card Timestamp: ${_detail!.timestamp.toIso8601String()}');
+    contextString.writeln(
+        'Card Local Time: ${formatLocalDateTimeWithZone(_detail!.timestamp)}');
     contextString.writeln('Card Title: ${_detail!.title}');
     contextString.writeln('Card Content: ${_detail!.rawContent}');
     if (_detail!.insight.text.isNotEmpty) {
@@ -168,9 +169,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
             comment.isAi ? 'AI' : (comment.character?.name ?? 'User');
         final authorId =
             comment.isAi ? 'ai_agent' : (comment.character?.id ?? 'user');
-        final time =
-            DateTime.fromMillisecondsSinceEpoch(comment.timestamp * 1000)
-                .toIso8601String();
+        final time = formatLocalDateTimeWithZone(
+          DateTime.fromMillisecondsSinceEpoch(comment.timestamp * 1000),
+        );
         contextString.writeln(
             '- [$time] $authorName (ID: $authorId): ${comment.content}');
       }

--- a/lib/utils/time_context.dart
+++ b/lib/utils/time_context.dart
@@ -1,0 +1,37 @@
+import 'package:intl/intl.dart';
+
+DateTime? tryParseUnixSeconds(dynamic value) {
+  if (value is num) {
+    return DateTime.fromMillisecondsSinceEpoch((value * 1000).round());
+  }
+  return null;
+}
+
+DateTime dateTimeFromUnixSeconds(dynamic value, {DateTime? fallback}) {
+  return tryParseUnixSeconds(value) ?? fallback ?? DateTime.now();
+}
+
+String formatTimeZoneOffset(Duration offset) {
+  final sign = offset.isNegative ? '-' : '+';
+  final absolute = offset.abs();
+  final hours = absolute.inHours.toString().padLeft(2, '0');
+  final minutes = (absolute.inMinutes % 60).toString().padLeft(2, '0');
+  return '$sign$hours:$minutes';
+}
+
+String formatLocalDateTimeWithZone(DateTime dateTime) {
+  final local = dateTime.toLocal();
+  final formatted = DateFormat('yyyy-MM-dd HH:mm:ss').format(local);
+  return '$formatted ${formatTimeZoneOffset(local.timeZoneOffset)} '
+      '(${local.timeZoneName})';
+}
+
+String buildCurrentTimeReminder(DateTime dateTime) {
+  return '<system-reminder>\n'
+      'Current Local Time: ${formatLocalDateTimeWithZone(dateTime)}\n'
+      '</system-reminder>\n\n';
+}
+
+String buildMessageTimePrefix(DateTime dateTime) {
+  return '<message_time>${formatLocalDateTimeWithZone(dateTime)}</message_time>\n';
+}

--- a/test/utils/time_context_test.dart
+++ b/test/utils/time_context_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/utils/time_context.dart';
+
+void main() {
+  group('time context helpers', () {
+    test('parses Unix seconds without losing precision', () {
+      final parsed = tryParseUnixSeconds(1777377646);
+
+      expect(parsed, isNotNull);
+      expect(parsed!.millisecondsSinceEpoch, 1777377646000);
+    });
+
+    test('formats timezone offsets with sign and minutes', () {
+      expect(formatTimeZoneOffset(const Duration(hours: 8)), '+08:00');
+      expect(
+        formatTimeZoneOffset(const Duration(hours: -5, minutes: -30)),
+        '-05:30',
+      );
+    });
+
+    test('formats local date time with explicit timezone context', () {
+      final formatted = formatLocalDateTimeWithZone(
+        DateTime(2026, 4, 28, 20, 0, 46),
+      );
+
+      expect(formatted, contains('2026-04-28 20:00:46'));
+      expect(formatted, matches(RegExp(r'[+-]\d{2}:\d{2}')));
+    });
+  });
+}


### PR DESCRIPTION
## 背景

排查 #28 时发现，4 月 28 日“死党”评论里把同日输入误称为“昨天”，根因更像是上下文缺少稳定的本地时间锚点，而不是 prompt 行为约束不足。备份现场里原始输入和评论都发生在 2026-04-28 晚上，未发现 UTC 把日期回退到前一天的直接证据。

## 改动

- 新增统一的本地时间上下文工具，输出 `yyyy-MM-dd HH:mm:ss +08:00 (CST)` 这类带时区的时间文本。
- 评论 Agent：
  - 将 `created_at_ts` 从任务 payload 继续传入 `processAICommentReply` 和 `CommentAgent`。
  - 在评论 skill 的上下文中增加当前输入的 `Entry Local Time`。
  - recent facts 改为按输入/评论发生时间取最近几天，避免异步任务跨天执行时漂移。
  - existing comments 增加每条评论的本地时间，评论回复也带用户评论发生时间。
- 角色私聊：历史消息和新消息传给 LLM 时附带 `<message_time>`，让模型能区分“今天/昨天”。
- 自定义 Agent：`user_input_submitted` 的 compact XML 增加原始输入本地时间和 Unix 秒。
- Card/PKM/Chat/Insight/Memory 等通用时间上下文改为显式本地时间+时区。
- 卡片详情聊天引用的卡片时间、评论时间改为本地时间+时区。

## 设计取舍

没有添加“只有明确日期不同才允许说昨天”这类强行为 prompt 规则。这里更合适的修复是把事实时间和用户本地时区作为上下文数据补齐，让模型有足够信息自然判断相对日期。

## 验证

- `flutter test test/utils/time_context_test.dart` 通过
- `flutter test` 通过
- `flutter analyze` 仍返回非 0，但为仓库既有 lint/info/warning；本次没有引入编译级 error

Fixes #28
