### PR TITLE
feat: add settings help search

### DIFF
--- a/lib/data/services/settings_registry.dart
+++ b/lib/data/services/settings_registry.dart
@@ -1,0 +1,466 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:memex/domain/models/settings_item.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/ui/settings/widgets/system_authorization_page.dart';
+import 'package:memex/ui/settings/widgets/model_config_list_page.dart';
+import 'package:memex/ui/settings/widgets/agent_config_list_page.dart';
+import 'package:memex/ui/settings/widgets/settings_page.dart';
+import 'package:memex/ui/settings/widgets/debug_settings_page.dart';
+import 'package:memex/ui/settings/widgets/data_storage_page.dart';
+import 'package:memex/ui/settings/widgets/backup_restore_page.dart';
+import 'package:memex/ui/memory/view_models/memory_viewmodel.dart';
+import 'package:memex/ui/memory/widgets/memory_screen.dart';
+import 'package:memex/ui/character/view_models/character_viewmodel.dart';
+import 'package:memex/ui/character/widgets/character_config_screen.dart';
+import 'package:memex/utils/user_storage.dart';
+
+/// Settings registry. Maintains a static list of all searchable settings items.
+/// Organized by feature module, extensible for new entries.
+class SettingsRegistry {
+  SettingsRegistry._();
+
+  /// All registered settings items.
+  /// Uses getters so l10n strings resolve to the current locale at access time.
+  static List<SettingsItem> get allItems => [
+        ..._personalCenterItems,
+        ..._settingsPageItems,
+      ];
+
+  // ---------------------------------------------------------------------------
+  // PersonalCenterScreen level items
+  // ---------------------------------------------------------------------------
+
+  static List<SettingsItem> get _personalCenterItems => [
+        SettingsItem(
+          id: 'system_authorization',
+          titleGetter: () => UserStorage.l10n.systemAuthorization,
+          descriptionGetter: () => UserStorage.l10n.systemAuthorization,
+          keywords: const [
+            '权限',
+            '授权',
+            '通知',
+            '相册',
+            '麦克风',
+            '定位',
+            '健康',
+            '运动',
+            '步数',
+            'permission',
+            'authorization',
+            'notification',
+            'photos',
+            'microphone',
+            'location',
+            'health',
+            'fitness',
+          ],
+          icon: Icons.security_outlined,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const SystemAuthorizationPage(),
+          ),
+          parentPathGetter: () => [UserStorage.l10n.personalCenter],
+        ),
+        SettingsItem(
+          id: 'model_config',
+          titleGetter: () => UserStorage.l10n.modelConfig,
+          descriptionGetter: () => UserStorage.l10n.modelConfiguration,
+          keywords: const [
+            '模型',
+            'API',
+            '密钥',
+            'LLM',
+            '大模型',
+            '配置',
+            '接口',
+            '服务商',
+            'token',
+            'model',
+            'api key',
+            'endpoint',
+            'llm',
+            'openai',
+            'claude',
+            'gemini',
+            'deepseek',
+            'provider',
+          ],
+          icon: Icons.settings_input_component_outlined,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const ModelConfigListPage(),
+          ),
+          parentPathGetter: () => [UserStorage.l10n.personalCenter],
+        ),
+        SettingsItem(
+          id: 'agent_config',
+          titleGetter: () => UserStorage.l10n.agentConfig,
+          descriptionGetter: () => UserStorage.l10n.agentConfiguration,
+          keywords: const [
+            'agent',
+            '智能体',
+            '代理',
+            '分配模型',
+            '卡片处理',
+            '知识提取',
+            '评论生成',
+            '聊天',
+            '图片分析',
+            'agent config',
+            'agent model',
+            'card agent',
+            'knowledge',
+            'comment',
+            'chat',
+          ],
+          icon: Icons.people_outline,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const AgentConfigListPage(),
+          ),
+          parentPathGetter: () => [UserStorage.l10n.personalCenter],
+        ),
+        SettingsItem(
+          id: 'memory',
+          titleGetter: () => UserStorage.l10n.memoryTitle,
+          descriptionGetter: () => UserStorage.l10n.memoryTitle,
+          keywords: const [
+            '记忆',
+            '了解',
+            '个人信息',
+            '偏好',
+            '用户画像',
+            '习惯',
+            '兴趣',
+            'memory',
+            'remember',
+            'personal info',
+            'preferences',
+            'profile',
+            'habit',
+            'interest',
+          ],
+          icon: Icons.memory,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (context) {
+              final vm = MemoryViewModel(router: context.read<MemexRouter>());
+              vm.loadMemory();
+              return MemoryScreen(viewModel: vm);
+            },
+          ),
+          parentPathGetter: () => [UserStorage.l10n.personalCenter],
+        ),
+        SettingsItem(
+          id: 'character_config',
+          titleGetter: () => UserStorage.l10n.aiCharacterConfig,
+          descriptionGetter: () => UserStorage.l10n.configureAiCharacter,
+          keywords: const [
+            '角色',
+            '性格',
+            '人设',
+            '头像',
+            'AI角色',
+            '评论风格',
+            '语气',
+            '虚拟人物',
+            'character',
+            'persona',
+            'personality',
+            'avatar',
+            'ai character',
+            'tone',
+            'style',
+          ],
+          icon: Icons.psychology,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (context) {
+              final vm =
+                  CharacterViewModel(router: context.read<MemexRouter>());
+              vm.loadCharacters();
+              return CharacterConfigScreen(viewModel: vm);
+            },
+          ),
+          parentPathGetter: () => [UserStorage.l10n.personalCenter],
+        ),
+        SettingsItem(
+          id: 'settings',
+          titleGetter: () => UserStorage.l10n.settings,
+          descriptionGetter: () => UserStorage.l10n.settings,
+          keywords: const [
+            '设置',
+            '通用',
+            '偏好',
+            '选项',
+            '配置',
+            'settings',
+            'general',
+            'preferences',
+            'options',
+            'config',
+          ],
+          icon: Icons.settings_outlined,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const SettingsPage(),
+          ),
+          parentPathGetter: () => [UserStorage.l10n.personalCenter],
+        ),
+        SettingsItem(
+          id: 'debug',
+          titleGetter: () => 'Debug',
+          descriptionGetter: () => 'Debug',
+          keywords: const [
+            '调试',
+            '开发',
+            '日志',
+            '重建索引',
+            '清除数据',
+            '重新处理',
+            '搜索索引',
+            '退出登录',
+            'debug',
+            'developer',
+            'logs',
+            'rebuild index',
+            'clear data',
+            'reprocess',
+            'logout',
+          ],
+          icon: Icons.bug_report_outlined,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => DebugSettingsPage(
+              onClearToken: () async {},
+              onClearData: () async {},
+              onReprocessCards: () async {},
+              onReprocessComments: () async {},
+              onReprocessKnowledgeBase: () async {},
+              onRebuildSearchIndex: () async {},
+              isClearingData: false,
+              isReprocessingCards: false,
+              isReprocessingComments: false,
+              isReprocessingKnowledgeBase: false,
+              isRebuildingSearchIndex: false,
+            ),
+          ),
+          parentPathGetter: () => [UserStorage.l10n.personalCenter],
+        ),
+      ];
+
+  // ---------------------------------------------------------------------------
+  // SettingsPage level items
+  // ---------------------------------------------------------------------------
+
+  static List<SettingsItem> get _settingsPageItems => [
+        SettingsItem(
+          id: 'settings.language',
+          titleGetter: () => UserStorage.l10n.languageSettings,
+          descriptionGetter: () => UserStorage.l10n.languageSettingsDesc,
+          keywords: const [
+            '语言',
+            '中文',
+            '英文',
+            '切换语言',
+            '界面语言',
+            '翻译',
+            'language',
+            'english',
+            'chinese',
+            'locale',
+            'switch language',
+            'i18n',
+          ],
+          icon: Icons.language,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const SettingsPage(),
+          ),
+          parentPathGetter: () =>
+              [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
+        ),
+        SettingsItem(
+          id: 'settings.local_speech',
+          titleGetter: () => UserStorage.l10n.useLocalSpeechToTextTitle,
+          descriptionGetter: () => UserStorage.l10n.useLocalSpeechToTextDesc,
+          keywords: const [
+            '语音',
+            '识别',
+            '转文字',
+            '本地语音',
+            '录音',
+            '输入',
+            '麦克风',
+            'speech',
+            'recognition',
+            'voice',
+            'speech to text',
+            'stt',
+            'whisper',
+            'recording',
+            'dictation',
+          ],
+          icon: Icons.graphic_eq,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const SettingsPage(),
+          ),
+          parentPathGetter: () =>
+              [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
+        ),
+        SettingsItem(
+          id: 'settings.show_insight',
+          titleGetter: () => UserStorage.l10n.showInsightTextTitle,
+          descriptionGetter: () => UserStorage.l10n.showInsightTextDesc,
+          keywords: const [
+            '洞察',
+            '文本',
+            '显示',
+            '隐藏',
+            '卡片详情',
+            '卡片详情页',
+            '时间线',
+            'insight',
+            'text',
+            'show',
+            'hide',
+            'card text',
+            'card detail',
+            'timeline',
+          ],
+          icon: Icons.lightbulb_outline,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const SettingsPage(),
+          ),
+          parentPathGetter: () =>
+              [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
+        ),
+        SettingsItem(
+          id: 'settings.character_comment',
+          titleGetter: () => UserStorage.l10n.enableCharacterCommentTitle,
+          descriptionGetter: () => UserStorage.l10n.enableCharacterCommentDesc,
+          keywords: const [
+            '评论',
+            '角色评论',
+            '评价',
+            '反馈',
+            '卡片评论',
+            '卡片详情',
+            '卡片详情页',
+            '开关',
+            'comment',
+            'character comment',
+            'feedback',
+            'reaction',
+            'card detail',
+            'card comment',
+            'toggle',
+          ],
+          icon: Icons.chat_bubble_outline,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const SettingsPage(),
+          ),
+          parentPathGetter: () =>
+              [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
+        ),
+        SettingsItem(
+          id: 'settings.max_comment_characters',
+          titleGetter: () => UserStorage.l10n.maxCommentCharactersTitle,
+          descriptionGetter: () => UserStorage.l10n.maxCommentCharactersDesc,
+          keywords: const [
+            '评论数量',
+            '角色数量',
+            '最大数量',
+            '几个角色',
+            '多少角色',
+            '评论人数',
+            '卡片详情',
+            '卡片详情页',
+            'max characters',
+            'comment count',
+            'number of characters',
+            'how many',
+            'card detail',
+          ],
+          icon: Icons.groups_outlined,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const SettingsPage(),
+          ),
+          parentPathGetter: () =>
+              [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
+        ),
+        SettingsItem(
+          id: 'settings.data_storage',
+          titleGetter: () => UserStorage.l10n.dataStorage,
+          descriptionGetter: () => UserStorage.l10n.dataStorageDescriptionIOS,
+          keywords: const [
+            '存储',
+            '数据',
+            '路径',
+            'iCloud',
+            '存储位置',
+            '文件',
+            '空间',
+            '迁移',
+            'storage',
+            'data',
+            'path',
+            'icloud',
+            'location',
+            'file',
+            'space',
+            'migrate',
+          ],
+          icon: Icons.folder_outlined,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const DataStoragePage(),
+          ),
+          parentPathGetter: () =>
+              [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
+        ),
+        SettingsItem(
+          id: 'settings.backup_restore',
+          titleGetter: () => UserStorage.l10n.backupAndRestore,
+          descriptionGetter: () => UserStorage.l10n.backupDescription,
+          keywords: const [
+            '备份',
+            '恢复',
+            '导出',
+            '导入',
+            '数据迁移',
+            '换手机',
+            '同步',
+            'backup',
+            'restore',
+            'export',
+            'import',
+            'migrate',
+            'sync',
+            'transfer',
+          ],
+          icon: Icons.backup_outlined,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const BackupRestorePage(),
+          ),
+          parentPathGetter: () =>
+              [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
+        ),
+        SettingsItem(
+          id: 'settings.privacy_policy',
+          titleGetter: () => UserStorage.l10n.privacyPolicy,
+          descriptionGetter: () => UserStorage.l10n.privacyPolicyDesc,
+          keywords: const [
+            '隐私',
+            '政策',
+            '条款',
+            '协议',
+            '数据安全',
+            '用户协议',
+            'privacy',
+            'policy',
+            'terms',
+            'agreement',
+            'data safety',
+          ],
+          icon: Icons.privacy_tip_outlined,
+          navigationTarget: NavigationTarget(
+            pageBuilder: (_) => const SettingsPage(),
+          ),
+          parentPathGetter: () =>
+              [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
+        ),
+      ];
+}

--- a/lib/data/services/settings_search_service.dart
+++ b/lib/data/services/settings_search_service.dart
@@ -1,0 +1,56 @@
+import 'package:memex/data/services/settings_registry.dart';
+import 'package:memex/domain/models/settings_item.dart';
+
+/// Settings search service. Pure local keyword search.
+class SettingsSearchService {
+  SettingsSearchService._();
+  static final SettingsSearchService instance = SettingsSearchService._();
+
+  /// Local keyword search. Matches against title, description, and keywords.
+  /// Searches both Chinese and English content regardless of current locale.
+  /// Empty query returns all items. Results sorted by relevanceScore descending.
+  List<SettingsSearchResult> localSearch(String query) {
+    if (query.trim().isEmpty) {
+      return SettingsRegistry.allItems
+          .map((item) => SettingsSearchResult(item: item))
+          .toList();
+    }
+
+    final lowerQuery = query.toLowerCase();
+    final results = <SettingsSearchResult>[];
+
+    for (final item in SettingsRegistry.allItems) {
+      final score = _calculateRelevance(item, lowerQuery);
+      if (score > 0) {
+        results.add(SettingsSearchResult(
+          item: item,
+          relevanceScore: score,
+        ));
+      }
+    }
+
+    results.sort((a, b) => b.relevanceScore.compareTo(a.relevanceScore));
+    return results;
+  }
+
+  /// Calculate relevance score for a settings item against the query.
+  /// Title match = 1.0, keyword match = 0.8, description match = 0.5.
+  double _calculateRelevance(SettingsItem item, String lowerQuery) {
+    // Title match has highest weight
+    if (item.title.toLowerCase().contains(lowerQuery)) {
+      return 1.0;
+    }
+    // Keyword match is next
+    for (final keyword in item.keywords) {
+      if (keyword.toLowerCase().contains(lowerQuery) ||
+          lowerQuery.contains(keyword.toLowerCase())) {
+        return 0.8;
+      }
+    }
+    // Description match has lowest weight
+    if (item.description.toLowerCase().contains(lowerQuery)) {
+      return 0.5;
+    }
+    return 0.0;
+  }
+}

--- a/lib/domain/models/settings_item.dart
+++ b/lib/domain/models/settings_item.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/widgets.dart';
+
+/// Navigation target describing how to navigate to the page containing a setting.
+class NavigationTarget {
+  const NavigationTarget({
+    required this.pageBuilder,
+  });
+
+  /// Page builder function. Returns the target Widget.
+  /// Uses a function instead of a route string because existing settings pages
+  /// are not in the go_router route table.
+  final Widget Function(BuildContext context) pageBuilder;
+}
+
+/// Data model for a searchable settings item.
+class SettingsItem {
+  const SettingsItem({
+    required this.id,
+    required this.titleGetter,
+    required this.descriptionGetter,
+    required this.keywords,
+    required this.icon,
+    required this.navigationTarget,
+    required this.parentPathGetter,
+  });
+
+  /// Unique identifier, e.g. 'settings.language'
+  final String id;
+
+  /// Returns the localized title using the current l10n.
+  final String Function() titleGetter;
+
+  /// Returns the localized description using the current l10n.
+  final String Function() descriptionGetter;
+
+  /// Searchable keywords (both Chinese and English, always searched regardless of locale).
+  final List<String> keywords;
+
+  /// Display icon.
+  final IconData icon;
+
+  /// Navigation target.
+  final NavigationTarget navigationTarget;
+
+  /// Returns the localized breadcrumb path segments using the current l10n.
+  /// e.g. ['Personal Center', 'Settings']
+  final List<String> Function() parentPathGetter;
+
+  /// Get the current localized title.
+  String get title => titleGetter();
+
+  /// Get the current localized description.
+  String get description => descriptionGetter();
+
+  /// Get the breadcrumb string for display.
+  String get breadcrumb {
+    final path = parentPathGetter();
+    if (path.isEmpty) return title;
+    return '${path.join(' > ')} > $title';
+  }
+}
+
+/// Search result wrapping a SettingsItem with relevance metadata.
+class SettingsSearchResult {
+  const SettingsSearchResult({
+    required this.item,
+    this.relevanceScore = 0.0,
+  });
+
+  final SettingsItem item;
+
+  /// Relevance score (0.0-1.0) for sorting.
+  final double relevanceScore;
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -964,5 +964,8 @@
   "cdnSignalsComments": "New reply received",
   "cdnSignalsInsight": "New insight generated",
   "cdnSignalsBoth": "New reply and insight",
-  "untitledCard": "Untitled card"
+  "untitledCard": "Untitled card",
+
+  "settingsSearchPlaceholder": "Search settings...",
+  "settingsSearchEmpty": "No matching settings found"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3913,6 +3913,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Untitled card'**
   String get untitledCard;
+
+  /// No description provided for @settingsSearchPlaceholder.
+  ///
+  /// In en, this message translates to:
+  /// **'Search settings...'**
+  String get settingsSearchPlaceholder;
+
+  /// No description provided for @settingsSearchEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No matching settings found'**
+  String get settingsSearchEmpty;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2143,4 +2143,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get untitledCard => 'Untitled card';
+
+  @override
+  String get settingsSearchPlaceholder => 'Search settings...';
+
+  @override
+  String get settingsSearchEmpty => 'No matching settings found';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2063,4 +2063,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get untitledCard => '未命名卡片';
+
+  @override
+  String get settingsSearchPlaceholder => '搜索设置项...';
+
+  @override
+  String get settingsSearchEmpty => '未找到匹配的设置项';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -942,5 +942,8 @@
   "cdnSignalsComments": "收到新回复",
   "cdnSignalsInsight": "生成了新洞察",
   "cdnSignalsBoth": "有新回复和洞察",
-  "untitledCard": "未命名卡片"
+  "untitledCard": "未命名卡片",
+
+  "settingsSearchPlaceholder": "搜索设置项...",
+  "settingsSearchEmpty": "未找到匹配的设置项"
 }

--- a/lib/ui/settings/view_models/settings_search_viewmodel.dart
+++ b/lib/ui/settings/view_models/settings_search_viewmodel.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/settings_search_service.dart';
+import 'package:memex/domain/models/settings_item.dart';
+
+/// 设置搜索 ViewModel。管理搜索状态和结果。
+class SettingsSearchViewModel extends ChangeNotifier {
+  SettingsSearchViewModel({required MemexRouter router}) : _router = router;
+
+  // ignore: unused_field — kept per project convention (ViewModels receive MemexRouter)
+  final MemexRouter _router;
+  final SettingsSearchService _searchService = SettingsSearchService.instance;
+
+  String _query = '';
+  List<SettingsSearchResult> _results = [];
+
+  String get query => _query;
+  List<SettingsSearchResult> get results => _results;
+  bool get hasResults => _results.isNotEmpty;
+
+  /// 更新搜索查询，立即执行本地搜索
+  void updateQuery(String query) {
+    _query = query;
+    _results = _searchService.localSearch(query);
+    notifyListeners();
+  }
+
+  /// 导航到设置项
+  void navigateToItem(BuildContext context, SettingsItem item) {
+    final page = item.navigationTarget.pageBuilder(context);
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => page),
+    );
+  }
+}

--- a/lib/ui/settings/widgets/personal_center_screen.dart
+++ b/lib/ui/settings/widgets/personal_center_screen.dart
@@ -11,6 +11,8 @@ import 'package:memex/ui/settings/widgets/model_config_list_page.dart';
 import 'package:memex/ui/settings/widgets/system_authorization_page.dart';
 import 'package:memex/ui/settings/widgets/debug_settings_page.dart';
 import 'package:memex/ui/settings/widgets/settings_page.dart';
+import 'package:memex/ui/settings/widgets/settings_search_screen.dart';
+import 'package:memex/ui/settings/view_models/settings_search_viewmodel.dart';
 import 'package:memex/utils/permission_utils.dart';
 import 'package:memex/ui/core/widgets/avatar_picker.dart';
 import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
@@ -740,18 +742,48 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                   children: [
                     // Header
                     Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+                      padding: const EdgeInsets.fromLTRB(20, 16, 12, 0),
                       child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        mainAxisAlignment: MainAxisAlignment.end,
                         children: [
-                          Text(
-                            UserStorage.l10n.personalCenter,
-                            style: const TextStyle(
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                              color: Color(0xFF0F172A),
+                          GestureDetector(
+                            onTap: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => SettingsSearchScreen(
+                                    viewModel: SettingsSearchViewModel(
+                                      router: _memexRouter,
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 14, vertical: 8),
+                              decoration: BoxDecoration(
+                                color: const Color(0xFFF1F5F9),
+                                borderRadius: BorderRadius.circular(20),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Icon(Icons.search,
+                                      color: Color(0xFF94A3B8), size: 16),
+                                  const SizedBox(width: 6),
+                                  Text(
+                                    UserStorage.l10n.settingsSearchPlaceholder,
+                                    style: const TextStyle(
+                                      fontSize: 13,
+                                      color: Color(0xFF94A3B8),
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
+                          const SizedBox(width: 4),
                           IconButton(
                             icon: const Icon(Icons.close),
                             onPressed: () => Navigator.of(context).pop(),

--- a/lib/ui/settings/widgets/settings_search_screen.dart
+++ b/lib/ui/settings/widgets/settings_search_screen.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:memex/domain/models/settings_item.dart';
+import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/ui/settings/view_models/settings_search_viewmodel.dart';
+import 'package:memex/utils/user_storage.dart';
+
+/// Full-screen settings search page.
+class SettingsSearchScreen extends StatefulWidget {
+  const SettingsSearchScreen({super.key, required this.viewModel});
+
+  final SettingsSearchViewModel viewModel;
+
+  @override
+  State<SettingsSearchScreen> createState() => _SettingsSearchScreenState();
+}
+
+class _SettingsSearchScreenState extends State<SettingsSearchScreen> {
+  final TextEditingController _textController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    // Trigger initial load (empty query shows all items)
+    widget.viewModel.updateQuery('');
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        surfaceTintColor: AppColors.background,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: _buildSearchField(),
+      ),
+      body: ListenableBuilder(
+        listenable: widget.viewModel,
+        builder: (context, _) {
+          return _buildBody();
+        },
+      ),
+    );
+  }
+
+  Widget _buildSearchField() {
+    return TextField(
+      controller: _textController,
+      autofocus: true,
+      decoration: InputDecoration(
+        hintText: UserStorage.l10n.settingsSearchPlaceholder,
+        hintStyle: const TextStyle(
+          color: AppColors.textTertiary,
+          fontSize: 16,
+        ),
+        border: InputBorder.none,
+        contentPadding: EdgeInsets.zero,
+      ),
+      style: const TextStyle(
+        fontSize: 16,
+        color: AppColors.textPrimary,
+      ),
+      onChanged: widget.viewModel.updateQuery,
+    );
+  }
+
+  Widget _buildBody() {
+    final results = widget.viewModel.results;
+
+    if (widget.viewModel.query.trim().isNotEmpty && results.isEmpty) {
+      return _buildEmptyState();
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: results.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        return _buildResultItem(results[index]);
+      },
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.search_off,
+            size: 48,
+            color: AppColors.textTertiary.withValues(alpha: 0.5),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            UserStorage.l10n.settingsSearchEmpty,
+            style: const TextStyle(
+              fontSize: 15,
+              color: AppColors.textTertiary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResultItem(SettingsSearchResult result) {
+    final item = result.item;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () => widget.viewModel.navigateToItem(context, item),
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(16),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.textSecondary.withValues(alpha: 0.08),
+                blurRadius: 16,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              Icon(item.icon, color: AppColors.primary, size: 22),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.title,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                        color: AppColors.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      item.breadcrumb,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        color: AppColors.textTertiary,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(Icons.chevron_right, color: AppColors.textTertiary),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Add a settings search/help feature to help users quickly find configuration options across the multi-level settings pages.

## Changes

- **SettingsItem model** — l10n-aware data model with title/description/breadcrumb getters that follow current locale
- **SettingsRegistry** — static registry of 15 searchable settings items (Personal Center + Settings Page levels) with bilingual keywords
- **SettingsSearchService** — local keyword search with relevance scoring (title > keywords > description)
- **SettingsSearchViewModel** — MVVM state management for search
- **SettingsSearchScreen** — full-page search UI with instant results, breadcrumb paths, and empty state
- **PersonalCenterScreen** — pill-shaped search entry button in header area
- **l10n** — added settingsSearchPlaceholder and settingsSearchEmpty strings

## What was tested

- flutter analyze passes with no issues
- Verified locale switching correctly updates search result titles and breadcrumbs
- Keyword matching works for both Chinese and English terms regardless of current locale