### PR TITLE
feat: duplicate model configuration

### DIFF
--- a/lib/domain/models/llm_config.dart
+++ b/lib/domain/models/llm_config.dart
@@ -558,6 +558,19 @@ class LLMConfig {
     );
   }
 
+  /// Creates a duplicate of this config with a new unique key.
+  /// The new key will be `{originalKey}_copy`, or `{originalKey}_copy_N`
+  /// if conflicts exist in [existingKeys].
+  LLMConfig duplicate({required List<String> existingKeys}) {
+    String newKey = '${key}_copy';
+    int counter = 2;
+    while (existingKeys.contains(newKey)) {
+      newKey = '${key}_copy_$counter';
+      counter++;
+    }
+    return copyWith(key: newKey);
+  }
+
   static LLMConfig createDefaultClientConfig() {
     if (AppFlavor.isCN) {
       return const LLMConfig(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -639,6 +639,8 @@
   "configurationResetPressSave": "Configuration reset. Press Save to apply.",
   "addConfiguration": "Add Configuration",
   "editConfiguration": "Edit Configuration",
+  "duplicateConfiguration": "Duplicate Configuration",
+  "duplicate": "Duplicate",
   "keyIdLabel": "Key (ID)",
   "keyIdHelper": "Unique identifier for this configuration",
   "required": "Required",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2474,6 +2474,18 @@ abstract class AppLocalizations {
   /// **'Edit Configuration'**
   String get editConfiguration;
 
+  /// No description provided for @duplicateConfiguration.
+  ///
+  /// In en, this message translates to:
+  /// **'Duplicate Configuration'**
+  String get duplicateConfiguration;
+
+  /// No description provided for @duplicate.
+  ///
+  /// In en, this message translates to:
+  /// **'Duplicate'**
+  String get duplicate;
+
   /// No description provided for @keyIdLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1345,6 +1345,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get editConfiguration => 'Edit Configuration';
 
   @override
+  String get duplicateConfiguration => 'Duplicate Configuration';
+
+  @override
+  String get duplicate => 'Duplicate';
+
+  @override
   String get keyIdLabel => 'Key (ID)';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1301,6 +1301,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get editConfiguration => '编辑配置';
 
   @override
+  String get duplicateConfiguration => '复制配置';
+
+  @override
+  String get duplicate => '复制';
+
+  @override
   String get keyIdLabel => 'Key (ID)';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -639,6 +639,8 @@
   "configurationResetPressSave": "配置已重置，请点击保存以应用。",
   "addConfiguration": "添加配置",
   "editConfiguration": "编辑配置",
+  "duplicateConfiguration": "复制配置",
+  "duplicate": "复制",
   "keyIdLabel": "Key (ID)",
   "keyIdHelper": "此配置的唯一标识符",
   "required": "必填",

--- a/lib/ui/settings/widgets/model_config_edit_page.dart
+++ b/lib/ui/settings/widgets/model_config_edit_page.dart
@@ -14,8 +14,9 @@ import 'package:memex/ui/core/themes/app_colors.dart';
 
 class ModelConfigEditPage extends StatefulWidget {
   final LLMConfig? config;
+  final LLMConfig? duplicateSource;
 
-  const ModelConfigEditPage({super.key, this.config});
+  const ModelConfigEditPage({super.key, this.config, this.duplicateSource});
 
   @override
   State<ModelConfigEditPage> createState() => _ModelConfigEditPageState();
@@ -57,7 +58,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    final config = widget.config;
+    final config = widget.config ?? widget.duplicateSource;
     _keyController = TextEditingController(text: config?.key ?? '');
     _modelIdController = TextEditingController(text: config?.modelId ?? '');
     _apiKeyController = TextEditingController(text: config?.apiKey ?? '');
@@ -115,6 +116,11 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
       vsync: this,
       duration: const Duration(milliseconds: 800),
     );
+
+    if (widget.duplicateSource != null) {
+      _hasChanges = true;
+      _animationController.repeat(reverse: true);
+    }
 
     _keyController.addListener(_checkChanges);
     _modelIdController.addListener(_checkChanges);
@@ -787,14 +793,14 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
       }
     }
 
-    if (widget.config != null) {
+    if (widget.config != null && widget.duplicateSource == null) {
       // Update
       final index = configs.indexWhere((c) => c.key == widget.config!.key);
       if (index != -1) {
         configs[index] = newConfig;
       }
     } else {
-      // Add
+      // Add (new or duplicate)
       configs.add(newConfig);
     }
 
@@ -927,7 +933,9 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
           surfaceTintColor: AppColors.background,
           title: Text(
             widget.config == null
-                ? UserStorage.l10n.addConfiguration
+                ? (widget.duplicateSource != null
+                    ? UserStorage.l10n.duplicateConfiguration
+                    : UserStorage.l10n.addConfiguration)
                 : UserStorage.l10n.editConfiguration,
           ),
           actions: [

--- a/lib/ui/settings/widgets/model_config_list_page.dart
+++ b/lib/ui/settings/widgets/model_config_list_page.dart
@@ -145,17 +145,27 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
     }
   }
 
-  void _editConfig(LLMConfig? config) async {
+  void _editConfig(LLMConfig? config, {LLMConfig? duplicateSource}) async {
     final result = await Navigator.push<bool>(
       context,
       MaterialPageRoute(
-        builder: (context) => ModelConfigEditPage(config: config),
+        builder: (context) => ModelConfigEditPage(
+          config: config,
+          duplicateSource: duplicateSource,
+        ),
       ),
     );
 
     if (result == true) {
       _loadConfigs();
     }
+  }
+
+  void _duplicateConfig(LLMConfig config) {
+    final duplicated = config.duplicate(
+      existingKeys: _configs.map((c) => c.key).toList(),
+    );
+    _editConfig(null, duplicateSource: duplicated);
   }
 
   @override
@@ -408,19 +418,52 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                               ),
                             ],
                           ),
-                          trailing: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              if (!config.isDefault)
-                                IconButton(
-                                  icon: const Icon(
-                                    Icons.delete_outline,
-                                    color: Colors.grey,
+                          trailing: PopupMenuButton<String>(
+                            onSelected: (value) {
+                              if (value == 'duplicate') {
+                                _duplicateConfig(config);
+                              } else if (value == 'delete') {
+                                _deleteConfig(index);
+                              }
+                            },
+                            itemBuilder: (context) {
+                              final l10n = UserStorage.l10n;
+                              return [
+                                PopupMenuItem<String>(
+                                  value: 'duplicate',
+                                  child: Row(
+                                    children: [
+                                      const Icon(
+                                        Icons.copy_outlined,
+                                        size: 20,
+                                      ),
+                                      const SizedBox(width: 8),
+                                      Text(l10n.duplicate),
+                                    ],
                                   ),
-                                  onPressed: () => _deleteConfig(index),
                                 ),
-                              const Icon(Icons.chevron_right),
-                            ],
+                                if (!config.isDefault)
+                                  PopupMenuItem<String>(
+                                    value: 'delete',
+                                    child: Row(
+                                      children: [
+                                        const Icon(
+                                          Icons.delete_outline,
+                                          size: 20,
+                                          color: Colors.red,
+                                        ),
+                                        const SizedBox(width: 8),
+                                        Text(
+                                          l10n.delete,
+                                          style: const TextStyle(
+                                            color: Colors.red,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                              ];
+                            },
                           ),
                           onTap: () => _editConfig(config),
                         ),

--- a/lib/ui/settings/widgets/model_config_list_page.dart
+++ b/lib/ui/settings/widgets/model_config_list_page.dart
@@ -86,20 +86,19 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
     return usedByagents;
   }
 
-  Future<void> _deleteConfig(int index) async {
-    final config = _configs[index];
+  Future<bool> _confirmDeleteConfig(LLMConfig config) async {
     final l10n = UserStorage.l10n;
     if (config.isDefault) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.cannotDeleteDefaultConfiguration)),
       );
-      return;
+      return false;
     }
 
     final usingAgents = await _getAgentsUsingConfig(config.key);
     if (usingAgents.isNotEmpty) {
-      if (!mounted) return;
-      showDialog(
+      if (!mounted) return false;
+      await showDialog<void>(
         context: context,
         builder: (context) => AlertDialog(
           backgroundColor: Colors.white,
@@ -113,33 +112,39 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
           ],
         ),
       );
-      return;
+      return false;
     }
 
-    if (!mounted) return;
+    if (!mounted) return false;
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: Colors.white,
-        title: Text(l10n.deleteConfigurationTitle),
-        content: Text(l10n.confirmDeleteConfigMessage(config.key)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text(l10n.cancel),
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            backgroundColor: Colors.white,
+            title: Text(l10n.deleteConfigurationTitle),
+            content: Text(l10n.confirmDeleteConfigMessage(config.key)),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: Text(l10n.cancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: Text(
+                  l10n.delete,
+                  style: const TextStyle(color: Colors.red),
+                ),
+              ),
+            ],
           ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: Text(l10n.delete, style: const TextStyle(color: Colors.red)),
-          ),
-        ],
-      ),
-    );
+        ) ??
+        false;
+  }
 
-    if (confirmed == true) {
+  Future<void> _deleteConfig(LLMConfig config) async {
+    if (await _confirmDeleteConfig(config)) {
       setState(() {
-        _configs.removeAt(index);
+        _configs.removeWhere((item) => item.key == config.key);
       });
       await MemexRouter().saveLLMConfigs(_configs);
     }
@@ -256,65 +261,13 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                           child: const Icon(Icons.delete, color: Colors.white),
                         ),
                         confirmDismiss: (direction) async {
-                          if (config.isDefault) return false;
-
-                          final usingAgents = await _getAgentsUsingConfig(
-                            config.key,
-                          );
-                          if (usingAgents.isNotEmpty) {
-                            if (!context.mounted) return false;
-                            final l10n = UserStorage.l10n;
-                            showDialog(
-                              context: context,
-                              builder: (context) => AlertDialog(
-                                backgroundColor: Colors.white,
-                                title: Text(
-                                  l10n.cannotDeleteConfigurationTitle,
-                                ),
-                                content: Text(
-                                  l10n.configUsedByAgentsMessage(
-                                    usingAgents.join('\n'),
-                                  ),
-                                ),
-                                actions: [
-                                  TextButton(
-                                    onPressed: () => Navigator.pop(context),
-                                    child: Text(l10n.ok),
-                                  ),
-                                ],
-                              ),
-                            );
-                            return false;
-                          }
-
-                          if (!context.mounted) return false;
-
-                          final l10n = UserStorage.l10n;
-                          return await showDialog<bool>(
-                            context: context,
-                            builder: (context) => AlertDialog(
-                              backgroundColor: Colors.white,
-                              title: Text(l10n.deleteConfigurationTitle),
-                              content: Text(
-                                l10n.confirmDeleteConfigMessage(config.key),
-                              ),
-                              actions: [
-                                TextButton(
-                                  onPressed: () =>
-                                      Navigator.pop(context, false),
-                                  child: Text(l10n.cancel),
-                                ),
-                                TextButton(
-                                  onPressed: () => Navigator.pop(context, true),
-                                  child: Text(l10n.delete),
-                                ),
-                              ],
-                            ),
-                          );
+                          return _confirmDeleteConfig(config);
                         },
                         onDismissed: (direction) async {
                           setState(() {
-                            _configs.removeAt(index);
+                            _configs.removeWhere(
+                              (item) => item.key == config.key,
+                            );
                           });
                           await MemexRouter().saveLLMConfigs(_configs);
                         },
@@ -365,8 +318,9 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                                     color: Colors.green.withValues(alpha: 0.1),
                                     borderRadius: BorderRadius.circular(4),
                                     border: Border.all(
-                                      color:
-                                          Colors.green.withValues(alpha: 0.5),
+                                      color: Colors.green.withValues(
+                                        alpha: 0.5,
+                                      ),
                                     ),
                                   ),
                                   child: Text(
@@ -419,11 +373,15 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                             ],
                           ),
                           trailing: PopupMenuButton<String>(
+                            icon: const Icon(Icons.more_vert),
+                            tooltip: MaterialLocalizations.of(
+                              context,
+                            ).moreButtonTooltip,
                             onSelected: (value) {
                               if (value == 'duplicate') {
                                 _duplicateConfig(config);
                               } else if (value == 'delete') {
-                                _deleteConfig(index);
+                                _deleteConfig(config);
                               }
                             },
                             itemBuilder: (context) {
@@ -433,10 +391,7 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                                   value: 'duplicate',
                                   child: Row(
                                     children: [
-                                      const Icon(
-                                        Icons.copy_outlined,
-                                        size: 20,
-                                      ),
+                                      const Icon(Icons.copy_outlined, size: 20),
                                       const SizedBox(width: 8),
                                       Text(l10n.duplicate),
                                     ],

--- a/test/domain/models/llm_config_test.dart
+++ b/test/domain/models/llm_config_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/llm_config.dart';
+
+void main() {
+  group('LLMConfig.duplicate', () {
+    const baseConfig = LLMConfig(
+      key: 'my-config',
+      type: LLMConfig.typeChatCompletion,
+      modelId: 'gpt-5.4',
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.openai.com/v1',
+      proxyUrl: 'http://127.0.0.1:7890',
+      extra: {'reasoning_effort': 'medium'},
+      temperature: 0.7,
+      maxTokens: 4096,
+      topP: 0.9,
+    );
+
+    test('creates copy with "_copy" suffix when no conflict', () {
+      final duplicated = baseConfig.duplicate(existingKeys: ['other-config']);
+
+      expect(duplicated.key, 'my-config_copy');
+      expect(duplicated.type, baseConfig.type);
+      expect(duplicated.modelId, baseConfig.modelId);
+      expect(duplicated.apiKey, baseConfig.apiKey);
+      expect(duplicated.baseUrl, baseConfig.baseUrl);
+      expect(duplicated.proxyUrl, baseConfig.proxyUrl);
+      expect(duplicated.extra, baseConfig.extra);
+      expect(duplicated.temperature, baseConfig.temperature);
+      expect(duplicated.maxTokens, baseConfig.maxTokens);
+      expect(duplicated.topP, baseConfig.topP);
+    });
+
+    test('appends _copy_2 when "_copy" already exists', () {
+      final duplicated = baseConfig.duplicate(
+        existingKeys: ['my-config_copy'],
+      );
+      expect(duplicated.key, 'my-config_copy_2');
+    });
+
+    test('increments counter until unique key is found', () {
+      final duplicated = baseConfig.duplicate(
+        existingKeys: [
+          'my-config_copy',
+          'my-config_copy_2',
+          'my-config_copy_3',
+        ],
+      );
+      expect(duplicated.key, 'my-config_copy_4');
+    });
+
+    test('does not modify the original config', () {
+      final duplicated = baseConfig.duplicate(existingKeys: []);
+      expect(baseConfig.key, 'my-config');
+      expect(duplicated.key, isNot(baseConfig.key));
+    });
+
+    test('handles keys with special characters gracefully', () {
+      const config = LLMConfig(
+        key: 'config-v1.2_test',
+        type: LLMConfig.typeKimi,
+        modelId: 'kimi-k2.5',
+        apiKey: 'key',
+        baseUrl: 'https://api.moonshot.cn/v1',
+      );
+      final duplicated = config.duplicate(existingKeys: []);
+      expect(duplicated.key, 'config-v1.2_test_copy');
+    });
+  });
+}

--- a/test/ui/settings/widgets/model_config_edit_page_test.dart
+++ b/test/ui/settings/widgets/model_config_edit_page_test.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/domain/models/llm_config.dart';
@@ -36,7 +34,9 @@ void main() {
       topP: 0.9,
     );
 
-    testWidgets('shows "Duplicate Configuration" title when duplicateSource is provided', (tester) async {
+    testWidgets(
+        'shows "Duplicate Configuration" title when duplicateSource is provided',
+        (tester) async {
       await tester.pumpWidget(
         buildTestableWidget(
           const ModelConfigEditPage(duplicateSource: sourceConfig),
@@ -64,7 +64,8 @@ void main() {
       // are inside a collapsed ExpansionTile and not checked here.
     });
 
-    testWidgets('save button is present when duplicateSource is provided', (tester) async {
+    testWidgets('save button is present when duplicateSource is provided',
+        (tester) async {
       await tester.pumpWidget(
         buildTestableWidget(
           const ModelConfigEditPage(duplicateSource: sourceConfig),
@@ -125,7 +126,8 @@ void main() {
       expect(duplicated.proxyUrl, customConfig.proxyUrl);
     });
 
-    testWidgets('increments counter when duplicate key already exists', (tester) async {
+    testWidgets('increments counter when duplicate key already exists',
+        (tester) async {
       final defaultConfig = LLMConfig.createDefaultClientConfig();
       const customConfig = LLMConfig(
         key: 'myconfig',
@@ -141,7 +143,8 @@ void main() {
         apiKey: 'sk-other',
         baseUrl: 'https://other.example.com/v1',
       );
-      await UserStorage.saveLLMConfigs([defaultConfig, customConfig, existingCopy]);
+      await UserStorage.saveLLMConfigs(
+          [defaultConfig, customConfig, existingCopy]);
       await UserStorage.saveLLMConsent(
         true,
         providerType: LLMConfig.typeChatCompletion,

--- a/test/ui/settings/widgets/model_config_edit_page_test.dart
+++ b/test/ui/settings/widgets/model_config_edit_page_test.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/llm_config.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/settings/widgets/model_config_edit_page.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  Widget buildTestableWidget(Widget child) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: child,
+    );
+  }
+
+  group('ModelConfigEditPage duplicate mode', () {
+    const sourceConfig = LLMConfig(
+      key: 'source-config',
+      type: LLMConfig.typeChatCompletion,
+      modelId: 'gpt-5.4',
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.openai.com/v1',
+      proxyUrl: 'http://127.0.0.1:7890',
+      extra: {'reasoning_effort': 'medium'},
+      temperature: 0.7,
+      maxTokens: 4096,
+      topP: 0.9,
+    );
+
+    testWidgets('shows "Duplicate Configuration" title when duplicateSource is provided', (tester) async {
+      await tester.pumpWidget(
+        buildTestableWidget(
+          const ModelConfigEditPage(duplicateSource: sourceConfig),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Duplicate Configuration'), findsOneWidget);
+    });
+
+    testWidgets('pre-fills fields from duplicateSource', (tester) async {
+      await tester.pumpWidget(
+        buildTestableWidget(
+          const ModelConfigEditPage(duplicateSource: sourceConfig),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Basic fields are visible on page load
+      expect(find.text('source-config'), findsOneWidget);
+      expect(find.text('gpt-5.4'), findsOneWidget);
+      expect(find.text('sk-test'), findsOneWidget);
+      expect(find.text('https://api.openai.com/v1'), findsOneWidget);
+      // Advanced fields (proxy, temperature, maxTokens, topP, extra)
+      // are inside a collapsed ExpansionTile and not checked here.
+    });
+
+    testWidgets('save button is present when duplicateSource is provided', (tester) async {
+      await tester.pumpWidget(
+        buildTestableWidget(
+          const ModelConfigEditPage(duplicateSource: sourceConfig),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+
+      final saveButton = find.byIcon(Icons.save);
+      expect(saveButton, findsOneWidget);
+    });
+
+    testWidgets('saves duplicate config with unique key', (tester) async {
+      // Pre-populate storage with a default config and a custom config
+      final defaultConfig = LLMConfig.createDefaultClientConfig();
+      const customConfig = LLMConfig(
+        key: 'myconfig',
+        type: LLMConfig.typeChatCompletion,
+        modelId: 'gpt-4o',
+        apiKey: 'sk-real-key',
+        baseUrl: 'https://custom.example.com/v1',
+        proxyUrl: 'http://proxy.example.com:8080',
+      );
+      await UserStorage.saveLLMConfigs([defaultConfig, customConfig]);
+      await UserStorage.saveLLMConsent(
+        true,
+        providerType: LLMConfig.typeChatCompletion,
+      );
+
+      // Simulate what ModelConfigListPage._duplicateConfig does:
+      // generate a unique key before passing to edit page
+      final duplicatedConfig = customConfig.duplicate(
+        existingKeys: [defaultConfig.key, customConfig.key],
+      );
+
+      await tester.pumpWidget(
+        buildTestableWidget(
+          ModelConfigEditPage(duplicateSource: duplicatedConfig),
+        ),
+      );
+      await tester.pump();
+
+      // Tap save — duplicate config should be added
+      await tester.tap(find.byIcon(Icons.save));
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // Verify storage now has 3 configs: default + myconfig + myconfig_copy
+      final configs = await UserStorage.getLLMConfigs();
+      expect(configs.length, 3);
+      expect(configs.any((c) => c.key == 'myconfig'), isTrue);
+      expect(configs.any((c) => c.key == 'myconfig_copy'), isTrue);
+
+      // Verify duplicated config preserves original values
+      final duplicated = configs.firstWhere((c) => c.key == 'myconfig_copy');
+      expect(duplicated.type, customConfig.type);
+      expect(duplicated.modelId, customConfig.modelId);
+      expect(duplicated.apiKey, customConfig.apiKey);
+      expect(duplicated.baseUrl, customConfig.baseUrl);
+      expect(duplicated.proxyUrl, customConfig.proxyUrl);
+    });
+
+    testWidgets('increments counter when duplicate key already exists', (tester) async {
+      final defaultConfig = LLMConfig.createDefaultClientConfig();
+      const customConfig = LLMConfig(
+        key: 'myconfig',
+        type: LLMConfig.typeChatCompletion,
+        modelId: 'gpt-4o',
+        apiKey: 'sk-real-key',
+        baseUrl: 'https://custom.example.com/v1',
+      );
+      const existingCopy = LLMConfig(
+        key: 'myconfig_copy',
+        type: LLMConfig.typeChatCompletion,
+        modelId: 'gpt-4o-mini',
+        apiKey: 'sk-other',
+        baseUrl: 'https://other.example.com/v1',
+      );
+      await UserStorage.saveLLMConfigs([defaultConfig, customConfig, existingCopy]);
+      await UserStorage.saveLLMConsent(
+        true,
+        providerType: LLMConfig.typeChatCompletion,
+      );
+
+      // Simulate what ModelConfigListPage._duplicateConfig does:
+      // generate a unique key before passing to edit page
+      final duplicatedConfig = customConfig.duplicate(
+        existingKeys: [defaultConfig.key, customConfig.key, existingCopy.key],
+      );
+
+      await tester.pumpWidget(
+        buildTestableWidget(
+          ModelConfigEditPage(duplicateSource: duplicatedConfig),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.save));
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final configs = await UserStorage.getLLMConfigs();
+      expect(configs.length, 4);
+      expect(configs.any((c) => c.key == 'myconfig_copy_2'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add a duplicate flow for model configurations that pre-fills the edit page from an existing config.
- Generate unique copied keys with `_copy` / `_copy_N` suffixes.
- Align row actions behind a more-actions menu while keeping swipe-to-delete as the fast path.

Closes #50

## Validation

- `dart analyze lib/domain/models/llm_config.dart lib/ui/settings/widgets/model_config_list_page.dart lib/ui/settings/widgets/model_config_edit_page.dart test/domain/models/llm_config_test.dart test/ui/settings/widgets/model_config_edit_page_test.dart`
- `flutter test test/domain/models/llm_config_test.dart test/ui/settings/widgets/model_config_edit_page_test.dart`
