### PR TITLE
[codex] Fix insight language prompt interpolation

### DIFF
--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -393,7 +393,7 @@ $relatedKnowledge
 
   static String knowledgeInsightAgentKnowledgeInsightSkillPrompt(
           String instruction) =>
-      r'''## Skill Name
+      '''## Skill Name
 `update_knowledge_insight`
 
 ## Persona

--- a/test/agent/knowledge_insight_prompt_test.dart
+++ b/test/agent/knowledge_insight_prompt_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/prompts.dart';
+
+void main() {
+  group('Knowledge insight language prompts', () {
+    const zhInstruction =
+        '**Important**: All output text must be in **zh-CN (Simplified Chinese)**.';
+
+    test('skill prompt interpolates the configured language instruction', () {
+      final prompt = Prompts.knowledgeInsightAgentKnowledgeInsightSkillPrompt(
+        zhInstruction,
+      );
+
+      expect(prompt, contains(zhInstruction));
+      expect(prompt, isNot(contains(r'$instruction')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fix the Knowledge Insight skill prompt so the configured language instruction is actually interpolated into the prompt.

## Root cause

`knowledgeInsightAgentKnowledgeInsightSkillPrompt(String instruction)` used a Dart raw triple-quoted string. As a result, `$instruction` was passed through literally instead of being replaced with `UserStorage.l10n.knowledgeInsightLanguageInstruction`. In a Chinese environment, the Knowledge Insight skill could therefore miss the intended Chinese-output constraint, matching the Chinese-title + English-card-content behavior reported in #55.

## Changes

- Remove the raw-string prefix from the Knowledge Insight skill prompt so `$instruction` is interpolated.
- Add a focused regression test that fails if the prompt still contains literal `$instruction` or omits the configured zh-CN instruction.

Fixes #55

## Validation

- `dart analyze lib/agent/prompts.dart test/agent/knowledge_insight_prompt_test.dart`
- `flutter test test/agent/knowledge_insight_prompt_test.dart`
- `git diff --check`