### PR TITLE
优化 Agent 模型默认配置

### DIFF
--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -1250,6 +1250,12 @@ class MemexRouter {
 
   Future<void> resetLLMConfigs() => UserStorage.resetLLMConfigs();
 
+  Future<String> getDefaultLLMConfigKey() =>
+      UserStorage.getDefaultLLMConfigKey();
+
+  Future<void> setDefaultLLMConfigKey(String configKey) =>
+      UserStorage.setDefaultLLMConfigKey(configKey);
+
   Future<AgentConfig> getAgentConfig(String agentId) =>
       UserStorage.getAgentConfig(agentId);
 

--- a/lib/domain/models/agent_config.dart
+++ b/lib/domain/models/agent_config.dart
@@ -1,4 +1,6 @@
 class AgentConfig {
+  static const Object _unset = Object();
+
   /// The key of the LLMConfig to use for this agent.
   final String? llmConfigKey;
 
@@ -19,10 +21,12 @@ class AgentConfig {
   }
 
   AgentConfig copyWith({
-    String? llmConfigKey,
+    Object? llmConfigKey = _unset,
   }) {
     return AgentConfig(
-      llmConfigKey: llmConfigKey ?? this.llmConfigKey,
+      llmConfigKey: identical(llmConfigKey, _unset)
+          ? this.llmConfigKey
+          : llmConfigKey as String?,
     );
   }
 }

--- a/lib/domain/models/agent_definitions.dart
+++ b/lib/domain/models/agent_definitions.dart
@@ -19,4 +19,11 @@ class AgentDefinitions {
     analyzeAssets: 'Media analysis',
     clarificationResolutionAgent: 'Ask resolution',
   };
+
+  /// Agent IDs exposed in the model configuration screen.
+  ///
+  /// Keeping this derived from the display-name registry makes the settings UI
+  /// pick up newly registered built-in agents automatically.
+  static List<String> get configurableAgentIds =>
+      List.unmodifiable(displayNames.keys);
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -631,6 +631,7 @@
   },
   "confirmDeleteConfigMessage": "Are you sure you want to delete \"{key}\"?",
   "defaultLabel": "Default",
+  "setAsDefault": "Set as default",
   "missingApiKey": "Missing API Key",
   "invalidJsonInExtraField": "Invalid JSON in Extra field",
   "keyAlreadyExists": "Key already exists",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2426,6 +2426,12 @@ abstract class AppLocalizations {
   /// **'Default'**
   String get defaultLabel;
 
+  /// No description provided for @setAsDefault.
+  ///
+  /// In en, this message translates to:
+  /// **'Set as default'**
+  String get setAsDefault;
+
   /// No description provided for @missingApiKey.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1319,6 +1319,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get defaultLabel => 'Default';
 
   @override
+  String get setAsDefault => 'Set as default';
+
+  @override
   String get missingApiKey => 'Missing API Key';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1277,6 +1277,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get defaultLabel => '默认';
 
   @override
+  String get setAsDefault => '设为默认';
+
+  @override
   String get missingApiKey => '缺少 API Key';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -631,6 +631,7 @@
   },
   "confirmDeleteConfigMessage": "确定要删除「{key}」吗？",
   "defaultLabel": "默认",
+  "setAsDefault": "设为默认",
   "missingApiKey": "缺少 API Key",
   "invalidJsonInExtraField": "扩展字段 JSON 格式无效",
   "keyAlreadyExists": "该 Key 已存在",

--- a/lib/ui/settings/widgets/agent_config_list_page.dart
+++ b/lib/ui/settings/widgets/agent_config_list_page.dart
@@ -16,19 +16,14 @@ class AgentConfigListPage extends StatefulWidget {
 }
 
 class _AgentConfigListPageState extends State<AgentConfigListPage> {
+  static const String _defaultSelectionValue = '__memex_default_llm_config__';
+
   List<LLMConfig> _llmConfigs = [];
   Map<String, AgentConfig> _agentConfigs = {};
+  String _defaultConfigKey = LLMConfig.defaultClientKey;
   bool _isLoading = true;
 
-  final List<String> _agentIds = [
-    AgentDefinitions.pkmAgent,
-    AgentDefinitions.cardAgent,
-    AgentDefinitions.profileAgent,
-    AgentDefinitions.knowledgeInsightAgent,
-    AgentDefinitions.commentAgent,
-    AgentDefinitions.chatAgent,
-    AgentDefinitions.analyzeAssets,
-  ];
+  final List<String> _agentIds = AgentDefinitions.configurableAgentIds;
 
   @override
   void initState() {
@@ -39,16 +34,19 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
   Future<void> _loadData() async {
     setState(() => _isLoading = true);
     try {
-      final configs = await MemexRouter().getLLMConfigs();
+      final router = MemexRouter();
+      final configs = await router.getLLMConfigs();
+      final defaultConfigKey = await router.getDefaultLLMConfigKey();
       final agentConfigs = <String, AgentConfig>{};
 
       for (var agentId in _agentIds) {
-        agentConfigs[agentId] = await MemexRouter().getAgentConfig(agentId);
+        agentConfigs[agentId] = await router.getAgentConfig(agentId);
       }
 
       if (mounted) {
         setState(() {
           _llmConfigs = configs;
+          _defaultConfigKey = defaultConfigKey;
           _agentConfigs = agentConfigs;
           _isLoading = false;
         });
@@ -106,7 +104,9 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
   }
 
   LLMConfig? _effectiveConfig(String? selectedKey) =>
-      _findConfig(selectedKey) ?? _findConfig(LLMConfig.defaultClientKey);
+      _findConfig(selectedKey) ??
+      _findConfig(_defaultConfigKey) ??
+      _findConfig(LLMConfig.defaultClientKey);
 
   bool _isKnownMultimodalConfig(LLMConfig config) =>
       LLMConfig.isKnownMultimodal(config.type, config.modelId);
@@ -201,7 +201,12 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                 final currentConfig =
                     _agentConfigs[agentId] ?? const AgentConfig();
                 final selectedKey = currentConfig.llmConfigKey;
+                final selectedConfig = _findConfig(selectedKey);
+                final usesDefault =
+                    selectedKey == null || selectedConfig == null;
                 final effectiveConfig = _effectiveConfig(selectedKey);
+                final dropdownValue =
+                    usesDefault ? _defaultSelectionValue : selectedKey;
 
                 return Container(
                   margin: const EdgeInsets.only(bottom: 12),
@@ -236,7 +241,7 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                           color: AppColors.textTertiary,
                         ),
                       ),
-                      if (selectedKey == null && effectiveConfig != null) ...[
+                      if (usesDefault && effectiveConfig != null) ...[
                         const SizedBox(height: 4),
                         Text(
                           '$_defaultModelPrefix: ${effectiveConfig.key} / ${effectiveConfig.modelId}',
@@ -250,13 +255,26 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                       const SizedBox(height: 12),
                       DropdownButtonFormField<String>(
                         key: ValueKey(
-                          'agent-model-$agentId-${selectedKey ?? ''}',
+                          'agent-model-$agentId-$dropdownValue-$_defaultConfigKey',
                         ),
-                        initialValue: selectedKey,
+                        initialValue: dropdownValue,
                         isExpanded: true,
                         decoration: _dropdownDecoration(),
                         hint: const Text(''),
                         items: [
+                          DropdownMenuItem<String>(
+                            value: _defaultSelectionValue,
+                            child: Text(
+                              effectiveConfig == null
+                                  ? UserStorage.l10n.defaultLabel
+                                  : '$_defaultModelPrefix: ${effectiveConfig.key} / ${effectiveConfig.modelId}',
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                fontSize: 14,
+                                color: AppColors.textPrimary,
+                              ),
+                            ),
+                          ),
                           ..._llmConfigs.map((config) {
                             return DropdownMenuItem<String>(
                               value: config.key,
@@ -300,8 +318,12 @@ class _AgentConfigListPageState extends State<AgentConfigListPage> {
                           }),
                         ],
                         onChanged: (String? newValue) {
-                          if (newValue != selectedKey) {
-                            _updateAgentModelConfig(agentId, newValue);
+                          final effectiveValue =
+                              newValue == _defaultSelectionValue
+                                  ? null
+                                  : newValue;
+                          if (effectiveValue != selectedKey) {
+                            _updateAgentModelConfig(agentId, effectiveValue);
                           }
                         },
                       ),

--- a/lib/ui/settings/widgets/model_config_edit_page.dart
+++ b/lib/ui/settings/widgets/model_config_edit_page.dart
@@ -15,8 +15,14 @@ import 'package:memex/ui/core/themes/app_colors.dart';
 class ModelConfigEditPage extends StatefulWidget {
   final LLMConfig? config;
   final LLMConfig? duplicateSource;
+  final bool isDefaultConfig;
 
-  const ModelConfigEditPage({super.key, this.config, this.duplicateSource});
+  const ModelConfigEditPage({
+    super.key,
+    this.config,
+    this.duplicateSource,
+    this.isDefaultConfig = false,
+  });
 
   @override
   State<ModelConfigEditPage> createState() => _ModelConfigEditPageState();
@@ -916,7 +922,8 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
 
   @override
   Widget build(BuildContext context) {
-    final isDefault = widget.config?.isDefault ?? false;
+    final isBuiltInDefault = widget.config?.isDefault ?? false;
+    final locksKey = isBuiltInDefault || widget.isDefaultConfig;
 
     return PopScope(
       canPop: !_hasChanges,
@@ -939,7 +946,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                 : UserStorage.l10n.editConfiguration,
           ),
           actions: [
-            if (isDefault)
+            if (isBuiltInDefault)
               IconButton(
                 icon: const Icon(Icons.restore),
                 tooltip: UserStorage.l10n.resetToDefaults,
@@ -1010,7 +1017,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
                   helperText: UserStorage.l10n.keyIdHelper,
                   border: const OutlineInputBorder(),
                 ),
-                enabled: !isDefault, // Default keys cannot be changed
+                enabled: !locksKey,
                 validator: (value) {
                   if (value == null || value.isEmpty) {
                     return UserStorage.l10n.required;

--- a/lib/ui/settings/widgets/model_config_list_page.dart
+++ b/lib/ui/settings/widgets/model_config_list_page.dart
@@ -17,6 +17,7 @@ class ModelConfigListPage extends StatefulWidget {
 
 class _ModelConfigListPageState extends State<ModelConfigListPage> {
   List<LLMConfig> _configs = [];
+  String _defaultConfigKey = LLMConfig.defaultClientKey;
   bool _isLoading = true;
 
   String _providerDisplayName(String type) {
@@ -68,16 +69,20 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
 
   Future<void> _loadConfigs() async {
     setState(() => _isLoading = true);
-    final configs = await MemexRouter().getLLMConfigs();
+    final router = MemexRouter();
+    final configs = await router.getLLMConfigs();
+    final defaultConfigKey = await router.getDefaultLLMConfigKey();
+    if (!mounted) return;
     setState(() {
       _configs = configs;
+      _defaultConfigKey = defaultConfigKey;
       _isLoading = false;
     });
   }
 
   Future<List<String>> _getAgentsUsingConfig(String configKey) async {
     final usedByagents = <String>[];
-    for (var agentId in AgentDefinitions.displayNames.keys) {
+    for (var agentId in AgentDefinitions.configurableAgentIds) {
       final config = await MemexRouter().getAgentConfig(agentId);
       if (config.llmConfigKey == configKey) {
         usedByagents.add(AgentDefinitions.displayNames[agentId] ?? agentId);
@@ -86,9 +91,11 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
     return usedByagents;
   }
 
+  bool _isDefaultConfig(LLMConfig config) => config.key == _defaultConfigKey;
+
   Future<bool> _confirmDeleteConfig(LLMConfig config) async {
     final l10n = UserStorage.l10n;
-    if (config.isDefault) {
+    if (_isDefaultConfig(config) || config.isDefault) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.cannotDeleteDefaultConfiguration)),
       );
@@ -150,6 +157,23 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
     }
   }
 
+  Future<void> _setDefaultConfig(LLMConfig config) async {
+    final l10n = UserStorage.l10n;
+    try {
+      await MemexRouter().setDefaultLLMConfigKey(config.key);
+      await _loadConfigs();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.modelSetAsDefault(config.modelId))),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.saveConfigFailed(e.toString()))),
+      );
+    }
+  }
+
   void _editConfig(LLMConfig? config, {LLMConfig? duplicateSource}) async {
     final result = await Navigator.push<bool>(
       context,
@@ -157,6 +181,7 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
         builder: (context) => ModelConfigEditPage(
           config: config,
           duplicateSource: duplicateSource,
+          isDefaultConfig: config != null && _isDefaultConfig(config),
         ),
       ),
     );
@@ -248,12 +273,14 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                     itemCount: _configs.length,
                     itemBuilder: (context, index) {
                       final config = _configs[index];
+                      final isDefaultConfig = _isDefaultConfig(config);
+                      final canDelete = !isDefaultConfig && !config.isDefault;
 
                       return Dismissible(
                         key: Key(config.key),
-                        direction: config.isDefault
-                            ? DismissDirection.none
-                            : DismissDirection.endToStart,
+                        direction: canDelete
+                            ? DismissDirection.endToStart
+                            : DismissDirection.none,
                         background: Container(
                           color: Colors.red,
                           alignment: Alignment.centerRight,
@@ -285,7 +312,7 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                                   maxLines: 1,
                                 ),
                               ),
-                              if (config.isDefault)
+                              if (isDefaultConfig)
                                 Container(
                                   margin: const EdgeInsets.only(left: 8),
                                   padding: const EdgeInsets.symmetric(
@@ -380,6 +407,8 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                             onSelected: (value) {
                               if (value == 'duplicate') {
                                 _duplicateConfig(config);
+                              } else if (value == 'set_default') {
+                                _setDefaultConfig(config);
                               } else if (value == 'delete') {
                                 _deleteConfig(config);
                               }
@@ -397,7 +426,21 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
                                     ],
                                   ),
                                 ),
-                                if (!config.isDefault)
+                                if (!isDefaultConfig)
+                                  PopupMenuItem<String>(
+                                    value: 'set_default',
+                                    child: Row(
+                                      children: [
+                                        const Icon(
+                                          Icons.star_outline,
+                                          size: 20,
+                                        ),
+                                        const SizedBox(width: 8),
+                                        Text(l10n.setAsDefault),
+                                      ],
+                                    ),
+                                  ),
+                                if (canDelete)
                                   PopupMenuItem<String>(
                                     value: 'delete',
                                     child: Row(

--- a/lib/utils/user_storage.dart
+++ b/lib/utils/user_storage.dart
@@ -144,6 +144,7 @@ class UserStorage {
   }
 
   static const String _keyLLMConfigs = 'llm_client_configs';
+  static const String _keyDefaultLLMConfigKey = 'default_llm_config_key';
 
   /// Get stored LLM config list. Creates default config if none.
   static Future<List<LLMConfig>> getLLMConfigs() async {
@@ -182,9 +183,62 @@ class UserStorage {
       final prefs = await SharedPreferences.getInstance();
       final jsonString = jsonEncode(configs.map((c) => c.toJson()).toList());
       await prefs.setString(_keyLLMConfigs, jsonString);
+
+      final defaultKey = prefs.getString(_keyDefaultLLMConfigKey);
+      if (defaultKey != null && !configs.any((c) => c.key == defaultKey)) {
+        if (configs.any((c) => c.key == LLMConfig.defaultClientKey)) {
+          await prefs.setString(
+              _keyDefaultLLMConfigKey, LLMConfig.defaultClientKey);
+        } else {
+          await prefs.remove(_keyDefaultLLMConfigKey);
+        }
+      }
     } catch (e) {
       throw Exception(UserStorage.l10n.saveLlmConfigFailed(e));
     }
+  }
+
+  /// Get the globally selected default LLM config key.
+  ///
+  /// Agents without an explicit model selection use this key. The legacy
+  /// `default` config remains the fallback so existing installs keep working.
+  static Future<String> getDefaultLLMConfigKey() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final configs = await getLLMConfigs();
+      final storedKey = prefs.getString(_keyDefaultLLMConfigKey);
+
+      if (storedKey != null && configs.any((c) => c.key == storedKey)) {
+        return storedKey;
+      }
+
+      final fallbackKey = configs.any((c) => c.key == LLMConfig.defaultClientKey)
+          ? LLMConfig.defaultClientKey
+          : configs.isNotEmpty
+              ? configs.first.key
+              : LLMConfig.defaultClientKey;
+
+      if (configs.any((c) => c.key == fallbackKey)) {
+        await prefs.setString(_keyDefaultLLMConfigKey, fallbackKey);
+      }
+      return fallbackKey;
+    } catch (e) {
+      return LLMConfig.defaultClientKey;
+    }
+  }
+
+  /// Set the globally selected default LLM config key.
+  static Future<void> setDefaultLLMConfigKey(String configKey) async {
+    final configs = await getLLMConfigs();
+    final exists = configs.any((c) => c.key == configKey);
+    if (!exists) {
+      final availableKeys = configs.map((c) => c.key).join(', ');
+      throw Exception(
+          'Invalid default LLM Config Key: $configKey. Available keys: $availableKeys');
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_keyDefaultLLMConfigKey, configKey);
   }
 
   static const String _keyLanguage = 'language';
@@ -354,6 +408,7 @@ class UserStorage {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(_keyLLMConfigs);
+      await prefs.remove(_keyDefaultLLMConfigKey);
       // Force reload to ensure defaults are re-populated
       await getLLMConfigs();
     } catch (e) {
@@ -390,7 +445,9 @@ class UserStorage {
 
     // If no user-set key, use the provided default for this agent
     if (keyToUse == null || keyToUse.isEmpty) {
-      keyToUse = defaultClientKey;
+      keyToUse = defaultClientKey == LLMConfig.defaultClientKey
+          ? await getDefaultLLMConfigKey()
+          : defaultClientKey;
     }
 
     if (keyToUse == null) {

--- a/test/ui/settings/model_agent_config_pages_test.dart
+++ b/test/ui/settings/model_agent_config_pages_test.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/agent_definitions.dart';
+import 'package:memex/domain/models/llm_config.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+import 'package:memex/ui/settings/widgets/agent_config_list_page.dart';
+import 'package:memex/ui/settings/widgets/model_config_list_page.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tempDir;
+  late LLMConfig builtInDefault;
+  late LLMConfig customDefault;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    tempDir = await Directory.systemTemp.createTemp('memex_widget_test_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, (call) async {
+      switch (call.method) {
+        case 'getApplicationDocumentsDirectory':
+          return tempDir.path;
+        default:
+          return null;
+      }
+    });
+
+    await UserStorage.initL10n();
+    builtInDefault = LLMConfig.createDefaultClientConfig();
+    customDefault = builtInDefault.copyWith(
+      key: 'custom',
+      modelId: 'custom-model',
+      apiKey: 'test-key',
+    );
+    await UserStorage.saveLLMConfigs([builtInDefault, customDefault]);
+  });
+
+  tearDown(() async {
+    await LocalAssetServer.stopServer();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Future<void> pumpSettingsPage(WidgetTester tester, Widget page) async {
+    await tester.pumpWidget(MaterialApp(home: page));
+    for (var i = 0; i < 6; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+  }
+
+  Future<void> stopLocalAssetServer(WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await LocalAssetServer.stopServer();
+    });
+  }
+
+  testWidgets('model config page can set a custom config as default',
+      (tester) async {
+    await pumpSettingsPage(tester, const ModelConfigListPage());
+
+    expect(await UserStorage.getDefaultLLMConfigKey(), builtInDefault.key);
+    expect(find.text('custom'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.more_vert).last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(UserStorage.l10n.setAsDefault));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(await UserStorage.getDefaultLLMConfigKey(), customDefault.key);
+    expect(
+      find.text(UserStorage.l10n.modelSetAsDefault(customDefault.modelId)),
+      findsOneWidget,
+    );
+    await stopLocalAssetServer(tester);
+  });
+
+  testWidgets(
+      'agent config page discovers registered agents and shows default choice',
+      (tester) async {
+    await UserStorage.setDefaultLLMConfigKey(customDefault.key);
+
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    await pumpSettingsPage(tester, const AgentConfigListPage());
+
+    expect(
+        find.text(AgentDefinitions.displayNames[AgentDefinitions.chatAgent]!),
+        findsOneWidget);
+    expect(
+      find.text(
+        AgentDefinitions
+            .displayNames[AgentDefinitions.clarificationResolutionAgent]!,
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Default: custom / custom-model'), findsWidgets);
+    await stopLocalAssetServer(tester);
+  });
+}

--- a/test/utils/user_storage_llm_config_test.dart
+++ b/test/utils/user_storage_llm_config_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/agent_config.dart';
+import 'package:memex/domain/models/agent_definitions.dart';
+import 'package:memex/domain/models/llm_config.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('UserStorage LLM defaults', () {
+    test('agents without explicit config use selected global default',
+        () async {
+      final defaultConfig = LLMConfig.createDefaultClientConfig();
+      final customConfig = defaultConfig.copyWith(
+        key: 'fast',
+        modelId: 'gpt-fast',
+      );
+
+      await UserStorage.saveLLMConfigs([defaultConfig, customConfig]);
+      expect(
+        await UserStorage.getDefaultLLMConfigKey(),
+        LLMConfig.defaultClientKey,
+      );
+
+      await UserStorage.setDefaultLLMConfigKey(customConfig.key);
+
+      final resolved = await UserStorage.getAgentLLMConfig(
+        AgentDefinitions.chatAgent,
+        defaultClientKey: LLMConfig.defaultClientKey,
+      );
+
+      expect(await UserStorage.getDefaultLLMConfigKey(), customConfig.key);
+      expect(resolved.key, customConfig.key);
+      expect(resolved.modelId, customConfig.modelId);
+    });
+
+    test('removed selected default falls back to legacy default config',
+        () async {
+      final defaultConfig = LLMConfig.createDefaultClientConfig();
+      final customConfig = defaultConfig.copyWith(key: 'custom');
+
+      await UserStorage.saveLLMConfigs([defaultConfig, customConfig]);
+      await UserStorage.setDefaultLLMConfigKey(customConfig.key);
+      await UserStorage.saveLLMConfigs([defaultConfig]);
+
+      expect(
+        await UserStorage.getDefaultLLMConfigKey(),
+        LLMConfig.defaultClientKey,
+      );
+    });
+
+    test('AgentConfig.copyWith can clear explicit model selection', () {
+      const config = AgentConfig(llmConfigKey: 'custom');
+
+      expect(config.copyWith(llmConfigKey: null).llmConfigKey, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## 背景

Closes #57。模型配置页需要支持将任意配置设为全局默认，Agent 配置页也需要从注册表自动发现可配置 Agent，避免新增 Agent 后漏出现在设置页。

Issue 当前仍带有 `needs product decision` 标签，因此先以 Draft PR 提交实现，方便 maintainer 最终确认产品方向。

## 变更

- 在 `UserStorage`/`MemexRouter` 增加全局默认模型配置 key 的读写，并保留 legacy `default` 配置作为兼容回退。
- 模型配置列表新增“设为默认”菜单项、默认标记，并禁止删除当前默认配置；同时兼容 main 上已有的“复制配置”菜单。
- Agent 配置页改为通过 `AgentDefinitions.configurableAgentIds` 自动发现 Agent，并提供“默认使用”下拉项以回到全局默认模型。
- 更新中英文 l10n，并补充默认模型和 Agent 配置页相关 widget/unit tests。

## 验证

- `dart analyze lib/utils/user_storage.dart lib/data/repositories/memex_router.dart lib/domain/models/agent_config.dart lib/domain/models/agent_definitions.dart lib/ui/settings/widgets/agent_config_list_page.dart lib/ui/settings/widgets/model_config_list_page.dart lib/ui/settings/widgets/model_config_edit_page.dart test/utils/user_storage_llm_config_test.dart test/ui/settings/model_agent_config_pages_test.dart`
- `flutter test test/utils/user_storage_llm_config_test.dart test/ui/settings/model_agent_config_pages_test.dart test/domain/models/llm_config_test.dart test/ui/settings/widgets/model_config_edit_page_test.dart`
- `flutter analyze --no-fatal-infos --no-fatal-warnings`，命令退出码为 0；仓库仍有既有 warning/info 噪声。

## 冲突检查

已基于最新 `upstream/main` 重新应用改动，并解决了与 #52 复制模型配置功能在模型配置列表/编辑页上的冲突。当前分支只包含 issue #57 相关文件变更。