### PR TITLE
[codex] 修复首页输入框返回键行为

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ result.when(
 - `ListenableBuilder(listenable: Listenable.merge([vm, vm.load]))` for reactive rebuilds
 - `ToastHelper.showSuccess/showError/showInfo` for feedback
 - `showGeneralDialog` with `AgentChatDialog` for AI chat overlays
+- Any interaction UI change must include a widget test covering the behavior.
 
 ### Timeline Screen boundaries
 
@@ -128,4 +129,3 @@ Two approaches — pick the right one based on string length:
 - **Multi-line text** (long descriptions, agent prompts, onboarding copy): defined directly in `AppLocalizationsExt` (`lib/l10n/app_localizations_ext.dart`) as Dart code — better readability than JSON for multi-line content.
 
 Access all strings via `UserStorage.l10n` (static, initialized in `main()`).
-

--- a/lib/ui/main_screen/widgets/input_sheet.dart
+++ b/lib/ui/main_screen/widgets/input_sheet.dart
@@ -381,8 +381,8 @@ class _InputSheetState extends State<InputSheet>
     await _draftService.saveTextDraft(_textController.text);
   }
 
-  Future<void> _handleClose() async {
-    await _flushDraft();
+  void _handleClose() {
+    unawaited(_flushDraft());
     widget.onClose();
   }
 
@@ -1265,6 +1265,14 @@ class _InputSheetState extends State<InputSheet>
 
     return Stack(
       children: [
+        PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (didPop, result) {
+            if (didPop || !widget.isOpen) return;
+            _handleClose();
+          },
+          child: const SizedBox.shrink(),
+        ),
         FadeTransition(
           opacity: _fadeAnimation,
           child: GestureDetector(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -330,7 +330,7 @@ packages:
     source: hosted
     version: "0.3.5+1"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   intl: ^0.20.2
   uuid: ^4.3.3
   collection: ^1.18.0
+  crypto: ^3.0.7
   dart_jsonwebtoken: ^2.9.1
   logging: ^1.2.0
   share_handler: ^0.0.25

--- a/test/ui/main_screen/widgets/input_sheet_test.dart
+++ b/test/ui/main_screen/widgets/input_sheet_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/main_screen/widgets/input_sheet.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory testDataRoot;
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({'user_id': 'input-sheet-test'});
+    await UserStorage.initL10n();
+
+    testDataRoot = await Directory.systemTemp.createTemp('memex_input_sheet_');
+    await FileSystemService.init(testDataRoot.path);
+  });
+
+  tearDownAll(() async {
+    await LocalAssetServer.stopServer();
+    if (await testDataRoot.exists()) {
+      await testDataRoot.delete(recursive: true);
+    }
+  });
+
+  Widget buildHost() {
+    var isOpen = true;
+    var closeCount = 0;
+
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: StatefulBuilder(
+          builder: (context, setState) {
+            return Stack(
+              children: [
+                const Center(child: Text('Home content')),
+                InputSheet(
+                  isOpen: isOpen,
+                  initialData: InputData(text: 'started note'),
+                  onClose: () {
+                    setState(() {
+                      isOpen = false;
+                      closeCount += 1;
+                    });
+                  },
+                  onSubmit: (_) async => true,
+                ),
+                Text('close count: $closeCount'),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  testWidgets('Android back closes the open input sheet without popping home', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildHost());
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(find.text('Home content'), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'typed before back');
+    await tester.pump();
+
+    final handled = await tester.binding.handlePopRoute();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(handled, isTrue);
+    expect(find.text('Home content'), findsOneWidget);
+    expect(find.byType(TextField), findsNothing);
+    expect(find.text('close count: 1'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 背景

Closes #62

首页点击加号打开输入框后，Android 系统返回键应该保持原生交互节奏：键盘打开时第一次返回先收起键盘，键盘收起后第二次返回关闭输入框，并继续停留在首页。当前输入框打开时没有消费外层 route pop，可能让返回事件继续传递并退出应用。

## 改动

- 在 `InputSheet` 打开时通过 `PopScope` 消费系统返回，并关闭输入框。
- 关闭输入框时不再等待草稿写入完成，先响应 UI，再异步保存草稿。
- 增加首页输入框返回键行为的 widget test。
- 补充 `crypto` 直接依赖，避免 `input_sheet.dart` 已有 import 触发 analyze 依赖告警。
- 在 `AGENTS.md` 固化交互 UI 改动需要 widget test 的约定。

## 验证

- `dart format --set-exit-if-changed lib/ui/main_screen/widgets/input_sheet.dart test/ui/main_screen/widgets/input_sheet_test.dart`
- `flutter test test/ui/main_screen/widgets/input_sheet_test.dart`
- `flutter analyze lib/ui/main_screen/widgets/input_sheet.dart test/ui/main_screen/widgets/input_sheet_test.dart`
- `git diff --check`
- Android API 35 模拟器手动验证：第一次返回收起键盘，第二次返回关闭输入框，应用仍停留在首页。