### PR TITLE
收紧 SuperAgent 的 memory 写入边界

### DIFF
--- a/lib/agent/memory/memory_management.dart
+++ b/lib/agent/memory/memory_management.dart
@@ -407,6 +407,31 @@ While executing your primary directive, **silently observe** the conversation fo
 ''';
   }
 
+  Future<String> buildSuperAgentMemoryManagementPrompt() async {
+    final basePrompt = await buildMemoryManagementPrompt();
+    return '''$basePrompt
+
+## SuperAgent Memory Boundary (Conservative Mode)
+SuperAgent often searches and summarizes existing workspace history. Apply these extra rules when deciding whether to call `append_memories`:
+- Treat retrieved Facts, PKM files, chat history, existing memory, and event logs as read-only evidence. Do not convert them into new memories by themselves.
+- Only write memory when the current conversation introduces or explicitly confirms durable user profile information, or when the user explicitly asks you to remember/update memory.
+- Deduplicate against `<user_memory_context>`; do not rewrite or paraphrase information that is already known.
+''';
+  }
+
+  Future<String> buildMemoryReadOnlyPrompt() async {
+    return '''## Memory System Capabilities (Read-Only Context)
+You have access to the user's long-term memory context as **reference material only**.
+**Primary Directive**: Use the `<user_memory_context>` block to tailor your response to the user's preferences, active projects, and constraints.
+
+---
+### 🧠 Core Memory Logic
+1. **Recall Only**: Use the context provided in the `<user_memory_context>` block to answer the user's immediate request accurately and helpfully.
+2. **No Memory Updates**: You cannot and must not create, update, delete, or propose changes to memory in this mode.
+3. **Read-Only Task Boundary**: When searching, summarizing, listing, or comparing existing Facts/PKM/history/chat records, treat all retrieved information as read-only evidence for the answer, not as new memory candidates.
+''';
+  }
+
   Future<String> buildMemoryPrompt() async {
     return _runWithMemoryLock(() async {
       final mem = await _loadMemory();

--- a/lib/agent/super_agent/super_agent.dart
+++ b/lib/agent/super_agent/super_agent.dart
@@ -95,8 +95,9 @@ class SuperAgent {
       userId: userId,
       sourceAgent: name,
     );
-    final memoryManagementPrompt =
-        await memoryManagement.buildMemoryManagementPrompt();
+    final memorySystemPrompt = quickQuery
+        ? await memoryManagement.buildMemoryReadOnlyPrompt()
+        : await memoryManagement.buildSuperAgentMemoryManagementPrompt();
     if (!quickQuery) {
       final memoryManagementTools =
           memoryManagement.buildMemoryManagementTools();
@@ -126,7 +127,7 @@ class SuperAgent {
       }
     }
 
-    final systemPrompts = [superAgentSystemPrompt, memoryManagementPrompt];
+    final systemPrompts = [superAgentSystemPrompt, memorySystemPrompt];
     if (quickQuery) {
       systemPrompts.add(
         '## Quick Query Mode\n'


### PR DESCRIPTION
## 背景

修复 #64。普通 Chat / SuperAgent 在处理“查询历史、总结历史、列 ideas/todos”等任务时，虽然用户没有表达写入 memory 的意图，但模型仍可能因为读写版 memory prompt 的“后台观察”指令和写工具暴露，调用 `append_memories` 写入长期记忆。

## 方案判断

这次把 memory prompt 按 Agent 职责分层，而不是直接收紧共享 prompt，避免影响面过大：

| Agent | 适合的 memory 策略 |
| --- | --- |
| SuperAgent - Quick Query | 只读 memory context；不挂 `append_memories`，不注入写 memory prompt。 |
| SuperAgent - 普通 Chat | 使用 SuperAgent 专属保守读写 prompt；允许写当前对话中新产生/明确确认的长期信息，但不把历史检索结果当成新 memory。 |
| MemoryAgent | 保持专用 Strict Memory Curator prompt，不受本次改动影响。 |
| ClarificationResolutionAgent | 保持专用 clarification resolution prompt，不受本次改动影响。 |
| PkmAgent / CardAgent | 继续只读 `buildMemoryPrompt()`，不挂写工具。 |
| CommentAgent / CompanionAgent / KnowledgeInsightAgent | 继续使用原共享读写 prompt；不套 SuperAgent 的历史查询边界，避免误伤角色对话、评论和洞察链路。 |

## 改动

- 新增 `buildMemoryReadOnlyPrompt()`，用于 Quick Query / 只读模式。
- 新增 `buildSuperAgentMemoryManagementPrompt()`，在原共享读写 prompt 之上追加 SuperAgent 专属保守边界。
- SuperAgent 根据 `quickQuery` 选择只读 prompt 或 SuperAgent 专属读写 prompt。
- 保留原 `buildMemoryManagementPrompt()` 行为，避免改变 CommentAgent、CompanionAgent、KnowledgeInsightAgent 等链路。

## 验证

- `flutter pub get`
- `dart analyze lib/agent/memory/memory_management.dart lib/agent/super_agent/super_agent.dart`

## 说明

这次没有改成写入前用户确认，也没有增加审计日志；目标是保持现有自动 memory 能力，但让 SuperAgent 的只读入口和查询型任务边界更清楚。