### PR TITLE
修复后台任务导致的启动 crash loop

### DIFF
--- a/lib/data/services/local_task_executor.dart
+++ b/lib/data/services/local_task_executor.dart
@@ -67,6 +67,7 @@ class LocalTaskExecutor {
   static const Duration _pollInterval = Duration(seconds: 1);
   static const String _crashGuardBucket = 'local_task_executor_crash_guard';
   static const String _activeTaskMarkerKeyPrefix = 'active_task_marker:';
+  static const String _gracefulExitMarkerKey = 'graceful_exit_marker';
   static const int crashLoopFailureThreshold = 2;
   static const Duration crashLikeExitWindow = Duration(minutes: 10);
 
@@ -129,6 +130,32 @@ class LocalTaskExecutor {
     _isRunning = false;
     _pollTimer?.cancel();
     _logger.info('LocalTaskExecutor stopped');
+  }
+
+  Future<void> recordGracefulShutdown({String reason = 'unknown'}) async {
+    if (!AppDatabase.isInitialized) return;
+
+    final marker = _GracefulExitMarker(
+      markedAt: DateTime.now(),
+      reason: reason,
+    );
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    await _db.into(_db.kvStore).insertOnConflictUpdate(
+          KvStoreCompanion.insert(
+            key: _gracefulExitMarkerKey,
+            value: Value(jsonEncode(marker.toJson())),
+            bucket: const Value(_crashGuardBucket),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> clearGracefulShutdownMarker() async {
+    if (!AppDatabase.isInitialized) return;
+
+    await (_db.delete(_db.kvStore)
+          ..where((kv) => kv.key.equals(_gracefulExitMarkerKey)))
+        .go();
   }
 
   // Max concurrent tasks
@@ -417,10 +444,12 @@ class LocalTaskExecutor {
     try {
       final markers = await _loadTaskExecutionMarkers();
       if (markers.isEmpty) return;
+      final gracefulExitMarker = await _loadGracefulExitMarker();
 
       for (final marker in markers) {
-        await _handlePreviousExecutionMarker(marker);
+        await _handlePreviousExecutionMarker(marker, gracefulExitMarker);
       }
+      await _deleteGracefulExitMarker();
     } catch (e, stack) {
       _logger.severe(
         'Failed to handle previous task execution markers',
@@ -432,6 +461,7 @@ class LocalTaskExecutor {
 
   Future<void> _handlePreviousExecutionMarker(
     _TaskExecutionMarker marker,
+    _GracefulExitMarker? gracefulExitMarker,
   ) async {
     final task = await (_db.select(
       _db.tasks,
@@ -445,6 +475,15 @@ class LocalTaskExecutor {
     if (!marker.matchesTask(task)) {
       _logger.warning(
         'Ignoring stale crash guard marker for task ${marker.taskId}: task metadata changed',
+      );
+      await _deleteTaskExecutionMarker(marker.taskId);
+      return;
+    }
+
+    if (gracefulExitMarker != null &&
+        !gracefulExitMarker.markedAt.isBefore(marker.startedAt)) {
+      _logger.info(
+        'Ignoring crash guard marker for task ${marker.taskId}: previous app exit was graceful (${gracefulExitMarker.reason})',
       );
       await _deleteTaskExecutionMarker(marker.taskId);
       return;
@@ -480,6 +519,7 @@ class LocalTaskExecutor {
   }
 
   Future<void> _markTaskExecutionStarted(Task task) async {
+    await clearGracefulShutdownMarker();
     final existing = await _loadTaskExecutionMarker(task.id);
     final marker = _TaskExecutionMarker.fromTask(
       task,
@@ -533,6 +573,29 @@ class LocalTaskExecutor {
     }
 
     return markers;
+  }
+
+  Future<_GracefulExitMarker?> _loadGracefulExitMarker() async {
+    final row = await (_db.select(_db.kvStore)
+          ..where((kv) => kv.key.equals(_gracefulExitMarkerKey)))
+        .getSingleOrNull();
+    if (row?.value == null) return null;
+
+    try {
+      return _GracefulExitMarker.fromJson(
+        jsonDecode(row!.value!) as Map<String, dynamic>,
+      );
+    } catch (e) {
+      _logger.warning('Failed to parse graceful exit marker: $e');
+      await _deleteGracefulExitMarker();
+      return null;
+    }
+  }
+
+  Future<void> _deleteGracefulExitMarker() async {
+    await (_db.delete(_db.kvStore)
+          ..where((kv) => kv.key.equals(_gracefulExitMarkerKey)))
+        .go();
   }
 
   Future<void> _saveTaskExecutionMarker(_TaskExecutionMarker marker) async {
@@ -607,6 +670,13 @@ class LocalTaskExecutor {
       _db.kvStore,
     )..where((kv) => kv.key.like('$_activeTaskMarkerKeyPrefix%')))
         .get();
+  }
+
+  @visibleForTesting
+  Future<KvStoreData?> getGracefulExitMarkerForTesting() {
+    return (_db.select(_db.kvStore)
+          ..where((kv) => kv.key.equals(_gracefulExitMarkerKey)))
+        .getSingleOrNull();
   }
 
   /// Check if a task of [taskType] with [bizId] has failed.
@@ -795,5 +865,31 @@ class _TaskExecutionMarker {
 
   static String _payloadHashFor(String? payload) {
     return sha256.convert(utf8.encode(payload ?? '')).toString();
+  }
+}
+
+class _GracefulExitMarker {
+  _GracefulExitMarker({
+    required this.markedAt,
+    required this.reason,
+  });
+
+  final DateTime markedAt;
+  final String reason;
+
+  factory _GracefulExitMarker.fromJson(Map<String, dynamic> json) {
+    return _GracefulExitMarker(
+      markedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['marked_at_ms'] as int,
+      ),
+      reason: json['reason'] as String? ?? 'unknown',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'marked_at_ms': markedAt.millisecondsSinceEpoch,
+      'reason': reason,
+    };
   }
 }

--- a/lib/data/services/local_task_executor.dart
+++ b/lib/data/services/local_task_executor.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
-import 'package:meta/meta.dart';
 import 'dart:convert';
-import 'package:logging/logging.dart';
+
+import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
 import 'package:memex/db/app_database.dart';
-import 'package:memex/utils/logger.dart';
 import 'package:memex/domain/models/task_exceptions.dart';
+import 'package:memex/utils/logger.dart';
 
 /// Context for task execution
 class TaskContext {
@@ -63,6 +65,10 @@ class LocalTaskExecutor {
 
   // Polling interval
   static const Duration _pollInterval = Duration(seconds: 1);
+  static const String _crashGuardBucket = 'local_task_executor_crash_guard';
+  static const String _activeTaskMarkerKeyPrefix = 'active_task_marker:';
+  static const int crashLoopFailureThreshold = 2;
+  static const Duration crashLikeExitWindow = Duration(minutes: 10);
 
   /// Stream that emits true if there are any active (pending, processing, retrying) tasks in the DB.
   /// Useful for global UI loading indicators.
@@ -86,6 +92,11 @@ class LocalTaskExecutor {
   Future<void> start({String? userId}) async {
     if (_isRunning) return;
     _currentUserId = userId; // Store for use in worker loop
+
+    // Detect whether the previous process exited while a task was running.
+    // This must happen before resetting stale tasks, otherwise we lose the only
+    // durable signal that a crash-like exit happened during task execution.
+    await _handlePreviousExecutionMarkers();
 
     // Reset any stale 'processing' tasks that might have been left over from a crash
     await _resetStaleTasks();
@@ -245,7 +256,7 @@ class LocalTaskExecutor {
           } catch (e) {
             _logger.warning(
                 'Failed to parse dependencies for task ${task.id}: $e');
-            // If parsing fails, assume dependencies met or fail? Safe to skip.
+            await _failTask(task, 'Invalid task dependencies: $e');
             dependenciesMet = false;
           }
         }
@@ -292,6 +303,7 @@ class LocalTaskExecutor {
           updatedAt: Value(now),
         ),
       );
+      await _markTaskExecutionStarted(task);
 
       final handler = _handlers[task.type];
       if (handler == null) {
@@ -304,12 +316,9 @@ class LocalTaskExecutor {
 
       final currentUserId = _currentUserId;
       if (currentUserId == null) {
-        _logger.severe(
-            'Task execution failed: No active user ID in LocalTaskExecutor');
-        // Should we fail the task? Yes, otherwise it hangs in processing if we don't update status.
-        // Or just return and let it stay processing until restart?
-        // Better to retry later.
-        return;
+        throw StateError(
+          'Task execution failed: no active user ID in LocalTaskExecutor',
+        );
       }
 
       await handler(
@@ -341,7 +350,7 @@ class LocalTaskExecutor {
 
       if (e is! NonRetryableTaskException && nextRetry <= task.maxRetries) {
         // Exponential backoff
-        final backoff = 30; //* (1 << (task.retryCount));
+        const backoff = 30; //* (1 << (task.retryCount));
         final nextRun = now + backoff;
 
         await (_db.update(_db.tasks)..where((t) => t.id.equals(task.id))).write(
@@ -395,11 +404,209 @@ class LocalTaskExecutor {
         _logger.severe('Task ${task.id} permanently failed');
       }
     } finally {
+      await _clearTaskExecutionMarker(task.id);
+
       // Trigger poll to pick up next tasks immediately upon completion of one
       if (_isRunning) {
         _scheduleNextPoll(immediate: true);
       }
     }
+  }
+
+  Future<void> _handlePreviousExecutionMarkers() async {
+    try {
+      final markers = await _loadTaskExecutionMarkers();
+      if (markers.isEmpty) return;
+
+      for (final marker in markers) {
+        await _handlePreviousExecutionMarker(marker);
+      }
+    } catch (e, stack) {
+      _logger.severe(
+        'Failed to handle previous task execution markers',
+        e,
+        stack,
+      );
+    }
+  }
+
+  Future<void> _handlePreviousExecutionMarker(
+    _TaskExecutionMarker marker,
+  ) async {
+    final task = await (_db.select(
+      _db.tasks,
+    )..where((t) => t.id.equals(marker.taskId)))
+        .getSingleOrNull();
+    if (task == null || task.status != 'processing') {
+      await _deleteTaskExecutionMarker(marker.taskId);
+      return;
+    }
+
+    if (!marker.matchesTask(task)) {
+      _logger.warning(
+        'Ignoring stale crash guard marker for task ${marker.taskId}: task metadata changed',
+      );
+      await _deleteTaskExecutionMarker(marker.taskId);
+      return;
+    }
+
+    final now = DateTime.now();
+    if (now.difference(marker.startedAt) > crashLikeExitWindow) {
+      _logger.info(
+        'Ignoring old crash guard marker for task ${marker.taskId}; previous process likely stopped outside crash window',
+      );
+      await _deleteTaskExecutionMarker(marker.taskId);
+      return;
+    }
+
+    final updatedMarker = marker.copyWith(crashCount: marker.crashCount + 1);
+    if (updatedMarker.crashCount >= crashLoopFailureThreshold) {
+      await _failTask(
+        task,
+        'Task failed after ${updatedMarker.crashCount} crash-like exits while processing. '
+        'Marked failed to stop startup crash loop.',
+      );
+      await _deleteTaskExecutionMarker(marker.taskId);
+      _logger.severe(
+        'Task ${task.id} failed by crash loop guard after ${updatedMarker.crashCount} crash-like exits',
+      );
+      return;
+    }
+
+    await _saveTaskExecutionMarker(updatedMarker);
+    _logger.warning(
+      'Detected crash-like exit while processing task ${task.id}; crash count is ${updatedMarker.crashCount}',
+    );
+  }
+
+  Future<void> _markTaskExecutionStarted(Task task) async {
+    final existing = await _loadTaskExecutionMarker(task.id);
+    final marker = _TaskExecutionMarker.fromTask(
+      task,
+      crashCount: existing != null && existing.matchesTask(task)
+          ? existing.crashCount
+          : 0,
+    );
+    await _saveTaskExecutionMarker(marker);
+  }
+
+  Future<_TaskExecutionMarker?> _loadTaskExecutionMarker(String taskId) async {
+    final row = await (_db.select(
+      _db.kvStore,
+    )..where((kv) => kv.key.equals(_taskExecutionMarkerKey(taskId))))
+        .getSingleOrNull();
+    if (row?.value == null) return null;
+
+    try {
+      return _TaskExecutionMarker.fromJson(
+        jsonDecode(row!.value!) as Map<String, dynamic>,
+      );
+    } catch (e) {
+      _logger.warning('Failed to parse task execution marker: $e');
+      await _deleteTaskExecutionMarker(taskId);
+      return null;
+    }
+  }
+
+  Future<List<_TaskExecutionMarker>> _loadTaskExecutionMarkers() async {
+    final rows = await (_db.select(_db.kvStore)
+          ..where((kv) => kv.key.like('$_activeTaskMarkerKeyPrefix%')))
+        .get();
+    final markers = <_TaskExecutionMarker>[];
+
+    for (final row in rows) {
+      if (row.value == null) {
+        await _deleteTaskExecutionMarkerByKey(row.key);
+        continue;
+      }
+
+      try {
+        markers.add(
+          _TaskExecutionMarker.fromJson(
+            jsonDecode(row.value!) as Map<String, dynamic>,
+          ),
+        );
+      } catch (e) {
+        _logger.warning('Failed to parse task execution marker: $e');
+        await _deleteTaskExecutionMarkerByKey(row.key);
+      }
+    }
+
+    return markers;
+  }
+
+  Future<void> _saveTaskExecutionMarker(_TaskExecutionMarker marker) async {
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    await _db.into(_db.kvStore).insertOnConflictUpdate(
+          KvStoreCompanion.insert(
+            key: _taskExecutionMarkerKey(marker.taskId),
+            value: Value(jsonEncode(marker.toJson())),
+            bucket: const Value(_crashGuardBucket),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> _deleteTaskExecutionMarker(String taskId) {
+    return _deleteTaskExecutionMarkerByKey(_taskExecutionMarkerKey(taskId));
+  }
+
+  Future<void> _deleteTaskExecutionMarkerByKey(String key) async {
+    await (_db.delete(
+      _db.kvStore,
+    )..where((kv) => kv.key.equals(key)))
+        .go();
+  }
+
+  Future<void> _clearTaskExecutionMarker(String taskId) async {
+    final marker = await _loadTaskExecutionMarker(taskId);
+    if (marker == null || marker.taskId != taskId) return;
+    await _deleteTaskExecutionMarker(taskId);
+  }
+
+  String _taskExecutionMarkerKey(String taskId) {
+    return '$_activeTaskMarkerKeyPrefix$taskId';
+  }
+
+  Future<void> _failTask(Task task, String error) async {
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    await (_db.update(_db.tasks)..where((t) => t.id.equals(task.id))).write(
+      TasksCompanion(
+        status: const Value('failed'),
+        completedAt: Value(now),
+        updatedAt: Value(now),
+        error: Value(error),
+      ),
+    );
+  }
+
+  @visibleForTesting
+  Future<void> markTaskExecutionStartedForTesting(Task task) =>
+      _markTaskExecutionStarted(task);
+
+  @visibleForTesting
+  Future<KvStoreData?> getTaskExecutionMarkerForTesting([String? taskId]) {
+    if (taskId != null) {
+      return (_db.select(
+        _db.kvStore,
+      )..where((kv) => kv.key.equals(_taskExecutionMarkerKey(taskId))))
+          .getSingleOrNull();
+    }
+
+    return (_db.select(
+      _db.kvStore,
+    )
+          ..where((kv) => kv.key.like('$_activeTaskMarkerKeyPrefix%'))
+          ..limit(1))
+        .getSingleOrNull();
+  }
+
+  @visibleForTesting
+  Future<List<KvStoreData>> getTaskExecutionMarkersForTesting() {
+    return (_db.select(
+      _db.kvStore,
+    )..where((kv) => kv.key.like('$_activeTaskMarkerKeyPrefix%')))
+        .get();
   }
 
   /// Check if a task of [taskType] with [bizId] has failed.
@@ -513,5 +720,80 @@ class LocalTaskExecutor {
 
     final result = await query.getSingleOrNull();
     return result?.read(_db.tasks.id);
+  }
+}
+
+class _TaskExecutionMarker {
+  _TaskExecutionMarker({
+    required this.taskId,
+    required this.taskType,
+    required this.payloadHash,
+    required this.startedAt,
+    required this.crashCount,
+    this.bizId,
+  });
+
+  final String taskId;
+  final String taskType;
+  final String? bizId;
+  final String payloadHash;
+  final DateTime startedAt;
+  final int crashCount;
+
+  factory _TaskExecutionMarker.fromTask(Task task, {required int crashCount}) {
+    return _TaskExecutionMarker(
+      taskId: task.id,
+      taskType: task.type,
+      bizId: task.bizId,
+      payloadHash: _payloadHashFor(task.payload),
+      startedAt: DateTime.now(),
+      crashCount: crashCount,
+    );
+  }
+
+  factory _TaskExecutionMarker.fromJson(Map<String, dynamic> json) {
+    return _TaskExecutionMarker(
+      taskId: json['task_id'] as String,
+      taskType: json['task_type'] as String,
+      bizId: json['biz_id'] as String?,
+      payloadHash: json['payload_hash'] as String,
+      startedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['started_at_ms'] as int,
+      ),
+      crashCount: json['crash_count'] as int,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'task_id': taskId,
+      'task_type': taskType,
+      'biz_id': bizId,
+      'payload_hash': payloadHash,
+      'started_at_ms': startedAt.millisecondsSinceEpoch,
+      'crash_count': crashCount,
+    };
+  }
+
+  _TaskExecutionMarker copyWith({int? crashCount}) {
+    return _TaskExecutionMarker(
+      taskId: taskId,
+      taskType: taskType,
+      bizId: bizId,
+      payloadHash: payloadHash,
+      startedAt: startedAt,
+      crashCount: crashCount ?? this.crashCount,
+    );
+  }
+
+  bool matchesTask(Task task) {
+    return task.id == taskId &&
+        task.type == taskType &&
+        task.bizId == bizId &&
+        _payloadHashFor(task.payload) == payloadHash;
+  }
+
+  static String _payloadHashFor(String? payload) {
+    return sha256.convert(utf8.encode(payload ?? '')).toString();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'package:memex/ui/main_screen/widgets/input_sheet.dart';
 import 'package:memex/ui/settings/widgets/model_config_list_page.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/data/services/publish_timestamp_service.dart';
 import 'package:memex/data/services/health_service.dart';
@@ -306,10 +307,16 @@ class _MemexAppState extends State<MemexApp> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused) {
+      unawaited(LocalTaskExecutor.instance
+          .recordGracefulShutdown(reason: 'app_lifecycle_paused'));
       _lastPausedTime = DateTime.now();
       _checkLockSettingsBeforeLocking();
     } else if (state == AppLifecycleState.resumed) {
+      unawaited(LocalTaskExecutor.instance.clearGracefulShutdownMarker());
       _checkGracePeriod();
+    } else if (state == AppLifecycleState.detached) {
+      unawaited(LocalTaskExecutor.instance
+          .recordGracefulShutdown(reason: 'app_lifecycle_detached'));
     }
   }
 

--- a/test/data/services/local_task_executor_test.dart
+++ b/test/data/services/local_task_executor_test.dart
@@ -1,0 +1,319 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/db/app_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late LocalTaskExecutor executor;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    AppDatabase.setTestInstance(db);
+    executor = LocalTaskExecutor.forTesting();
+  });
+
+  tearDown(() async {
+    executor.stop();
+    await db.close();
+  });
+
+  group('LocalTaskExecutor crash loop guard', () {
+    test('clears execution marker after successful task completion', () async {
+      var handled = false;
+      executor.registerHandler('ok_task', (userId, payload, context) async {
+        handled = true;
+      });
+
+      await executor.start(userId: 'user-a');
+      final taskId = await executor.enqueueTask(
+        userId: 'user-a',
+        taskType: 'ok_task',
+        payload: {'value': 1},
+      );
+
+      final task = await _waitForTaskStatus(db, taskId, 'completed');
+
+      expect(handled, isTrue);
+      expect(task.status, 'completed');
+      expect(await executor.getTaskExecutionMarkerForTesting(), isNull);
+    });
+
+    test(
+      'clears execution marker when Dart handler failure is retryable',
+      () async {
+        executor.registerHandler('throw_task', (
+          userId,
+          payload,
+          context,
+        ) async {
+          throw StateError('boom');
+        });
+
+        await executor.start(userId: 'user-a');
+        final taskId = await executor.enqueueTask(
+          userId: 'user-a',
+          taskType: 'throw_task',
+          payload: {'value': 1},
+          maxRetries: 1,
+        );
+
+        final task = await _waitForTaskStatus(db, taskId, 'retrying');
+
+        expect(task.retryCount, 1);
+        expect(task.error, contains('boom'));
+        expect(await executor.getTaskExecutionMarkerForTesting(), isNull);
+      },
+    );
+
+    test('first crash-like restart requeues stale processing task', () async {
+      final task = await _insertTask(
+        db,
+        id: 'task-first-crash',
+        type: 'dangerous_task',
+        status: 'processing',
+        payload: {'asset': 'large-image'},
+      );
+      await executor.markTaskExecutionStartedForTesting(task);
+
+      await executor.start(userId: 'user-a');
+      executor.stop();
+
+      final updated = await _getTask(db, task.id);
+      final marker = await executor.getTaskExecutionMarkerForTesting(task.id);
+      final markerPayload = jsonDecode(marker!.value!) as Map<String, dynamic>;
+
+      expect(updated.status, 'pending');
+      expect(markerPayload['task_id'], task.id);
+      expect(markerPayload['crash_count'], 1);
+    });
+
+    test('keeps separate crash markers for concurrent processing tasks',
+        () async {
+      final taskA = await _insertTask(
+        db,
+        id: 'task-concurrent-a',
+        type: 'dangerous_task_a',
+        status: 'processing',
+        payload: {'asset': 'large-image-a'},
+      );
+      final taskB = await _insertTask(
+        db,
+        id: 'task-concurrent-b',
+        type: 'dangerous_task_b',
+        status: 'processing',
+        payload: {'asset': 'large-image-b'},
+      );
+      await executor.markTaskExecutionStartedForTesting(taskA);
+      await executor.markTaskExecutionStartedForTesting(taskB);
+
+      await executor.start(userId: 'user-a');
+      executor.stop();
+
+      final updatedA = await _getTask(db, taskA.id);
+      final updatedB = await _getTask(db, taskB.id);
+      final markerRows = await executor.getTaskExecutionMarkersForTesting();
+      final crashCounts = {
+        for (final row in markerRows)
+          (jsonDecode(row.value!) as Map<String, dynamic>)['task_id']:
+              (jsonDecode(row.value!) as Map<String, dynamic>)['crash_count'],
+      };
+
+      expect(updatedA.status, 'pending');
+      expect(updatedB.status, 'pending');
+      expect(markerRows, hasLength(2));
+      expect(crashCounts[taskA.id], 1);
+      expect(crashCounts[taskB.id], 1);
+    });
+
+    test('simulates process death while a real task execution is in progress',
+        () async {
+      final firstHandlerStarted = Completer<void>();
+      final firstNeverCompletes = Completer<void>();
+      executor.registerHandler('native_crash_task', (
+        userId,
+        payload,
+        context,
+      ) async {
+        if (!firstHandlerStarted.isCompleted) {
+          firstHandlerStarted.complete();
+        }
+        await firstNeverCompletes.future;
+      });
+
+      await executor.start(userId: 'user-a');
+      final taskId = await executor.enqueueTask(
+        userId: 'user-a',
+        taskType: 'native_crash_task',
+        payload: {'asset': 'oversized-image'},
+      );
+      await firstHandlerStarted.future.timeout(const Duration(seconds: 3));
+      await _waitForTaskStatus(db, taskId, 'processing');
+      await _waitForMarkerCrashCount(executor, taskId, 0);
+
+      // Simulate process death: the task is still in progress, so the marker
+      // remains and Dart finally/catch never gets a chance to clean it up.
+      executor.stop();
+
+      final secondHandlerStarted = Completer<void>();
+      final secondNeverCompletes = Completer<void>();
+      executor = LocalTaskExecutor.forTesting()
+        ..registerHandler('native_crash_task', (
+          userId,
+          payload,
+          context,
+        ) async {
+          if (!secondHandlerStarted.isCompleted) {
+            secondHandlerStarted.complete();
+          }
+          await secondNeverCompletes.future;
+        });
+
+      await executor.start(userId: 'user-a');
+      await secondHandlerStarted.future.timeout(const Duration(seconds: 3));
+      await _waitForTaskStatus(db, taskId, 'processing');
+      await _waitForMarkerCrashCount(executor, taskId, 1);
+      executor.stop();
+
+      executor = LocalTaskExecutor.forTesting();
+      await executor.start(userId: 'user-a');
+      executor.stop();
+
+      final updated = await _getTask(db, taskId);
+
+      expect(updated.status, 'failed');
+      expect(updated.error, contains('crash-like exits'));
+      expect(await executor.getTaskExecutionMarkerForTesting(taskId), isNull);
+    });
+
+    test('second crash-like restart fails task and clears marker', () async {
+      final task = await _insertTask(
+        db,
+        id: 'task-second-crash',
+        type: 'dangerous_task',
+        status: 'processing',
+        payload: {'asset': 'large-image'},
+      );
+      await executor.markTaskExecutionStartedForTesting(task);
+      await _setMarkerCrashCount(db, executor, task.id, 1);
+
+      await executor.start(userId: 'user-a');
+      executor.stop();
+
+      final updated = await _getTask(db, task.id);
+
+      expect(updated.status, 'failed');
+      expect(updated.error, contains('crash-like exits'));
+      expect(await executor.getTaskExecutionMarkerForTesting(), isNull);
+    });
+
+    test(
+      'bad dependency JSON fails task instead of leaving it pending forever',
+      () async {
+        await _insertTask(
+          db,
+          id: 'task-bad-deps',
+          type: 'never_runs',
+          status: 'pending',
+          payload: {'value': 1},
+          dependencies: 'not-json',
+        );
+
+        await executor.start(userId: 'user-a');
+
+        final updated = await _waitForTaskStatus(db, 'task-bad-deps', 'failed');
+
+        expect(updated.error, contains('Invalid task dependencies'));
+        expect(await executor.getTaskExecutionMarkerForTesting(), isNull);
+      },
+    );
+  });
+}
+
+Future<Task> _insertTask(
+  AppDatabase db, {
+  required String id,
+  required String type,
+  required String status,
+  required Map<String, dynamic> payload,
+  String? dependencies,
+}) async {
+  final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  await db.into(db.tasks).insert(
+        TasksCompanion.insert(
+          id: id,
+          type: type,
+          payload: Value(jsonEncode(payload)),
+          status: status,
+          createdAt: Value(now),
+          updatedAt: Value(now),
+          maxRetries: const Value(5),
+          dependencies: Value(dependencies),
+        ),
+      );
+  return _getTask(db, id);
+}
+
+Future<Task> _getTask(AppDatabase db, String id) {
+  return (db.select(db.tasks)..where((t) => t.id.equals(id))).getSingle();
+}
+
+Future<Task> _waitForTaskStatus(
+  AppDatabase db,
+  String taskId,
+  String status, {
+  Duration timeout = const Duration(seconds: 3),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    final task = await _getTask(db, taskId);
+    if (task.status == status) return task;
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+  }
+  final task = await _getTask(db, taskId);
+  fail('Task $taskId did not reach $status. Last status: ${task.status}');
+}
+
+Future<Map<String, dynamic>> _waitForMarkerCrashCount(
+  LocalTaskExecutor executor,
+  String taskId,
+  int crashCount, {
+  Duration timeout = const Duration(seconds: 3),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    final marker = await executor.getTaskExecutionMarkerForTesting(taskId);
+    if (marker?.value != null) {
+      final payload = jsonDecode(marker!.value!) as Map<String, dynamic>;
+      if (payload['crash_count'] == crashCount) return payload;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+  }
+  final marker = await executor.getTaskExecutionMarkerForTesting(taskId);
+  fail(
+    'Task $taskId marker did not reach crash_count=$crashCount. '
+    'Last marker: ${marker?.value}',
+  );
+}
+
+Future<void> _setMarkerCrashCount(
+  AppDatabase db,
+  LocalTaskExecutor executor,
+  String taskId,
+  int crashCount,
+) async {
+  final marker = await executor.getTaskExecutionMarkerForTesting(taskId);
+  final payload = jsonDecode(marker!.value!) as Map<String, dynamic>;
+  payload['crash_count'] = crashCount;
+
+  await (db.update(db.kvStore)..where((kv) => kv.key.equals(marker.key))).write(
+    KvStoreCompanion(
+      value: Value(jsonEncode(payload)),
+      updatedAt: Value(DateTime.now().millisecondsSinceEpoch ~/ 1000),
+    ),
+  );
+}

--- a/test/data/services/local_task_executor_test.dart
+++ b/test/data/services/local_task_executor_test.dart
@@ -92,6 +92,29 @@ void main() {
       expect(markerPayload['crash_count'], 1);
     });
 
+    test('graceful app exit requeues stale task without crash count',
+        () async {
+      final task = await _insertTask(
+        db,
+        id: 'task-graceful-exit',
+        type: 'long_running_task',
+        status: 'processing',
+        payload: {'value': 1},
+      );
+      await executor.markTaskExecutionStartedForTesting(task);
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+      await executor.recordGracefulShutdown(reason: 'test_manual_exit');
+
+      await executor.start(userId: 'user-a');
+      executor.stop();
+
+      final updated = await _getTask(db, task.id);
+
+      expect(updated.status, 'pending');
+      expect(await executor.getTaskExecutionMarkerForTesting(task.id), isNull);
+      expect(await executor.getGracefulExitMarkerForTesting(), isNull);
+    });
+
     test('keeps separate crash markers for concurrent processing tasks',
         () async {
       final taskA = await _insertTask(


### PR DESCRIPTION
## 背景

关联父问题 #66，解决高优子问题 #67。大图片、长图片、大音频的防御方案仍放在 #68 讨论，本 PR 不实现媒体防御。

`LocalTaskExecutor` 之前在启动时会直接把遗留的 `processing` 任务重置为 `pending`。如果任务触发 native crash / OOM，Dart 层来不及进入 `catch` 和 retry 逻辑，下次启动又会恢复同一个任务，可能形成用户每次打开 App 几秒后继续闪退的 crash loop。

## 改动

- 在任务进入 handler 前写入持久化执行 marker，正常完成或 Dart 层失败/重试后清理 marker。
- App 启动时先检查上次遗留 marker，再重置 stale `processing` 任务。
- 对同一个任务在短时间窗内连续出现疑似进程级退出时累加 `crashCount`，达到阈值后标记为 `failed`，阻断无限恢复执行。
- 新增 graceful exit marker：App 正常 `paused/detached` 时记录正常离开，启动恢复时如果看到对应 marker，则只重置任务为 `pending`，不累加 crash count，避免手动退出/正常退后台误判。
- App `resumed` 或新任务真正开始执行时清理 graceful exit marker，避免恢复前台后的真实崩溃被误判为正常退出。
- marker 按 task 维度保存，避免并发任务互相覆盖 marker。
- 依赖 JSON 解析失败时将任务标记为 `failed`，避免坏任务永久留在 pending/retrying 队列里。
- 修复无 active userId 时直接 return 导致任务停在 `processing` 的路径，改为进入原有 retry/failure 逻辑。

## 兼容说明

- 旧版本里已经处于 crash loop 的用户，升级后不做额外 legacy 特判；如果旧版本没有写入 task marker，新版本可能还需要再经历阈值内的一到两次崩溃，之后会被本机制熔断，避免永久卡死。
- 手动强杀/系统强杀在部分平台上无法可靠区分于 native crash；本 PR 只把能观测到的正常 lifecycle 退出从 crash count 中排除。

## 测试

- `flutter test --no-pub test/data/services/local_task_executor_test.dart`：8 个用例通过，覆盖正常完成、Dart 异常重试、首次疑似崩溃恢复、正常退出不计 crash、并发任务 marker、真实执行路径中的进程死亡模拟、二次疑似崩溃熔断、坏依赖失败。
- `flutter analyze --no-pub lib/data/services/local_task_executor.dart test/data/services/local_task_executor_test.dart`：通过。
- `flutter analyze --no-pub lib/main.dart`：仍有 12 个既有 info 级 lint（如 `dart:ui` unnecessary import、Workmanager deprecated、若干 const 建议），没有新增 error。
- 曾尝试运行 `flutter test` 全量，现有测试有 3 个失败，与本改动无关：
  - `test/live_agent_eval_test.dart` 缺 `OPENAI_BASE_URL / OPENAI_API_KEY`。
  - `test/agent_refactor_functional_test.dart` 的 context compressor 期望非空但实际为空。
  - `test/agent_refactor_functional_test.dart` 缺测试 fixture JSON card file。

Closes #67
