### PR TITLE
[codex] 补充 Android Early 版本号和保留策略

### DIFF
--- a/.github/workflows/android-daily-early.yml
+++ b/.github/workflows/android-daily-early.yml
@@ -120,17 +120,85 @@ jobs:
             echo "title=Android Early ${{ steps.version.outputs.display_date }} (${{ steps.version.outputs.short_sha }})"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Prepare release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          DISPLAY_DATE: ${{ steps.version.outputs.display_date }}
+          BUILD_NAME: ${{ steps.version.outputs.build_name }}
+          BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+        run: |
+          releases_json="$(gh release list \
+            --repo "$GITHUB_REPOSITORY" \
+            --limit 100 \
+            --json tagName,isPrerelease,isDraft,createdAt)"
+
+          previous_early_tag="$(echo "$releases_json" \
+            | jq -r \
+              --arg current "$RELEASE_TAG" \
+              '[.[] | select(.isPrerelease and (.isDraft | not) and (.tagName | startswith("android-early-")) and .tagName != $current)] | sort_by(.createdAt) | reverse | .[0].tagName // ""')"
+
+          previous_release_tag="$(echo "$releases_json" \
+            | jq -r \
+              --arg current "$RELEASE_TAG" \
+              '[.[] | select((.isPrerelease | not) and (.isDraft | not) and .tagName != $current)] | sort_by(.createdAt) | reverse | .[0].tagName // ""')"
+
           cat > release_notes.md <<EOF
           Android Early build from main.
 
           - Commit: ${GITHUB_SHA}
-          - Date: ${{ steps.version.outputs.display_date }} Asia/Shanghai
+          - Date: ${DISPLAY_DATE} Asia/Shanghai
           - Channel: Early
-          - Version: ${{ steps.version.outputs.build_name }}+${{ steps.version.outputs.build_number }}
+          - Version: ${BUILD_NAME}+${BUILD_NUMBER}
           - Packages:
             - Global: com.memexlab.memex.early
             - CN: com.memexlab.memex.cn.early
 
+          EOF
+
+          append_generated_notes() {
+            local heading="$1"
+            local previous_tag="$2"
+            local notes_file
+
+            {
+              echo "## ${heading}"
+              echo
+            } >> release_notes.md
+
+            if [ -z "$previous_tag" ]; then
+              echo "No previous GitHub release was found for this comparison." >> release_notes.md
+              echo >> release_notes.md
+              return
+            fi
+
+            echo "Compared with \`${previous_tag}\`." >> release_notes.md
+            echo >> release_notes.md
+
+            notes_file="$(mktemp)"
+            if gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$RELEASE_TAG" \
+              -f target_commitish="$GITHUB_SHA" \
+              -f previous_tag_name="$previous_tag" \
+              --jq '.body' > "$notes_file"; then
+              if [ -s "$notes_file" ]; then
+                cat "$notes_file" >> release_notes.md
+              else
+                echo "No changes detected." >> release_notes.md
+              fi
+            else
+              echo "Failed to generate GitHub release notes automatically." >> release_notes.md
+              echo "Compare: https://github.com/${GITHUB_REPOSITORY}/compare/${previous_tag}...${GITHUB_SHA}" >> release_notes.md
+            fi
+
+            echo >> release_notes.md
+            rm -f "$notes_file"
+          }
+
+          append_generated_notes "Changes since previous Early prerelease" "$previous_early_tag"
+          append_generated_notes "Changes since latest Release" "$previous_release_tag"
+
+          cat >> release_notes.md <<EOF
           Early builds use isolated Android application IDs and do not overwrite Stable app data.
           EOF
 

--- a/.github/workflows/android-daily-early.yml
+++ b/.github/workflows/android-daily-early.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  EARLY_RELEASES_TO_KEEP: "14"
+
 jobs:
   build-android-early:
     name: Build Android Early APKs
@@ -70,11 +73,36 @@ jobs:
       - name: Install Flutter dependencies
         run: flutter pub get
 
+      - name: Prepare Early version
+        id: version
+        run: |
+          pubspec_version="$(grep '^version:' pubspec.yaml | awk '{print $2}')"
+          base_version="${pubspec_version%%+*}"
+          date_ymd="$(TZ=Asia/Shanghai date +'%Y%m%d')"
+          display_date="$(TZ=Asia/Shanghai date +'%Y-%m-%d')"
+          short_sha="${GITHUB_SHA::7}"
+          build_number="$(date +'%s')"
+          build_name="${base_version}-early.${date_ymd}.${short_sha}"
+
+          {
+            echo "date_ymd=${date_ymd}"
+            echo "display_date=${display_date}"
+            echo "short_sha=${short_sha}"
+            echo "build_name=${build_name}"
+            echo "build_number=${build_number}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build Global Early APK
-        run: flutter build apk --release --flavor globalEarly
+        run: >
+          flutter build apk --release --flavor globalEarly
+          --build-name "${{ steps.version.outputs.build_name }}"
+          --build-number "${{ steps.version.outputs.build_number }}"
 
       - name: Build CN Early APK
-        run: flutter build apk --release --flavor cnEarly
+        run: >
+          flutter build apk --release --flavor cnEarly
+          --build-name "${{ steps.version.outputs.build_name }}"
+          --build-number "${{ steps.version.outputs.build_number }}"
 
       - name: Collect APK artifacts
         run: |
@@ -85,22 +113,20 @@ jobs:
       - name: Prepare release metadata
         id: release
         run: |
-          date_ymd="$(TZ=Asia/Shanghai date +'%Y%m%d')"
-          display_date="$(TZ=Asia/Shanghai date +'%Y-%m-%d')"
-          short_sha="${GITHUB_SHA::7}"
-          tag="android-early-${date_ymd}-${short_sha}"
+          tag="android-early-${{ steps.version.outputs.date_ymd }}-${{ steps.version.outputs.short_sha }}"
 
           {
             echo "tag=${tag}"
-            echo "title=Android Early ${display_date} (${short_sha})"
+            echo "title=Android Early ${{ steps.version.outputs.display_date }} (${{ steps.version.outputs.short_sha }})"
           } >> "$GITHUB_OUTPUT"
 
           cat > release_notes.md <<EOF
           Android Early build from main.
 
           - Commit: ${GITHUB_SHA}
-          - Date: ${display_date} Asia/Shanghai
+          - Date: ${{ steps.version.outputs.display_date }} Asia/Shanghai
           - Channel: Early
+          - Version: ${{ steps.version.outputs.build_name }}+${{ steps.version.outputs.build_number }}
           - Packages:
             - Global: com.memexlab.memex.early
             - CN: com.memexlab.memex.cn.early
@@ -124,3 +150,22 @@ jobs:
             --title "${{ steps.release.outputs.title }}" \
             --notes-file release_notes.md \
             --prerelease
+
+      - name: Prune old Early prereleases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release list \
+            --repo "$GITHUB_REPOSITORY" \
+            --limit 100 \
+            --json tagName,isPrerelease,createdAt \
+            | jq -r \
+              --argjson keep "$EARLY_RELEASES_TO_KEEP" \
+              '[.[] | select(.isPrerelease and (.tagName | startswith("android-early-")))] | sort_by(.createdAt) | reverse | .[$keep:][] | .tagName' \
+            | while read -r tag; do
+                [ -n "$tag" ] || continue
+                gh release delete "$tag" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --yes \
+                  --cleanup-tag
+              done


### PR DESCRIPTION
## 背景

关联 #72；这是 #74 合并后的一个小补充。

#74 已经把 Android Daily Early 打包和 prerelease 发布跑起来了。这个 PR 进一步补齐三个运维细节：Early 包内部版本号要能看出日期，旧的 Early prerelease 不能无限堆积，发布说明要能直接看出相对上个 Early 和上个正式 release 的差异。

## 改动

- Early APK 构建时显式传入 `--build-name`，格式为 `pubspec基础版本-early.YYYYMMDD.shortsha`，例如 `1.0.29-early.20260514.da70e9d`。
- Early APK 构建时显式传入 `--build-number`，使用 epoch seconds，保证同一天多次构建也递增。
- prerelease notes 中展示完整 Early 版本号。
- prerelease notes 自动生成两段差异：
  - 相对最近一个 `android-early-*` prerelease。
  - 相对最近一个非 prerelease 的正式 release。
- 发布完成后清理旧的 `android-early-*` prerelease 和 tag，默认只保留最近 14 个 Early prerelease。

## 验证

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-daily-early.yml"); puts "workflow yaml ok"'`
- `git diff --check upstream/main...HEAD`
- `ruby ... | bash -n` 验证 `Prepare release notes` 脚本语法
- 本地执行 `Prepare release notes` 脚本片段，确认会生成：
  - `Changes since previous Early prerelease`，对比 `android-early-20260514-0a7f950`
  - `Changes since latest Release`，对比 `v1.0.29`
- `flutter build apk --debug --flavor globalEarly --build-name "1.0.29-early.20260514.da70e9d" --build-number "1778745425"`
