### PR TITLE
[codex] 升级 dart_agent_core 至 1.0.9

### DIFF
--- a/lib/agent/agent_system_prompt_helper.dart
+++ b/lib/agent/agent_system_prompt_helper.dart
@@ -1,16 +1,16 @@
-/// Agent System Prompt Helper
-///
-/// Load agent custom prompt config from workspace/_user_id/_UserSettings/prompts/.
-/// Config file name is {agent_name}.conf, supporting:
-///
-/// 1. System Prompt:
-///    - Override mode: replace the entire system_prompt
-///    - Replace mode: replace specified strings in system_prompt (supports multiline)
-///
-/// 2. Tool:
-///    - Match tools by name, override description and/or parameters
-///
-/// Config format: see doc comments in Python agent_system_prompt_helper.py.
+// Agent System Prompt Helper
+//
+// Load agent custom prompt config from workspace/_user_id/_UserSettings/prompts/.
+// Config file name is {agent_name}.conf, supporting:
+//
+// 1. System Prompt:
+//    - Override mode: replace the entire system_prompt
+//    - Replace mode: replace specified strings in system_prompt (supports multiline)
+//
+// 2. Tool:
+//    - Match tools by name, override description and/or parameters
+//
+// Config format: see doc comments in Python agent_system_prompt_helper.py.
 
 import 'dart:convert';
 import 'dart:io';
@@ -67,15 +67,18 @@ AgentPromptConfig _parseConfig(String content) {
   final config = AgentPromptConfig();
   final lines = content.split('\n');
   var i = 0;
-  final p = _tagPrefix;
+  const p = _tagPrefix;
 
   while (i < lines.length) {
     final line = lines[i].trim();
 
     if (line == '$p[system_prompt:override]') {
       i++;
-      final (block, nextI) =
-          _extractBlock(lines, i, '$p[/system_prompt:override]');
+      final (block, nextI) = _extractBlock(
+        lines,
+        i,
+        '$p[/system_prompt:override]',
+      );
       i = nextI;
       config.systemPrompt.overrideContent = block;
     } else if (line == '$p[system_prompt:replace]') {
@@ -122,7 +125,8 @@ AgentPromptConfig _parseConfig(String content) {
           );
         } catch (e) {
           _logger.warning(
-              'Failed to parse tool override JSON for "$toolName": $e');
+            'Failed to parse tool override JSON for "$toolName": $e',
+          );
         }
       }
     } else {
@@ -139,7 +143,9 @@ String _getConfigPath(String userId, String agentName) {
 }
 
 Future<AgentPromptConfig?> loadAgentPromptConfig(
-    String userId, String agentName) async {
+  String userId,
+  String agentName,
+) async {
   final configPath = _getConfigPath(userId, agentName);
   final file = File(configPath);
   if (!await file.exists()) return null;
@@ -152,7 +158,7 @@ Future<AgentPromptConfig?> loadAgentPromptConfig(
   }
 }
 
-(SystemMessage?, List<Tool>, List<LLMMessage>) applyPromptConfig(
+SystemCallbackResult applyPromptConfig(
   AgentPromptConfig config,
   SystemMessage? systemMessage,
   List<Tool> tools,
@@ -186,12 +192,17 @@ Future<AgentPromptConfig?> loadAgentPromptConfig(
           parameters: override.parameters ?? newTools[idx].parameters,
           executable: newTools[idx].executable,
           namedParameters: newTools[idx].namedParameters,
+          parameterMode: newTools[idx].parameterMode,
         );
       }
     }
   }
 
-  return (newSystemMessage, newTools, newRequestMessages);
+  return SystemCallbackResult(
+    systemMessage: newSystemMessage,
+    tools: newTools,
+    requestMessages: newRequestMessages,
+  );
 }
 
 /// Create a systemCallback to pass to StatefulAgent.
@@ -199,11 +210,19 @@ Future<AgentPromptConfig?> loadAgentPromptConfig(
 ///
 /// Usage: StatefulAgent(..., systemCallback: createSystemCallback(userId))
 SystemCallback createSystemCallback(String userId) {
-  return (StatefulAgent agent, SystemMessage? systemMessage, List<Tool> tools,
-      List<LLMMessage> requestMessages) async {
+  return (
+    StatefulAgent agent,
+    SystemMessage? systemMessage,
+    List<Tool> tools,
+    List<LLMMessage> requestMessages,
+  ) async {
     final config = await loadAgentPromptConfig(userId, agent.name);
     if (config == null) {
-      return (systemMessage, tools, requestMessages);
+      return SystemCallbackResult(
+        systemMessage: systemMessage,
+        tools: tools,
+        requestMessages: requestMessages,
+      );
     }
     return applyPromptConfig(config, systemMessage, tools, requestMessages);
   };
@@ -226,13 +245,24 @@ SystemCallback createSystemCallbackWithWorkingDirectory(
       ? workingDirectory.substring(0, workingDirectory.length - 1)
       : workingDirectory;
 
-  return (StatefulAgent agent, SystemMessage? systemMessage, List<Tool> tools,
-      List<LLMMessage> requestMessages) async {
+  return (
+    StatefulAgent agent,
+    SystemMessage? systemMessage,
+    List<Tool> tools,
+    List<LLMMessage> requestMessages,
+  ) async {
     // 1. Apply user prompt config first (same as createSystemCallback).
     final config = await loadAgentPromptConfig(userId, agent.name);
     if (config != null) {
-      (systemMessage, tools, requestMessages) =
-          applyPromptConfig(config, systemMessage, tools, requestMessages);
+      final result = applyPromptConfig(
+        config,
+        systemMessage,
+        tools,
+        requestMessages,
+      );
+      systemMessage = result.systemMessage;
+      tools = result.tools;
+      requestMessages = result.requestMessages;
     }
 
     // 2. Mask workingDirectory in system message (skill paths appear here).
@@ -249,7 +279,11 @@ SystemCallback createSystemCallbackWithWorkingDirectory(
     // 4. Wrap RunJavaScript tool to resolve virtual paths back to absolute.
     tools = _wrapRunJavaScriptTool(tools, wd);
 
-    return (systemMessage, tools, requestMessages);
+    return SystemCallbackResult(
+      systemMessage: systemMessage,
+      tools: tools,
+      requestMessages: requestMessages,
+    );
   };
 }
 
@@ -288,8 +322,13 @@ List<LLMMessage> _maskMessagesWorkingDirectory(
         }
       }
       if (msgChanged) {
-        result.add(UserMessage(newContents,
-            timestamp: msg.timestamp, metadata: msg.metadata));
+        result.add(
+          UserMessage(
+            newContents,
+            timestamp: msg.timestamp,
+            metadata: msg.metadata,
+          ),
+        );
         changed = true;
       } else {
         result.add(msg);
@@ -317,17 +356,18 @@ List<Tool> _wrapRunJavaScriptTool(List<Tool> tools, String wd) {
     description: original.description,
     parameters: original.parameters,
     namedParameters: original.namedParameters,
-    executable: (String script_path, String? args, int? timeout_ms) {
+    parameterMode: original.parameterMode,
+    executable: (String scriptPath, String? args, int? timeoutMs) {
       // Resolve virtual path to absolute, same logic as FileToolFactory._resolvePath.
-      if (!script_path.startsWith(wd)) {
-        if (script_path.startsWith('/')) {
-          script_path =
-              script_path == '/' ? wd : path.join(wd, script_path.substring(1));
+      if (!scriptPath.startsWith(wd)) {
+        if (scriptPath.startsWith('/')) {
+          scriptPath =
+              scriptPath == '/' ? wd : path.join(wd, scriptPath.substring(1));
         } else {
-          script_path = path.join(wd, script_path);
+          scriptPath = path.join(wd, scriptPath);
         }
       }
-      return Function.apply(originalExec, [script_path, args, timeout_ms]);
+      return Function.apply(originalExec, [scriptPath, args, timeoutMs]);
     },
   );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -357,10 +357,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_agent_core
-      sha256: "032bf63eb9c802865b4a773460b7cdc401223b53699ba8f4e84352ba5235031e"
+      sha256: a8865d6699dbbdb18baf08e072105e1233f78c497d20a67adccf35ca7ac80084
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.9"
   dart_jsonwebtoken:
     dependency: "direct main"
     description:
@@ -2179,5 +2179,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.4 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"
   flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   health: ^13.2.1
   pedometer: ^4.0.0
   workmanager: ^0.9.0
-  dart_agent_core: ^1.0.6
+  dart_agent_core: ^1.0.9
   flutter_js: ^0.8.7
   drift: ^2.30.0
   sqlite3_flutter_libs: ^0.5.41

--- a/test/agent/agent_system_prompt_helper_test.dart
+++ b/test/agent/agent_system_prompt_helper_test.dart
@@ -1,0 +1,132 @@
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:memex/agent/agent_system_prompt_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('applyPromptConfig', () {
+    test('keeps messages and tools unchanged when config is empty', () {
+      final config = AgentPromptConfig();
+      final tool = Tool(
+        name: 'read',
+        description: 'Read a file',
+        parameters: const {'type': 'object'},
+        executable: () => 'ok',
+      );
+      final requestMessages = [UserMessage.text('hello')];
+
+      final result = applyPromptConfig(
+        config,
+        null,
+        [tool],
+        requestMessages,
+      );
+
+      expect(result.systemMessage, isNull);
+      expect(result.tools.single, same(tool));
+      expect(result.requestMessages.single, same(requestMessages.single));
+    });
+
+    test('system override takes precedence over replacements', () {
+      final config = AgentPromptConfig();
+      config.systemPrompt.overrideContent = 'override content';
+      config.systemPrompt.replacements.add(('original', 'replacement'));
+
+      final result = applyPromptConfig(
+        config,
+        SystemMessage('original content'),
+        const [],
+        const [],
+      );
+
+      expect(result.systemMessage?.content, 'override content');
+    });
+
+    test('applies multiple system prompt replacements in order', () {
+      final config = AgentPromptConfig();
+      config.systemPrompt.replacements.add(('first', 'second'));
+      config.systemPrompt.replacements.add(('second', 'third'));
+
+      final result = applyPromptConfig(
+        config,
+        SystemMessage('first prompt'),
+        const [],
+        const [],
+      );
+
+      expect(result.systemMessage?.content, 'third prompt');
+    });
+
+    test('returns SystemCallbackResult and preserves tool parameter mode', () {
+      final config = AgentPromptConfig();
+      config.systemPrompt.replacements.add(('old system', 'new system'));
+      config.toolOverrides['object_tool'] = ToolOverride(
+        name: 'object_tool',
+        description: 'Updated description',
+        parameters: {
+          'type': 'object',
+          'properties': {
+            'query': {'type': 'string'},
+          },
+        },
+      );
+
+      final originalTool = Tool(
+        name: 'object_tool',
+        description: 'Original description',
+        parameters: const {'type': 'object', 'properties': {}},
+        executable: (Map<String, dynamic> args) => args,
+        namedParameters: const ['unused'],
+        parameterMode: ToolParameterMode.object,
+      );
+      final requestMessages = [UserMessage.text('hello')];
+
+      final result = applyPromptConfig(
+        config,
+        SystemMessage('old system prompt'),
+        [originalTool],
+        requestMessages,
+      );
+
+      expect(result, isA<SystemCallbackResult>());
+      expect(result.systemMessage?.content, 'new system prompt');
+      expect(result.tools, hasLength(1));
+      expect(result.tools.single.description, 'Updated description');
+      expect(result.tools.single.executable, same(originalTool.executable));
+      expect(result.tools.single.namedParameters, originalTool.namedParameters);
+      expect(result.tools.single.parameterMode, ToolParameterMode.object);
+      expect(result.requestMessages.single, same(requestMessages.single));
+    });
+
+    test('only overrides matching tools', () {
+      final config = AgentPromptConfig();
+      config.toolOverrides['target'] = ToolOverride(
+        name: 'target',
+        parameters: const {
+          'type': 'object',
+          'required': ['value'],
+        },
+      );
+      final target = Tool(
+        name: 'target',
+        description: 'Target description',
+        parameters: const {'type': 'object'},
+      );
+      final other = Tool(
+        name: 'other',
+        description: 'Other description',
+        parameters: const {'type': 'object'},
+      );
+
+      final result = applyPromptConfig(
+        config,
+        SystemMessage('system'),
+        [target, other],
+        const [],
+      );
+
+      expect(result.tools.first.description, 'Target description');
+      expect(result.tools.first.parameters['required'], ['value']);
+      expect(result.tools.last, same(other));
+    });
+  });
+}


### PR DESCRIPTION
## 背景

pub.dev 上 `dart_agent_core` 最新版本已发布到 `1.0.9`。本次升级前确认了 `memex-lab/dart_agent_core#10` 已合并，并且 `dart_agent_core-1.0.9` 的 pub 包中已经包含 Claude content blocks 回传修复。

`1.0.9` 同时引入了一个 breaking change：`SystemCallback` 不再返回 record，而是返回 `SystemCallbackResult`。

## 变更

- 将 `dart_agent_core` 依赖从 `^1.0.6` 升级到 `^1.0.9`，并更新 lockfile。
- 适配 `agent_system_prompt_helper.dart` 中的 `SystemCallbackResult` 返回类型。
- 在 prompt config 工具覆盖和 RunJavaScript wrapper 中保留 `Tool.parameterMode`，避免新版 object-mode 工具被误改回 function-mode。
- 新增 `agent_system_prompt_helper_test.dart`，覆盖空配置、system override 优先级、多段 replacement、工具覆盖字段保留、仅覆盖匹配工具等场景。

## 验证

- `flutter pub get --offline` 通过
- `dart analyze lib/agent/agent_system_prompt_helper.dart test/agent/agent_system_prompt_helper_test.dart` 通过
- `flutter test --no-pub test/agent/agent_system_prompt_helper_test.dart test/utils/token_usage_utils_test.dart` 通过，17 个测试通过
- `flutter analyze --no-pub` 仍有仓库既有 lint/warning 噪声，当前为 370 条；本 PR 触碰文件的定向 analyze 已通过

## 备注

本 PR 不包含 UI、i18n、平台资源或生成文件改动。