### PR TITLE
[codex] 修复 Grep 内联正则 flag 兼容性 / Fix Grep inline regex flags

### DIFF
--- a/lib/agent/built_in_tools/file_tools.dart
+++ b/lib/agent/built_in_tools/file_tools.dart
@@ -561,7 +561,7 @@ class FileToolFactory {
           type: type,
           headLimit: head_limit,
           multiline: multiline ?? false,
-          filter: (p) => permissionManager.allowsRead(p),
+          accessScope: permissionManager.buildSearchAccessScope(searchPath),
         );
       },
     );

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -312,10 +312,10 @@ Usage:
 
 Usage:
 - Always use Grep for search tasks. The Grep tool is optimized for correct permissions and access.
-- Supports full regular expression syntax (e.g., "log.*Error", "function\\s+\\w+")
+- Uses ripgrep regex syntax when the `rg` executable is available; on platforms without `rg`, falls back to Dart RegExp with common leading ripgrep-style inline flags such as `(?i)`, `(?m)`, `(?s)`, and combinations like `(?im)`
 - Use the glob parameter to filter files (e.g., "*.md", "**/*.md") or use the type parameter (e.g., "md", "py", "txt")
 - Output modes: "content" shows matching lines, "files_with_matches" shows only file paths (default), "count" shows match counts
-- Pattern syntax: Uses ripgrep (not grep) - literal braces need escaping (use `interface\\{\\}` to find `interface{}` in Go code)
+- Pattern syntax: Prefer ripgrep/Rust regex syntax. Literal braces need escaping (use `interface\\{\\}` to find `interface{}` in Go code). If a platform cannot run `rg`, advanced ripgrep-only syntax may be unavailable, but common leading inline flags are still supported by the fallback engine.
 - Multiline matching: By default, patterns match within single lines only. For cross-line patterns such as `struct \\{[\\s\\S]*?field`, use `multiline: true`
 - Use the path parameter to reduce the search range, and do not directly use the root directory as the default path.
 ''';

--- a/lib/agent/security/file_permission_manager.dart
+++ b/lib/agent/security/file_permission_manager.dart
@@ -1,4 +1,5 @@
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/file_search_access_scope.dart';
 import 'package:path/path.dart' as p;
 import 'package:collection/collection.dart';
 
@@ -123,11 +124,61 @@ class FilePermissionManager {
     }
   }
 
+  FileSearchAccessScope buildSearchAccessScope(String searchRoot) {
+    final normalizedRoot = _normalize(searchRoot);
+    final excludedPaths = <String>[];
+    var canUseDirectorySearch = true;
+
+    for (final rule in _rules) {
+      if (rule.access != FileAccessType.none) {
+        continue;
+      }
+      if (!_isSameOrUnder(rule.path, normalizedRoot)) {
+        continue;
+      }
+      if (allowsRead(rule.path)) {
+        continue;
+      }
+
+      final hasReadableDescendant = _rules.any((other) =>
+          other.path != rule.path &&
+          _isSameOrUnder(other.path, rule.path) &&
+          _hasAccess(other.access, FileAccessType.read));
+      if (hasReadableDescendant) {
+        canUseDirectorySearch = false;
+        break;
+      }
+
+      final alreadyExcluded =
+          excludedPaths.any((excluded) => _isSameOrUnder(rule.path, excluded));
+      if (!alreadyExcluded) {
+        excludedPaths.add(rule.path);
+      }
+    }
+
+    return FileSearchAccessScope(
+      allowsRead: allowsRead,
+      excludedPaths: excludedPaths,
+      canUseDirectorySearch: canUseDirectorySearch,
+    );
+  }
+
   bool _hasAccess(FileAccessType granted, FileAccessType required) {
     if (granted == FileAccessType.none) return false;
     if (granted == FileAccessType.write) return true; // Write implies Read
     if (granted == FileAccessType.read && required == FileAccessType.read) {
       return true;
+    }
+    return false;
+  }
+
+  bool _isSameOrUnder(String childPath, String parentPath) {
+    final child = _normalize(childPath);
+    final parent = _normalize(parentPath);
+    if (child == parent) return true;
+    if (child.startsWith(parent)) {
+      final rest = child.substring(parent.length);
+      return rest.startsWith(p.separator) || parent == p.separator;
     }
     return false;
   }

--- a/lib/data/services/file_operation_service.dart
+++ b/lib/data/services/file_operation_service.dart
@@ -1,11 +1,13 @@
 import 'dart:io';
 import 'dart:async';
+import 'dart:convert';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:logging/logging.dart';
 import 'package:memex/utils/logger.dart';
 import 'api_exception.dart';
 import 'base_file_service.dart';
+import 'file_search_access_scope.dart';
 import 'file_operation_utils.dart';
 
 /// Callback signature for file change notifications.
@@ -13,6 +15,20 @@ import 'file_operation_utils.dart';
 /// For 'moved', [oldFilePath] is the original path.
 typedef FileChangedCallback = void Function(String filePath, String changeType,
     {String? oldFilePath});
+
+class _GrepPatternOptions {
+  final String pattern;
+  final bool caseSensitive;
+  final bool multiLine;
+  final bool dotAll;
+
+  const _GrepPatternOptions({
+    required this.pattern,
+    required this.caseSensitive,
+    required this.multiLine,
+    required this.dotAll,
+  });
+}
 
 /// File operation service: wraps server file ops; params and results match server.
 class FileOperationService {
@@ -23,6 +39,7 @@ class FileOperationService {
   }
 
   final BaseFileService _baseService;
+  final String? _ripgrepExecutable;
   final Logger _logger = getLogger('FileOperationService');
 
   /// Track ongoing operations per file to prevent concurrent writes
@@ -32,11 +49,14 @@ class FileOperationService {
   FileChangedCallback? onFileChanged;
 
   FileOperationService._({BaseFileService? baseService})
-      : _baseService = baseService ?? BaseFileService();
+      : _baseService = baseService ?? BaseFileService(),
+        _ripgrepExecutable = null;
 
   @visibleForTesting
-  FileOperationService.forTesting({BaseFileService? baseService})
-      : _baseService = baseService ?? BaseFileService();
+  FileOperationService.forTesting(
+      {BaseFileService? baseService, String? ripgrepExecutable})
+      : _baseService = baseService ?? BaseFileService(),
+        _ripgrepExecutable = ripgrepExecutable;
 
   /// Execute operation with file lock to prevent concurrent writes to the same file
   ///
@@ -1026,6 +1046,7 @@ ${addLineNumbers(snippet, startLine: startLine)}''';
     bool multiline = false,
     bool r = true,
     bool Function(String path)? filter,
+    FileSearchAccessScope? accessScope,
   }) async {
     // Resolve search path
     if (searchPath != null) {
@@ -1057,21 +1078,39 @@ ${addLineNumbers(snippet, startLine: startLine)}''';
           _maskResult('path $searchPathStr does not exist', workingDirectory));
     }
 
-    RegExp regex;
-    try {
-      regex = RegExp(
-        pattern,
-        multiLine: multiline,
-        caseSensitive: !i,
-        dotAll: multiline,
-      );
-    } catch (e) {
-      throw ApiException(
-          _maskResult('Invalid regex pattern: $e', workingDirectory));
-    }
-
     // buildfiletypefiltermap
     final typeExtensions = _getFileTypeExtensions(type);
+    final effectiveFilter = _combineGrepFilters(filter, accessScope);
+
+    final ripgrepResult = await _tryGrepWithRipgrep(
+      pattern: pattern,
+      searchPath: searchPathStr,
+      includeGlob: include,
+      typeExtensions: typeExtensions,
+      accessScope: accessScope,
+      hasCustomFilter: filter != null,
+      outputMode: outputMode,
+      B: B,
+      A: A,
+      C: C,
+      showLineNumbers: n,
+      caseInsensitive: i,
+      headLimit: headLimit,
+      multiline: multiline,
+      r: r,
+      filter: effectiveFilter,
+      workingDirectory: workingDirectory,
+    );
+    if (ripgrepResult != null) {
+      return _maskResult(ripgrepResult, workingDirectory);
+    }
+
+    final regex = _compileGrepPattern(
+      pattern,
+      caseInsensitive: i,
+      multiline: multiline,
+      workingDirectory: workingDirectory,
+    );
 
     String result;
     switch (outputMode) {
@@ -1083,7 +1122,7 @@ ${addLineNumbers(snippet, startLine: startLine)}''';
           typeExtensions,
           headLimit,
           r: r,
-          filter: filter,
+          filter: effectiveFilter,
         );
         break;
       case 'content':
@@ -1098,7 +1137,7 @@ ${addLineNumbers(snippet, startLine: startLine)}''';
           n,
           headLimit,
           r: r,
-          filter: filter,
+          filter: effectiveFilter,
         );
         break;
       case 'count':
@@ -1109,7 +1148,7 @@ ${addLineNumbers(snippet, startLine: startLine)}''';
           typeExtensions,
           headLimit,
           r: r,
-          filter: filter,
+          filter: effectiveFilter,
         );
         break;
       default:
@@ -1118,6 +1157,661 @@ ${addLineNumbers(snippet, startLine: startLine)}''';
     }
 
     return _maskResult(result, workingDirectory);
+  }
+
+  bool Function(String path)? _combineGrepFilters(
+    bool Function(String path)? filter,
+    FileSearchAccessScope? accessScope,
+  ) {
+    if (filter == null) {
+      return accessScope?.allowsRead;
+    }
+    if (accessScope == null) {
+      return filter;
+    }
+    return (path) => filter(path) && accessScope.allowsRead(path);
+  }
+
+  Future<String?> _tryGrepWithRipgrep({
+    required String pattern,
+    required String searchPath,
+    required String? includeGlob,
+    required Set<String>? typeExtensions,
+    required FileSearchAccessScope? accessScope,
+    required bool hasCustomFilter,
+    required String outputMode,
+    required int? B,
+    required int? A,
+    required int? C,
+    required bool showLineNumbers,
+    required bool caseInsensitive,
+    required int? headLimit,
+    required bool multiline,
+    required bool r,
+    required bool Function(String path)? filter,
+    required String? workingDirectory,
+  }) async {
+    final executable = await _resolveRipgrepExecutable();
+    if (executable == null) {
+      return null;
+    }
+
+    final directoryArgs = await _buildRipgrepDirectoryArgs(
+      searchPath,
+      includeGlob,
+      typeExtensions,
+      accessScope,
+      r: r,
+      hasCustomFilter: hasCustomFilter,
+    );
+    if (directoryArgs != null) {
+      switch (outputMode) {
+        case 'files_with_matches':
+          return _grepFilesWithMatchesUsingRipgrep(
+            executable,
+            pattern,
+            [searchPath],
+            caseInsensitive: caseInsensitive,
+            multiline: multiline,
+            headLimit: headLimit,
+            workingDirectory: workingDirectory,
+            extraArgs: directoryArgs,
+            chunkTargets: false,
+          );
+        case 'content':
+          return _grepContentUsingRipgrep(
+            executable,
+            pattern,
+            [searchPath],
+            B: B,
+            A: A,
+            C: C,
+            showLineNumbers: showLineNumbers,
+            caseInsensitive: caseInsensitive,
+            headLimit: headLimit,
+            multiline: multiline,
+            workingDirectory: workingDirectory,
+            extraArgs: directoryArgs,
+            chunkTargets: false,
+          );
+        case 'count':
+          return _grepCountUsingRipgrep(
+            executable,
+            pattern,
+            [searchPath],
+            caseInsensitive: caseInsensitive,
+            multiline: multiline,
+            headLimit: headLimit,
+            workingDirectory: workingDirectory,
+            extraArgs: directoryArgs,
+            chunkTargets: false,
+          );
+      }
+    }
+
+    final files = await _collectGrepCandidateFiles(
+      searchPath,
+      includeGlob,
+      typeExtensions,
+      r: r,
+      filter: filter,
+    );
+    if (files.isEmpty) {
+      return outputMode == 'files_with_matches'
+          ? 'No files found'
+          : 'No matches found';
+    }
+
+    switch (outputMode) {
+      case 'files_with_matches':
+        return _grepFilesWithMatchesUsingRipgrep(
+          executable,
+          pattern,
+          files,
+          caseInsensitive: caseInsensitive,
+          multiline: multiline,
+          headLimit: headLimit,
+          workingDirectory: workingDirectory,
+        );
+      case 'content':
+        return _grepContentUsingRipgrep(
+          executable,
+          pattern,
+          files,
+          B: B,
+          A: A,
+          C: C,
+          showLineNumbers: showLineNumbers,
+          caseInsensitive: caseInsensitive,
+          headLimit: headLimit,
+          multiline: multiline,
+          workingDirectory: workingDirectory,
+        );
+      case 'count':
+        return _grepCountUsingRipgrep(
+          executable,
+          pattern,
+          files,
+          caseInsensitive: caseInsensitive,
+          multiline: multiline,
+          headLimit: headLimit,
+          workingDirectory: workingDirectory,
+        );
+      default:
+        return null;
+    }
+  }
+
+  @visibleForTesting
+  Future<List<String>?> buildRipgrepDirectoryArgsForTesting({
+    required String searchPath,
+    String? includeGlob,
+    Set<String>? typeExtensions,
+    FileSearchAccessScope? accessScope,
+    bool r = true,
+    bool hasCustomFilter = false,
+  }) {
+    return _buildRipgrepDirectoryArgs(
+      searchPath,
+      includeGlob,
+      typeExtensions,
+      accessScope,
+      r: r,
+      hasCustomFilter: hasCustomFilter,
+    );
+  }
+
+  Future<List<String>?> _buildRipgrepDirectoryArgs(
+    String searchPath,
+    String? includeGlob,
+    Set<String>? typeExtensions,
+    FileSearchAccessScope? accessScope, {
+    required bool r,
+    required bool hasCustomFilter,
+  }) async {
+    if (hasCustomFilter ||
+        accessScope == null ||
+        !accessScope.canUseDirectorySearch) {
+      return null;
+    }
+    if (!await _baseService.isDirectory(searchPath)) {
+      return null;
+    }
+
+    final args = <String>['--no-ignore'];
+    if (!r) {
+      args.addAll(['--max-depth', '1']);
+    }
+    if (includeGlob != null) {
+      args.addAll(['--glob', includeGlob]);
+    }
+    final typeGlob = _typeExtensionsToGlob(typeExtensions);
+    if (typeGlob != null) {
+      args.addAll(['--glob', typeGlob]);
+    }
+    for (final excludedPath in accessScope.excludedPaths) {
+      final relativePath = path.relative(excludedPath, from: searchPath);
+      if (relativePath.startsWith('..')) {
+        continue;
+      }
+      final posixPath = relativePath.replaceAll(path.separator, '/');
+      args.addAll(['--glob', '!$posixPath']);
+      args.addAll(['--glob', '!$posixPath/**']);
+    }
+    return args;
+  }
+
+  String? _typeExtensionsToGlob(Set<String>? typeExtensions) {
+    if (typeExtensions == null || typeExtensions.isEmpty) {
+      return null;
+    }
+    if (typeExtensions.length == 1) {
+      return '*.${typeExtensions.first}';
+    }
+    return '*.{${typeExtensions.join(',')}}';
+  }
+
+  Future<String?> _resolveRipgrepExecutable() async {
+    final executable = _ripgrepExecutable ?? 'rg';
+    try {
+      final result = await Process.run(
+        executable,
+        ['--version'],
+      ).timeout(const Duration(seconds: 1));
+      return result.exitCode == 0 ? executable : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<List<String>> _collectGrepCandidateFiles(
+    String searchPath,
+    String? includeGlob,
+    Set<String>? typeExtensions, {
+    required bool r,
+    required bool Function(String path)? filter,
+  }) async {
+    final files = <String>[];
+
+    Future<void> maybeAddFile(String filePath, String rootPath) async {
+      if (filter != null && !filter(filePath)) {
+        return;
+      }
+
+      final fileName = path.basename(filePath);
+      if (fileName.startsWith('.')) {
+        return;
+      }
+
+      if (includeGlob != null) {
+        final relativePath = path.relative(filePath, from: rootPath);
+        final posixPath = relativePath.replaceAll(path.separator, '/');
+        final globRegex = RegExp(_globToRegex(includeGlob));
+        if (!globRegex.hasMatch(posixPath) && !globRegex.hasMatch(fileName)) {
+          return;
+        }
+      }
+
+      if (typeExtensions != null) {
+        final ext = path.extension(fileName).toLowerCase();
+        if (ext.isNotEmpty && !typeExtensions.contains(ext.substring(1))) {
+          return;
+        }
+      }
+
+      files.add(filePath);
+    }
+
+    Future<void> walkDirectory(String rootPath, String currentPath) async {
+      try {
+        final dir = Directory(currentPath);
+        await for (final entity in dir.list(recursive: false)) {
+          try {
+            final stat = await entity.stat();
+            if (stat.type == FileSystemEntityType.directory) {
+              if (filter != null && !filter(entity.path)) {
+                continue;
+              }
+              final dirName = path.basename(entity.path);
+              if (!dirName.startsWith('.') && r) {
+                await walkDirectory(rootPath, entity.path);
+              }
+              continue;
+            }
+
+            if (stat.type == FileSystemEntityType.file) {
+              await maybeAddFile(entity.path, rootPath);
+            }
+          } catch (_) {
+            continue;
+          }
+        }
+      } catch (e) {
+        _logger.warning('Cannot access directory $currentPath: $e');
+      }
+    }
+
+    if (await _baseService.isFile(searchPath)) {
+      await maybeAddFile(searchPath, path.dirname(searchPath));
+      return files;
+    }
+
+    await walkDirectory(searchPath, searchPath);
+    return files;
+  }
+
+  Future<String> _grepFilesWithMatchesUsingRipgrep(
+    String executable,
+    String pattern,
+    List<String> files, {
+    required bool caseInsensitive,
+    required bool multiline,
+    required int? headLimit,
+    required String? workingDirectory,
+    List<String> extraArgs = const [],
+    bool chunkTargets = true,
+  }) async {
+    final output = <String>[];
+    final batches = chunkTargets ? _chunkFiles(files) : [files];
+    for (final batch in batches) {
+      final result = await _runRipgrep(
+        executable,
+        [
+          '--color',
+          'never',
+          '--files-with-matches',
+          if (caseInsensitive) '--ignore-case',
+          if (multiline) ...['--multiline', '--multiline-dotall'],
+          ...extraArgs,
+          '--',
+          pattern,
+          ...batch,
+        ],
+        workingDirectory,
+      );
+      if (result.exitCode == 1) {
+        continue;
+      }
+      _throwIfRipgrepFailed(result, workingDirectory);
+      output.addAll(_splitRipgrepOutput(result.stdout));
+    }
+
+    final uniqueFiles = output.toSet().toList();
+    final filesWithTime = await Future.wait(
+      uniqueFiles.map((file) async {
+        try {
+          final mtime = await _baseService.getModificationTime(file);
+          return MapEntry(file, mtime);
+        } catch (e) {
+          return MapEntry(file, DateTime.fromMillisecondsSinceEpoch(0));
+        }
+      }),
+    );
+
+    filesWithTime.sort((a, b) => b.value.compareTo(a.value));
+    var sortedFiles = filesWithTime.map((e) => e.key).toList();
+
+    const maxResults = 100;
+    final truncated = sortedFiles.length > maxResults;
+    sortedFiles = sortedFiles.take(maxResults).toList();
+
+    if (headLimit != null && headLimit > 0) {
+      sortedFiles = sortedFiles.take(headLimit).toList();
+    }
+
+    if (sortedFiles.isEmpty) {
+      return 'No files found';
+    }
+
+    final result =
+        'Found ${sortedFiles.length} file${sortedFiles.length > 1 ? 's' : ''}\n${sortedFiles.join('\n')}';
+    if (truncated && headLimit == null) {
+      return '$result\n(Results are truncated. Consider using a more specific path or pattern.)';
+    }
+    return result;
+  }
+
+  Future<String> _grepContentUsingRipgrep(
+    String executable,
+    String pattern,
+    List<String> files, {
+    required int? B,
+    required int? A,
+    required int? C,
+    required bool showLineNumbers,
+    required bool caseInsensitive,
+    required int? headLimit,
+    required bool multiline,
+    required String? workingDirectory,
+    List<String> extraArgs = const [],
+    bool chunkTargets = true,
+  }) async {
+    final outputLines = <String>[];
+    final batches = chunkTargets ? _chunkFiles(files) : [files];
+    for (final batch in batches) {
+      final result = await _runRipgrep(
+        executable,
+        [
+          '--json',
+          if (caseInsensitive) '--ignore-case',
+          if (multiline) ...['--multiline', '--multiline-dotall'],
+          if (C != null) ...['--context', '$C'],
+          if (C == null && B != null) ...['--before-context', '$B'],
+          if (C == null && A != null) ...['--after-context', '$A'],
+          ...extraArgs,
+          '--',
+          pattern,
+          ...batch,
+        ],
+        workingDirectory,
+      );
+      if (result.exitCode == 1) {
+        continue;
+      }
+      _throwIfRipgrepFailed(result, workingDirectory);
+
+      for (final line in _splitRipgrepOutput(result.stdout)) {
+        final event = jsonDecode(line);
+        if (event is! Map<String, dynamic>) {
+          continue;
+        }
+        final eventType = event['type'];
+        if (eventType != 'match' && eventType != 'context') {
+          continue;
+        }
+        final data = event['data'];
+        if (data is! Map<String, dynamic>) {
+          continue;
+        }
+        final filePath = _textFromRipgrepJson(data['path']);
+        final text = _textFromRipgrepJson(data['lines']);
+        final lineNumber = data['line_number'];
+        if (filePath == null || text == null || lineNumber is! int) {
+          continue;
+        }
+
+        final lines = _stripTrailingNewline(text).split('\n');
+        for (var i = 0; i < lines.length; i++) {
+          if (headLimit != null && outputLines.length >= headLimit) {
+            break;
+          }
+          final separator = eventType == 'context' ? '-' : ':';
+          final linePrefix =
+              showLineNumbers ? '${lineNumber + i}$separator' : '';
+          outputLines.add('$filePath:$linePrefix${lines[i]}');
+        }
+      }
+    }
+
+    if (outputLines.isEmpty) {
+      return 'No matches found';
+    }
+
+    final result = outputLines.join('\n');
+    if (headLimit != null && outputLines.length >= headLimit) {
+      return '$result\n(Output limited to first $headLimit lines)';
+    }
+    return result;
+  }
+
+  Future<String> _grepCountUsingRipgrep(
+    String executable,
+    String pattern,
+    List<String> files, {
+    required bool caseInsensitive,
+    required bool multiline,
+    required int? headLimit,
+    required String? workingDirectory,
+    List<String> extraArgs = const [],
+    bool chunkTargets = true,
+  }) async {
+    final output = <String>[];
+    final batches = chunkTargets ? _chunkFiles(files) : [files];
+    for (final batch in batches) {
+      final result = await _runRipgrep(
+        executable,
+        [
+          '--color',
+          'never',
+          '--with-filename',
+          '--count',
+          if (caseInsensitive) '--ignore-case',
+          if (multiline) ...['--multiline', '--multiline-dotall'],
+          ...extraArgs,
+          '--',
+          pattern,
+          ...batch,
+        ],
+        workingDirectory,
+      );
+      if (result.exitCode == 1) {
+        continue;
+      }
+      _throwIfRipgrepFailed(result, workingDirectory);
+      output.addAll(_splitRipgrepOutput(result.stdout));
+    }
+
+    if (headLimit != null && headLimit > 0 && output.length > headLimit) {
+      output.removeRange(headLimit, output.length);
+    }
+
+    if (output.isEmpty) {
+      return 'No matches found';
+    }
+
+    final result = output.join('\n');
+    if (headLimit != null && output.length >= headLimit) {
+      return '$result\n(Output limited to first $headLimit entries)';
+    }
+    return result;
+  }
+
+  Iterable<List<String>> _chunkFiles(List<String> files) sync* {
+    const batchSize = 200;
+    for (var i = 0; i < files.length; i += batchSize) {
+      yield files.sublist(
+        i,
+        (i + batchSize).clamp(0, files.length),
+      );
+    }
+  }
+
+  Future<ProcessResult> _runRipgrep(
+    String executable,
+    List<String> args,
+    String? workingDirectory,
+  ) async {
+    try {
+      return await Process.run(executable, args);
+    } on ProcessException catch (e) {
+      throw ApiException(
+          _maskResult('Error executing ripgrep: $e', workingDirectory));
+    } catch (e) {
+      throw ApiException(
+          _maskResult('Error executing ripgrep: $e', workingDirectory));
+    }
+  }
+
+  void _throwIfRipgrepFailed(
+    ProcessResult result,
+    String? workingDirectory,
+  ) {
+    if (result.exitCode == 0) {
+      return;
+    }
+
+    final error = result.stderr.toString().trim();
+    throw ApiException(_maskResult(
+      'Invalid ripgrep pattern or execution error: $error',
+      workingDirectory,
+    ));
+  }
+
+  List<String> _splitRipgrepOutput(dynamic output) {
+    final text = output is String ? output : output.toString();
+    return text
+        .split('\n')
+        .where((line) => line.isNotEmpty)
+        .toList(growable: true);
+  }
+
+  String? _textFromRipgrepJson(dynamic value) {
+    if (value is! Map<String, dynamic>) {
+      return null;
+    }
+    final text = value['text'];
+    if (text is String) {
+      return text;
+    }
+    final bytes = value['bytes'];
+    if (bytes is String) {
+      return utf8.decode(base64.decode(bytes));
+    }
+    return null;
+  }
+
+  String _stripTrailingNewline(String text) {
+    if (text.endsWith('\r\n')) {
+      return text.substring(0, text.length - 2);
+    }
+    if (text.endsWith('\n')) {
+      return text.substring(0, text.length - 1);
+    }
+    return text;
+  }
+
+  RegExp _compileGrepPattern(
+    String pattern, {
+    required bool caseInsensitive,
+    required bool multiline,
+    required String? workingDirectory,
+  }) {
+    final options = _resolveGrepPatternOptions(
+      pattern,
+      caseInsensitive: caseInsensitive,
+      multiline: multiline,
+    );
+
+    try {
+      return RegExp(
+        options.pattern,
+        multiLine: options.multiLine,
+        caseSensitive: options.caseSensitive,
+        dotAll: options.dotAll,
+      );
+    } catch (e) {
+      throw ApiException(
+          _maskResult('Invalid regex pattern: $e', workingDirectory));
+    }
+  }
+
+  _GrepPatternOptions _resolveGrepPatternOptions(
+    String pattern, {
+    required bool caseInsensitive,
+    required bool multiline,
+  }) {
+    var normalizedPattern = pattern;
+    var caseSensitive = !caseInsensitive;
+    var multiLine = multiline;
+    var dotAll = multiline;
+
+    final leadingFlags = RegExp(r'^\(\?([ims]+(?:-[ims]+)?|-[ims]+)\)');
+    while (true) {
+      final match = leadingFlags.firstMatch(normalizedPattern);
+      if (match == null) {
+        break;
+      }
+
+      var enabled = true;
+      for (final codePoint in match.group(1)!.runes) {
+        final flag = String.fromCharCode(codePoint);
+        if (flag == '-') {
+          enabled = false;
+          continue;
+        }
+
+        switch (flag) {
+          case 'i':
+            caseSensitive = !enabled;
+            break;
+          case 'm':
+            multiLine = enabled;
+            break;
+          case 's':
+            dotAll = enabled;
+            break;
+        }
+      }
+
+      normalizedPattern = normalizedPattern.substring(match.end);
+    }
+
+    return _GrepPatternOptions(
+      pattern: normalizedPattern,
+      caseSensitive: caseSensitive,
+      multiLine: multiLine,
+      dotAll: dotAll,
+    );
   }
 
   /// Files with matches (files_with_matches mode)
@@ -1242,7 +1936,7 @@ ${addLineNumbers(snippet, startLine: startLine)}''';
       filter: filter,
     );
 
-    if (headLimit != null && headLimit > 0) {
+    if (headLimit != null && headLimit > 0 && outputLines.length > headLimit) {
       outputLines.removeRange(headLimit, outputLines.length);
     }
 
@@ -1284,7 +1978,7 @@ ${addLineNumbers(snippet, startLine: startLine)}''';
       filter: filter,
     );
 
-    if (headLimit != null && headLimit > 0) {
+    if (headLimit != null && headLimit > 0 && countResults.length > headLimit) {
       countResults.removeRange(headLimit, countResults.length);
     }
 

--- a/lib/data/services/file_search_access_scope.dart
+++ b/lib/data/services/file_search_access_scope.dart
@@ -1,0 +1,18 @@
+typedef FilePathAccessPredicate = bool Function(String path);
+
+/// Describes the file access boundary for a search operation.
+///
+/// FileOperationService consumes this as an execution hint only; the permission
+/// system owns the policy and decides which subtrees must be excluded before a
+/// directory-level search can be delegated to an external search engine.
+class FileSearchAccessScope {
+  final FilePathAccessPredicate allowsRead;
+  final List<String> excludedPaths;
+  final bool canUseDirectorySearch;
+
+  const FileSearchAccessScope({
+    required this.allowsRead,
+    this.excludedPaths = const [],
+    this.canUseDirectorySearch = true,
+  });
+}

--- a/test/agent/security/file_permission_manager_test.dart
+++ b/test/agent/security/file_permission_manager_test.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:memex/agent/security/file_permission_manager.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('FilePermissionManager.buildSearchAccessScope', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir =
+          await Directory.systemTemp.createTemp('memex_permission_scope_test_');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('exports denied subtrees as directory-search exclusions', () {
+      final deniedPath = p.join(tempDir.path, '_System');
+      final manager = FilePermissionManager(
+        'user-1',
+        [
+          PermissionRule(
+            rootPath: tempDir.path,
+            access: FileAccessType.read,
+          ),
+          PermissionRule(
+            rootPath: deniedPath,
+            access: FileAccessType.none,
+          ),
+        ],
+        withDefaultRules: false,
+      );
+
+      final scope = manager.buildSearchAccessScope(tempDir.path);
+
+      expect(scope.canUseDirectorySearch, isTrue);
+      expect(scope.excludedPaths, [deniedPath]);
+      expect(scope.allowsRead(tempDir.path), isTrue);
+      expect(scope.allowsRead(deniedPath), isFalse);
+    });
+
+    test('disables directory search when denied subtree has readable override',
+        () {
+      final deniedPath = p.join(tempDir.path, '_System');
+      final readableOverride = p.join(deniedPath, 'Public');
+      final manager = FilePermissionManager(
+        'user-1',
+        [
+          PermissionRule(
+            rootPath: tempDir.path,
+            access: FileAccessType.read,
+          ),
+          PermissionRule(
+            rootPath: deniedPath,
+            access: FileAccessType.none,
+          ),
+          PermissionRule(
+            rootPath: readableOverride,
+            access: FileAccessType.read,
+          ),
+        ],
+        withDefaultRules: false,
+      );
+
+      final scope = manager.buildSearchAccessScope(tempDir.path);
+
+      expect(scope.canUseDirectorySearch, isFalse);
+      expect(scope.allowsRead(deniedPath), isFalse);
+      expect(scope.allowsRead(readableOverride), isTrue);
+    });
+
+    test('ignores denied rules outside the requested search root', () {
+      final outsidePath = p.join(tempDir.parent.path, 'outside-denied');
+      final manager = FilePermissionManager(
+        'user-1',
+        [
+          PermissionRule(
+            rootPath: tempDir.path,
+            access: FileAccessType.read,
+          ),
+          PermissionRule(
+            rootPath: outsidePath,
+            access: FileAccessType.none,
+          ),
+        ],
+        withDefaultRules: false,
+      );
+
+      final scope = manager.buildSearchAccessScope(tempDir.path);
+
+      expect(scope.canUseDirectorySearch, isTrue);
+      expect(scope.excludedPaths, isEmpty);
+    });
+  });
+}

--- a/test/data/services/file_operation_service_grep_test.dart
+++ b/test/data/services/file_operation_service_grep_test.dart
@@ -1,0 +1,198 @@
+import 'dart:io';
+
+import 'package:memex/data/services/file_search_access_scope.dart';
+import 'package:memex/data/services/file_operation_service.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  final ripgrepExecutable = _findRipgrepExecutable();
+
+  group('FileOperationService.grepFiles inline regex flags', () {
+    late Directory tempDir;
+    late Directory factsDir;
+    late FileOperationService service;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('memex_grep_test_');
+      factsDir = Directory(p.join(tempDir.path, 'Facts'));
+      await factsDir.create(recursive: true);
+      service = FileOperationService.forTesting(
+        ripgrepExecutable: '__memex_missing_rg_for_fallback_test__',
+      );
+
+      await File(p.join(factsDir.path, 'note.md')).writeAsString('''
+Before
+Memex is local-first
+After
+lower memex mention
+MemeX stylized
+''');
+      await File(
+        p.join(factsDir.path, 'case.md'),
+      ).writeAsString('Memex only mixed case\n');
+      await File(
+        p.join(factsDir.path, 'other.md'),
+      ).writeAsString('No product keyword here\n');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('files_with_matches accepts leading (?i)', () async {
+      final result = await service.grepFiles(
+        pattern: r'(?i)memex',
+        searchPath: '/Facts/case.md',
+        workingDirectory: tempDir.path,
+      );
+
+      expect(result, contains('Found 1 file'));
+      expect(result, contains('/Facts/case.md'));
+    });
+
+    test(
+      'content mode accepts leading (?i) with context and line numbers',
+      () async {
+        final result = await service.grepFiles(
+          pattern: r'(?i)meme[xX]|MemeX',
+          searchPath: '/Facts/note.md',
+          workingDirectory: tempDir.path,
+          outputMode: 'content',
+          C: 1,
+          n: true,
+          headLimit: 50,
+        );
+
+        expect(result, contains('/Facts/note.md:2:Memex is local-first'));
+        expect(result, contains('/Facts/note.md:4:lower memex mention'));
+        expect(result, contains('/Facts/note.md:5:MemeX stylized'));
+      },
+    );
+
+    test(
+      'count mode accepts combined leading flags and large head_limit',
+      () async {
+        final result = await service.grepFiles(
+          pattern: r'(?is)meme[xX]',
+          searchPath: '/Facts/note.md',
+          workingDirectory: tempDir.path,
+          outputMode: 'count',
+          headLimit: 50,
+        );
+
+        expect(result, '/Facts/note.md:3');
+      },
+    );
+
+    test(
+      'leading (?-i) overrides the default case-insensitive search',
+      () async {
+        final defaultResult = await service.grepFiles(
+          pattern: r'memex',
+          searchPath: '/Facts/case.md',
+          workingDirectory: tempDir.path,
+        );
+        final strictResult = await service.grepFiles(
+          pattern: r'(?-i)memex',
+          searchPath: '/Facts/case.md',
+          workingDirectory: tempDir.path,
+        );
+
+        expect(defaultResult, contains('/Facts/case.md'));
+        expect(strictResult, 'No files found');
+      },
+    );
+  });
+
+  group('FileOperationService.grepFiles ripgrep engine', () {
+    late Directory tempDir;
+    late FileOperationService service;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('memex_rg_test_');
+      service = FileOperationService.forTesting(
+        ripgrepExecutable: ripgrepExecutable,
+      );
+
+      await File(
+        p.join(tempDir.path, 'allowed.md'),
+      ).writeAsString('Memex mixed case\n');
+      await File(
+        p.join(tempDir.path, 'blocked.md'),
+      ).writeAsString('secret should stay unread\n');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'uses real ripgrep syntax when rg is available',
+      () async {
+        final result = await service.grepFiles(
+          pattern: r'(?i:memex)',
+          searchPath: tempDir.path,
+          outputMode: 'content',
+          n: true,
+        );
+
+        expect(result, contains('/allowed.md:1:Memex mixed case'));
+      },
+      skip: ripgrepExecutable == null ? 'ripgrep is not available' : false,
+    );
+
+    test(
+      'uses access scope exclusions before invoking directory ripgrep',
+      () async {
+        final blockedPath = p.join(tempDir.path, 'blocked.md');
+        final result = await service.grepFiles(
+          pattern: r'(?i:memex)|secret',
+          searchPath: tempDir.path,
+          accessScope: FileSearchAccessScope(
+            allowsRead: (filePath) => filePath != blockedPath,
+            excludedPaths: [blockedPath],
+          ),
+        );
+
+        expect(result, contains('/allowed.md'));
+        expect(result, isNot(contains('/blocked.md')));
+        expect(result, isNot(contains('secret')));
+      },
+      skip: ripgrepExecutable == null ? 'ripgrep is not available' : false,
+    );
+
+    test('builds directory ripgrep args from access scope', () async {
+      final blockedPath = p.join(tempDir.path, 'blocked.md');
+      final args = await service.buildRipgrepDirectoryArgsForTesting(
+        searchPath: tempDir.path,
+        includeGlob: '*.md',
+        typeExtensions: {'md', 'markdown'},
+        accessScope: FileSearchAccessScope(
+          allowsRead: (filePath) => filePath != blockedPath,
+          excludedPaths: [blockedPath],
+        ),
+      );
+
+      expect(args, isNotNull);
+      expect(args, contains('--no-ignore'));
+      expect(args, contains('*.md'));
+      expect(args, contains('*.{md,markdown}'));
+      expect(args, contains('!blocked.md'));
+      expect(args, contains('!blocked.md/**'));
+    });
+  });
+}
+
+String? _findRipgrepExecutable() {
+  try {
+    final result = Process.runSync('rg', ['--version']);
+    return result.exitCode == 0 ? 'rg' : null;
+  } catch (_) {
+    return null;
+  }
+}


### PR DESCRIPTION
## 中文

### 背景

Closes #79。

AI 助手在调用 `Grep` 工具时会根据工具说明生成 ripgrep 风格的正则，例如 `(?i)meme[xX]|MemeX`。之前 `Grep` 实际只通过 Dart `RegExp` 编译 pattern，Dart 不支持这类 ripgrep/Rust regex 内联 flag，因此工具会返回 `Invalid regex pattern: FormatException: Invalid group`，导致检索流程失败。

这版实现改为：优先使用真实 `rg` 执行搜索，以获得完整 ripgrep/Rust regex 兼容；当运行环境没有 `rg` 可执行文件时，再回退到 Dart 扫描实现，并保留常见内联 flag 的兼容层。

### 变更

- `FileOperationService.grepFiles` 优先检测并调用 `rg`，覆盖 `files_with_matches`、`content`、`count` 三种输出模式。
- 新增 `FileSearchAccessScope`，由权限层表达“读取判定 + 可传给目录级 rg 的排除子树”。
- `FilePermissionManager.buildSearchAccessScope()` 从权限规则生成搜索 scope：
  - 普通 deny 子树会转成 `rg --glob '!path' --glob '!path/**'`，因此可以安全地让 `rg` 直接搜索目录。
  - 如果 deny 子树下面又有更细的 allow override，无法用简单排除规则无损表达，则禁用目录级快路径，退回逐文件候选列表。
- `FileToolFactory` 不再给 Grep 传匿名 filter，而是传权限模块生成的 access scope，保持权限职责集中在 `FilePermissionManager`。
- `content` 模式使用 `rg --json` 解析结果，再输出为现有工具格式，保留上下文行和行号行为。
- 无 `rg` 环境下继续使用 Dart fallback，并支持 `(?i)`、`(?m)`、`(?s)`、组合形式如 `(?im)`，以及禁用形式如 `(?-i)`。
- 修复 `content` 和 `count` 输出模式下 `head_limit` 大于结果数量时可能触发 `RangeError` 的边界问题。
- 更新 `Grep` 工具说明：优先 ripgrep/Rust regex，无法运行 `rg` 的平台使用 fallback。
- 新增服务级和权限级单元测试，覆盖 fallback、真实 `rg` scoped flag（`(?i:...)`）、目录级 `rg` 排除参数、权限 scope 生成、复杂权限覆盖退回策略、三种输出模式和大 `head_limit` 场景。

### 验证

- `flutter test --no-pub test/data/services/file_operation_service_grep_test.dart test/agent/security/file_permission_manager_test.dart` ✅（10 tests）
- `flutter analyze --no-pub lib/data/services/file_search_access_scope.dart lib/agent/security/file_permission_manager.dart test/data/services/file_operation_service_grep_test.dart test/agent/security/file_permission_manager_test.dart lib/agent/prompts.dart` ✅
- `flutter analyze --no-pub lib/data/services/file_operation_service.dart lib/agent/built_in_tools/file_tools.dart` 仍报告既有 info，均不在本次新增逻辑中：`file_tools.dart` 里的工具参数命名、`file_operation_service.dart` 里的 `meta` 依赖声明 / `prefer_const_declarations` / `empty_catches`。
- `git diff --check upstream/main...HEAD` ✅

### 说明

在 Android/iOS 上，如果应用包内没有可执行的 `rg`，仍会走 Dart fallback。完整移动端 ripgrep 兼容需要后续引入 native Rust regex/ripgrep 能力或可执行分发方案；本 PR 已确保有 `rg` 的环境使用真实 ripgrep，并且无 `rg` 时不会再因为 `(?i)` 这类常见表达式失败。

## English

### Background

Closes #79.

The assistant can generate ripgrep-style regex patterns for the built-in `Grep` tool, for example `(?i)meme[xX]|MemeX`. The previous implementation compiled patterns only with Dart `RegExp`, which rejects ripgrep/Rust-regex inline flags such as `(?i)`, so the tool returned `Invalid regex pattern: FormatException: Invalid group` and interrupted retrieval.

This PR now prefers the real `rg` executable for full ripgrep/Rust-regex compatibility when available. If the runtime cannot execute `rg`, it falls back to the Dart scanner with a compatibility layer for common inline flags.

### Changes

- Makes `FileOperationService.grepFiles` detect and call `rg` first across `files_with_matches`, `content`, and `count` modes.
- Adds `FileSearchAccessScope`, a data-layer search boundary object that carries read checks plus subtrees that can be safely excluded from directory-level `rg`.
- Adds `FilePermissionManager.buildSearchAccessScope()` to generate the scope from permission rules:
  - Plain denied subtrees become `rg --glob '!path' --glob '!path/**'`, so `rg` can search the directory directly.
  - If a denied subtree contains a more specific readable override, the permission boundary cannot be represented losslessly as simple excludes, so directory-level search is disabled and Grep falls back to the candidate-file path.
- Updates `FileToolFactory` to pass the permission-owned access scope instead of an anonymous filter, keeping permission responsibilities inside `FilePermissionManager`.
- Uses `rg --json` for `content` mode and converts events back into the existing tool output format with context and line-number behavior.
- Keeps the Dart fallback for environments without `rg`, supporting `(?i)`, `(?m)`, `(?s)`, combinations such as `(?im)`, and disabling forms such as `(?-i)`.
- Fixes `RangeError` edge cases when `head_limit` is larger than the result count in `content` and `count` modes.
- Updates the `Grep` prompt to document the preferred ripgrep engine and fallback behavior.
- Adds focused service and permission tests covering fallback behavior, real `rg` scoped flags (`(?i:...)`), directory-level `rg` exclude args, permission scope generation, complex override fallback, all three output modes, and large `head_limit` behavior.

### Validation

- `flutter test --no-pub test/data/services/file_operation_service_grep_test.dart test/agent/security/file_permission_manager_test.dart` ✅ (10 tests)
- `flutter analyze --no-pub lib/data/services/file_search_access_scope.dart lib/agent/security/file_permission_manager.dart test/data/services/file_operation_service_grep_test.dart test/agent/security/file_permission_manager_test.dart lib/agent/prompts.dart` ✅
- `flutter analyze --no-pub lib/data/services/file_operation_service.dart lib/agent/built_in_tools/file_tools.dart` still reports pre-existing info-level findings outside this new logic: tool parameter naming in `file_tools.dart`, plus `meta` dependency declaration / `prefer_const_declarations` / `empty_catches` in `file_operation_service.dart`.
- `git diff --check upstream/main...HEAD` ✅

### Note

On Android/iOS, if the app bundle does not provide an executable `rg`, Memex will still use the Dart fallback. Full mobile ripgrep compatibility requires a follow-up native Rust regex/ripgrep integration or executable distribution strategy. This PR ensures environments with `rg` get real ripgrep behavior, while environments without `rg` no longer fail on common patterns like `(?i)`.
