### PR TITLE
[codex] 修复角色评论回复归属

### DIFF
--- a/lib/agent/comment_agent/comment_agent.dart
+++ b/lib/agent/comment_agent/comment_agent.dart
@@ -28,13 +28,15 @@ class CommentAgent {
     required String factId,
     String? characterId,
     required String rawInputContent,
+    String? forcedReplyToId,
     bool withMemoryManagement = false,
   }) async {
     final fileService = FileSystemService.instance;
     final characterService = CharacterService.instance;
     final factIdSafe = fileService.makeFactIdSafe(factId);
-    final characterKey =
-        fileService.makeFactIdSafe(characterId ?? 'no_character');
+    final characterKey = fileService.makeFactIdSafe(
+      characterId ?? 'no_character',
+    );
     final sessionPrefix = "comment_${userId}_${characterKey}_$factIdSafe";
     final resolved = await resolveCharacterSessionId(
       prefix: sessionPrefix,
@@ -100,8 +102,9 @@ class CommentAgent {
           parts.add('## Compressed Interaction History\n${ctx.checkpoints}');
         }
         if (ctx.recentTimeline.isNotEmpty) {
-          parts
-              .add('## Recent Cross-Scene Interactions\n${ctx.recentTimeline}');
+          parts.add(
+            '## Recent Cross-Scene Interactions\n${ctx.recentTimeline}',
+          );
         }
         if (parts.isNotEmpty) {
           state.systemReminders['character_timeline'] = parts.join('\n\n');
@@ -124,28 +127,31 @@ class CommentAgent {
       userName: userId,
       userProfile: userProfile,
       characterMemories: characterMemories,
+      forcedReplyToId: forcedReplyToId,
       forceActivate: true,
     );
     final skills = [skill];
     final agent = StatefulAgent(
-        systemPrompts: [commentAgentSystemPrompt, memoryManagementPrompt],
-        name: 'comment_agent',
-        client: client,
-        modelConfig: modelConfig,
-        state: state,
-        tools: tools,
-        skills: skills,
-        disableSubAgents: true,
-        controller: controller,
-        withGeneralPrinciples: true,
-        planMode: PlanMode.none,
-        autoSaveStateFunc: (state) async {
-          await saveAgentState(state);
-        },
-        systemCallback: createSystemCallback(userId));
+      systemPrompts: [commentAgentSystemPrompt, memoryManagementPrompt],
+      name: 'comment_agent',
+      client: client,
+      modelConfig: modelConfig,
+      state: state,
+      tools: tools,
+      skills: skills,
+      disableSubAgents: true,
+      controller: controller,
+      withGeneralPrinciples: true,
+      planMode: PlanMode.none,
+      autoSaveStateFunc: (state) async {
+        await saveAgentState(state);
+      },
+      systemCallback: createSystemCallback(userId),
+    );
 
     _logger.info(
-        'CommentAgent created, userId: $userId, sessionId: ${resolved.sessionId}');
+      'CommentAgent created, userId: $userId, sessionId: ${resolved.sessionId}',
+    );
     return agent;
   }
 
@@ -161,6 +167,7 @@ class CommentAgent {
     required String rawInputContent,
     String? initialInsight,
     String existingCommentsContext = '',
+    String? forcedReplyToId,
     DateTime? currentTime,
     DateTime? entryTime,
     bool withMemoryManagement = false,
@@ -173,6 +180,7 @@ class CommentAgent {
       factId: factId,
       characterId: characterId,
       rawInputContent: rawInputContent,
+      forcedReplyToId: forcedReplyToId,
       withMemoryManagement: withMemoryManagement,
     );
     final state = agent.state;
@@ -183,18 +191,21 @@ class CommentAgent {
     );
     final systemReminder = buildCurrentTimeReminder(effectiveCurrentTime);
     final userMessage = UserMessage([
-      TextPart(_buildCommentTaskMessage(
-        userContent: userContent,
-        factId: factId,
-        rawInputContent: rawInputContent,
-        initialInsight: initialInsight,
-        pkmContext: pkmContext,
-        entryTime: entryTime,
-        systemReminder: systemReminder,
-        existingCommentsContext: existingCommentsContext,
-        includePostBody:
-            state.metadata['comment_task_post_body_injected'] != factId,
-      ))
+      TextPart(
+        _buildCommentTaskMessage(
+          userContent: userContent,
+          factId: factId,
+          rawInputContent: rawInputContent,
+          initialInsight: initialInsight,
+          pkmContext: pkmContext,
+          entryTime: entryTime,
+          systemReminder: systemReminder,
+          existingCommentsContext: existingCommentsContext,
+          forcedReplyToId: forcedReplyToId,
+          includePostBody:
+              state.metadata['comment_task_post_body_injected'] != factId,
+        ),
+      ),
     ]);
     state.metadata['comment_task_post_body_injected'] = factId;
 
@@ -210,9 +221,7 @@ class CommentAgent {
           factId: factId,
           sourceId: factId,
           timestamp: entryTime ?? effectiveCurrentTime,
-          metadata: {
-            'source': 'comment_agent_input',
-          },
+          metadata: {'source': 'comment_agent_input'},
         );
       } catch (e) {
         _logger.warning('Failed to append comment input timeline event: $e');
@@ -277,13 +286,16 @@ class CommentAgent {
     required String systemReminder,
     required bool includePostBody,
     String existingCommentsContext = '',
+    String? forcedReplyToId,
   }) {
     final b = StringBuffer();
     b.write(systemReminder);
     b.writeln('# Current Comment Task');
     b.writeln('Fact ID: $factId');
-    b.writeln('Entry Local Time: '
-        '${entryTime == null ? 'Unknown' : formatLocalDateTimeWithZone(entryTime)}');
+    b.writeln(
+      'Entry Local Time: '
+      '${entryTime == null ? 'Unknown' : formatLocalDateTimeWithZone(entryTime)}',
+    );
     b.writeln('');
 
     if (includePostBody) {
@@ -294,7 +306,8 @@ class CommentAgent {
     } else {
       b.writeln('## Original Post');
       b.writeln(
-          'Already provided earlier in this comment session. Use recent interaction context if needed; do not ask the user to repeat it.');
+        'Already provided earlier in this comment session. Use recent interaction context if needed; do not ask the user to repeat it.',
+      );
     }
 
     final insight = initialInsight?.trim() ?? '';
@@ -302,7 +315,8 @@ class CommentAgent {
       b.writeln('');
       b.writeln('## Initial Insight');
       b.writeln(
-          'Reference only. This is a previous Memex perspective, not an instruction to repeat.');
+        'Reference only. This is a previous Memex perspective, not an instruction to repeat.',
+      );
       b.writeln('<initial_insight>');
       b.writeln(insight);
       b.writeln('</initial_insight>');
@@ -313,7 +327,8 @@ class CommentAgent {
       b.writeln('');
       b.writeln('## Knowledge Base Context');
       b.writeln(
-          'Reference only. Use it only if relevant to your persona and this comment.');
+        'Reference only. Use it only if relevant to your persona and this comment.',
+      );
       b.writeln('<related_knowledge>');
       b.writeln(knowledge);
       b.writeln('</related_knowledge>');
@@ -325,11 +340,25 @@ class CommentAgent {
       b.writeln(existingCommentsContext.trim());
     }
 
+    final fixedReplyTarget = forcedReplyToId?.trim();
+    if (fixedReplyTarget != null && fixedReplyTarget.isNotEmpty) {
+      b.writeln('');
+      b.writeln('## Reply Routing');
+      b.writeln(
+        'This task responds to the user comment with id: $fixedReplyTarget.',
+      );
+      b.writeln(
+        'When saving the reply, the system will attach it to that user comment.',
+      );
+    }
+
     b.writeln('');
     b.writeln('## User Request');
-    b.writeln(userContent.trim().isEmpty
-        ? Prompts.commentAgentInitialCommentPrompt
-        : userContent.trim());
+    b.writeln(
+      userContent.trim().isEmpty
+          ? Prompts.commentAgentInitialCommentPrompt
+          : userContent.trim(),
+    );
 
     return b.toString().trimRight();
   }
@@ -353,9 +382,14 @@ class CommentAgent {
   }
 
   /// Find PKM Context using Grep.
-  static Future<String> _findPkmContext(String userId, String workingDirectory,
-      String pkmPath, String factId, FileOperationService fileOpService,
-      {int contextLines = 10}) async {
+  static Future<String> _findPkmContext(
+    String userId,
+    String workingDirectory,
+    String pkmPath,
+    String factId,
+    FileOperationService fileOpService, {
+    int contextLines = 10,
+  }) async {
     final buffer = StringBuffer();
 
     // 1. Try to find the specific fact_id in PKM
@@ -375,8 +409,9 @@ class CommentAgent {
         buffer.writeln(result);
       }
     } catch (e) {
-      getLogger('CommentAgent')
-          .warning("Error finding PKM context for fact_id $factId: $e");
+      getLogger(
+        'CommentAgent',
+      ).warning("Error finding PKM context for fact_id $factId: $e");
     }
 
     return buffer.toString();

--- a/lib/agent/skills/character_tools_factory.dart
+++ b/lib/agent/skills/character_tools_factory.dart
@@ -32,6 +32,7 @@ class CharacterToolsFactory {
     required String workingDirectory,
     required String factId,
     String? characterId,
+    String? forcedReplyToId,
     bool includeSaveCommentTool = true,
     bool includeFileTools = true,
   }) {
@@ -54,6 +55,7 @@ class CharacterToolsFactory {
         userId: userId,
         cardId: factId,
         characterId: characterId,
+        forcedReplyToId: forcedReplyToId,
       );
       tools.add(commentFactory.buildSaveCommentTool());
     }

--- a/lib/agent/skills/comment_agent/comment_agent_skill.dart
+++ b/lib/agent/skills/comment_agent/comment_agent_skill.dart
@@ -15,6 +15,7 @@ class CommentAgentSkill extends Skill {
     String userName = '',
     String userProfile = '',
     String characterMemories = '',
+    String? forcedReplyToId,
     super.forceActivate,
   }) : super(
           name: "persona_comment",
@@ -30,6 +31,7 @@ class CommentAgentSkill extends Skill {
             workingDirectory: workingDirectory,
             factId: factId,
             characterId: character?.id,
+            forcedReplyToId: forcedReplyToId,
           ),
         );
 
@@ -62,8 +64,13 @@ class CommentAgentSkill extends Skill {
         character.systemPromptOverride != null &&
         character.systemPromptOverride!.trim().isNotEmpty) {
       final charName = character.name;
-      b.writeln(TavernMacro.resolve(character.systemPromptOverride!,
-          userName: userName, charName: charName));
+      b.writeln(
+        TavernMacro.resolve(
+          character.systemPromptOverride!,
+          userName: userName,
+          charName: charName,
+        ),
+      );
       b.writeln('');
     }
 
@@ -87,8 +94,13 @@ class CommentAgentSkill extends Skill {
       final charName = character.name;
       b.writeln('');
       b.writeln('## Style Examples');
-      b.writeln(TavernMacro.resolve(character.mesExample!,
-          userName: userName, charName: charName));
+      b.writeln(
+        TavernMacro.resolve(
+          character.mesExample!,
+          userName: userName,
+          charName: charName,
+        ),
+      );
     }
 
     return b.toString();
@@ -99,12 +111,14 @@ class CommentAgentSkill extends Skill {
     required String workingDirectory,
     required String factId,
     String? characterId,
+    String? forcedReplyToId,
   }) {
     return CharacterToolsFactory.buildCommentTools(
       userId: userId,
       workingDirectory: workingDirectory,
       factId: factId,
       characterId: characterId,
+      forcedReplyToId: forcedReplyToId,
     );
   }
 }

--- a/lib/agent/skills/comment_agent/tools/comment_tools.dart
+++ b/lib/agent/skills/comment_agent/tools/comment_tools.dart
@@ -11,31 +11,37 @@ class CommentToolFactory {
   final String userId;
   final String cardId;
   final String? characterId;
+  final String? forcedReplyToId;
 
   CommentToolFactory({
     required this.userId,
     required this.cardId,
     this.characterId,
+    this.forcedReplyToId,
   });
 
   Tool buildSaveCommentTool() {
+    final fixedReplyTarget = _normalizedReplyToId(forcedReplyToId);
     return Tool(
       name: 'SaveComment',
-      description: 'Saves your comment to the current raw input or reply.',
+      description: fixedReplyTarget == null
+          ? 'Saves your comment to the current raw input or reply.'
+          : 'Saves your comment as a reply to the current user comment. '
+              'The reply_to_id parameter is fixed by the system for this task.',
       parameters: {
         'type': 'object',
         'properties': {
           'content': {
             'type': 'string',
-            'description': 'The content of your comment.'
+            'description': 'The content of your comment.',
           },
           'reply_to_id': {
             'type': 'string',
             'description':
-                'Optional. The ID of the comment you are replying to. Leave empty for a top-level comment.'
+                'Optional. The ID of the comment you are replying to. Leave empty for a top-level comment.',
           },
         },
-        'required': ['content']
+        'required': ['content'],
       },
       executable: (String content, String? reply_to_id) async {
         if (content.isEmpty) {
@@ -46,6 +52,8 @@ class CommentToolFactory {
           final fileSystemService = FileSystemService.instance;
           final commentId = const Uuid().v4();
           final now = DateTime.now();
+          final resolvedReplyToId =
+              fixedReplyTarget ?? _normalizedReplyToId(reply_to_id);
 
           final updatedCardData = await fileSystemService.updateCardFile(
             userId,
@@ -57,7 +65,7 @@ class CommentToolFactory {
                 isAi: true,
                 timestamp: now.millisecondsSinceEpoch ~/ 1000,
                 characterId: characterId,
-                replyToId: reply_to_id,
+                replyToId: resolvedReplyToId,
               );
               return card.copyWith(comments: [...card.comments, newComment]);
             },
@@ -71,8 +79,10 @@ class CommentToolFactory {
           try {
             final cardPath = fileSystemService.getCardPath(userId, cardId);
             final workspacePath = fileSystemService.getWorkspacePath(userId);
-            final relativePath = fileSystemService.toRelativePath(cardPath,
-                rootPath: workspacePath);
+            final relativePath = fileSystemService.toRelativePath(
+              cardPath,
+              rootPath: workspacePath,
+            );
             await fileSystemService.eventLogService.logFileModified(
               userId: userId,
               filePath: relativePath,
@@ -81,7 +91,7 @@ class CommentToolFactory {
                 'card_id': cardId,
                 'comment_id': commentId,
                 'character_id': characterId,
-                'content': content
+                'content': content,
               },
             );
           } catch (e) {
@@ -99,20 +109,19 @@ class CommentToolFactory {
                 threadId: cardId,
                 factId: cardId,
                 commentId: commentId,
-                replyToId: reply_to_id != null && reply_to_id.isNotEmpty
-                    ? reply_to_id
-                    : null,
+                replyToId: resolvedReplyToId,
                 sourceId: commentId,
                 timestamp: now,
                 metadata: {
-                  if (reply_to_id != null && reply_to_id.isNotEmpty)
-                    'reply_to_id': reply_to_id,
+                  if (resolvedReplyToId != null)
+                    'reply_to_id': resolvedReplyToId,
                   'source': 'comment_tool',
                 },
               );
             } catch (e) {
-              getLogger('CommentTool')
-                  .warning('Failed to append character timeline event: $e');
+              getLogger(
+                'CommentTool',
+              ).warning('Failed to append character timeline event: $e');
             }
           }
 
@@ -125,5 +134,10 @@ class CommentToolFactory {
         }
       },
     );
+  }
+
+  static String? _normalizedReplyToId(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
   }
 }

--- a/lib/data/repositories/post_comment.dart
+++ b/lib/data/repositories/post_comment.dart
@@ -33,7 +33,8 @@ Future<Map<String, dynamic>> postCommentEndpoint(
   String? replyToId,
 }) async {
   _logger.info(
-      'PostCommentEndpoint: postComment called: cardId=$cardId, userId=$userId');
+    'PostCommentEndpoint: postComment called: cardId=$cardId, userId=$userId',
+  );
 
   try {
     // Read card file
@@ -78,8 +79,9 @@ Future<Map<String, dynamic>> postCommentEndpoint(
           commentId: commentId,
           replyToId: replyToId,
           sourceId: commentId,
-          timestamp:
-              DateTime.fromMillisecondsSinceEpoch(commentTimestamp * 1000),
+          timestamp: DateTime.fromMillisecondsSinceEpoch(
+            commentTimestamp * 1000,
+          ),
           metadata: {
             if (replyToId != null && replyToId.isNotEmpty)
               'reply_to_id': replyToId,
@@ -97,8 +99,10 @@ Future<Map<String, dynamic>> postCommentEndpoint(
     try {
       final cardPath = _fileSystemService.getCardPath(userId, cardId);
       final workspacePath = _fileSystemService.getWorkspacePath(userId);
-      final relativePath =
-          _fileSystemService.toRelativePath(cardPath, rootPath: workspacePath);
+      final relativePath = _fileSystemService.toRelativePath(
+        cardPath,
+        rootPath: workspacePath,
+      );
       await _fileSystemService.eventLogService.logFileModified(
         userId: userId,
         filePath: relativePath,
@@ -163,7 +167,8 @@ Future<void> processAICommentReply({
   bool withMemoryManagement = false,
 }) async {
   _logger.info(
-      'PostCommentEndpoint: processAICommentReply called: cardId=$cardId, userId=$userId');
+    'PostCommentEndpoint: processAICommentReply called: cardId=$cardId, userId=$userId',
+  );
 
   try {
     // 1. Read card file
@@ -198,8 +203,10 @@ Future<void> processAICommentReply({
     // 3. Raw Input Content
     // If rawInputContent is null, we should try to extract it from file.
     // Always extract factContent to get assetAnalyses
-    final factContent =
-        await _fileSystemService.extractFactContentFromFile(userId, cardId);
+    final factContent = await _fileSystemService.extractFactContentFromFile(
+      userId,
+      cardId,
+    );
     String contentToUse = rawInputContent ?? '';
     if (contentToUse.isEmpty) {
       contentToUse = factContent?.content ?? '';
@@ -238,7 +245,8 @@ Future<void> processAICommentReply({
           DateTime.fromMillisecondsSinceEpoch(c.timestamp * 1000),
         );
         buf.writeln(
-            '- [$author] (id: ${c.id}, time: $commentTime)$replyInfo: ${c.content}');
+          '- [$author] (id: ${c.id}, time: $commentTime)$replyInfo: ${c.content}',
+        );
       }
       buf.writeln('</existing_comments>');
       existingCommentsContext = buf.toString();
@@ -256,6 +264,7 @@ Future<void> processAICommentReply({
         initialInsight: initialInsight,
         existingCommentsContext: existingCommentsContext,
         characterId: characterId,
+        forcedReplyToId: userCommentId,
         currentTime: inputDateTime ?? DateTime.now(),
         entryTime: entryDateTime,
         withMemoryManagement: withMemoryManagement,
@@ -270,9 +279,9 @@ Future<void> processAICommentReply({
 
     // 8. EventBus Update
     if (sendEventBus) {
-      EventBusService.instance.emitEvent(CardDetailUpdatedMessage(
-        cardId: cardId,
-      ));
+      EventBusService.instance.emitEvent(
+        CardDetailUpdatedMessage(cardId: cardId),
+      );
     }
   } catch (e) {
     _logger.severe('Failed to process AI comment reply for card $cardId: $e');

--- a/test/agent/comment_tool_factory_test.dart
+++ b/test/agent/comment_tool_factory_test.dart
@@ -1,0 +1,179 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/widgets.dart';
+import 'package:memex/agent/memory/character_memory_service.dart';
+import 'package:memex/agent/skills/comment_agent/tools/comment_tools.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  group('CommentToolFactory SaveComment reply routing', () {
+    late Directory tempRoot;
+    late AppDatabase db;
+    late String userId;
+    const cardId = '2026/05/15.md#ts_1';
+    const characterId = 'char-a';
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await UserStorage.initL10n();
+      userId = 'comment_tool_${DateTime.now().microsecondsSinceEpoch}';
+      await UserStorage.saveUser(userId);
+
+      tempRoot = await Directory.systemTemp.createTemp('memex_comment_tool_');
+      await FileSystemService.init(tempRoot.path);
+
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      AppDatabase.setTestInstance(db);
+      await db.searchDao.createFtsTables();
+
+      await _writeCard(
+        userId: userId,
+        cardId: cardId,
+        comments: const [
+          CardComment(
+            id: 'char-comment',
+            content: 'I am the original character comment.',
+            isAi: true,
+            timestamp: 1000,
+            characterId: characterId,
+          ),
+          CardComment(
+            id: 'user-comment',
+            content: 'User replied to the character.',
+            isAi: false,
+            timestamp: 1001,
+            replyToId: 'char-comment',
+          ),
+        ],
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test(
+        'forcedReplyToId pins AI reply to the user comment even when '
+        'the model supplies the original character comment id', () async {
+      final tool = CommentToolFactory(
+        userId: userId,
+        cardId: cardId,
+        characterId: characterId,
+        forcedReplyToId: 'user-comment',
+      ).buildSaveCommentTool();
+
+      await Function.apply(tool.executable!, [
+        'Character answer to the user.',
+        'char-comment',
+      ]);
+
+      final latest = await _latestComment(userId, cardId);
+      expect(latest.isAi, isTrue);
+      expect(latest.characterId, characterId);
+      expect(latest.replyToId, 'user-comment');
+
+      final timeline = await CharacterMemoryService.instance.loadTimelineLines(
+        userId,
+        characterId,
+      );
+      expect(timeline.join('\n'), contains('"reply_to_id":"user-comment"'));
+      expect(
+        timeline.join('\n'),
+        isNot(contains('"reply_to_id":"char-comment"')),
+      );
+    });
+
+    test(
+        'forcedReplyToId still attaches to the user comment when '
+        'the model leaves reply_to_id empty', () async {
+      final tool = CommentToolFactory(
+        userId: userId,
+        cardId: cardId,
+        characterId: characterId,
+        forcedReplyToId: 'user-comment',
+      ).buildSaveCommentTool();
+
+      await Function.apply(tool.executable!, [
+        'Character answer without explicit tool routing.',
+        '',
+      ]);
+
+      final latest = await _latestComment(userId, cardId);
+      expect(latest.replyToId, 'user-comment');
+    });
+
+    test(
+      'without forcedReplyToId, SaveComment preserves a valid model-supplied '
+      'reply target for character-to-character interactions',
+      () async {
+        final tool = CommentToolFactory(
+          userId: userId,
+          cardId: cardId,
+          characterId: characterId,
+        ).buildSaveCommentTool();
+
+        await Function.apply(tool.executable!, [
+          'Character builds on another character.',
+          'char-comment',
+        ]);
+
+        final latest = await _latestComment(userId, cardId);
+        expect(latest.replyToId, 'char-comment');
+      },
+    );
+
+    test('empty reply_to_id is normalized to a top-level comment', () async {
+      final tool = CommentToolFactory(
+        userId: userId,
+        cardId: cardId,
+        characterId: characterId,
+      ).buildSaveCommentTool();
+
+      await Function.apply(tool.executable!, [
+        'Top-level character comment.',
+        '   ',
+      ]);
+
+      final latest = await _latestComment(userId, cardId);
+      expect(latest.replyToId, isNull);
+    });
+  });
+}
+
+Future<void> _writeCard({
+  required String userId,
+  required String cardId,
+  required List<CardComment> comments,
+}) async {
+  await FileSystemService.instance.safeWriteCardFile(
+    userId,
+    cardId,
+    CardData(
+      factId: cardId,
+      timestamp: 1000,
+      status: 'done',
+      tags: const [],
+      uiConfigs: const [],
+      title: 'Reply routing fixture',
+      comments: comments,
+    ),
+  );
+}
+
+Future<CardComment> _latestComment(String userId, String cardId) async {
+  final card = await FileSystemService.instance.readCardFile(userId, cardId);
+  expect(card, isNotNull);
+  expect(card!.comments, isNotEmpty);
+  return card.comments.last;
+}


### PR DESCRIPTION
## 背景

修复 #78。用户回复某个角色评论后，后续角色自动回复有概率显示成“角色回复自己”。

关联：Fixes #78

## 根因

用户评论会正确保存 `reply_to_id`，但 `process_ai_reply` 任务没有把“本次用户评论 id”固定传给 `SaveComment` 工具。评论 agent 只能从已有评论上下文里看到用户是在回复某个角色评论，因此模型可能把 AI 回复的 `reply_to_id` 也填成那条原始角色评论 id，最终 UI 展示成同一个角色指向自己。

## 改动

- 为评论保存工具增加系统固定回复目标 `forcedReplyToId`。
- 在处理用户评论触发的 AI 回复时，将 AI 回复强制挂到本次用户评论 id 上。
- 在 agent 任务消息里补充回复路由说明，降低模型误选旧评论 id 的概率。
- 保留没有固定目标时的原行为，角色之间仍然可以显式互相回复。
- 新增 `CommentToolFactory` 单元测试，覆盖固定回复目标、空目标归一化、保留角色间回复目标等场景。

## 验证

- `flutter pub get --offline`
- `dart format --set-exit-if-changed lib/agent/skills/comment_agent/tools/comment_tools.dart lib/agent/skills/character_tools_factory.dart lib/agent/skills/comment_agent/comment_agent_skill.dart lib/agent/comment_agent/comment_agent.dart lib/data/repositories/post_comment.dart test/agent/comment_tool_factory_test.dart`
- `flutter test --no-pub test/agent/comment_tool_factory_test.dart`
- `flutter analyze --no-pub lib/agent/skills/comment_agent/tools/comment_tools.dart lib/agent/skills/character_tools_factory.dart lib/agent/skills/comment_agent/comment_agent_skill.dart lib/agent/comment_agent/comment_agent.dart lib/data/repositories/post_comment.dart test/agent/comment_tool_factory_test.dart`
- `git diff --check upstream/main...HEAD`