### PR TITLE
[codex] Move Android Early schedule off the hour

### DIFF
--- a/.github/workflows/android-daily-early.yml
+++ b/.github/workflows/android-daily-early.yml
@@ -2,8 +2,8 @@ name: Android Daily Early
 
 on:
   schedule:
-    # 02:00 Asia/Shanghai. Scheduled workflows run on the default branch.
-    - cron: "0 18 * * *"
+    # 02:42 Asia/Shanghai. Scheduled workflows run on the default branch.
+    - cron: "42 18 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Move the Android Daily Early schedule from 02:00 to 02:42 Asia/Shanghai.
- Update the cron expression from `0 18 * * *` to `42 18 * * *` to avoid GitHub Actions start-of-hour scheduling load.

## Validation
- `git diff --check`
- Verified `2026-05-14T18:42:00Z` converts to `2026-05-15 02:42` in `Asia/Shanghai`.

## Notes
- Workflow-only change; no Flutter code or generated files touched.