### PR TITLE
feat: add reply button next to comment date

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -564,6 +564,7 @@
   "relatedMemories": "Related memories",
   "viewMore": "View more",
   "relatedRecords": "Related records",
+  "reply": "Reply",
   "replySent": "Reply sent",
   "insightTemplateGalleryTitle": "Insight card templates",
   "timelineTemplateGalleryTitle": "Timeline card templates",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2204,6 +2204,12 @@ abstract class AppLocalizations {
   /// **'Related records'**
   String get relatedRecords;
 
+  /// No description provided for @reply.
+  ///
+  /// In en, this message translates to:
+  /// **'Reply'**
+  String get reply;
+
   /// No description provided for @replySent.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1191,6 +1191,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relatedRecords => 'Related records';
 
   @override
+  String get reply => 'Reply';
+
+  @override
   String get replySent => 'Reply sent';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1152,6 +1152,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get relatedRecords => '相关记录';
 
   @override
+  String get reply => '回复';
+
+  @override
   String get replySent => '回复已发送';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -564,6 +564,7 @@
   "relatedMemories": "相关回忆",
   "viewMore": "查看更多",
   "relatedRecords": "相关记录",
+  "reply": "回复",
   "replySent": "回复已发送",
   "insightTemplateGalleryTitle": "洞察卡片模板展示",
   "timelineTemplateGalleryTitle": "Timeline 卡片模板展示",

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -1693,7 +1693,21 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
               else
                 Text(content, style: AppTextStyles.commentContent),
               const SizedBox(height: 6),
-              Text(time, style: AppTextStyles.commentDate),
+              Row(
+                children: [
+                  Text(time, style: AppTextStyles.commentDate),
+                  if (!isAuthor) ...[
+                    const SizedBox(width: 12),
+                    Text(
+                      UserStorage.l10n.reply,
+                      style: AppTextStyles.commentDate.copyWith(
+                        fontSize: 12,
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
## Changes

- 评论区日期旁边添加「回复」按钮，提升回复操作的可发现性
- 洞察初始评论（isAuthor）不显示回复按钮
- 回复字体 12px，视觉上作为辅助操作入口
- 新增 `reply` 本地化 key（en: Reply, zh: 回复）

## Files changed

- `lib/ui/timeline/widgets/timeline_card_detail_screen.dart`
- `lib/l10n/app_en.arb` / `app_zh.arb` + generated files