### PR TITLE
[codex] 增加 Android Early 应用内更新

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -151,5 +151,6 @@ flutter {
 }
 
 dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
     implementation("com.google.mlkit:text-recognition-chinese:16.0.1")
 }

--- a/android/app/src/cnEarly/AndroidManifest.xml
+++ b/android/app/src/cnEarly/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+</manifest>

--- a/android/app/src/globalEarly/AndroidManifest.xml
+++ b/android/app/src/globalEarly/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -79,6 +79,15 @@
 
             <!-- Note: currently only supports text + images (no audio/file shares). -->
         </activity>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/update_file_paths" />
+        </provider>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data android:name="flutterEmbedding" android:value="2" />

--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/AppUpdateChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/AppUpdateChannelHandler.kt
@@ -1,0 +1,113 @@
+package com.memexlab.memex.channels
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.core.content.FileProvider
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+
+/**
+ * Handles `com.memexlab.memex/app_update` MethodChannel.
+ *
+ * Android does not allow silent APK installs for normal apps. The "install"
+ * operation opens the system package installer after the APK has been
+ * downloaded by Dart.
+ */
+class AppUpdateChannelHandler(private val activity: Activity) {
+
+    companion object {
+        private const val CHANNEL = "com.memexlab.memex/app_update"
+
+        fun register(flutterEngine: FlutterEngine, activity: Activity) {
+            val handler = AppUpdateChannelHandler(activity)
+            MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+                .setMethodCallHandler { call, result ->
+                    when (call.method) {
+                        "isWifiConnected" -> result.success(handler.isWifiConnected())
+                        "canInstallApk" -> result.success(handler.canInstallApk())
+                        "openInstallPermissionSettings" -> {
+                            handler.openInstallPermissionSettings()
+                            result.success(null)
+                        }
+                        "installApk" -> {
+                            val apkPath = call.argument<String>("apkPath")
+                            if (apkPath.isNullOrBlank()) {
+                                result.error("INVALID_ARGUMENTS", "Missing apkPath", null)
+                                return@setMethodCallHandler
+                            }
+                            try {
+                                handler.installApk(apkPath)
+                                result.success(null)
+                            } catch (e: ActivityNotFoundException) {
+                                result.error("NO_INSTALLER", "No package installer found", null)
+                            } catch (e: IllegalArgumentException) {
+                                result.error("INVALID_APK", e.message, null)
+                            } catch (e: Exception) {
+                                result.error("INSTALL_ERROR", e.message, null)
+                            }
+                        }
+                        else -> result.notImplemented()
+                    }
+                }
+        }
+    }
+
+    private fun isWifiConnected(): Boolean {
+        val connectivityManager =
+            activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+    }
+
+    private fun canInstallApk(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            activity.packageManager.canRequestPackageInstalls()
+        } else {
+            true
+        }
+    }
+
+    private fun openInstallPermissionSettings() {
+        val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Intent(
+                Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                Uri.parse("package:${activity.packageName}")
+            )
+        } else {
+            Intent(Settings.ACTION_SECURITY_SETTINGS)
+        }
+        activity.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+    }
+
+    private fun installApk(apkPath: String) {
+        val apkFile = File(apkPath)
+        require(apkFile.exists() && apkFile.isFile) {
+            "APK file does not exist: $apkPath"
+        }
+        require(apkFile.extension.equals("apk", ignoreCase = true)) {
+            "File is not an APK: $apkPath"
+        }
+
+        val uri = FileProvider.getUriForFile(
+            activity,
+            "${activity.packageName}.fileprovider",
+            apkFile
+        )
+
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        activity.startActivity(intent)
+    }
+}

--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/ChannelRegistrar.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/ChannelRegistrar.kt
@@ -18,5 +18,6 @@ object ChannelRegistrar {
         WebViewChannelHandler.register(flutterEngine, activity)
         AudioConverterChannelHandler.register(flutterEngine, activity)
         SystemActionsChannelHandler.register(flutterEngine, activity)
+        AppUpdateChannelHandler.register(flutterEngine, activity)
     }
 }

--- a/android/app/src/main/res/xml/update_file_paths.xml
+++ b/android/app/src/main/res/xml/update_file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path
+        name="early_update_cache"
+        path="updates/" />
+</paths>

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -11,6 +11,7 @@ import 'package:memex/data/services/table_change_notifier.dart';
 import 'package:memex/data/services/card_attachment_service.dart';
 import 'package:memex/data/services/card_detail_notifier.dart';
 import 'package:memex/data/services/clarification_request_service.dart';
+import 'package:memex/data/services/app_update_service.dart';
 import 'package:memex/data/services/user_notification_service.dart';
 import 'package:path/path.dart' as path;
 import 'package:image_picker/image_picker.dart';
@@ -566,6 +567,42 @@ class MemexRouter {
     final userId = await UserStorage.getUserId();
     if (userId == null) return;
     await CommentSettingsService.save(userId, settings);
+  }
+
+  Future<AppUpdateSettings> getAppUpdateSettings() {
+    return AppUpdateService.instance.loadSettings();
+  }
+
+  Future<void> saveAppUpdateSettings(AppUpdateSettings settings) {
+    return AppUpdateService.instance.saveSettings(settings);
+  }
+
+  Future<Result<AppUpdateCheckResult>> checkEarlyUpdate({
+    bool manual = false,
+    bool respectWifi = false,
+  }) {
+    return runResult(() {
+      return AppUpdateService.instance.checkForUpdate(
+        manual: manual,
+        respectWifi: respectWifi,
+      );
+    });
+  }
+
+  Future<Result<AppUpdateDownloadResult>> downloadEarlyUpdate(
+    AppUpdateInfo update, {
+    void Function(int receivedBytes, int totalBytes)? onProgress,
+  }) {
+    return runResult(() {
+      return AppUpdateService.instance.downloadUpdate(
+        update,
+        onProgress: onProgress,
+      );
+    });
+  }
+
+  Future<Result<AppUpdateInstallResult>> installEarlyUpdate(String apkPath) {
+    return runResult(() => AppUpdateService.instance.installUpdate(apkPath));
   }
 
   Future<void> enqueueTask({

--- a/lib/data/services/app_update_service.dart
+++ b/lib/data/services/app_update_service.dart
@@ -1,0 +1,567 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:memex/config/app_flavor.dart';
+import 'package:memex/utils/logger.dart';
+
+class AppUpdateSettings {
+  final bool autoCheckEnabled;
+  final bool wifiOnlyDownloads;
+  final bool autoDownloadAndInstall;
+  final DateTime? lastCheckAt;
+
+  const AppUpdateSettings({
+    this.autoCheckEnabled = true,
+    this.wifiOnlyDownloads = true,
+    this.autoDownloadAndInstall = false,
+    this.lastCheckAt,
+  });
+
+  factory AppUpdateSettings.fromJson(Map<String, dynamic> json) {
+    return AppUpdateSettings(
+      autoCheckEnabled: json['auto_check_enabled'] as bool? ?? true,
+      wifiOnlyDownloads: json['wifi_only_downloads'] as bool? ?? true,
+      autoDownloadAndInstall:
+          json['auto_download_and_install'] as bool? ?? false,
+      lastCheckAt: DateTime.tryParse(json['last_check_at'] as String? ?? ''),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'auto_check_enabled': autoCheckEnabled,
+        'wifi_only_downloads': wifiOnlyDownloads,
+        'auto_download_and_install': autoDownloadAndInstall,
+        if (lastCheckAt != null)
+          'last_check_at': lastCheckAt!.toIso8601String(),
+      };
+
+  AppUpdateSettings copyWith({
+    bool? autoCheckEnabled,
+    bool? wifiOnlyDownloads,
+    bool? autoDownloadAndInstall,
+    DateTime? lastCheckAt,
+    bool clearLastCheckAt = false,
+  }) {
+    return AppUpdateSettings(
+      autoCheckEnabled: autoCheckEnabled ?? this.autoCheckEnabled,
+      wifiOnlyDownloads: wifiOnlyDownloads ?? this.wifiOnlyDownloads,
+      autoDownloadAndInstall:
+          autoDownloadAndInstall ?? this.autoDownloadAndInstall,
+      lastCheckAt: clearLastCheckAt ? null : (lastCheckAt ?? this.lastCheckAt),
+    );
+  }
+
+  bool shouldAutoCheck({
+    required DateTime now,
+    Duration minInterval = const Duration(hours: 12),
+  }) {
+    if (!autoCheckEnabled) return false;
+    final checkedAt = lastCheckAt;
+    if (checkedAt == null) return true;
+    return now.difference(checkedAt) >= minInterval;
+  }
+}
+
+class AppPackageVersion {
+  final String versionName;
+  final int buildNumber;
+
+  const AppPackageVersion({
+    required this.versionName,
+    required this.buildNumber,
+  });
+}
+
+class AppUpdateInfo {
+  final String releaseName;
+  final String tagName;
+  final String versionName;
+  final int buildNumber;
+  final String assetName;
+  final int sizeBytes;
+  final String downloadUrl;
+  final String releaseNotes;
+  final DateTime? publishedAt;
+
+  const AppUpdateInfo({
+    required this.releaseName,
+    required this.tagName,
+    required this.versionName,
+    required this.buildNumber,
+    required this.assetName,
+    required this.sizeBytes,
+    required this.downloadUrl,
+    required this.releaseNotes,
+    this.publishedAt,
+  });
+
+  String get displayVersion => '$versionName+$buildNumber';
+}
+
+enum AppUpdateCheckStatus {
+  unsupported,
+  skippedNotWifi,
+  noUpdate,
+  updateAvailable,
+}
+
+class AppUpdateCheckResult {
+  final AppUpdateCheckStatus status;
+  final AppUpdateInfo? update;
+
+  const AppUpdateCheckResult._(this.status, [this.update]);
+
+  const AppUpdateCheckResult.unsupported()
+      : this._(AppUpdateCheckStatus.unsupported);
+
+  const AppUpdateCheckResult.skippedNotWifi()
+      : this._(AppUpdateCheckStatus.skippedNotWifi);
+
+  const AppUpdateCheckResult.noUpdate() : this._(AppUpdateCheckStatus.noUpdate);
+
+  const AppUpdateCheckResult.updateAvailable(AppUpdateInfo update)
+      : this._(AppUpdateCheckStatus.updateAvailable, update);
+}
+
+class AppUpdateDownloadResult {
+  final AppUpdateInfo update;
+  final String apkPath;
+
+  const AppUpdateDownloadResult({
+    required this.update,
+    required this.apkPath,
+  });
+}
+
+enum AppUpdateInstallStatus {
+  started,
+  permissionRequired,
+  unsupported,
+}
+
+class AppUpdateInstallResult {
+  final AppUpdateInstallStatus status;
+
+  const AppUpdateInstallResult(this.status);
+}
+
+class AppUpdateWifiRequiredException implements Exception {
+  const AppUpdateWifiRequiredException();
+
+  @override
+  String toString() => 'Wi-Fi is required to download this update.';
+}
+
+class AppUpdateEnvironment {
+  final bool isAndroid;
+  final bool isEarlyChannel;
+  final String flavorName;
+
+  const AppUpdateEnvironment({
+    required this.isAndroid,
+    required this.isEarlyChannel,
+    required this.flavorName,
+  });
+
+  factory AppUpdateEnvironment.current() {
+    final flavorName = switch ((AppFlavor.current, AppFlavor.channel)) {
+      (AppFlavorType.cn, AppChannelType.early) => 'cnEarly',
+      (AppFlavorType.global, AppChannelType.early) => 'globalEarly',
+      (AppFlavorType.cn, AppChannelType.stable) => 'cn',
+      _ => 'global',
+    };
+
+    return AppUpdateEnvironment(
+      isAndroid: Platform.isAndroid,
+      isEarlyChannel: AppFlavor.isEarly,
+      flavorName: flavorName,
+    );
+  }
+}
+
+abstract class AppUpdatePlatform {
+  Future<bool> isWifiConnected();
+  Future<bool> canInstallApk();
+  Future<void> openInstallPermissionSettings();
+  Future<void> installApk(String apkPath);
+}
+
+class MethodChannelAppUpdatePlatform implements AppUpdatePlatform {
+  static const MethodChannel _channel =
+      MethodChannel('com.memexlab.memex/app_update');
+
+  const MethodChannelAppUpdatePlatform();
+
+  @override
+  Future<bool> isWifiConnected() async {
+    final result = await _channel.invokeMethod<bool>('isWifiConnected');
+    return result ?? false;
+  }
+
+  @override
+  Future<bool> canInstallApk() async {
+    final result = await _channel.invokeMethod<bool>('canInstallApk');
+    return result ?? false;
+  }
+
+  @override
+  Future<void> openInstallPermissionSettings() {
+    return _channel.invokeMethod<void>('openInstallPermissionSettings');
+  }
+
+  @override
+  Future<void> installApk(String apkPath) {
+    return _channel.invokeMethod<void>('installApk', {'apkPath': apkPath});
+  }
+}
+
+class AppUpdateSettingsStore {
+  static const String _key = 'early_update_settings';
+
+  Future<AppUpdateSettings> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null || raw.trim().isEmpty) {
+      return const AppUpdateSettings();
+    }
+
+    try {
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      return AppUpdateSettings.fromJson(json);
+    } catch (_) {
+      return const AppUpdateSettings();
+    }
+  }
+
+  Future<void> save(AppUpdateSettings settings) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, jsonEncode(settings.toJson()));
+  }
+}
+
+typedef PackageVersionLoader = Future<AppPackageVersion> Function();
+typedef UpdateDirectoryProvider = Future<Directory> Function();
+typedef Clock = DateTime Function();
+
+class AppUpdateService {
+  AppUpdateService({
+    http.Client? httpClient,
+    AppUpdatePlatform? platform,
+    AppUpdateSettingsStore? settingsStore,
+    AppUpdateEnvironment? environment,
+    PackageVersionLoader? packageVersionLoader,
+    UpdateDirectoryProvider? updateDirectoryProvider,
+    Clock? clock,
+  })  : _httpClient = httpClient ?? http.Client(),
+        _platform = platform ?? const MethodChannelAppUpdatePlatform(),
+        _settingsStore = settingsStore ?? AppUpdateSettingsStore(),
+        _environment = environment ?? AppUpdateEnvironment.current(),
+        _packageVersionLoader = packageVersionLoader ?? _loadPackageVersion,
+        _updateDirectoryProvider =
+            updateDirectoryProvider ?? _defaultUpdateDirectory,
+        _clock = clock ?? DateTime.now;
+
+  static final AppUpdateService instance = AppUpdateService();
+  static const String releasesUrl =
+      'https://api.github.com/repos/memex-lab/memex/releases?per_page=20';
+
+  final http.Client _httpClient;
+  final AppUpdatePlatform _platform;
+  final AppUpdateSettingsStore _settingsStore;
+  final AppUpdateEnvironment _environment;
+  final PackageVersionLoader _packageVersionLoader;
+  final UpdateDirectoryProvider _updateDirectoryProvider;
+  final Clock _clock;
+  final _logger = getLogger('AppUpdateService');
+
+  bool get isSupported => _environment.isAndroid && _environment.isEarlyChannel;
+
+  Future<AppUpdateSettings> loadSettings() => _settingsStore.load();
+
+  Future<void> saveSettings(AppUpdateSettings settings) {
+    return _settingsStore.save(settings);
+  }
+
+  Future<bool> shouldRunAutoCheck() async {
+    if (!isSupported) return false;
+    final settings = await loadSettings();
+    return settings.shouldAutoCheck(now: _clock());
+  }
+
+  Future<AppUpdateCheckResult> checkForUpdate({
+    bool manual = false,
+    bool respectWifi = false,
+  }) async {
+    if (!isSupported) {
+      return const AppUpdateCheckResult.unsupported();
+    }
+
+    final settings = await loadSettings();
+    if (respectWifi && settings.wifiOnlyDownloads) {
+      final isWifi = await _platform.isWifiConnected();
+      if (!isWifi) {
+        if (manual) {
+          await saveSettings(settings.copyWith(lastCheckAt: _clock()));
+        }
+        return const AppUpdateCheckResult.skippedNotWifi();
+      }
+    }
+
+    final packageVersion = await _packageVersionLoader();
+    final releases = await _fetchReleases();
+    final update = selectBestUpdate(
+      releases: releases,
+      currentBuildNumber: packageVersion.buildNumber,
+      flavorName: _environment.flavorName,
+    );
+
+    await saveSettings(settings.copyWith(lastCheckAt: _clock()));
+    if (update == null) {
+      return const AppUpdateCheckResult.noUpdate();
+    }
+    return AppUpdateCheckResult.updateAvailable(update);
+  }
+
+  Future<AppUpdateDownloadResult> downloadUpdate(
+    AppUpdateInfo update, {
+    void Function(int receivedBytes, int totalBytes)? onProgress,
+  }) async {
+    final settings = await loadSettings();
+    if (settings.wifiOnlyDownloads && !await _platform.isWifiConnected()) {
+      throw const AppUpdateWifiRequiredException();
+    }
+
+    final dir = await _updateDirectoryProvider();
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+
+    final fileName = _safeFileName(update.assetName);
+    final targetFile = File(path.join(dir.path, fileName));
+    final tempFile = File('${targetFile.path}.part');
+    if (await tempFile.exists()) {
+      await tempFile.delete();
+    }
+
+    final request = http.Request('GET', Uri.parse(update.downloadUrl));
+    request.headers.addAll(_githubHeaders);
+    final response = await _httpClient.send(request);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'APK download failed: HTTP ${response.statusCode}',
+        uri: Uri.parse(update.downloadUrl),
+      );
+    }
+
+    final totalBytes = response.contentLength ?? update.sizeBytes;
+    var receivedBytes = 0;
+    final sink = tempFile.openWrite();
+    try {
+      await for (final chunk in response.stream) {
+        sink.add(chunk);
+        receivedBytes += chunk.length;
+        onProgress?.call(receivedBytes, totalBytes);
+      }
+    } finally {
+      await sink.close();
+    }
+
+    if (await targetFile.exists()) {
+      await targetFile.delete();
+    }
+    await tempFile.rename(targetFile.path);
+
+    return AppUpdateDownloadResult(
+      update: update,
+      apkPath: targetFile.path,
+    );
+  }
+
+  Future<AppUpdateInstallResult> installUpdate(String apkPath) async {
+    if (!isSupported) {
+      return const AppUpdateInstallResult(AppUpdateInstallStatus.unsupported);
+    }
+
+    final canInstall = await _platform.canInstallApk();
+    if (!canInstall) {
+      await _platform.openInstallPermissionSettings();
+      return const AppUpdateInstallResult(
+        AppUpdateInstallStatus.permissionRequired,
+      );
+    }
+
+    await _platform.installApk(apkPath);
+    return const AppUpdateInstallResult(AppUpdateInstallStatus.started);
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchReleases() async {
+    final response =
+        await _httpClient.get(Uri.parse(releasesUrl), headers: _githubHeaders);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'GitHub releases request failed: HTTP ${response.statusCode}',
+        uri: Uri.parse(releasesUrl),
+      );
+    }
+
+    final decoded = jsonDecode(response.body);
+    if (decoded is! List) {
+      throw const FormatException('GitHub releases response is not a list');
+    }
+
+    return decoded
+        .whereType<Map>()
+        .map((item) => Map<String, dynamic>.from(item))
+        .toList();
+  }
+
+  AppUpdateInfo? selectBestUpdate({
+    required List<Map<String, dynamic>> releases,
+    required int currentBuildNumber,
+    required String flavorName,
+  }) {
+    final candidates = <AppUpdateInfo>[];
+
+    for (final release in releases) {
+      if (release['draft'] == true || release['prerelease'] != true) {
+        continue;
+      }
+
+      final tagName = release['tag_name'] as String? ?? '';
+      final assets = release['assets'];
+      if (assets is! List) continue;
+
+      for (final rawAsset in assets.whereType<Map>()) {
+        final asset = Map<String, dynamic>.from(rawAsset);
+        final name = asset['name'] as String? ?? '';
+        final downloadUrl = asset['browser_download_url'] as String? ?? '';
+        if (!name.toLowerCase().endsWith('.apk')) continue;
+        if (!_assetMatchesFlavor(name, flavorName)) continue;
+        if (downloadUrl.isEmpty) continue;
+
+        final releaseNotes = release['body'] as String? ?? '';
+        final buildNumber = _parseBuildNumber(name) ??
+            _parseBuildNumber(releaseNotes) ??
+            _parseBuildNumber(tagName);
+        if (buildNumber == null || buildNumber <= currentBuildNumber) {
+          continue;
+        }
+
+        candidates.add(
+          AppUpdateInfo(
+            releaseName: release['name'] as String? ?? name,
+            tagName: tagName,
+            versionName: _parseVersionName(name) ??
+                _parseVersionName(releaseNotes) ??
+                _parseVersionName(tagName) ??
+                (tagName.isEmpty ? null : tagName) ??
+                name,
+            buildNumber: buildNumber,
+            assetName: name,
+            sizeBytes: (asset['size'] as num?)?.toInt() ?? 0,
+            downloadUrl: downloadUrl,
+            releaseNotes: releaseNotes,
+            publishedAt:
+                DateTime.tryParse(release['published_at'] as String? ?? ''),
+          ),
+        );
+      }
+    }
+
+    candidates.sort((a, b) => b.buildNumber.compareTo(a.buildNumber));
+    final selected = candidates.isEmpty ? null : candidates.first;
+    if (selected == null) {
+      _logger.fine('No early update found for $flavorName');
+    }
+    return selected;
+  }
+
+  static Future<AppPackageVersion> _loadPackageVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    return AppPackageVersion(
+      versionName: info.version,
+      buildNumber: int.tryParse(info.buildNumber) ?? 0,
+    );
+  }
+
+  static Future<Directory> _defaultUpdateDirectory() async {
+    final cacheDir = await getApplicationCacheDirectory();
+    return Directory(path.join(cacheDir.path, 'updates'));
+  }
+
+  static Map<String, String> get _githubHeaders => const {
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'Memex-Early-Updater',
+      };
+
+  static String _normalize(String value) {
+    return value.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
+  }
+
+  static bool _assetMatchesFlavor(String assetName, String flavorName) {
+    final normalizedName = _normalize(assetName);
+    final normalizedFlavor = _normalize(flavorName);
+    if (normalizedName.contains(normalizedFlavor)) return true;
+
+    if (normalizedFlavor == 'globalearly') {
+      return normalizedName.contains('early') &&
+          !normalizedName.contains('cnearly');
+    }
+    return false;
+  }
+
+  static int? _parseBuildNumber(String value) {
+    final versionLineMatch =
+        RegExp(r'Version:\s*[^\s+]+\+(\d+)', caseSensitive: false)
+            .firstMatch(value.trim());
+    if (versionLineMatch != null) {
+      return int.tryParse(versionLineMatch.group(1)!);
+    }
+
+    final assetMatch =
+        RegExp(r'_(\d+)\.apk$', caseSensitive: false).firstMatch(value.trim());
+    if (assetMatch != null) {
+      return int.tryParse(assetMatch.group(1)!);
+    }
+
+    final tagMatch = RegExp(r'[+_-](\d+)$').firstMatch(value.trim());
+    if (tagMatch != null) {
+      return int.tryParse(tagMatch.group(1)!);
+    }
+    return null;
+  }
+
+  static String? _parseVersionName(String value) {
+    final versionLineMatch =
+        RegExp(r'Version:\s*([^\s+]+)\+\d+', caseSensitive: false)
+            .firstMatch(value.trim());
+    if (versionLineMatch != null) {
+      return versionLineMatch.group(1);
+    }
+
+    final assetMatch = RegExp(
+      r'memex_[^_]+_([^_]+)_\d+\.apk$',
+      caseSensitive: false,
+    ).firstMatch(value.trim());
+    if (assetMatch != null) {
+      return assetMatch.group(1);
+    }
+
+    final tagMatch =
+        RegExp(r'v?(\d+(?:\.\d+){1,3})(?:[+_-]\d+)?').firstMatch(value);
+    return tagMatch?.group(1);
+  }
+
+  static String _safeFileName(String value) {
+    final fallback = value.trim().isEmpty ? 'memex_early_update.apk' : value;
+    return fallback.replaceAll(RegExp(r'[^a-zA-Z0-9._-]'), '_');
+  }
+}

--- a/lib/data/services/settings_registry.dart
+++ b/lib/data/services/settings_registry.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:memex/config/app_flavor.dart';
 import 'package:memex/domain/models/settings_item.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/ui/settings/widgets/system_authorization_page.dart';
@@ -301,6 +304,35 @@ class SettingsRegistry {
           parentPathGetter: () =>
               [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
         ),
+        if (Platform.isAndroid && AppFlavor.isEarly)
+          SettingsItem(
+            id: 'settings.early_updates',
+            titleGetter: () => UserStorage.l10n.earlyUpdateSettingsTitle,
+            descriptionGetter: () => UserStorage.l10n.earlyUpdateSettingsDesc,
+            keywords: const [
+              '更新',
+              '自动更新',
+              'Early',
+              '预发布',
+              '内测',
+              'APK',
+              'GitHub',
+              'Wi-Fi',
+              'update',
+              'auto update',
+              'pre-release',
+              'prerelease',
+              'download',
+              'install',
+              'wifi',
+            ],
+            icon: Icons.system_update_alt,
+            navigationTarget: NavigationTarget(
+              pageBuilder: (_) => const SettingsPage(),
+            ),
+            parentPathGetter: () =>
+                [UserStorage.l10n.personalCenter, UserStorage.l10n.settings],
+          ),
         SettingsItem(
           id: 'settings.show_insight',
           titleGetter: () => UserStorage.l10n.showInsightTextTitle,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1065,5 +1065,48 @@
   "setPrimaryCompanionSubtitle": "Automatically set as your primary companion after import",
   "confirmImport": "Confirm Import",
   "chatBackground": "Chat Background",
-  "chooseChatBackgroundImage": "Choose background image"
+  "chooseChatBackgroundImage": "Choose background image",
+  "earlyUpdateSettingsTitle": "Early access updates",
+  "earlyUpdateSettingsDesc": "Check GitHub pre-releases for the matching Early APK, download it, and hand it to Android's installer.",
+  "earlyUpdateUnsupported": "Early updates are only available in the Android Early build.",
+  "earlyUpdateAutoCheckTitle": "Auto check for updates",
+  "earlyUpdateAutoCheckDesc": "Check at startup at most once every 12 hours.",
+  "earlyUpdateWifiOnlyTitle": "Download on Wi-Fi only",
+  "earlyUpdateWifiOnlyDesc": "Skip update downloads while using mobile data.",
+  "earlyUpdateAutoInstallTitle": "Auto download and install",
+  "earlyUpdateAutoInstallDesc": "When a new build is found, download it and open the Android installer automatically.",
+  "earlyUpdateCheckNow": "Check now",
+  "earlyUpdateChecking": "Checking GitHub pre-releases...",
+  "earlyUpdateSkippedMobile": "Skipped because Wi-Fi-only downloads are enabled.",
+  "earlyUpdateNoUpdate": "You are already on the latest Early build.",
+  "@earlyUpdateFound": {
+    "placeholders": {
+      "version": {},
+      "build": {}
+    }
+  },
+  "earlyUpdateFound": "Early build {version}+{build} is available.",
+  "earlyUpdateDownloadAndInstall": "Download and install",
+  "@earlyUpdateDownloadingPercent": {
+    "placeholders": {
+      "percent": {}
+    }
+  },
+  "earlyUpdateDownloadingPercent": "Downloading update: {percent}%",
+  "earlyUpdateInstallStarted": "Android installer opened.",
+  "earlyUpdateInstallPermissionRequired": "Allow Memex to install unknown apps, then tap download and install again.",
+  "@earlyUpdateLastChecked": {
+    "placeholders": {
+      "time": {}
+    }
+  },
+  "earlyUpdateLastChecked": "Last checked: {time}",
+  "@earlyUpdateCheckFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "earlyUpdateCheckFailed": "Update check failed: {error}",
+  "earlyUpdateDialogTitle": "Early update available",
+  "earlyUpdateReleaseNotes": "Release notes"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4267,6 +4267,138 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Choose background image'**
   String get chooseChatBackgroundImage;
+
+  /// No description provided for @earlyUpdateSettingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Early access updates'**
+  String get earlyUpdateSettingsTitle;
+
+  /// No description provided for @earlyUpdateSettingsDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Check GitHub pre-releases for the matching Early APK, download it, and hand it to Android\'s installer.'**
+  String get earlyUpdateSettingsDesc;
+
+  /// No description provided for @earlyUpdateUnsupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Early updates are only available in the Android Early build.'**
+  String get earlyUpdateUnsupported;
+
+  /// No description provided for @earlyUpdateAutoCheckTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto check for updates'**
+  String get earlyUpdateAutoCheckTitle;
+
+  /// No description provided for @earlyUpdateAutoCheckDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Check at startup at most once every 12 hours.'**
+  String get earlyUpdateAutoCheckDesc;
+
+  /// No description provided for @earlyUpdateWifiOnlyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Download on Wi-Fi only'**
+  String get earlyUpdateWifiOnlyTitle;
+
+  /// No description provided for @earlyUpdateWifiOnlyDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Skip update downloads while using mobile data.'**
+  String get earlyUpdateWifiOnlyDesc;
+
+  /// No description provided for @earlyUpdateAutoInstallTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto download and install'**
+  String get earlyUpdateAutoInstallTitle;
+
+  /// No description provided for @earlyUpdateAutoInstallDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'When a new build is found, download it and open the Android installer automatically.'**
+  String get earlyUpdateAutoInstallDesc;
+
+  /// No description provided for @earlyUpdateCheckNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Check now'**
+  String get earlyUpdateCheckNow;
+
+  /// No description provided for @earlyUpdateChecking.
+  ///
+  /// In en, this message translates to:
+  /// **'Checking GitHub pre-releases...'**
+  String get earlyUpdateChecking;
+
+  /// No description provided for @earlyUpdateSkippedMobile.
+  ///
+  /// In en, this message translates to:
+  /// **'Skipped because Wi-Fi-only downloads are enabled.'**
+  String get earlyUpdateSkippedMobile;
+
+  /// No description provided for @earlyUpdateNoUpdate.
+  ///
+  /// In en, this message translates to:
+  /// **'You are already on the latest Early build.'**
+  String get earlyUpdateNoUpdate;
+
+  /// No description provided for @earlyUpdateFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Early build {version}+{build} is available.'**
+  String earlyUpdateFound(Object version, Object build);
+
+  /// No description provided for @earlyUpdateDownloadAndInstall.
+  ///
+  /// In en, this message translates to:
+  /// **'Download and install'**
+  String get earlyUpdateDownloadAndInstall;
+
+  /// No description provided for @earlyUpdateDownloadingPercent.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading update: {percent}%'**
+  String earlyUpdateDownloadingPercent(Object percent);
+
+  /// No description provided for @earlyUpdateInstallStarted.
+  ///
+  /// In en, this message translates to:
+  /// **'Android installer opened.'**
+  String get earlyUpdateInstallStarted;
+
+  /// No description provided for @earlyUpdateInstallPermissionRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Allow Memex to install unknown apps, then tap download and install again.'**
+  String get earlyUpdateInstallPermissionRequired;
+
+  /// No description provided for @earlyUpdateLastChecked.
+  ///
+  /// In en, this message translates to:
+  /// **'Last checked: {time}'**
+  String earlyUpdateLastChecked(Object time);
+
+  /// No description provided for @earlyUpdateCheckFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Update check failed: {error}'**
+  String earlyUpdateCheckFailed(Object error);
+
+  /// No description provided for @earlyUpdateDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Early update available'**
+  String get earlyUpdateDialogTitle;
+
+  /// No description provided for @earlyUpdateReleaseNotes.
+  ///
+  /// In en, this message translates to:
+  /// **'Release notes'**
+  String get earlyUpdateReleaseNotes;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2346,4 +2346,86 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get chooseChatBackgroundImage => 'Choose background image';
+
+  @override
+  String get earlyUpdateSettingsTitle => 'Early access updates';
+
+  @override
+  String get earlyUpdateSettingsDesc =>
+      'Check GitHub pre-releases for the matching Early APK, download it, and hand it to Android\'s installer.';
+
+  @override
+  String get earlyUpdateUnsupported =>
+      'Early updates are only available in the Android Early build.';
+
+  @override
+  String get earlyUpdateAutoCheckTitle => 'Auto check for updates';
+
+  @override
+  String get earlyUpdateAutoCheckDesc =>
+      'Check at startup at most once every 12 hours.';
+
+  @override
+  String get earlyUpdateWifiOnlyTitle => 'Download on Wi-Fi only';
+
+  @override
+  String get earlyUpdateWifiOnlyDesc =>
+      'Skip update downloads while using mobile data.';
+
+  @override
+  String get earlyUpdateAutoInstallTitle => 'Auto download and install';
+
+  @override
+  String get earlyUpdateAutoInstallDesc =>
+      'When a new build is found, download it and open the Android installer automatically.';
+
+  @override
+  String get earlyUpdateCheckNow => 'Check now';
+
+  @override
+  String get earlyUpdateChecking => 'Checking GitHub pre-releases...';
+
+  @override
+  String get earlyUpdateSkippedMobile =>
+      'Skipped because Wi-Fi-only downloads are enabled.';
+
+  @override
+  String get earlyUpdateNoUpdate =>
+      'You are already on the latest Early build.';
+
+  @override
+  String earlyUpdateFound(Object version, Object build) {
+    return 'Early build $version+$build is available.';
+  }
+
+  @override
+  String get earlyUpdateDownloadAndInstall => 'Download and install';
+
+  @override
+  String earlyUpdateDownloadingPercent(Object percent) {
+    return 'Downloading update: $percent%';
+  }
+
+  @override
+  String get earlyUpdateInstallStarted => 'Android installer opened.';
+
+  @override
+  String get earlyUpdateInstallPermissionRequired =>
+      'Allow Memex to install unknown apps, then tap download and install again.';
+
+  @override
+  String earlyUpdateLastChecked(Object time) {
+    return 'Last checked: $time';
+  }
+
+  @override
+  String earlyUpdateCheckFailed(Object error) {
+    return 'Update check failed: $error';
+  }
+
+  @override
+  String get earlyUpdateDialogTitle => 'Early update available';
+
+  @override
+  String get earlyUpdateReleaseNotes => 'Release notes';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2257,4 +2257,80 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get chooseChatBackgroundImage => '选择聊天背景图';
+
+  @override
+  String get earlyUpdateSettingsTitle => 'Early 体验版更新';
+
+  @override
+  String get earlyUpdateSettingsDesc =>
+      '从 GitHub 预发布版本中检测匹配当前 Early 渠道的 APK，下载后交给 Android 系统安装器安装。';
+
+  @override
+  String get earlyUpdateUnsupported => 'Early 更新仅支持 Android Early 包。';
+
+  @override
+  String get earlyUpdateAutoCheckTitle => '自动检测更新';
+
+  @override
+  String get earlyUpdateAutoCheckDesc => '启动时检测，每 12 小时最多一次。';
+
+  @override
+  String get earlyUpdateWifiOnlyTitle => '仅在 Wi-Fi 下载';
+
+  @override
+  String get earlyUpdateWifiOnlyDesc => '使用移动数据时跳过更新下载。';
+
+  @override
+  String get earlyUpdateAutoInstallTitle => '自动下载并安装';
+
+  @override
+  String get earlyUpdateAutoInstallDesc => '发现新版本后自动下载，并打开 Android 系统安装器。';
+
+  @override
+  String get earlyUpdateCheckNow => '立即检查';
+
+  @override
+  String get earlyUpdateChecking => '正在检查 GitHub 预发布版本...';
+
+  @override
+  String get earlyUpdateSkippedMobile => '已跳过：当前开启了仅 Wi-Fi 下载。';
+
+  @override
+  String get earlyUpdateNoUpdate => '当前已经是最新 Early 版本。';
+
+  @override
+  String earlyUpdateFound(Object version, Object build) {
+    return '发现 Early 版本 $version+$build。';
+  }
+
+  @override
+  String get earlyUpdateDownloadAndInstall => '下载并安装';
+
+  @override
+  String earlyUpdateDownloadingPercent(Object percent) {
+    return '正在下载更新：$percent%';
+  }
+
+  @override
+  String get earlyUpdateInstallStarted => '已打开 Android 系统安装器。';
+
+  @override
+  String get earlyUpdateInstallPermissionRequired =>
+      '请允许 Memex 安装未知来源应用，然后再次点击下载并安装。';
+
+  @override
+  String earlyUpdateLastChecked(Object time) {
+    return '上次检查：$time';
+  }
+
+  @override
+  String earlyUpdateCheckFailed(Object error) {
+    return '检查更新失败：$error';
+  }
+
+  @override
+  String get earlyUpdateDialogTitle => '发现 Early 更新';
+
+  @override
+  String get earlyUpdateReleaseNotes => '更新说明';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1043,5 +1043,48 @@
   "setPrimaryCompanionSubtitle": "导入后自动设为你的主要陪伴角色",
   "confirmImport": "确认导入",
   "chatBackground": "聊天背景",
-  "chooseChatBackgroundImage": "选择聊天背景图"
+  "chooseChatBackgroundImage": "选择聊天背景图",
+  "earlyUpdateSettingsTitle": "Early 体验版更新",
+  "earlyUpdateSettingsDesc": "从 GitHub 预发布版本中检测匹配当前 Early 渠道的 APK，下载后交给 Android 系统安装器安装。",
+  "earlyUpdateUnsupported": "Early 更新仅支持 Android Early 包。",
+  "earlyUpdateAutoCheckTitle": "自动检测更新",
+  "earlyUpdateAutoCheckDesc": "启动时检测，每 12 小时最多一次。",
+  "earlyUpdateWifiOnlyTitle": "仅在 Wi-Fi 下载",
+  "earlyUpdateWifiOnlyDesc": "使用移动数据时跳过更新下载。",
+  "earlyUpdateAutoInstallTitle": "自动下载并安装",
+  "earlyUpdateAutoInstallDesc": "发现新版本后自动下载，并打开 Android 系统安装器。",
+  "earlyUpdateCheckNow": "立即检查",
+  "earlyUpdateChecking": "正在检查 GitHub 预发布版本...",
+  "earlyUpdateSkippedMobile": "已跳过：当前开启了仅 Wi-Fi 下载。",
+  "earlyUpdateNoUpdate": "当前已经是最新 Early 版本。",
+  "@earlyUpdateFound": {
+    "placeholders": {
+      "version": {},
+      "build": {}
+    }
+  },
+  "earlyUpdateFound": "发现 Early 版本 {version}+{build}。",
+  "earlyUpdateDownloadAndInstall": "下载并安装",
+  "@earlyUpdateDownloadingPercent": {
+    "placeholders": {
+      "percent": {}
+    }
+  },
+  "earlyUpdateDownloadingPercent": "正在下载更新：{percent}%",
+  "earlyUpdateInstallStarted": "已打开 Android 系统安装器。",
+  "earlyUpdateInstallPermissionRequired": "请允许 Memex 安装未知来源应用，然后再次点击下载并安装。",
+  "@earlyUpdateLastChecked": {
+    "placeholders": {
+      "time": {}
+    }
+  },
+  "earlyUpdateLastChecked": "上次检查：{time}",
+  "@earlyUpdateCheckFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "earlyUpdateCheckFailed": "检查更新失败：{error}",
+  "earlyUpdateDialogTitle": "发现 Early 更新",
+  "earlyUpdateReleaseNotes": "更新说明"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,6 +50,7 @@ import 'package:memex/ui/agent_activity/widgets/agent_activity_widget.dart';
 import 'package:memex/ui/main_screen/widgets/ai_core_button.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/data/services/local_server_service.dart';
+import 'package:memex/data/services/app_update_service.dart';
 import 'package:go_router/go_router.dart';
 import 'package:memex/routing/router.dart';
 import 'package:memex/data/services/onboarding_service.dart';
@@ -449,6 +450,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
   final GlobalKey _mainStackKey = GlobalKey();
   bool _isInvalidConfigDialogShowing = false;
   bool _isErrorNotificationDialogShowing = false;
+  bool _earlyUpdateCheckStarted = false;
   late final ShareIntentHandler _shareIntentHandler;
   InputData? _sharedDraft;
 
@@ -503,6 +505,139 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     // Consume pending quick action (app icon long-press shortcut).
     QuickActionService.instance.attach();
     _consumeQuickActionIfNeeded();
+
+    _scheduleEarlyUpdateCheck();
+  }
+
+  void _scheduleEarlyUpdateCheck() {
+    final service = AppUpdateService.instance;
+    if (!service.isSupported || _earlyUpdateCheckStarted) return;
+    _earlyUpdateCheckStarted = true;
+    Future.delayed(const Duration(seconds: 3), () {
+      if (!mounted) return;
+      unawaited(_checkEarlyUpdateInBackground());
+    });
+  }
+
+  Future<void> _checkEarlyUpdateInBackground() async {
+    final service = AppUpdateService.instance;
+    if (!await service.shouldRunAutoCheck()) return;
+
+    try {
+      final settings = await service.loadSettings();
+      final result = await service.checkForUpdate(manual: false);
+      if (!mounted || result.status != AppUpdateCheckStatus.updateAvailable) {
+        return;
+      }
+
+      final update = result.update!;
+      if (settings.autoDownloadAndInstall) {
+        await _downloadAndInstallEarlyUpdate(update);
+      } else {
+        _showEarlyUpdateDialog(update);
+      }
+    } catch (e, st) {
+      _logger.warning('Early update check failed: $e', e, st);
+    }
+  }
+
+  void _showEarlyUpdateDialog(AppUpdateInfo update) {
+    final context = rootNavigatorKey.currentContext;
+    if (context == null) return;
+
+    showDialog<void>(
+      context: context,
+      builder: (context) {
+        final notes = update.releaseNotes.trim();
+        return AlertDialog(
+          title: Text(UserStorage.l10n.earlyUpdateDialogTitle),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  UserStorage.l10n.earlyUpdateFound(
+                    update.versionName,
+                    update.buildNumber,
+                  ),
+                ),
+                if (notes.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    UserStorage.l10n.earlyUpdateReleaseNotes,
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    notes,
+                    maxLines: 8,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(UserStorage.l10n.cancel),
+            ),
+            FilledButton.icon(
+              onPressed: () {
+                Navigator.of(context).pop();
+                unawaited(_downloadAndInstallEarlyUpdate(update));
+              },
+              icon: const Icon(Icons.download, size: 18),
+              label: Text(UserStorage.l10n.earlyUpdateDownloadAndInstall),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _downloadAndInstallEarlyUpdate(AppUpdateInfo update) async {
+    final context = rootNavigatorKey.currentContext;
+    if (context != null) {
+      ToastHelper.showInfo(
+        context,
+        UserStorage.l10n.earlyUpdateDownloadingPercent(0),
+      );
+    }
+
+    try {
+      final download = await AppUpdateService.instance.downloadUpdate(update);
+      final install =
+          await AppUpdateService.instance.installUpdate(download.apkPath);
+      final currentContext = rootNavigatorKey.currentContext;
+      if (currentContext == null) return;
+
+      switch (install.status) {
+        case AppUpdateInstallStatus.started:
+          ToastHelper.showSuccess(
+            currentContext,
+            UserStorage.l10n.earlyUpdateInstallStarted,
+          );
+        case AppUpdateInstallStatus.permissionRequired:
+          ToastHelper.showInfo(
+            currentContext,
+            UserStorage.l10n.earlyUpdateInstallPermissionRequired,
+          );
+        case AppUpdateInstallStatus.unsupported:
+          break;
+      }
+    } catch (e) {
+      final currentContext = rootNavigatorKey.currentContext;
+      if (e is AppUpdateWifiRequiredException) {
+        ToastHelper.showInfo(
+          currentContext,
+          UserStorage.l10n.earlyUpdateSkippedMobile,
+        );
+      } else {
+        ToastHelper.showError(currentContext, e);
+      }
+    }
   }
 
   void _handleInvalidModelConfig(EventBusMessage message) {

--- a/lib/ui/settings/widgets/early_update_settings_card.dart
+++ b/lib/ui/settings/widgets/early_update_settings_card.dart
@@ -1,0 +1,340 @@
+import 'package:flutter/material.dart';
+
+import 'package:memex/data/services/app_update_service.dart';
+import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/utils/toast_helper.dart';
+import 'package:memex/utils/user_storage.dart';
+
+class EarlyUpdateSettingsCard extends StatefulWidget {
+  EarlyUpdateSettingsCard({
+    super.key,
+    AppUpdateService? service,
+    this.forceVisible = false,
+  }) : service = service ?? AppUpdateService.instance;
+
+  final AppUpdateService service;
+  final bool forceVisible;
+
+  @override
+  State<EarlyUpdateSettingsCard> createState() =>
+      _EarlyUpdateSettingsCardState();
+}
+
+class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
+  AppUpdateSettings? _settings;
+  AppUpdateInfo? _availableUpdate;
+  bool _checking = false;
+  bool _downloading = false;
+  int _downloadPercent = 0;
+  String? _statusText;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  Future<void> _loadSettings() async {
+    if (!widget.forceVisible && !widget.service.isSupported) return;
+    final settings = await widget.service.loadSettings();
+    if (!mounted) return;
+    setState(() {
+      _settings = settings;
+      _statusText = _lastCheckedText(settings);
+    });
+  }
+
+  Future<void> _saveSettings(AppUpdateSettings settings) async {
+    await widget.service.saveSettings(settings);
+    if (!mounted) return;
+    setState(() => _settings = settings);
+  }
+
+  Future<void> _checkNow() async {
+    if (_checking || _downloading) return;
+    setState(() {
+      _checking = true;
+      _statusText = UserStorage.l10n.earlyUpdateChecking;
+    });
+
+    try {
+      final result = await widget.service.checkForUpdate(manual: true);
+      if (!mounted) return;
+      final latestSettings = await widget.service.loadSettings();
+      setState(() {
+        _checking = false;
+        _settings = latestSettings;
+        switch (result.status) {
+          case AppUpdateCheckStatus.unsupported:
+            _availableUpdate = null;
+            _statusText = UserStorage.l10n.earlyUpdateUnsupported;
+          case AppUpdateCheckStatus.skippedNotWifi:
+            _availableUpdate = null;
+            _statusText = UserStorage.l10n.earlyUpdateSkippedMobile;
+          case AppUpdateCheckStatus.noUpdate:
+            _availableUpdate = null;
+            _statusText = UserStorage.l10n.earlyUpdateNoUpdate;
+          case AppUpdateCheckStatus.updateAvailable:
+            _availableUpdate = result.update;
+            final update = result.update!;
+            _statusText = UserStorage.l10n.earlyUpdateFound(
+              update.versionName,
+              update.buildNumber,
+            );
+        }
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _checking = false;
+        _statusText = UserStorage.l10n.earlyUpdateCheckFailed(e);
+      });
+    }
+  }
+
+  Future<void> _downloadAndInstall() async {
+    final update = _availableUpdate;
+    if (update == null || _downloading) return;
+
+    setState(() {
+      _downloading = true;
+      _downloadPercent = 0;
+      _statusText = UserStorage.l10n.earlyUpdateDownloadingPercent(0);
+    });
+
+    try {
+      final download = await widget.service.downloadUpdate(
+        update,
+        onProgress: (receivedBytes, totalBytes) {
+          if (!mounted || totalBytes <= 0) return;
+          final percent =
+              ((receivedBytes / totalBytes) * 100).clamp(0, 100).round();
+          setState(() {
+            _downloadPercent = percent;
+            _statusText =
+                UserStorage.l10n.earlyUpdateDownloadingPercent(percent);
+          });
+        },
+      );
+
+      final install = await widget.service.installUpdate(download.apkPath);
+      if (!mounted) return;
+      setState(() {
+        _downloading = false;
+        _downloadPercent = 100;
+        _statusText = switch (install.status) {
+          AppUpdateInstallStatus.started =>
+            UserStorage.l10n.earlyUpdateInstallStarted,
+          AppUpdateInstallStatus.permissionRequired =>
+            UserStorage.l10n.earlyUpdateInstallPermissionRequired,
+          AppUpdateInstallStatus.unsupported =>
+            UserStorage.l10n.earlyUpdateUnsupported,
+        };
+      });
+    } catch (e) {
+      if (!mounted) return;
+      final statusText = e is AppUpdateWifiRequiredException
+          ? UserStorage.l10n.earlyUpdateSkippedMobile
+          : UserStorage.l10n.earlyUpdateCheckFailed(e);
+      setState(() {
+        _downloading = false;
+        _statusText = statusText;
+      });
+      if (e is AppUpdateWifiRequiredException) {
+        ToastHelper.showInfo(
+            context, UserStorage.l10n.earlyUpdateSkippedMobile);
+      } else {
+        ToastHelper.showError(context, e);
+      }
+    }
+  }
+
+  String? _lastCheckedText(AppUpdateSettings settings) {
+    final checkedAt = settings.lastCheckAt;
+    if (checkedAt == null) return null;
+    final local = checkedAt.toLocal();
+    final formatted =
+        '${local.year}-${_two(local.month)}-${_two(local.day)} ${_two(local.hour)}:${_two(local.minute)}';
+    return UserStorage.l10n.earlyUpdateLastChecked(formatted);
+  }
+
+  String _two(int value) => value.toString().padLeft(2, '0');
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.forceVisible && !widget.service.isSupported) {
+      return const SizedBox.shrink();
+    }
+
+    final settings = _settings;
+    if (settings == null) {
+      return _buildShell(
+        child: const SizedBox(
+          height: 72,
+          child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+        ),
+      );
+    }
+
+    return _buildShell(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Icon(
+                Icons.system_update_alt,
+                color: AppColors.primary,
+                size: 22,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      UserStorage.l10n.earlyUpdateSettingsTitle,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      UserStorage.l10n.earlyUpdateSettingsDesc,
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: Colors.grey[600],
+                        height: 1.35,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          _buildSwitch(
+            title: UserStorage.l10n.earlyUpdateAutoCheckTitle,
+            subtitle: UserStorage.l10n.earlyUpdateAutoCheckDesc,
+            value: settings.autoCheckEnabled,
+            onChanged: (value) =>
+                _saveSettings(settings.copyWith(autoCheckEnabled: value)),
+          ),
+          _buildSwitch(
+            title: UserStorage.l10n.earlyUpdateWifiOnlyTitle,
+            subtitle: UserStorage.l10n.earlyUpdateWifiOnlyDesc,
+            value: settings.wifiOnlyDownloads,
+            onChanged: (value) =>
+                _saveSettings(settings.copyWith(wifiOnlyDownloads: value)),
+          ),
+          _buildSwitch(
+            title: UserStorage.l10n.earlyUpdateAutoInstallTitle,
+            subtitle: UserStorage.l10n.earlyUpdateAutoInstallDesc,
+            value: settings.autoDownloadAndInstall,
+            onChanged: (value) => _saveSettings(
+              settings.copyWith(autoDownloadAndInstall: value),
+            ),
+          ),
+          if (_statusText != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              _statusText!,
+              style: const TextStyle(
+                fontSize: 13,
+                color: AppColors.textSecondary,
+                height: 1.35,
+              ),
+            ),
+          ],
+          if (_downloading) ...[
+            const SizedBox(height: 10),
+            LinearProgressIndicator(
+              value: _downloadPercent <= 0 ? null : _downloadPercent / 100,
+              color: AppColors.primary,
+              minHeight: 4,
+            ),
+          ],
+          const SizedBox(height: 14),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: [
+              OutlinedButton.icon(
+                onPressed: _checking || _downloading ? null : _checkNow,
+                icon: _checking
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.refresh, size: 18),
+                label: Text(UserStorage.l10n.earlyUpdateCheckNow),
+              ),
+              if (_availableUpdate != null)
+                FilledButton.icon(
+                  onPressed:
+                      _checking || _downloading ? null : _downloadAndInstall,
+                  icon: const Icon(Icons.download, size: 18),
+                  label: Text(UserStorage.l10n.earlyUpdateDownloadAndInstall),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildShell({required Widget child}) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.textSecondary.withValues(alpha: 0.08),
+            blurRadius: 16,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+
+  Widget _buildSwitch({
+    required String title,
+    required String subtitle,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+  }) {
+    return SwitchListTile(
+      contentPadding: EdgeInsets.zero,
+      dense: true,
+      title: Text(
+        title,
+        style: const TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w500,
+          color: AppColors.textPrimary,
+        ),
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(top: 2),
+        child: Text(
+          subtitle,
+          style: TextStyle(
+            fontSize: 12,
+            color: Colors.grey[600],
+            height: 1.35,
+          ),
+        ),
+      ),
+      value: value,
+      onChanged: _checking || _downloading ? null : onChanged,
+    );
+  }
+}

--- a/lib/ui/settings/widgets/settings_page.dart
+++ b/lib/ui/settings/widgets/settings_page.dart
@@ -1,10 +1,12 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:memex/config/app_flavor.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/ui/settings/widgets/backup_restore_page.dart';
 import 'package:memex/ui/settings/widgets/data_storage_page.dart';
+import 'package:memex/ui/settings/widgets/early_update_settings_card.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
@@ -196,6 +198,10 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
           ),
           const SizedBox(height: 16),
+          if (Platform.isAndroid && AppFlavor.isEarly) ...[
+            EarlyUpdateSettingsCard(),
+            const SizedBox(height: 16),
+          ],
           // Show Insight Text toggle
           Container(
             padding: const EdgeInsets.all(20),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1110,7 +1110,7 @@ packages:
     source: hosted
     version: "2.2.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
       sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   # Local Storage
   shared_preferences: ^2.2.2
   path_provider: ^2.1.1
+  package_info_plus: ^9.0.0
 
   # Quick Actions (app icon long-press shortcuts)
   quick_actions: ^1.1.0

--- a/test/data/services/app_update_service_test.dart
+++ b/test/data/services/app_update_service_test.dart
@@ -1,0 +1,316 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:memex/data/services/app_update_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late FakeUpdatePlatform platform;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    tempDir = await Directory.systemTemp.createTemp('memex_update_test_');
+    platform = FakeUpdatePlatform();
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  AppUpdateService buildService({
+    http.Client? client,
+    int currentBuild = 112,
+    String flavorName = 'globalEarly',
+    bool isSupported = true,
+  }) {
+    return AppUpdateService(
+      httpClient: client ?? MockClient((_) async => http.Response('[]', 200)),
+      platform: platform,
+      environment: AppUpdateEnvironment(
+        isAndroid: isSupported,
+        isEarlyChannel: isSupported,
+        flavorName: flavorName,
+      ),
+      packageVersionLoader: () async => AppPackageVersion(
+        versionName: '1.0.29',
+        buildNumber: currentBuild,
+      ),
+      updateDirectoryProvider: () async => tempDir,
+      clock: () => DateTime(2026, 5, 15, 10),
+    );
+  }
+
+  group('AppUpdateSettingsStore', () {
+    test('loads conservative defaults', () async {
+      final store = AppUpdateSettingsStore();
+      final settings = await store.load();
+
+      expect(settings.autoCheckEnabled, isTrue);
+      expect(settings.wifiOnlyDownloads, isTrue);
+      expect(settings.autoDownloadAndInstall, isFalse);
+      expect(settings.lastCheckAt, isNull);
+    });
+
+    test('persists toggles and last check time', () async {
+      final store = AppUpdateSettingsStore();
+      final saved = AppUpdateSettings(
+        autoCheckEnabled: false,
+        wifiOnlyDownloads: false,
+        autoDownloadAndInstall: true,
+        lastCheckAt: DateTime.utc(2026, 5, 15, 2, 30),
+      );
+
+      await store.save(saved);
+      final loaded = await store.load();
+
+      expect(loaded.autoCheckEnabled, isFalse);
+      expect(loaded.wifiOnlyDownloads, isFalse);
+      expect(loaded.autoDownloadAndInstall, isTrue);
+      expect(loaded.lastCheckAt, DateTime.utc(2026, 5, 15, 2, 30));
+    });
+  });
+
+  group('release selection', () {
+    test('chooses the newest matching pre-release APK above current build', () {
+      final service = buildService();
+
+      final update = service.selectBestUpdate(
+        currentBuildNumber: 112,
+        flavorName: 'globalEarly',
+        releases: [
+          release(
+            prerelease: false,
+            assetName: 'memex_globalEarly_1.0.31_114.apk',
+            downloadUrl: 'https://example.com/stable.apk',
+          ),
+          release(
+            assetName: 'memex_cnEarly_1.0.31_114.apk',
+            downloadUrl: 'https://example.com/cn.apk',
+          ),
+          release(
+            assetName: 'memex_globalEarly_1.0.30_113.apk',
+            downloadUrl: 'https://example.com/global.apk',
+          ),
+        ],
+      );
+
+      expect(update, isNotNull);
+      expect(update!.versionName, '1.0.30');
+      expect(update.buildNumber, 113);
+      expect(update.downloadUrl, 'https://example.com/global.apk');
+    });
+
+    test('returns null when matching APK is not newer', () {
+      final service = buildService();
+
+      final update = service.selectBestUpdate(
+        currentBuildNumber: 113,
+        flavorName: 'globalEarly',
+        releases: [
+          release(
+            assetName: 'memex_globalEarly_1.0.30_113.apk',
+            downloadUrl: 'https://example.com/global.apk',
+          ),
+        ],
+      );
+
+      expect(update, isNull);
+    });
+
+    test('uses release notes version for Flutter default APK asset names', () {
+      final service = buildService();
+
+      final update = service.selectBestUpdate(
+        currentBuildNumber: 112,
+        flavorName: 'globalEarly',
+        releases: [
+          release(
+            assetName: 'app-globalearly-release.apk',
+            downloadUrl: 'https://example.com/global.apk',
+            body:
+                'Android Early build\n\n- Version: 1.0.30-early.20260515.abcdef0+113',
+          ),
+        ],
+      );
+
+      expect(update, isNotNull);
+      expect(update!.versionName, '1.0.30-early.20260515.abcdef0');
+      expect(update.buildNumber, 113);
+    });
+  });
+
+  group('check/download/install flow', () {
+    test('still checks releases on mobile data when Wi-Fi-only is enabled',
+        () async {
+      platform.wifiConnected = false;
+      final service = buildService(
+        client: MockClient((_) async {
+          return http.Response(
+            jsonEncode([
+              release(
+                assetName: 'memex_globalEarly_1.0.30_113.apk',
+                downloadUrl: 'https://example.com/global.apk',
+              ),
+            ]),
+            200,
+          );
+        }),
+      );
+
+      final result = await service.checkForUpdate(manual: true);
+
+      expect(result.status, AppUpdateCheckStatus.updateAvailable);
+      final settings = await service.loadSettings();
+      expect(settings.lastCheckAt, DateTime(2026, 5, 15, 10));
+    });
+
+    test('blocks APK download on mobile data when Wi-Fi-only is enabled',
+        () async {
+      platform.wifiConnected = false;
+      final service = buildService(
+        client: MockClient((_) async => throw StateError('should not fetch')),
+      );
+      const update = AppUpdateInfo(
+        releaseName: 'Early',
+        tagName: 'v1.0.30+113',
+        versionName: '1.0.30',
+        buildNumber: 113,
+        assetName: 'memex_globalEarly_1.0.30_113.apk',
+        sizeBytes: 4,
+        downloadUrl: 'https://example.com/global.apk',
+        releaseNotes: '',
+      );
+
+      expect(
+        () => service.downloadUpdate(update),
+        throwsA(isA<AppUpdateWifiRequiredException>()),
+      );
+    });
+
+    test('detects an available update from GitHub pre-releases', () async {
+      final service = buildService(
+        client: MockClient((request) async {
+          expect(request.url.toString(), AppUpdateService.releasesUrl);
+          return http.Response(
+            jsonEncode([
+              release(
+                assetName: 'memex_globalEarly_1.0.30_113.apk',
+                downloadUrl: 'https://example.com/global.apk',
+              ),
+            ]),
+            200,
+          );
+        }),
+      );
+
+      final result = await service.checkForUpdate(manual: true);
+
+      expect(result.status, AppUpdateCheckStatus.updateAvailable);
+      expect(result.update!.displayVersion, '1.0.30+113');
+      final settings = await service.loadSettings();
+      expect(settings.lastCheckAt, DateTime(2026, 5, 15, 10));
+    });
+
+    test('downloads APK and delegates install to Android platform channel',
+        () async {
+      final service = buildService(
+        client: MockClient((request) async {
+          expect(request.url.toString(), 'https://example.com/global.apk');
+          return http.Response.bytes(
+            [1, 2, 3, 4],
+            200,
+            headers: {'content-length': '4'},
+          );
+        }),
+      );
+      const update = AppUpdateInfo(
+        releaseName: 'Early',
+        tagName: 'v1.0.30+113',
+        versionName: '1.0.30',
+        buildNumber: 113,
+        assetName: 'memex_globalEarly_1.0.30_113.apk',
+        sizeBytes: 4,
+        downloadUrl: 'https://example.com/global.apk',
+        releaseNotes: '',
+      );
+      final progress = <int>[];
+
+      final download = await service.downloadUpdate(
+        update,
+        onProgress: (received, total) => progress.add(received),
+      );
+      final install = await service.installUpdate(download.apkPath);
+
+      expect(await File(download.apkPath).readAsBytes(), [1, 2, 3, 4]);
+      expect(progress, contains(4));
+      expect(install.status, AppUpdateInstallStatus.started);
+      expect(platform.installedApkPath, download.apkPath);
+    });
+
+    test('opens unknown-app settings when install permission is missing',
+        () async {
+      platform.canInstall = false;
+      final service = buildService();
+
+      final result = await service.installUpdate('/tmp/memex.apk');
+
+      expect(result.status, AppUpdateInstallStatus.permissionRequired);
+      expect(platform.openedInstallSettings, isTrue);
+      expect(platform.installedApkPath, isNull);
+    });
+  });
+}
+
+Map<String, dynamic> release({
+  bool prerelease = true,
+  String assetName = 'memex_globalEarly_1.0.30_113.apk',
+  String downloadUrl = 'https://example.com/memex.apk',
+  String body = 'Release notes',
+}) {
+  return {
+    'name': 'Memex Early',
+    'tag_name': 'v1.0.30+113',
+    'draft': false,
+    'prerelease': prerelease,
+    'body': body,
+    'published_at': '2026-05-15T00:00:00Z',
+    'assets': [
+      {
+        'name': assetName,
+        'size': 1234,
+        'browser_download_url': downloadUrl,
+      }
+    ],
+  };
+}
+
+class FakeUpdatePlatform implements AppUpdatePlatform {
+  bool wifiConnected = true;
+  bool canInstall = true;
+  bool openedInstallSettings = false;
+  String? installedApkPath;
+
+  @override
+  Future<bool> isWifiConnected() async => wifiConnected;
+
+  @override
+  Future<bool> canInstallApk() async => canInstall;
+
+  @override
+  Future<void> openInstallPermissionSettings() async {
+    openedInstallSettings = true;
+  }
+
+  @override
+  Future<void> installApk(String apkPath) async {
+    installedApkPath = apkPath;
+  }
+}

--- a/test/ui/settings/widgets/early_update_settings_card_test.dart
+++ b/test/ui/settings/widgets/early_update_settings_card_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/app_update_service.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/settings/widgets/early_update_settings_card.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  Future<void> pumpCard(WidgetTester tester, AppUpdateService service) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: EarlyUpdateSettingsCard(
+              service: service,
+              forceVisible: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders defaults and persists Wi-Fi-only toggle',
+      (tester) async {
+    final service = FakeWidgetUpdateService();
+    await pumpCard(tester, service);
+
+    expect(
+        find.text(UserStorage.l10n.earlyUpdateSettingsTitle), findsOneWidget);
+    expect(find.byType(Switch), findsNWidgets(3));
+
+    await tester.tap(find.byType(Switch).at(1));
+    await tester.pumpAndSettle();
+
+    final settings = await service.loadSettings();
+    expect(settings.wifiOnlyDownloads, isFalse);
+  });
+
+  testWidgets('manual check reveals update and download opens installer',
+      (tester) async {
+    final service = FakeWidgetUpdateService(update: testUpdate);
+    await pumpCard(tester, service);
+
+    await tester.tap(find.text(UserStorage.l10n.earlyUpdateCheckNow));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateFound('1.0.30', 113)),
+      findsOneWidget,
+    );
+    expect(find.text(UserStorage.l10n.earlyUpdateDownloadAndInstall),
+        findsOneWidget);
+
+    await tester.tap(find.text(UserStorage.l10n.earlyUpdateDownloadAndInstall));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(service.installStarted, isTrue);
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateInstallStarted),
+      findsOneWidget,
+    );
+  });
+}
+
+const testUpdate = AppUpdateInfo(
+  releaseName: 'Memex Early',
+  tagName: 'v1.0.30+113',
+  versionName: '1.0.30',
+  buildNumber: 113,
+  assetName: 'memex_globalEarly_1.0.30_113.apk',
+  sizeBytes: 4,
+  downloadUrl: 'https://example.com/global.apk',
+  releaseNotes: 'Release notes',
+);
+
+class FakeWidgetUpdateService extends AppUpdateService {
+  FakeWidgetUpdateService({this.update})
+      : super(
+          environment: const AppUpdateEnvironment(
+            isAndroid: true,
+            isEarlyChannel: true,
+            flavorName: 'globalEarly',
+          ),
+        );
+
+  final AppUpdateInfo? update;
+  AppUpdateSettings settings = const AppUpdateSettings();
+  bool installStarted = false;
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<AppUpdateSettings> loadSettings() async => settings;
+
+  @override
+  Future<void> saveSettings(AppUpdateSettings settings) async {
+    this.settings = settings;
+  }
+
+  @override
+  Future<AppUpdateCheckResult> checkForUpdate({
+    bool manual = false,
+    bool respectWifi = true,
+  }) async {
+    settings = settings.copyWith(lastCheckAt: DateTime(2026, 5, 15, 10));
+    final found = update;
+    return found == null
+        ? const AppUpdateCheckResult.noUpdate()
+        : AppUpdateCheckResult.updateAvailable(found);
+  }
+
+  @override
+  Future<AppUpdateDownloadResult> downloadUpdate(
+    AppUpdateInfo update, {
+    void Function(int receivedBytes, int totalBytes)? onProgress,
+  }) async {
+    onProgress?.call(4, 4);
+    return AppUpdateDownloadResult(update: update, apkPath: '/tmp/memex.apk');
+  }
+
+  @override
+  Future<AppUpdateInstallResult> installUpdate(String apkPath) async {
+    installStarted = true;
+    return const AppUpdateInstallResult(AppUpdateInstallStatus.started);
+  }
+}


### PR DESCRIPTION
## 背景

Closes #85。

Android Daily Early 已经通过 GitHub prerelease 产出 `globalEarly` / `cnEarly` APK，但 Early 用户仍然需要自己打开 GitHub Releases、判断版本、选择 APK 并处理 Android 安装权限。这个 PR 在 Android Early 包内补齐应用内检测和安装引导，让 prerelease 分发形成更完整的使用闭环。

## 改动

- 新增 Early 更新服务：
  - 拉取 `memex-lab/memex` GitHub prerelease。
  - 仅选择匹配当前 flavor 的 APK，避免 Global Early / CN Early 混用。
  - 使用 build number 判断是否有新版本。
  - 兼容 #75 workflow 的 release notes 版本格式，例如 `Version: 1.0.30-early.YYYYMMDD.sha+BUILD_NUMBER`。
  - 下载 APK 到 app cache 下的 `updates/` 目录。
- 新增 Android 原生 MethodChannel：
  - 检查当前是否为 Wi-Fi。
  - 检查 Android 8+ “允许安装未知来源应用”权限。
  - 缺少权限时打开系统设置页。
  - 通过 FileProvider 将 APK 交给 Android 系统安装器。
- 仅对 `globalEarly` / `cnEarly` flavor 声明 `REQUEST_INSTALL_PACKAGES`，Stable 包不增加该权限。
- 设置页新增「Early 体验版更新」卡片：
  - 自动检测更新，默认开启。
  - 仅在 Wi-Fi 下载，默认开启。
  - 自动下载并安装，默认关闭。
  - 立即检查、状态提示和下载进度。
- 主界面启动后对 Android Early 包做低频自动检测：
  - 最多 12 小时一次。
  - 发现更新后默认弹窗提示。
  - 用户开启自动下载并安装时，下载完成后打开系统安装器。
- 补齐英文/中文 ARB 文案并重新生成 Flutter l10n。
- 新增 service 单元测试和设置卡片 widget test。

## 设计说明

- iOS 不实现 GitHub IPA 下载和应用内安装，因为 iOS 普通应用不能从应用内直接下载安装包；iOS Early 更适合通过 TestFlight 或 App Store 更新提醒承载。
- Dart 负责 GitHub 请求、release 解析、策略判断、下载和设置持久化；Android 原生代码只负责系统能力：Wi-Fi 查询、未知来源权限、FileProvider URI 和系统安装器 Intent。
- Wi-Fi-only 策略只限制 APK 下载，不限制小体积的更新检测请求。
- 这个能力只访问 GitHub release 元数据和 APK，不上传用户数据，也不涉及 Memex 工作区内容。

## 验证

- `flutter test test/data/services/app_update_service_test.dart`
- `flutter test test/ui/settings/widgets/early_update_settings_card_test.dart`
- `flutter build apk --debug --flavor globalEarly`
- `flutter analyze 2>&1 | tee /tmp/memex_analyze.log >/dev/null; rg "error •|app_update|early_update|EarlyUpdate" /tmp/memex_analyze.log || true`
  - 结果：没有新增 error，也没有命中本次新增 update 文件。
  - 说明：整仓 `flutter analyze` 仍有既有 warning/info 噪音，当前为 374 条。
- `git diff --check`

## 已知限制

- Android 不支持普通应用静默安装 APK，本 PR 会打开系统安装器。
- 本地尝试启动 `memex_api35` AVD，但 adb 没有识别到设备，未完成模拟器安装/启动实测；已通过 `globalEarly` debug APK 构建验证 Android manifest merge 和 Kotlin channel 编译。
