### PR TITLE
[codex] bump version to 1.0.30+113

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: memex
 description: A personal knowledge management and insights app
 publish_to: "none"
-version: 1.0.29+112
+version: 1.0.30+113
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bump the Flutter app version from `1.0.29+112` to `1.0.30+113` in `pubspec.yaml`.
- Prepares a stable App Store release point where both the marketing version and build number advance.

## Validation
- `git diff --check`
- Attempted `flutter pub get`; it stalled in package download, so it was stopped. No dependency changes were made.