### PR TITLE
perf: remove BackdropFilter to reduce GPU overheating

### DIFF
--- a/lib/ui/agent_activity/widgets/agent_activity_widget.dart
+++ b/lib/ui/agent_activity/widgets/agent_activity_widget.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:intl/intl.dart';
@@ -128,84 +127,78 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
 
     return GestureDetector(
       onTap: _hasRunningAgent ? () => _showDetail(context) : null,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(20),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(20),
-              color: Colors.white.withValues(alpha: 0.75),
-              border: Border.all(
-                color: Colors.white.withValues(alpha: 0.5),
-                width: 0.5,
-              ),
-              boxShadow: [
-                BoxShadow(
-                  color: const Color(0xFF6366F1).withValues(alpha: 0.08),
-                  blurRadius: 16,
-                  offset: const Offset(0, 4),
-                ),
-              ],
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          color: Colors.white.withValues(alpha: 0.88),
+          border: Border.all(
+            color: Colors.white.withValues(alpha: 0.5),
+            width: 0.5,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: const Color(0xFF6366F1).withValues(alpha: 0.08),
+              blurRadius: 16,
+              offset: const Offset(0, 4),
             ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // Animated writing icon (alternates between two frames)
-                AnimatedBuilder(
-                  animation: _bounceController,
-                  builder: (context, child) {
-                    final frame = _bounceController.value < 0.5
-                        ? 'assets/icons/processing_1.png'
-                        : 'assets/icons/processing_2.png';
-                    return Image.asset(
-                      frame,
-                      width: 36,
-                      height: 36,
-                    );
-                  },
-                ),
-                const SizedBox(width: 8),
-                // Text
-                Flexible(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        UserStorage.l10n.agentProcessing,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          color: Color(0xFF1E293B),
-                          fontSize: 13,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      Text(
-                        UserStorage.l10n.keepAppOpen,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: const Color(0xFF64748B).withValues(alpha: 0.8),
-                          fontSize: 11,
-                        ),
-                      ),
-                    ],
+          ],
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Animated writing icon (alternates between two frames)
+            AnimatedBuilder(
+              animation: _bounceController,
+              builder: (context, child) {
+                final frame = _bounceController.value < 0.5
+                    ? 'assets/icons/processing_1.png'
+                    : 'assets/icons/processing_2.png';
+                return Image.asset(
+                  frame,
+                  width: 36,
+                  height: 36,
+                );
+              },
+            ),
+            const SizedBox(width: 8),
+            // Text
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    UserStorage.l10n.agentProcessing,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Color(0xFF1E293B),
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
-                ),
-                if (_hasRunningAgent) ...[
-                  const SizedBox(width: 6),
-                  const Icon(
-                    Icons.chevron_right_rounded,
-                    size: 16,
-                    color: Color(0xFF94A3B8),
+                  Text(
+                    UserStorage.l10n.keepAppOpen,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: const Color(0xFF64748B).withValues(alpha: 0.8),
+                      fontSize: 11,
+                    ),
                   ),
                 ],
-              ],
+              ),
             ),
-          ),
+            if (_hasRunningAgent) ...[
+              const SizedBox(width: 6),
+              const Icon(
+                Icons.chevron_right_rounded,
+                size: 16,
+                color: Color(0xFF94A3B8),
+              ),
+            ],
+          ],
         ),
       ),
     );

--- a/lib/ui/character/widgets/persona_chat_screen.dart
+++ b/lib/ui/character/widgets/persona_chat_screen.dart
@@ -1171,30 +1171,25 @@ class _FrostedCircleButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ClipOval(
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
-        child: Container(
-          width: 38,
-          height: 38,
-          alignment: Alignment.center,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: _personaPanel.withValues(alpha: 0.36),
-            border: Border.all(color: _personaAccent.withValues(alpha: 0.2)),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.34),
-                blurRadius: 18,
-                offset: const Offset(0, 10),
-              ),
-            ],
+    return Container(
+      width: 38,
+      height: 38,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: _personaPanel.withValues(alpha: 0.62),
+        border: Border.all(color: _personaAccent.withValues(alpha: 0.2)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.34),
+            blurRadius: 18,
+            offset: const Offset(0, 10),
           ),
-          child: IconTheme(
-            data: const IconThemeData(color: _personaText),
-            child: child,
-          ),
-        ),
+        ],
+      ),
+      child: IconTheme(
+        data: const IconThemeData(color: _personaText),
+        child: child,
       ),
     );
   }
@@ -1245,76 +1240,70 @@ class PersonaChatInputBar extends StatelessWidget {
     final bottomPadding = MediaQuery.of(context).padding.bottom;
     return Padding(
       padding: EdgeInsets.fromLTRB(14, 10, 14, bottomPadding + 12),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(30),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-          child: Container(
-            padding: const EdgeInsets.fromLTRB(18, 12, 12, 12),
-            decoration: BoxDecoration(
-              color: Colors.black.withValues(alpha: 0.42),
-              borderRadius: BorderRadius.circular(30),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.5),
-                  blurRadius: 34,
-                  offset: const Offset(0, 16),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(18, 12, 12, 12),
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.62),
+          borderRadius: BorderRadius.circular(30),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.5),
+              blurRadius: 34,
+              offset: const Offset(0, 16),
+            ),
+            BoxShadow(
+              color: _personaAccent.withValues(alpha: 0.06),
+              blurRadius: 18,
+              offset: const Offset(0, -2),
+            ),
+          ],
+        ),
+        child: ValueListenableBuilder<TextEditingValue>(
+          valueListenable: controller,
+          builder: (context, value, _) {
+            final canSend = _canSend(value.text);
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: controller,
+                    minLines: 1,
+                    maxLines: 5,
+                    decoration: InputDecoration(
+                      hintText: hintText,
+                      hintStyle: const TextStyle(
+                        color: _personaTextMuted,
+                        fontSize: 15,
+                      ),
+                      isDense: true,
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 6,
+                        vertical: 10,
+                      ),
+                      border: InputBorder.none,
+                    ),
+                    style: const TextStyle(
+                      fontSize: 15,
+                      height: 1.35,
+                      color: _personaText,
+                    ),
+                    textInputAction: TextInputAction.send,
+                    onSubmitted: (_) {
+                      if (canSend) onSend();
+                    },
+                    enabled: !isStreaming,
+                  ),
                 ),
-                BoxShadow(
-                  color: _personaAccent.withValues(alpha: 0.06),
-                  blurRadius: 18,
-                  offset: const Offset(0, -2),
+                const SizedBox(width: 8),
+                _SendButton(
+                  enabled: canSend,
+                  onTap: onSend,
                 ),
               ],
-            ),
-            child: ValueListenableBuilder<TextEditingValue>(
-              valueListenable: controller,
-              builder: (context, value, _) {
-                final canSend = _canSend(value.text);
-                return Row(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    Expanded(
-                      child: TextField(
-                        controller: controller,
-                        minLines: 1,
-                        maxLines: 5,
-                        decoration: InputDecoration(
-                          hintText: hintText,
-                          hintStyle: const TextStyle(
-                            color: _personaTextMuted,
-                            fontSize: 15,
-                          ),
-                          isDense: true,
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 6,
-                            vertical: 10,
-                          ),
-                          border: InputBorder.none,
-                        ),
-                        style: const TextStyle(
-                          fontSize: 15,
-                          height: 1.35,
-                          color: _personaText,
-                        ),
-                        textInputAction: TextInputAction.send,
-                        onSubmitted: (_) {
-                          if (canSend) onSend();
-                        },
-                        enabled: !isStreaming,
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    _SendButton(
-                      enabled: canSend,
-                      onTap: onSend,
-                    ),
-                  ],
-                );
-              },
-            ),
-          ),
+            );
+          },
         ),
       ),
     );

--- a/lib/ui/core/cards/templates/classic_card.dart
+++ b/lib/ui/core/cards/templates/classic_card.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ui';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:memex/ui/core/cards/style/timeline_theme.dart';
@@ -193,48 +192,42 @@ class _ClassicCardState extends State<ClassicCard> {
     final isProcessing = status == 'processing';
 
     if (isProcessing) {
-      return ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: [
-                  const Color(0xFF8B5CF6).withValues(alpha: 0.08),
-                  const Color(0xFF8B5CF6).withValues(alpha: 0.04),
-                ],
-              ),
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: const Color(0xFF8B5CF6).withValues(alpha: 0.15),
-                width: 0.5,
-              ),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                SizedBox(
-                  width: 14,
-                  height: 14,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: const Color(0xFF8B5CF6).withValues(alpha: 0.7),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  UserStorage.l10n.processingStatus,
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w500,
-                    color: const Color(0xFF8B5CF6).withValues(alpha: 0.8),
-                  ),
-                ),
-              ],
-            ),
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              const Color(0xFF8B5CF6).withValues(alpha: 0.08),
+              const Color(0xFF8B5CF6).withValues(alpha: 0.04),
+            ],
           ),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: const Color(0xFF8B5CF6).withValues(alpha: 0.15),
+            width: 0.5,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: const Color(0xFF8B5CF6).withValues(alpha: 0.7),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              UserStorage.l10n.processingStatus,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: const Color(0xFF8B5CF6).withValues(alpha: 0.8),
+              ),
+            ),
+          ],
         ),
       );
     }
@@ -242,44 +235,38 @@ class _ClassicCardState extends State<ClassicCard> {
     // Failed state
     return GestureDetector(
       onTap: () => _showFailureSheet(context),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: [
-                  const Color(0xFFEF4444).withValues(alpha: 0.06),
-                  const Color(0xFFEF4444).withValues(alpha: 0.03),
-                ],
-              ),
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: const Color(0xFFEF4444).withValues(alpha: 0.12),
-                width: 0.5,
-              ),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const SizedBox(width: 2),
-                Text(
-                  UserStorage.l10n.failedStatus,
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w500,
-                    color: const Color(0xFFEF4444).withValues(alpha: 0.8),
-                  ),
-                ),
-                const SizedBox(width: 6),
-                Icon(Icons.chevron_right,
-                    size: 14,
-                    color: const Color(0xFFEF4444).withValues(alpha: 0.5)),
-              ],
-            ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              const Color(0xFFEF4444).withValues(alpha: 0.06),
+              const Color(0xFFEF4444).withValues(alpha: 0.03),
+            ],
           ),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: const Color(0xFFEF4444).withValues(alpha: 0.12),
+            width: 0.5,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(width: 2),
+            Text(
+              UserStorage.l10n.failedStatus,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: const Color(0xFFEF4444).withValues(alpha: 0.8),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Icon(Icons.chevron_right,
+                size: 14,
+                color: const Color(0xFFEF4444).withValues(alpha: 0.5)),
+          ],
         ),
       ),
     );
@@ -293,149 +280,133 @@ class _ClassicCardState extends State<ClassicCard> {
       isScrollControlled: true,
       builder: (ctx) {
         final bottomPadding = MediaQuery.of(ctx).viewPadding.bottom;
-        return ClipRRect(
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 40, sigmaY: 40),
-            child: Container(
-              constraints: BoxConstraints(
-                maxHeight: MediaQuery.of(ctx).size.height * 0.55,
-              ),
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.white.withValues(alpha: 0.85),
-                    Colors.white.withValues(alpha: 0.92),
-                  ],
-                ),
-                borderRadius:
-                    const BorderRadius.vertical(top: Radius.circular(24)),
-                border: Border(
-                  top: BorderSide(
-                    color: Colors.white.withValues(alpha: 0.6),
-                    width: 0.5,
-                  ),
-                ),
-              ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Drag handle
-                  Padding(
-                    padding: const EdgeInsets.only(top: 12, bottom: 20),
-                    child: Container(
-                      width: 36,
-                      height: 4,
-                      decoration: BoxDecoration(
-                        color: const Color(0xFF99A1AF).withValues(alpha: 0.3),
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                    ),
-                  ),
-                  // Header
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 24),
-                    child: Row(
-                      children: [
-                        Container(
-                          width: 36,
-                          height: 36,
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                              colors: [
-                                const Color(0xFFEF4444).withValues(alpha: 0.15),
-                                const Color(0xFFEF4444).withValues(alpha: 0.08),
-                              ],
-                            ),
-                            borderRadius: BorderRadius.circular(10),
-                            border: Border.all(
-                              color: const Color(0xFFEF4444)
-                                  .withValues(alpha: 0.1),
-                              width: 0.5,
-                            ),
-                          ),
-                          child: const Icon(Icons.warning_amber_rounded,
-                              size: 20, color: Color(0xFFEF4444)),
-                        ),
-                        const SizedBox(width: 14),
-                        Expanded(
-                          child: Text(
-                            UserStorage.l10n.failureReason,
-                            style: const TextStyle(
-                              fontSize: 17,
-                              fontWeight: FontWeight.w600,
-                              color: Color(0xFF0A0A0A),
-                              letterSpacing: -0.3,
-                            ),
-                          ),
-                        ),
-                        GestureDetector(
-                          onTap: () => Navigator.pop(ctx),
-                          child: Container(
-                            width: 30,
-                            height: 30,
-                            decoration: BoxDecoration(
-                              color: const Color(0xFF99A1AF)
-                                  .withValues(alpha: 0.12),
-                              shape: BoxShape.circle,
-                            ),
-                            child: Icon(Icons.close_rounded,
-                                size: 16,
-                                color: const Color(0xFF4A5565)
-                                    .withValues(alpha: 0.8)),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(height: 20),
-                  // Error content
-                  Flexible(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 24),
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(14),
-                        child: BackdropFilter(
-                          filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
-                          child: Container(
-                            width: double.infinity,
-                            padding: const EdgeInsets.all(16),
-                            decoration: BoxDecoration(
-                              color: const Color(0xFF0A0A0A)
-                                  .withValues(alpha: 0.03),
-                              borderRadius: BorderRadius.circular(14),
-                              border: Border.all(
-                                color: const Color(0xFF99A1AF)
-                                    .withValues(alpha: 0.12),
-                                width: 0.5,
-                              ),
-                            ),
-                            child: SingleChildScrollView(
-                              physics: const BouncingScrollPhysics(),
-                              child: SelectableText(
-                                reason,
-                                style: const TextStyle(
-                                  fontSize: 13,
-                                  color: Color(0xFF4A5565),
-                                  height: 1.6,
-                                  fontFamily: 'monospace',
-                                  letterSpacing: -0.2,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                  SizedBox(height: 20 + bottomPadding),
-                ],
+        return Container(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(ctx).size.height * 0.55,
+          ),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                const Color(0xFFF8F9FA).withValues(alpha: 0.97),
+                Colors.white,
+              ],
+            ),
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+            border: Border(
+              top: BorderSide(
+                color: Colors.white.withValues(alpha: 0.6),
+                width: 0.5,
               ),
             ),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Drag handle
+              Padding(
+                padding: const EdgeInsets.only(top: 12, bottom: 20),
+                child: Container(
+                  width: 36,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF99A1AF).withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              // Header
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 36,
+                      height: 36,
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
+                          colors: [
+                            const Color(0xFFEF4444).withValues(alpha: 0.15),
+                            const Color(0xFFEF4444).withValues(alpha: 0.08),
+                          ],
+                        ),
+                        borderRadius: BorderRadius.circular(10),
+                        border: Border.all(
+                          color: const Color(0xFFEF4444).withValues(alpha: 0.1),
+                          width: 0.5,
+                        ),
+                      ),
+                      child: const Icon(Icons.warning_amber_rounded,
+                          size: 20, color: Color(0xFFEF4444)),
+                    ),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: Text(
+                        UserStorage.l10n.failureReason,
+                        style: const TextStyle(
+                          fontSize: 17,
+                          fontWeight: FontWeight.w600,
+                          color: Color(0xFF0A0A0A),
+                          letterSpacing: -0.3,
+                        ),
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () => Navigator.pop(ctx),
+                      child: Container(
+                        width: 30,
+                        height: 30,
+                        decoration: BoxDecoration(
+                          color:
+                              const Color(0xFF99A1AF).withValues(alpha: 0.12),
+                          shape: BoxShape.circle,
+                        ),
+                        child: Icon(Icons.close_rounded,
+                            size: 16,
+                            color:
+                                const Color(0xFF4A5565).withValues(alpha: 0.8)),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 20),
+              // Error content
+              Flexible(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF0A0A0A).withValues(alpha: 0.03),
+                      borderRadius: BorderRadius.circular(14),
+                      border: Border.all(
+                        color: const Color(0xFF99A1AF).withValues(alpha: 0.12),
+                        width: 0.5,
+                      ),
+                    ),
+                    child: SingleChildScrollView(
+                      physics: const BouncingScrollPhysics(),
+                      child: SelectableText(
+                        reason,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          color: Color(0xFF4A5565),
+                          height: 1.6,
+                          fontFamily: 'monospace',
+                          letterSpacing: -0.2,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              SizedBox(height: 20 + bottomPadding),
+            ],
           ),
         );
       },

--- a/lib/ui/core/cards/templates/system_task_card.dart
+++ b/lib/ui/core/cards/templates/system_task_card.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'dart:ui';
 import 'package:memex/utils/user_storage.dart';
 
 class SystemTaskCard extends StatefulWidget {
@@ -75,160 +74,157 @@ class _SystemTaskCardState extends State<SystemTaskCard>
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(24),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-          child: Container(
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.8),
-              borderRadius: BorderRadius.circular(24),
-              border: Border.all(
-                color: Colors.white.withValues(alpha: 0.5),
-                width: 1,
-              ),
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [
-                  Colors.white.withValues(alpha: 0.6),
-                  const Color(0xFFF5F3FF).withValues(alpha: 0.4),
-                ],
-              ),
+        child: Container(
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.92),
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(
+              color: Colors.white.withValues(alpha: 0.5),
+              width: 1,
             ),
-            child: Row(
-              children: [
-                // Animated AI Icon
-                Stack(
-                  alignment: Alignment.center,
-                  children: [
-                    AnimatedBuilder(
-                      animation: _spinController,
-                      builder: (context, child) {
-                        final isProcessing = widget.status == 'processing';
-                        return Transform.rotate(
-                          angle: isProcessing
-                              ? _spinController.value * 2 * 3.14159
-                              : 0,
-                          child: Container(
-                            width: 52,
-                            height: 52,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              gradient: SweepGradient(
-                                colors: [
-                                  isProcessing
-                                      ? const Color(0x00A855F7)
-                                      : Colors.transparent,
-                                  widget.status == 'failed'
-                                      ? Colors.red
-                                      : const Color(0xFFA855F7),
-                                  isProcessing
-                                      ? const Color(0x00A855F7)
-                                      : Colors.transparent,
-                                ],
-                              ),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                    Container(
-                      width: 44,
-                      height: 44,
-                      decoration: BoxDecoration(
-                        color: Colors.white,
-                        borderRadius: BorderRadius.circular(16),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.05),
-                            blurRadius: 4,
-                            offset: const Offset(0, 2),
-                          ),
-                        ],
-                      ),
-                      child: Center(
-                        child: Icon(
-                          widget.status == 'failed'
-                              ? Icons.error_outline
-                              : widget.status == 'completed'
-                                  ? Icons.check_circle_outline
-                                  : Icons.auto_awesome,
-                          color: widget.status == 'failed'
-                              ? Colors.red
-                              : const Color(0xFFA855F7),
-                          size: 24,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(width: 20),
-                // Text content with shimmer
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Row(
-                        children: [
-                          Text(
-                            widget.title,
-                            style: const TextStyle(
-                              fontSize: 17,
-                              fontWeight: FontWeight.w600,
-                              color: Color(0xFF0A0A0A),
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          if (widget.status == 'processing')
-                            AnimatedBuilder(
-                              animation: _pulseController,
-                              builder: (context, child) {
-                                return Opacity(
-                                  opacity: _pulseController.value,
-                                  child: Container(
-                                    width: 4,
-                                    height: 4,
-                                    decoration: const BoxDecoration(
-                                      color: Color(0xFFA855F7),
-                                      shape: BoxShape.circle,
-                                    ),
-                                  ),
-                                );
-                              },
-                            ),
-                        ],
-                      ),
-                      const SizedBox(height: 8),
-                      if (widget.status == 'processing')
-                        AnimatedBuilder(
-                          animation: _shimmerController,
-                          builder: (context, child) {
-                            return Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                _buildShimmerLine(widthRatio: 0.9),
-                                const SizedBox(height: 6),
-                                _buildShimmerLine(widthRatio: 0.6),
-                              ],
-                            );
-                          },
-                        ),
-                      if (widget.status == 'completed' ||
-                          widget.status == 'failed' ||
-                          widget.message.isNotEmpty)
-                        Text(
-                          widget.message,
-                          style: TextStyle(
-                            fontSize: 13,
-                            color: const Color(0xFF4A5565),
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                Colors.white.withValues(alpha: 0.88),
+                const Color(0xFFF5F3FF).withValues(alpha: 0.7),
               ],
             ),
+          ),
+          child: Row(
+            children: [
+              // Animated AI Icon
+              Stack(
+                alignment: Alignment.center,
+                children: [
+                  AnimatedBuilder(
+                    animation: _spinController,
+                    builder: (context, child) {
+                      final isProcessing = widget.status == 'processing';
+                      return Transform.rotate(
+                        angle: isProcessing
+                            ? _spinController.value * 2 * 3.14159
+                            : 0,
+                        child: Container(
+                          width: 52,
+                          height: 52,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            gradient: SweepGradient(
+                              colors: [
+                                isProcessing
+                                    ? const Color(0x00A855F7)
+                                    : Colors.transparent,
+                                widget.status == 'failed'
+                                    ? Colors.red
+                                    : const Color(0xFFA855F7),
+                                isProcessing
+                                    ? const Color(0x00A855F7)
+                                    : Colors.transparent,
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  Container(
+                    width: 44,
+                    height: 44,
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(16),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.05),
+                          blurRadius: 4,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                    child: Center(
+                      child: Icon(
+                        widget.status == 'failed'
+                            ? Icons.error_outline
+                            : widget.status == 'completed'
+                                ? Icons.check_circle_outline
+                                : Icons.auto_awesome,
+                        color: widget.status == 'failed'
+                            ? Colors.red
+                            : const Color(0xFFA855F7),
+                        size: 24,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(width: 20),
+              // Text content with shimmer
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          widget.title,
+                          style: const TextStyle(
+                            fontSize: 17,
+                            fontWeight: FontWeight.w600,
+                            color: Color(0xFF0A0A0A),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        if (widget.status == 'processing')
+                          AnimatedBuilder(
+                            animation: _pulseController,
+                            builder: (context, child) {
+                              return Opacity(
+                                opacity: _pulseController.value,
+                                child: Container(
+                                  width: 4,
+                                  height: 4,
+                                  decoration: const BoxDecoration(
+                                    color: Color(0xFFA855F7),
+                                    shape: BoxShape.circle,
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    if (widget.status == 'processing')
+                      AnimatedBuilder(
+                        animation: _shimmerController,
+                        builder: (context, child) {
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              _buildShimmerLine(widthRatio: 0.9),
+                              const SizedBox(height: 6),
+                              _buildShimmerLine(widthRatio: 0.6),
+                            ],
+                          );
+                        },
+                      ),
+                    if (widget.status == 'completed' ||
+                        widget.status == 'failed' ||
+                        widget.message.isNotEmpty)
+                      Text(
+                        widget.message,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: const Color(0xFF4A5565),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/ui/core/cards/templates/temporal/event_card.dart
+++ b/lib/ui/core/cards/templates/temporal/event_card.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -35,99 +34,114 @@ class EventCard extends StatelessWidget {
 
     return GestureDetector(
       onTap: onTap,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(24),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
-          child: Container(
-            margin: const EdgeInsets.symmetric(vertical: 8),
-            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
-            decoration: BoxDecoration(
-              // #FFFFFFD1 = white with 82% opacity
-              color: const Color(0xD1FFFFFF),
-              borderRadius: BorderRadius.circular(24),
-              border: Border.all(
-                color: const Color(0xD9FFFFFF),
-                width: 1,
-              ),
-              boxShadow: const [
-                BoxShadow(
-                  color: Color(0x08111827), // #11182708
-                  blurRadius: 18,
-                ),
-              ],
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+        decoration: BoxDecoration(
+          color: const Color(0xD1FFFFFF),
+          borderRadius: BorderRadius.circular(24),
+          border: Border.all(
+            color: const Color(0xD9FFFFFF),
+            width: 1,
+          ),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x08111827),
+              blurRadius: 18,
             ),
-            child: Row(
-              children: [
-                // Date block — Figma: 47w × 50h
-                Container(
-                  width: 47,
-                  height: 50,
-                  decoration: BoxDecoration(
-                    color: const Color(0xFF5B6CFF).withValues(alpha: 0.12),
-                    borderRadius: BorderRadius.circular(12),
+          ],
+        ),
+        child: Row(
+          children: [
+            // Date block
+            Container(
+              width: 47,
+              height: 50,
+              decoration: BoxDecoration(
+                color: const Color(0xFF5B6CFF).withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    startTime != null
+                        ? monthFormat.format(startTime).toUpperCase()
+                        : '---',
+                    style: GoogleFonts.inter(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w500,
+                      letterSpacing: -0.45,
+                      color: const Color(0xFF5B6CFF),
+                    ),
                   ),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
+                  Text(
+                    startTime != null ? dayFormat.format(startTime) : '--',
+                    style: GoogleFonts.inter(
+                      fontSize: 22,
+                      fontWeight: FontWeight.w500,
+                      height: 1.0,
+                      letterSpacing: -0.45,
+                      color: const Color(0xFF5B6CFF),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 16),
+            // Details
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    title,
+                    style: GoogleFonts.inter(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                      height: 23 / 18,
+                      letterSpacing: -0.45,
+                      color: const Color(0xFF0A0A0A),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
                     children: [
-                      Text(
-                        startTime != null
-                            ? monthFormat.format(startTime).toUpperCase()
-                            : '---',
-                        style: GoogleFonts.inter(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w500,
-                          letterSpacing: -0.45,
-                          color: const Color(0xFF5B6CFF),
+                      SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: SvgPicture.asset(
+                          'assets/icons/time_clock.svg',
+                          width: 13,
+                          height: 13,
                         ),
                       ),
+                      const SizedBox(width: 4),
                       Text(
-                        startTime != null ? dayFormat.format(startTime) : '--',
+                        startTime != null
+                            ? '${timeFormat.format(startTime)}-${endTime != null ? timeFormat.format(endTime) : '?'}'
+                            : 'TBD',
                         style: GoogleFonts.inter(
-                          fontSize: 22,
+                          fontSize: 14,
                           fontWeight: FontWeight.w500,
-                          height: 1.0,
+                          height: 23 / 14,
                           letterSpacing: -0.45,
-                          color: const Color(0xFF5B6CFF),
+                          color: const Color(0xFF99A1AF),
                         ),
                       ),
                     ],
                   ),
-                ),
-                const SizedBox(width: 16),
-                // Details
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        title,
-                        style: GoogleFonts.inter(
-                          fontSize: 18,
-                          fontWeight: FontWeight.w600,
-                          height: 23 / 18,
-                          letterSpacing: -0.45,
-                          color: const Color(0xFF0A0A0A),
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Row(
-                        children: [
-                          SizedBox(
-                            width: 14,
-                            height: 14,
-                            child: SvgPicture.asset(
-                              'assets/icons/time_clock.svg',
-                              width: 13,
-                              height: 13,
-                            ),
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            startTime != null
-                                ? '${timeFormat.format(startTime)}-${endTime != null ? timeFormat.format(endTime) : '?'}'
-                                : 'TBD',
+                  if (location != null) ...[
+                    const SizedBox(height: 2),
+                    Row(
+                      children: [
+                        const Icon(Icons.location_on_outlined,
+                            size: 14, color: Color(0xFF99A1AF)),
+                        const SizedBox(width: 4),
+                        Expanded(
+                          child: Text(
+                            location,
                             style: GoogleFonts.inter(
                               fontSize: 14,
                               fontWeight: FontWeight.w500,
@@ -135,39 +149,17 @@ class EventCard extends StatelessWidget {
                               letterSpacing: -0.45,
                               color: const Color(0xFF99A1AF),
                             ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                           ),
-                        ],
-                      ),
-                      if (location != null) ...[
-                        const SizedBox(height: 2),
-                        Row(
-                          children: [
-                            const Icon(Icons.location_on_outlined,
-                                size: 14, color: Color(0xFF99A1AF)),
-                            const SizedBox(width: 4),
-                            Expanded(
-                              child: Text(
-                                location,
-                                style: GoogleFonts.inter(
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w500,
-                                  height: 23 / 14,
-                                  letterSpacing: -0.45,
-                                  color: const Color(0xFF99A1AF),
-                                ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                          ],
                         ),
                       ],
-                    ],
-                  ),
-                ),
-              ],
+                    ),
+                  ],
+                ],
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/lib/ui/core/cards/templates/visual/snapshot_card.dart
+++ b/lib/ui/core/cards/templates/visual/snapshot_card.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -17,103 +16,97 @@ class SnapshotCard extends StatelessWidget {
 
     return GestureDetector(
       onTap: onTap,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(24),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
-          child: Container(
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(24),
-              boxShadow: const [
-                BoxShadow(
-                  color: Color(0x0D111827), // #1118270D
-                  blurRadius: 24,
-                ),
-              ],
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(24),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x0D111827),
+              blurRadius: 24,
             ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Image with SNAPSHOT badge
-                Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Stack(
-                    children: [
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(18),
-                        child: AspectRatio(
-                          aspectRatio: 1,
-                          child: LocalImage(
-                            url: imageUrl,
-                            width: double.infinity,
-                            fit: BoxFit.cover,
-                            errorBuilder: (_, __, ___) => Container(
-                              color: const Color(0xFFF7F8FA),
-                              child: const Center(
-                                child: Icon(Icons.broken_image,
-                                    color: Color(0xFF99A1AF)),
-                              ),
-                            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Image with SNAPSHOT badge
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: Stack(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(18),
+                    child: AspectRatio(
+                      aspectRatio: 1,
+                      child: LocalImage(
+                        url: imageUrl,
+                        width: double.infinity,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, __, ___) => Container(
+                          color: const Color(0xFFF7F8FA),
+                          child: const Center(
+                            child: Icon(Icons.broken_image,
+                                color: Color(0xFF99A1AF)),
                           ),
                         ),
-                      ),
-                      // SNAPSHOT badge
-                      Positioned(
-                        top: 10,
-                        right: 10,
-                        child: Container(
-                          height: 30,
-                          padding: const EdgeInsets.symmetric(horizontal: 12),
-                          decoration: BoxDecoration(
-                            color: const Color(0xCC000000), // #000000CC
-                            borderRadius: BorderRadius.circular(15),
-                          ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              SvgPicture.asset(
-                                'assets/icons/camera.svg',
-                                width: 12,
-                                height: 12,
-                              ),
-                              const SizedBox(width: 4),
-                              Text(
-                                'SNAPSHOT',
-                                style: GoogleFonts.inter(
-                                  fontSize: 12,
-                                  fontWeight: FontWeight.w500,
-                                  color: Colors.white,
-                                  letterSpacing: 0,
-                                  height: 18 / 12,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                // Title
-                if (caption.isNotEmpty)
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
-                    child: Text(
-                      caption,
-                      style: GoogleFonts.inter(
-                        fontSize: 20,
-                        fontWeight: FontWeight.w600,
-                        height: 23 / 20,
-                        letterSpacing: -0.45,
-                        color: const Color(0xFF0A0A0A),
                       ),
                     ),
                   ),
-              ],
+                  // SNAPSHOT badge
+                  Positioned(
+                    top: 10,
+                    right: 10,
+                    child: Container(
+                      height: 30,
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      decoration: BoxDecoration(
+                        color: const Color(0xCC000000),
+                        borderRadius: BorderRadius.circular(15),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          SvgPicture.asset(
+                            'assets/icons/camera.svg',
+                            width: 12,
+                            height: 12,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            'SNAPSHOT',
+                            style: GoogleFonts.inter(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w500,
+                              color: Colors.white,
+                              letterSpacing: 0,
+                              height: 18 / 12,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
+            // Title
+            if (caption.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                child: Text(
+                  caption,
+                  style: GoogleFonts.inter(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w600,
+                    height: 23 / 20,
+                    letterSpacing: -0.45,
+                    color: const Color(0xFF0A0A0A),
+                  ),
+                ),
+              ),
+          ],
         ),
       ),
     );

--- a/lib/ui/insight/widgets/insight_screen.dart
+++ b/lib/ui/insight/widgets/insight_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 
 import 'package:memex/domain/models/knowledge_insight_card.dart';
@@ -659,70 +658,63 @@ class _InsightScreenState extends State<InsightScreen> {
   }
 
   Widget _buildPremiumUpdateFab(InsightViewModel vm) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(24),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
-        child: Container(
-          height: 48,
-          padding: const EdgeInsets.symmetric(horizontal: 20),
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                const Color(0xFF5B6CFF).withOpacity(0.9),
-                const Color(0xFF8B5CF6).withOpacity(0.9),
-              ],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
-            borderRadius: BorderRadius.circular(24),
-            border: Border.all(
-              color: Colors.white.withOpacity(0.2),
-              width: 1.5,
-            ),
-            boxShadow: [
-              BoxShadow(
-                color: const Color(0xFF5B6CFF).withOpacity(0.3),
-                blurRadius: 12,
-                offset: const Offset(0, 4),
-              ),
-            ],
+    return Container(
+      height: 48,
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            const Color(0xFF5B6CFF),
+            const Color(0xFF8B5CF6),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(
+          color: Colors.white.withOpacity(0.2),
+          width: 1.5,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: const Color(0xFF5B6CFF).withOpacity(0.3),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
           ),
-          child: InkWell(
-            onTap: vm.isRefreshing ? null : () => _onRefreshInsights(vm),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                vm.isRefreshing
-                    ? const SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          valueColor:
-                              AlwaysStoppedAnimation<Color>(Colors.white),
-                        ),
-                      )
-                    : const Icon(
-                        Icons.auto_awesome,
-                        color: Colors.white,
-                        size: 20,
-                      ),
-                const SizedBox(width: 10),
-                Text(
-                  vm.isRefreshing
-                      ? UserStorage.l10n.updating
-                      : UserStorage.l10n.update,
-                  style: const TextStyle(
+        ],
+      ),
+      child: InkWell(
+        onTap: vm.isRefreshing ? null : () => _onRefreshInsights(vm),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            vm.isRefreshing
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                    ),
+                  )
+                : const Icon(
+                    Icons.auto_awesome,
                     color: Colors.white,
-                    fontWeight: FontWeight.w700,
-                    fontSize: 14,
-                    letterSpacing: 0.5,
+                    size: 20,
                   ),
-                ),
-              ],
+            const SizedBox(width: 10),
+            Text(
+              vm.isRefreshing
+                  ? UserStorage.l10n.updating
+                  : UserStorage.l10n.update,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w700,
+                fontSize: 14,
+                letterSpacing: 0.5,
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/lib/ui/main_screen/widgets/radial_menu.dart
+++ b/lib/ui/main_screen/widgets/radial_menu.dart
@@ -1,5 +1,4 @@
 import 'dart:math' as math;
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:memex/domain/models/shortcut_item.dart';
@@ -209,7 +208,7 @@ class RadialMenuState extends State<RadialMenu> with TickerProviderStateMixin {
 
           return Stack(
             children: [
-              // Background blur
+              // Background overlay
               if (widget.visible)
                 Container(
                   color: Colors.black.withOpacity(0.01),
@@ -217,15 +216,8 @@ class RadialMenuState extends State<RadialMenu> with TickerProviderStateMixin {
                     tween: Tween(begin: 0.0, end: widget.visible ? 1.0 : 0.0),
                     duration: const Duration(milliseconds: 300),
                     builder: (context, value, child) {
-                      return BackdropFilter(
-                        filter: ImageFilter.blur(
-                            sigmaX: 8 * value,
-                            sigmaY:
-                                8 * value), // Increased blur for premium feel
-                        child: Container(
-                          color: Colors.white.withOpacity(
-                              0.4 * value), // Light overlay instead of dark
-                        ),
+                      return Container(
+                        color: Colors.white.withOpacity(0.55 * value),
                       );
                     },
                   ),

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -494,100 +493,94 @@ class TimelineScreenState extends State<TimelineScreen> {
                       ),
                     ).then((_) => _checkModelConfig());
                   },
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(16),
-                    child: BackdropFilter(
-                      filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 14),
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.topLeft,
-                            end: Alignment.bottomRight,
-                            colors: [
-                              Colors.white.withOpacity(0.72),
-                              Colors.white.withOpacity(0.48),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 14),
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [
+                          Colors.white.withOpacity(0.92),
+                          Colors.white.withOpacity(0.82),
+                        ],
+                      ),
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                        color: Colors.white.withOpacity(0.6),
+                        width: 0.5,
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.06),
+                          blurRadius: 16,
+                          offset: const Offset(0, 4),
+                        ),
+                        BoxShadow(
+                          color: const Color(0xFF6366F1).withOpacity(0.08),
+                          blurRadius: 24,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 36,
+                          height: 36,
+                          decoration: BoxDecoration(
+                            gradient: const LinearGradient(
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                              colors: [
+                                Color(0xFF818CF8),
+                                Color(0xFF6366F1),
+                              ],
+                            ),
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: const Icon(Icons.auto_awesome,
+                              size: 18, color: Colors.white),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                UserStorage.l10n.configureNow,
+                                style: const TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  color: Color(0xFF1E293B),
+                                  letterSpacing: -0.2,
+                                ),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                UserStorage.l10n.modelNotConfiguredBanner,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color:
+                                      const Color(0xFF64748B).withOpacity(0.9),
+                                  height: 1.3,
+                                ),
+                              ),
                             ],
                           ),
-                          borderRadius: BorderRadius.circular(16),
-                          border: Border.all(
-                            color: Colors.white.withOpacity(0.6),
-                            width: 0.5,
+                        ),
+                        const SizedBox(width: 8),
+                        Container(
+                          width: 28,
+                          height: 28,
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF6366F1).withOpacity(0.1),
+                            borderRadius: BorderRadius.circular(8),
                           ),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Colors.black.withOpacity(0.06),
-                              blurRadius: 16,
-                              offset: const Offset(0, 4),
-                            ),
-                            BoxShadow(
-                              color: const Color(0xFF6366F1).withOpacity(0.08),
-                              blurRadius: 24,
-                              offset: const Offset(0, 2),
-                            ),
-                          ],
+                          child: const Icon(Icons.arrow_forward_ios,
+                              size: 12, color: Color(0xFF6366F1)),
                         ),
-                        child: Row(
-                          children: [
-                            Container(
-                              width: 36,
-                              height: 36,
-                              decoration: BoxDecoration(
-                                gradient: const LinearGradient(
-                                  begin: Alignment.topLeft,
-                                  end: Alignment.bottomRight,
-                                  colors: [
-                                    Color(0xFF818CF8),
-                                    Color(0xFF6366F1),
-                                  ],
-                                ),
-                                borderRadius: BorderRadius.circular(10),
-                              ),
-                              child: const Icon(Icons.auto_awesome,
-                                  size: 18, color: Colors.white),
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    UserStorage.l10n.configureNow,
-                                    style: const TextStyle(
-                                      fontSize: 14,
-                                      fontWeight: FontWeight.w600,
-                                      color: Color(0xFF1E293B),
-                                      letterSpacing: -0.2,
-                                    ),
-                                  ),
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    UserStorage.l10n.modelNotConfiguredBanner,
-                                    style: TextStyle(
-                                      fontSize: 12,
-                                      color: const Color(0xFF64748B)
-                                          .withOpacity(0.9),
-                                      height: 1.3,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                            const SizedBox(width: 8),
-                            Container(
-                              width: 28,
-                              height: 28,
-                              decoration: BoxDecoration(
-                                color: const Color(0xFF6366F1).withOpacity(0.1),
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              child: const Icon(Icons.arrow_forward_ios,
-                                  size: 12, color: Color(0xFF6366F1)),
-                            ),
-                          ],
-                        ),
-                      ),
+                      ],
                     ),
                   ),
                 ),
@@ -595,131 +588,125 @@ class TimelineScreenState extends State<TimelineScreen> {
             if (_showFitnessBanner)
               Padding(
                 padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(16),
-                  child: BackdropFilter(
-                    filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 16, vertical: 14),
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topLeft,
-                          end: Alignment.bottomRight,
-                          colors: [
-                            Colors.white.withOpacity(0.72),
-                            Colors.white.withOpacity(0.48),
-                          ],
-                        ),
-                        borderRadius: BorderRadius.circular(16),
-                        border: Border.all(
-                          color: Colors.white.withOpacity(0.6),
-                          width: 0.5,
-                        ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withOpacity(0.06),
-                            blurRadius: 16,
-                            offset: const Offset(0, 4),
-                          ),
-                          BoxShadow(
-                            color: const Color(0xFF10B981).withOpacity(0.08),
-                            blurRadius: 24,
-                            offset: const Offset(0, 2),
-                          ),
-                        ],
-                      ),
-                      child: Row(
-                        children: [
-                          GestureDetector(
-                            onTap: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (context) =>
-                                      const SystemAuthorizationPage(),
-                                ),
-                              ).then((_) {
-                                _checkPermissionBadge();
-                                _checkFitnessBanner();
-                              });
-                            },
-                            child: Container(
-                              width: 36,
-                              height: 36,
-                              decoration: BoxDecoration(
-                                gradient: const LinearGradient(
-                                  begin: Alignment.topLeft,
-                                  end: Alignment.bottomRight,
-                                  colors: [
-                                    Color(0xFF34D399),
-                                    Color(0xFF10B981),
-                                  ],
-                                ),
-                                borderRadius: BorderRadius.circular(10),
-                              ),
-                              child: const Icon(Icons.favorite_rounded,
-                                  size: 18, color: Colors.white),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: GestureDetector(
-                              onTap: () {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) =>
-                                        const SystemAuthorizationPage(),
-                                  ),
-                                ).then((_) {
-                                  _checkPermissionBadge();
-                                  _checkFitnessBanner();
-                                });
-                              },
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    UserStorage.l10n.enableFitness,
-                                    style: const TextStyle(
-                                      fontSize: 14,
-                                      fontWeight: FontWeight.w600,
-                                      color: Color(0xFF1E293B),
-                                      letterSpacing: -0.2,
-                                    ),
-                                  ),
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    UserStorage.l10n.fitnessBannerMessage,
-                                    style: TextStyle(
-                                      fontSize: 12,
-                                      color: const Color(0xFF64748B)
-                                          .withOpacity(0.9),
-                                      height: 1.3,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          GestureDetector(
-                            onTap: _dismissFitnessBanner,
-                            child: Container(
-                              width: 28,
-                              height: 28,
-                              decoration: BoxDecoration(
-                                color: const Color(0xFF94A3B8).withOpacity(0.1),
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              child: const Icon(Icons.close_rounded,
-                                  size: 14, color: Color(0xFF94A3B8)),
-                            ),
-                          ),
-                        ],
-                      ),
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: [
+                        Colors.white.withOpacity(0.92),
+                        Colors.white.withOpacity(0.82),
+                      ],
                     ),
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(
+                      color: Colors.white.withOpacity(0.6),
+                      width: 0.5,
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.06),
+                        blurRadius: 16,
+                        offset: const Offset(0, 4),
+                      ),
+                      BoxShadow(
+                        color: const Color(0xFF10B981).withOpacity(0.08),
+                        blurRadius: 24,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Row(
+                    children: [
+                      GestureDetector(
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  const SystemAuthorizationPage(),
+                            ),
+                          ).then((_) {
+                            _checkPermissionBadge();
+                            _checkFitnessBanner();
+                          });
+                        },
+                        child: Container(
+                          width: 36,
+                          height: 36,
+                          decoration: BoxDecoration(
+                            gradient: const LinearGradient(
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                              colors: [
+                                Color(0xFF34D399),
+                                Color(0xFF10B981),
+                              ],
+                            ),
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: const Icon(Icons.favorite_rounded,
+                              size: 18, color: Colors.white),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: GestureDetector(
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) =>
+                                    const SystemAuthorizationPage(),
+                              ),
+                            ).then((_) {
+                              _checkPermissionBadge();
+                              _checkFitnessBanner();
+                            });
+                          },
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                UserStorage.l10n.enableFitness,
+                                style: const TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  color: Color(0xFF1E293B),
+                                  letterSpacing: -0.2,
+                                ),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                UserStorage.l10n.fitnessBannerMessage,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color:
+                                      const Color(0xFF64748B).withOpacity(0.9),
+                                  height: 1.3,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      GestureDetector(
+                        onTap: _dismissFitnessBanner,
+                        child: Container(
+                          width: 28,
+                          height: 28,
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF94A3B8).withOpacity(0.1),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: const Icon(Icons.close_rounded,
+                              size: 14, color: Color(0xFF94A3B8)),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary

移除 12 处 BackdropFilter 使用，解决滚动时 GPU 高负载导致的卡顿和发热问题。

## Problem

BackdropFilter 在每一帧都执行像素级高斯模糊，是 GPU 密集型操作。在 Timeline 列表中，屏幕上同时可见 3-5 张带模糊的卡片时，GPU 负载成倍增加，导致严重发热和掉帧。

## Solution

用更高不透明度的半透明容器替代 BackdropFilter，保持相近的视觉效果，GPU 开销接近零。

### 改动范围

| 文件 | 移除数量 | 替代方案 |
|------|---------|---------|
| classic_card.dart | 4 | 半透明容器 + 渐变 |
| event_card.dart | 1 | 82% 不透明白色背景 |
| snapshot_card.dart | 1 | 纯白背景 + 阴影 |
| system_task_card.dart | 1 | alpha 0.92 白色背景 |
| timeline_screen.dart | 2 | alpha 0.92 渐变白色 |
| radial_menu.dart | 1 | 半透明白色遮罩动画 |
| agent_activity_widget.dart | 1 | alpha 0.88 白色背景 |
| insight_screen.dart | 1 | 实色渐变按钮 |
| persona_chat_screen.dart | 2 | 深色半透明容器 |

### 保留的 BackdropFilter（2处）

- `share_preview_dialog.dart` — 短暂弹窗
- `demo_overlay.dart` — 引导覆盖层，只出现一次

## Visual Impact

- Timeline 卡片：几乎无差异（原本背景就接近不透明）
- Banner/浮层：从毛玻璃变为高不透明度面板，差异轻微
- Persona chat 输入栏：从磨砂质感变为深色半透明，风格略有变化

## Testing

- `flutter analyze` 通过，无错误
- 需要在真机上验证滚动流畅度和发热改善