### PR TITLE
fix: prevent duplicate clarification ask cards

### DIFF
--- a/lib/data/services/clarification_request_service.dart
+++ b/lib/data/services/clarification_request_service.dart
@@ -91,6 +91,21 @@ class ClarificationRequestService {
     ClarificationRequest request,
   ) async {
     try {
+      // Optimistic claim: atomically set a placeholder factId so concurrent
+      // invocations for the same request will not proceed.
+      final claimed = await (_db.update(_db.clarificationRequests)
+            ..where((t) =>
+                t.id.equals(request.id) &
+                (t.factId.isNull() | t.factId.equals(''))))
+          .write(ClarificationRequestsCompanion(
+        factId: const Value('_claiming'),
+        updatedAt: Value(DateTime.now().millisecondsSinceEpoch ~/ 1000),
+      ));
+      if (claimed == 0) {
+        // Another invocation already claimed this request.
+        return;
+      }
+
       final now = DateTime.now();
       final timestampSec = now.millisecondsSinceEpoch ~/ 1000;
       final dateStr = DateFormat('yyyy/MM/dd').format(now);


### PR DESCRIPTION
## Problem

Clarification ask cards were being created 2-3 times for a single request. The `_onTableChanged` handler on `clarification_requests` table fires multiple times per request lifecycle (insert, updateFactId, etc.) and since `TableChangeNotifier` does not await async handlers, concurrent invocations could all read `factId == null` and each create a card.

## Fix

Added a CAS (compare-and-swap) style atomic UPDATE at the start of `_createTimelineCard`: it sets `factId = '_claiming'` only where `factId IS NULL OR factId = ''`. Only the first caller gets `affected rows > 0` and proceeds; others return early.