### PR TITLE
[codex] 优化位置调试与卡片地址规则

### DIFF
--- a/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
@@ -118,7 +118,7 @@ class TimelineCardSkill extends Skill {
             'address': {
               'type': 'string',
               'description':
-                  'Location information, set when raw input contains location-related information. Do not be too specific. Use the format "City · Specific Location" (e.g., Beijing · Chaoyang Park) if possible, otherwise just the specific location name is fine.'
+                  'Location information for where the card happened. If raw input explicitly names a place, use that. If raw input describes an immediate present-time event, check-in, photo capture, or daily activity and current_location_context is available, use its location_summary or full_address_candidate as a conservative default. Do not use current_location_context for memories, plans, remote events, or when raw input names a conflicting place. Do not be too specific. Use the format "City · Specific Location" (e.g., Beijing · Chaoyang Park) if possible, otherwise just the specific location name is fine.'
             },
             'user_mark_address': {
               'type': 'string',

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1084,6 +1084,20 @@
       }
     }
   },
+  "locationDebugGps": "GPS",
+  "locationDebugReverseGeocode": "Reverse geocode",
+  "locationDebugProvider": "Provider",
+  "locationDebugAgentContext": "Agent context",
+  "locationDebugSource": "Source",
+  "locationDebugAddressSummary": "Address summary",
+  "locationDebugFullAddress": "Full address",
+  "locationDebugCoordinates": "Coordinates",
+  "locationDebugAccuracy": "Accuracy",
+  "locationDebugReason": "Reason",
+  "locationDebugOk": "OK",
+  "locationDebugUnavailable": "unavailable",
+  "locationDebugInjected": "injected",
+  "locationDebugNotInjected": "not injected",
 
   "settingsSearchPlaceholder": "Search settings...",
   "settingsSearchEmpty": "No matching settings found",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4358,6 +4358,90 @@ abstract class AppLocalizations {
   /// **'Failed: {error}'**
   String locationTestFailed(String error);
 
+  /// No description provided for @locationDebugGps.
+  ///
+  /// In en, this message translates to:
+  /// **'GPS'**
+  String get locationDebugGps;
+
+  /// No description provided for @locationDebugReverseGeocode.
+  ///
+  /// In en, this message translates to:
+  /// **'Reverse geocode'**
+  String get locationDebugReverseGeocode;
+
+  /// No description provided for @locationDebugProvider.
+  ///
+  /// In en, this message translates to:
+  /// **'Provider'**
+  String get locationDebugProvider;
+
+  /// No description provided for @locationDebugAgentContext.
+  ///
+  /// In en, this message translates to:
+  /// **'Agent context'**
+  String get locationDebugAgentContext;
+
+  /// No description provided for @locationDebugSource.
+  ///
+  /// In en, this message translates to:
+  /// **'Source'**
+  String get locationDebugSource;
+
+  /// No description provided for @locationDebugAddressSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'Address summary'**
+  String get locationDebugAddressSummary;
+
+  /// No description provided for @locationDebugFullAddress.
+  ///
+  /// In en, this message translates to:
+  /// **'Full address'**
+  String get locationDebugFullAddress;
+
+  /// No description provided for @locationDebugCoordinates.
+  ///
+  /// In en, this message translates to:
+  /// **'Coordinates'**
+  String get locationDebugCoordinates;
+
+  /// No description provided for @locationDebugAccuracy.
+  ///
+  /// In en, this message translates to:
+  /// **'Accuracy'**
+  String get locationDebugAccuracy;
+
+  /// No description provided for @locationDebugReason.
+  ///
+  /// In en, this message translates to:
+  /// **'Reason'**
+  String get locationDebugReason;
+
+  /// No description provided for @locationDebugOk.
+  ///
+  /// In en, this message translates to:
+  /// **'OK'**
+  String get locationDebugOk;
+
+  /// No description provided for @locationDebugUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'unavailable'**
+  String get locationDebugUnavailable;
+
+  /// No description provided for @locationDebugInjected.
+  ///
+  /// In en, this message translates to:
+  /// **'injected'**
+  String get locationDebugInjected;
+
+  /// No description provided for @locationDebugNotInjected.
+  ///
+  /// In en, this message translates to:
+  /// **'not injected'**
+  String get locationDebugNotInjected;
+
   /// No description provided for @settingsSearchPlaceholder.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2391,6 +2391,48 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get locationDebugGps => 'GPS';
+
+  @override
+  String get locationDebugReverseGeocode => 'Reverse geocode';
+
+  @override
+  String get locationDebugProvider => 'Provider';
+
+  @override
+  String get locationDebugAgentContext => 'Agent context';
+
+  @override
+  String get locationDebugSource => 'Source';
+
+  @override
+  String get locationDebugAddressSummary => 'Address summary';
+
+  @override
+  String get locationDebugFullAddress => 'Full address';
+
+  @override
+  String get locationDebugCoordinates => 'Coordinates';
+
+  @override
+  String get locationDebugAccuracy => 'Accuracy';
+
+  @override
+  String get locationDebugReason => 'Reason';
+
+  @override
+  String get locationDebugOk => 'OK';
+
+  @override
+  String get locationDebugUnavailable => 'unavailable';
+
+  @override
+  String get locationDebugInjected => 'injected';
+
+  @override
+  String get locationDebugNotInjected => 'not injected';
+
+  @override
   String get settingsSearchPlaceholder => 'Search settings...';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2304,6 +2304,48 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get locationDebugGps => 'GPS';
+
+  @override
+  String get locationDebugReverseGeocode => '逆地理编码';
+
+  @override
+  String get locationDebugProvider => '服务商';
+
+  @override
+  String get locationDebugAgentContext => 'Agent 上下文';
+
+  @override
+  String get locationDebugSource => '来源';
+
+  @override
+  String get locationDebugAddressSummary => '地址摘要';
+
+  @override
+  String get locationDebugFullAddress => '完整地址';
+
+  @override
+  String get locationDebugCoordinates => '坐标';
+
+  @override
+  String get locationDebugAccuracy => '精度';
+
+  @override
+  String get locationDebugReason => '原因';
+
+  @override
+  String get locationDebugOk => '成功';
+
+  @override
+  String get locationDebugUnavailable => '不可用';
+
+  @override
+  String get locationDebugInjected => '已注入';
+
+  @override
+  String get locationDebugNotInjected => '未注入';
+
+  @override
   String get settingsSearchPlaceholder => '搜索设置项...';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1062,6 +1062,20 @@
       }
     }
   },
+  "locationDebugGps": "GPS",
+  "locationDebugReverseGeocode": "逆地理编码",
+  "locationDebugProvider": "服务商",
+  "locationDebugAgentContext": "Agent 上下文",
+  "locationDebugSource": "来源",
+  "locationDebugAddressSummary": "地址摘要",
+  "locationDebugFullAddress": "完整地址",
+  "locationDebugCoordinates": "坐标",
+  "locationDebugAccuracy": "精度",
+  "locationDebugReason": "原因",
+  "locationDebugOk": "成功",
+  "locationDebugUnavailable": "不可用",
+  "locationDebugInjected": "已注入",
+  "locationDebugNotInjected": "未注入",
 
   "settingsSearchPlaceholder": "搜索设置项...",
   "settingsSearchEmpty": "未找到匹配的设置项",

--- a/lib/ui/settings/widgets/location_context_settings_page.dart
+++ b/lib/ui/settings/widgets/location_context_settings_page.dart
@@ -4,8 +4,8 @@ import 'package:memex/domain/models/location_context_config.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/utils/user_storage.dart';
 
-typedef CurrentLocationContextLoader = Future<CurrentLocationContext> Function(
-    {bool forceRefresh});
+typedef CurrentLocationContextLoader =
+    Future<CurrentLocationContext> Function({bool forceRefresh});
 
 class LocationContextSettingsPage extends StatefulWidget {
   const LocationContextSettingsPage({super.key, this.loadCurrentContext});
@@ -54,34 +54,79 @@ class _LocationContextSettingsPageState
   }
 
   Future<void> _testLocation() async {
-    final l10n = UserStorage.l10n;
     setState(() {
       _testing = true;
       _testResult = null;
     });
     try {
-      final loader = widget.loadCurrentContext ??
+      final loader =
+          widget.loadCurrentContext ??
           LocationContextService.instance.getCurrentContext;
       final context = await loader(forceRefresh: true);
-      final summary = context.address?.summary(context.granularity);
       if (!mounted) return;
       setState(() {
-        _testResult = context.isFresh
-            ? [
-                if (summary != null && summary.isNotEmpty) summary,
-                if (context.address?.fullAddress != null)
-                  context.address!.fullAddress!,
-                '${context.latitude?.toStringAsFixed(6)}, ${context.longitude?.toStringAsFixed(6)}',
-              ].join('\n')
-            : '${context.status}: ${context.reason ?? l10n.locationUnavailable}';
+        _testResult = _formatLocationDebugResult(context);
       });
     } catch (e) {
       if (!mounted) return;
-      setState(() => _testResult = l10n.locationTestFailed(e.toString()));
+      setState(
+        () => _testResult = UserStorage.l10n.locationTestFailed(e.toString()),
+      );
     } finally {
       if (mounted) {
         setState(() => _testing = false);
       }
+    }
+  }
+
+  String _formatLocationDebugResult(CurrentLocationContext context) {
+    final l10n = UserStorage.l10n;
+    final address = context.address;
+    final summary = address?.summary(context.granularity);
+    final lines = <String>[
+      '${l10n.locationDebugGps}: ${context.status}',
+      '${l10n.locationDebugProvider}: ${_providerLabel(_config.provider)}',
+      '${l10n.locationDebugReverseGeocode}: '
+          '${address == null ? l10n.locationDebugUnavailable : l10n.locationDebugOk}',
+      '${l10n.locationDebugAgentContext}: '
+          '${context.toAgentSystemReminderContent() == null ? l10n.locationDebugNotInjected : l10n.locationDebugInjected}',
+    ];
+
+    if (context.source.trim().isNotEmpty) {
+      lines.add('${l10n.locationDebugSource}: ${context.source}');
+    }
+    if (summary != null && summary.isNotEmpty) {
+      lines.add('${l10n.locationDebugAddressSummary}: $summary');
+    }
+    if (address?.fullAddress != null) {
+      lines.add('${l10n.locationDebugFullAddress}: ${address!.fullAddress!}');
+    }
+    if (context.latitude != null && context.longitude != null) {
+      lines.add(
+        '${l10n.locationDebugCoordinates}: '
+        '${context.latitude!.toStringAsFixed(6)}, '
+        '${context.longitude!.toStringAsFixed(6)}',
+      );
+    }
+    if (context.accuracyMeters != null) {
+      lines.add(
+        '${l10n.locationDebugAccuracy}: '
+        '${context.accuracyMeters!.toStringAsFixed(1)}m',
+      );
+    }
+    if (context.reason != null && context.reason!.trim().isNotEmpty) {
+      lines.add('${l10n.locationDebugReason}: ${context.reason}');
+    }
+
+    return lines.join('\n');
+  }
+
+  String _providerLabel(GeocodingProvider provider) {
+    switch (provider) {
+      case GeocodingProvider.openStreetMap:
+        return 'OpenStreetMap / Nominatim';
+      case GeocodingProvider.amap:
+        return UserStorage.l10n.amapProviderName;
     }
   }
 

--- a/test/ui/settings/location_context_settings_page_test.dart
+++ b/test/ui/settings/location_context_settings_page_test.dart
@@ -34,7 +34,7 @@ void main() {
     await tester.scrollUntilVisible(
       find.text('Test current location'),
       300,
-      scrollable: find.byType(Scrollable),
+      scrollable: find.byType(Scrollable).first,
     );
     await tester.pumpAndSettle();
   }
@@ -150,6 +150,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(receivedForceRefresh, isTrue);
+    expect(find.textContaining('GPS: fresh'), findsOneWidget);
+    expect(find.textContaining('Reverse geocode: OK'), findsOneWidget);
+    expect(find.textContaining('Agent context: injected'), findsOneWidget);
     expect(
       find.textContaining('Shanghai · Huangpu · People Square'),
       findsOneWidget,
@@ -181,8 +184,52 @@ void main() {
     await tester.tap(find.text('Test current location'));
     await tester.pumpAndSettle();
 
+    expect(find.textContaining('GPS: unavailable'), findsOneWidget);
+    expect(find.textContaining('Reverse geocode: unavailable'), findsOneWidget);
     expect(
-      find.textContaining('unavailable: location permission denied'),
+      find.textContaining('Reason: location permission denied'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('test button explains GPS-only reverse geocode failure', (
+    WidgetTester tester,
+  ) async {
+    await pumpLocationSettingsPage(
+      tester,
+      config: const LocationContextConfig(
+        enabled: true,
+        provider: GeocodingProvider.amap,
+        granularity: LocationContextGranularity.neighborhood,
+      ),
+      loadCurrentContext: ({bool forceRefresh = false}) async {
+        return CurrentLocationContext(
+          status: 'fresh',
+          latitude: 31.230416,
+          longitude: 121.473701,
+          accuracyMeters: 8.5,
+          source: 'device_gps',
+          updatedAt: DateTime.utc(2026, 5, 15, 10),
+          granularity: LocationContextGranularity.neighborhood,
+          reason: 'reverse geocode unavailable (amap): amap api key is empty',
+        );
+      },
+    );
+
+    await scrollToTestButton(tester);
+    await tester.tap(find.text('Test current location'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('GPS: fresh'), findsOneWidget);
+    expect(find.textContaining('Provider: Amap'), findsOneWidget);
+    expect(find.textContaining('Reverse geocode: unavailable'), findsOneWidget);
+    expect(find.textContaining('Agent context: not injected'), findsOneWidget);
+    expect(
+      find.textContaining('Coordinates: 31.230416, 121.473701'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Reason: reverse geocode unavailable (amap)'),
       findsOneWidget,
     );
   });


### PR DESCRIPTION
## 背景

Closes #91。

位置上下文设置页原本在 GPS 成功但逆地理编码失败时只显示坐标，测试结果不够可诊断；同时 Card Agent 收到 `current_location_context` 后，是否把当前位置写入卡片 `address` 的规则不够清晰，导致部分当下记录生成后格子上不显示位置。

## 改动

- 优化「测试当前位置」结果展示，明确列出 GPS、逆地理编码、服务商、Agent 上下文注入、来源、地址摘要、完整地址、坐标、精度和失败原因。
- 补充中英文 localization 文案，并更新生成的 l10n Dart 文件。
- 新增 GPS-only 场景的 widget 测试，覆盖逆地理编码失败但 GPS 成功时的调试反馈。
- 最小化调整 `save_timeline_card.address` 工具描述：
  - 输入明确地点时优先使用输入地点。
  - 当下事件、打卡、照片拍摄、日常活动可使用 `current_location_context` 作为保守默认地址。
  - 回忆、计划、远程事件，或输入中存在冲突地点时，不使用当前位置覆盖。

## 验证

- `flutter pub get`
- `flutter gen-l10n`
- `flutter test --no-pub test/domain/models/location_context_config_test.dart test/ui/settings/location_context_settings_page_test.dart`
- `dart analyze lib/ui/settings/widgets/location_context_settings_page.dart test/ui/settings/location_context_settings_page_test.dart`
- `git diff --check`

## 说明

本 PR 有意保持为最小改动，没有新增确定性 `submission_location` 落盘字段。若后续观察到模型仍不能稳定填写 `address`，再单独引入可测试的确定性落盘和派生规则。