### PR TITLE
[codex] Repair legacy agent thinking state

### DIFF
--- a/lib/agent/state_util.dart
+++ b/lib/agent/state_util.dart
@@ -1,30 +1,115 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/data/services/file_system_service.dart';
 
 Future<AgentState> loadOrCreateAgentState(
-    String sessionId, Map<String, dynamic>? initialMetadata) async {
+  String sessionId,
+  Map<String, dynamic>? initialMetadata,
+) async {
   final userId = initialMetadata?['userId'] ?? 'mock_user_id';
-  final stateDirPath =
-      await FileSystemService.instance.getAgentStateDirectory(userId);
+  final stateDirPath = await FileSystemService.instance.getAgentStateDirectory(
+    userId,
+  );
   final stateDir = Directory(stateDirPath);
   final storage = FileStateStorage(stateDir);
-  return await storage.loadOrCreate(sessionId, initialMetadata);
+  final state = await storage.loadOrCreate(sessionId, initialMetadata);
+  if (_repairLegacyAssistantContentBlocks(state)) {
+    await storage.save(state);
+  }
+  return state;
 }
 
 Future<void> saveAgentState(AgentState state) async {
   final userId = state.metadata['userId'] ?? 'mock_user_id';
-  final stateDirPath =
-      await FileSystemService.instance.getAgentStateDirectory(userId);
+  final stateDirPath = await FileSystemService.instance.getAgentStateDirectory(
+    userId,
+  );
   final stateDir = Directory(stateDirPath);
   final storage = FileStateStorage(stateDir);
   await storage.save(state);
 }
 
+bool _repairLegacyAssistantContentBlocks(AgentState state) {
+  var changed = false;
+  final repairedMessages = <LLMMessage>[];
+
+  for (final message in state.history.messages) {
+    if (message is ModelMessage &&
+        message.contentBlocks.isEmpty &&
+        message.thought != null &&
+        message.thought!.isNotEmpty) {
+      repairedMessages.add(_withSynthesizedContentBlocks(message));
+      changed = true;
+    } else {
+      repairedMessages.add(message);
+    }
+  }
+
+  if (changed) {
+    state.history.messages = repairedMessages;
+  }
+  return changed;
+}
+
+ModelMessage _withSynthesizedContentBlocks(ModelMessage message) {
+  final contentBlocks = <Map<String, dynamic>>[
+    {
+      'type': 'thinking',
+      'thinking': message.thought,
+      if (message.thoughtSignature != null)
+        'signature': message.thoughtSignature,
+    },
+  ];
+
+  if (message.textOutput != null && message.textOutput!.isNotEmpty) {
+    contentBlocks.add({'type': 'text', 'text': message.textOutput});
+  }
+
+  for (final call in message.functionCalls) {
+    if (call.id.isEmpty) continue;
+    contentBlocks.add({
+      'type': 'tool_use',
+      'id': call.id,
+      'name': call.name,
+      'input': _decodeToolInput(call.arguments),
+    });
+  }
+
+  return ModelMessage(
+    thought: message.thought,
+    thoughtSignature: message.thoughtSignature,
+    contentBlocks: contentBlocks,
+    functionCalls: message.functionCalls,
+    textOutput: message.textOutput,
+    imageOutputs: message.imageOutputs,
+    videoOutputs: message.videoOutputs,
+    audioOutputs: message.audioOutputs,
+    usage: message.usage,
+    metadata: message.metadata,
+    stopReason: message.stopReason,
+    model: message.model,
+    responseId: message.responseId,
+    timestamp: message.timestamp,
+  );
+}
+
+dynamic _decodeToolInput(String arguments) {
+  if (arguments.isEmpty) {
+    return {};
+  }
+  try {
+    return jsonDecode(arguments);
+  } catch (_) {
+    return {};
+  }
+}
+
 Future<void> deleteAgentState(String userId, String sessionId) async {
-  final stateDirPath =
-      await FileSystemService.instance.getAgentStateDirectory(userId);
+  final stateDirPath = await FileSystemService.instance.getAgentStateDirectory(
+    userId,
+  );
   final stateDir = Directory(stateDirPath);
   final storage = FileStateStorage(stateDir);
   await storage.delete(sessionId);
@@ -43,8 +128,9 @@ Future<({String sessionId, bool isExisting})> resolveCharacterSessionId({
   required String prefix,
   required String userId,
 }) async {
-  final stateDirPath =
-      await FileSystemService.instance.getAgentStateDirectory(userId);
+  final stateDirPath = await FileSystemService.instance.getAgentStateDirectory(
+    userId,
+  );
   final stateDir = Directory(stateDirPath);
   if (!await stateDir.exists()) {
     return (sessionId: '${prefix}_1', isExisting: false);

--- a/lib/agent/state_util.dart
+++ b/lib/agent/state_util.dart
@@ -36,21 +36,46 @@ bool _repairLegacyAssistantContentBlocks(AgentState state) {
   final repairedMessages = <LLMMessage>[];
 
   for (final message in state.history.messages) {
-    if (message is ModelMessage &&
-        message.contentBlocks.isEmpty &&
-        message.thought != null &&
-        message.thought!.isNotEmpty) {
-      repairedMessages.add(_withSynthesizedContentBlocks(message));
-      changed = true;
-    } else {
+    if (message is! ModelMessage) {
       repairedMessages.add(message);
+      continue;
     }
+
+    var repaired = message;
+    if (repaired.contentBlocks.isEmpty &&
+        repaired.thought != null &&
+        repaired.thought!.isNotEmpty) {
+      repaired = _withSynthesizedContentBlocks(repaired);
+      changed = true;
+    }
+
+    if (_needsLegacyReasoningContentPlaceholder(repaired)) {
+      repaired = _withReasoningContentPlaceholder(repaired);
+      changed = true;
+    }
+
+    repairedMessages.add(repaired);
   }
 
   if (changed) {
     state.history.messages = repairedMessages;
   }
   return changed;
+}
+
+bool _needsLegacyReasoningContentPlaceholder(ModelMessage message) {
+  if (message.thought != null) return false;
+  if (message.functionCalls.isEmpty) return false;
+
+  final model = message.model.toLowerCase();
+  return model.contains('deepseek-v4');
+}
+
+ModelMessage _withReasoningContentPlaceholder(ModelMessage message) {
+  // Old interrupted DeepSeek V4 tool-call turns may have lost
+  // reasoning_content. We cannot reconstruct it, but a present field unblocks
+  // the next API call; fresh turns keep the real reasoning_content.
+  return _copyModelMessage(message, thought: ' ');
 }
 
 ModelMessage _withSynthesizedContentBlocks(ModelMessage message) {
@@ -77,10 +102,18 @@ ModelMessage _withSynthesizedContentBlocks(ModelMessage message) {
     });
   }
 
+  return _copyModelMessage(message, contentBlocks: contentBlocks);
+}
+
+ModelMessage _copyModelMessage(
+  ModelMessage message, {
+  String? thought,
+  List<Map<String, dynamic>>? contentBlocks,
+}) {
   return ModelMessage(
-    thought: message.thought,
+    thought: thought ?? message.thought,
     thoughtSignature: message.thoughtSignature,
-    contentBlocks: contentBlocks,
+    contentBlocks: contentBlocks ?? message.contentBlocks,
     functionCalls: message.functionCalls,
     textOutput: message.textOutput,
     imageOutputs: message.imageOutputs,

--- a/lib/llm_client/gemini_oauth_client.dart
+++ b/lib/llm_client/gemini_oauth_client.dart
@@ -90,8 +90,7 @@ class GeminiOAuthClient extends LLMClient {
         continue;
       }
       final filtered = parts
-          .where((p) =>
-              p is! Map<String, dynamic> || p['thought'] != true)
+          .where((p) => p is! Map<String, dynamic> || p['thought'] != true)
           .toList();
       if (filtered.isEmpty && record['role'] == 'model') continue;
       sanitized.add({...record, 'parts': filtered});
@@ -115,7 +114,7 @@ class GeminiOAuthClient extends LLMClient {
         modelConfig: modelConfig,
         jsonOutput: jsonOutput);
     final wrappedBody = await _wrapRequest(geminiBody, model);
-    final url = '$_codeAssistEndpoint/v1internal:generateContent';
+    const url = '$_codeAssistEndpoint/v1internal:generateContent';
 
     int retryCount = 0;
     int currentDelayMs = initialRetryDelayMs;
@@ -191,7 +190,7 @@ class GeminiOAuthClient extends LLMClient {
         modelConfig: modelConfig,
         jsonOutput: jsonOutput);
     final wrappedBody = await _wrapRequest(geminiBody, model);
-    final url = '$_codeAssistEndpoint/v1internal:streamGenerateContent?alt=sse';
+    const url = '$_codeAssistEndpoint/v1internal:streamGenerateContent?alt=sse';
 
     final controller = StreamController<StreamingMessage>();
     int retryCount = 0;
@@ -378,18 +377,21 @@ Map<String, dynamic> _createGeminiBody(
     } else if (m is ModelMessage) {
       if (m.textOutput != null) parts.add({'text': m.textOutput});
       for (final fc in m.functionCalls) {
-        final fcPart = <String, dynamic>{
+        parts.add({
           'functionCall': {
             'name': fc.name,
-            'args': fc.arguments is Map
-                ? fc.arguments
-                : jsonDecode(fc.arguments),
+            'args':
+                fc.arguments is Map ? fc.arguments : jsonDecode(fc.arguments),
           }
-        };
-        if (m.thoughtSignature != null) {
-          fcPart['thoughtSignature'] = m.thoughtSignature;
+        });
+      }
+      if (m.thoughtSignature != null && parts.isNotEmpty) {
+        final fcIndex = parts.indexWhere((p) => p.containsKey('functionCall'));
+        if (fcIndex != -1) {
+          parts[fcIndex]['thoughtSignature'] = m.thoughtSignature;
+        } else {
+          parts.last['thoughtSignature'] = m.thoughtSignature;
         }
-        parts.add(fcPart);
       }
     } else if (m is FunctionExecutionResultMessage) {
       for (final res in m.results) {
@@ -397,7 +399,8 @@ Map<String, dynamic> _createGeminiBody(
             res.content.whereType<TextPart>().map((t) => t.text).join('\n');
         parts.add({
           'functionResponse': {
-            'name': res.id,
+            'name': res.name,
+            if (res.id != res.name) 'id': res.id,
             'response': {'content': text},
           }
         });
@@ -496,7 +499,7 @@ ModelMessage? _parseResponse(
       if (part.containsKey('functionCall')) {
         final fc = part['functionCall'] as Map;
         functionCalls.add(FunctionCall(
-          id: fc['name'] as String,
+          id: (fc['id'] ?? fc['name']) as String,
           name: fc['name'] as String,
           arguments: jsonEncode(fc['args'] ?? {}),
         ));

--- a/test/agent/state_util_test.dart
+++ b/test/agent/state_util_test.dart
@@ -86,5 +86,35 @@ void main() {
       final message = loaded.history.messages.single as ModelMessage;
       expect(message.contentBlocks, blocks);
     });
+
+    test('repairs legacy DeepSeek V4 tool-call turns', () async {
+      final state = AgentState(
+        sessionId: 'legacy_deepseek_reasoning_state',
+        metadata: {'userId': userId},
+      );
+      state.history.messages.add(
+        ModelMessage(
+          model: 'deepseek-v4-pro',
+          functionCalls: [
+            FunctionCall(
+              id: 'call_1',
+              name: 'lookup',
+              arguments: '{}',
+            ),
+          ],
+          stopReason: 'tool_calls',
+          timestamp: 123,
+        ),
+      );
+      await saveAgentState(state);
+
+      final loaded = await loadOrCreateAgentState(
+        'legacy_deepseek_reasoning_state',
+        {'userId': userId},
+      );
+
+      final message = loaded.history.messages.single as ModelMessage;
+      expect(message.thought, ' ');
+    });
   });
 }

--- a/test/agent/state_util_test.dart
+++ b/test/agent/state_util_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:memex/agent/state_util.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('loadOrCreateAgentState', () {
+    late Directory tempRoot;
+    const userId = 'state_util_user';
+
+    setUp(() async {
+      tempRoot = await Directory.systemTemp.createTemp('memex_state_util_');
+      await FileSystemService.init(tempRoot.path);
+    });
+
+    tearDown(() async {
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('repairs legacy assistant thinking into content blocks', () async {
+      final state = AgentState(
+        sessionId: 'legacy_thinking_state',
+        metadata: {'userId': userId},
+      );
+      state.history.messages.add(
+        ModelMessage(
+          model: 'claude-test',
+          thought: 'Need to inspect a file first.',
+          textOutput: 'I will read it.',
+          functionCalls: [
+            FunctionCall(
+              id: 'toolu_1',
+              name: 'Read',
+              arguments: '{"path":"a.md"}',
+            ),
+          ],
+          stopReason: 'tool_use',
+          timestamp: 123,
+        ),
+      );
+      await saveAgentState(state);
+
+      final loaded = await loadOrCreateAgentState('legacy_thinking_state', {
+        'userId': userId,
+      });
+
+      final message = loaded.history.messages.single as ModelMessage;
+      expect(message.contentBlocks, [
+        {'type': 'thinking', 'thinking': 'Need to inspect a file first.'},
+        {'type': 'text', 'text': 'I will read it.'},
+        {
+          'type': 'tool_use',
+          'id': 'toolu_1',
+          'name': 'Read',
+          'input': {'path': 'a.md'},
+        },
+      ]);
+    });
+
+    test('preserves provider-native content blocks', () async {
+      final state = AgentState(
+        sessionId: 'native_blocks_state',
+        metadata: {'userId': userId},
+      );
+      const blocks = [
+        {'type': 'redacted_thinking', 'data': 'opaque-data'},
+      ];
+      state.history.messages.add(
+        ModelMessage(
+          model: 'claude-test',
+          thought: 'Hidden provider-native block exists.',
+          contentBlocks: blocks,
+          timestamp: 123,
+        ),
+      );
+      await saveAgentState(state);
+
+      final loaded = await loadOrCreateAgentState('native_blocks_state', {
+        'userId': userId,
+      });
+
+      final message = loaded.history.messages.single as ModelMessage;
+      expect(message.contentBlocks, blocks);
+    });
+  });
+}


### PR DESCRIPTION
## 摘要

- 在 Memex 加临时兼容修复：加载 agent state 时修复旧 assistant message，避免 thinking/reasoning 上下文丢失后恢复会话失败。
- 对旧 Claude/Anthropic-compatible 状态合成 `thinking` / `text` / `tool_use` content blocks，并保存修复后的 state。
- 对旧 DeepSeek V4 tool-call turn 增加窄兜底，避免缺失 `reasoning_content` 导致下一轮 API 400。
- 修复 Memex Gemini OAuth replay：`thoughtSignature` 只挂到一个模型 part，`functionResponse.name` 使用函数名，并保留可选 call id。
- 保留已有 provider-native `contentBlocks`，不覆盖新状态。

## 根因

`dart_agent_core` 新版本已经会保存 Anthropic provider-native content blocks，但用户本地可能还有旧的、被中断的 Memex agent state。旧 state 只有扁平字段：`thought`、`textOutput`、`functionCalls`，没有 provider 原生 blocks。

当这些旧状态继续跑 thinking/tool-use 模型时，API 要求上一轮 thinking/reasoning 内容必须被传回；如果 Memex 恢复会话时没有补齐，就会出现类似 `the reasoning_content in the thinking mode must be passed back to the api` 的 400。

这个 PR 是主 app 侧临时方案，用来保护已存在的用户状态。等 core 修复发布后，再升级依赖并收敛这层兼容逻辑。

## 验证

```bash
flutter test --no-pub test/agent/state_util_test.dart
flutter analyze --no-pub lib/agent/state_util.dart lib/llm_client/gemini_oauth_client.dart test/agent/state_util_test.dart
```

本轮已重新回归，全部通过。

备注：本 workspace 之前 `flutter pub get` 下载阶段卡住过，所以这里继续使用现有 package config 和 `--no-pub` 做定向验证。