### PR TITLE
[codex] 修复 Android 录音 SIGILL 崩溃

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -203,7 +203,7 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - sherpa_onnx_ios (1.12.36):
+  - sherpa_onnx_ios (1.13.2):
     - Flutter
   - sqlite3 (3.51.1):
     - sqlite3/common (= 3.51.1)
@@ -424,7 +424,7 @@ SPEC CHECKSUMS:
   share_handler_ios_models: fc638c9b4330dc7f082586c92aee9dfa0b87b871
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  sherpa_onnx_ios: e813293ef88f9a5dd1ff48b887f660ea6fc4144c
+  sherpa_onnx_ios: e8ce46d79d231ebdf2edd7b97891f5a601dd3565
   sqlite3: 8d708bc63e9f4ce48f0ad9d6269e478c5ced1d9b
   sqlite3_flutter_libs: d13b8b3003f18f596e542bcb9482d105577eff41
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4

--- a/lib/data/services/streaming_transcriber.dart
+++ b/lib/data/services/streaming_transcriber.dart
@@ -48,6 +48,7 @@ class StreamingTranscriber {
   sherpa.VoiceActivityDetector? _vad;
   bool _isRunning = false;
   final List<double> _sampleBuffer = [];
+  bool _hasLoggedFirstVadWindow = false;
   static const int _vadWindowSize = 512;
 
   /// Calibrate when pending audio reaches this duration.
@@ -149,6 +150,11 @@ class StreamingTranscriber {
         _sampleBuffer.sublist(0, _vadWindowSize),
       );
       _sampleBuffer.removeRange(0, _vadWindowSize);
+      if (!_hasLoggedFirstVadWindow) {
+        _hasLoggedFirstVadWindow = true;
+        _logger.info('Running first VAD acceptWaveform window: '
+            '${window.length} samples');
+      }
       _vad!.acceptWaveform(window);
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -956,6 +956,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     try {
       final speechService = SpeechTranscriptionService.instance;
 
+      _logger.info('Starting quick recording');
       // Check if local speech model needs downloading
       if (await speechService.requiresLocalModelDownload()) {
         setState(() => _isRadialMenuOpen = false);
@@ -969,6 +970,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         _quickTranscribedText = '';
         _quickPcmBuffer.clear();
         if (await speechService.supportsStreamingTranscription()) {
+          _logger
+              .info('Initializing streaming transcriber for quick recording');
           _quickTranscriber = StreamingTranscriber(
             onTextChanged: (fullText) {
               _quickTranscribedText = fullText;
@@ -976,9 +979,11 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
             },
           );
           await _quickTranscriber!.init();
+          _logger.info('Streaming transcriber initialized for quick recording');
         }
 
         // Start streaming PCM recording
+        _logger.info('Starting PCM audio stream for quick recording');
         final audioStream = await _audioRecorder.startStream(
           const RecordConfig(
             encoder: AudioEncoder.pcm16bits,
@@ -994,8 +999,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
         _recordingPath = 'streaming'; // marker that recording is active
       }
-    } catch (e) {
-      _logger.severe('Error starting recording: $e', e);
+    } catch (e, stackTrace) {
+      _logger.severe('Error starting quick recording', e, stackTrace);
     }
   }
 

--- a/lib/ui/main_screen/widgets/input_sheet.dart
+++ b/lib/ui/main_screen/widgets/input_sheet.dart
@@ -501,6 +501,7 @@ class _InputSheetState extends State<InputSheet>
     try {
       final speechService = SpeechTranscriptionService.instance;
 
+      _logger.info('Starting input sheet recording');
       if (!await _ensureLocalModelReady()) return;
 
       var status = await Permission.microphone.status;
@@ -520,6 +521,7 @@ class _InputSheetState extends State<InputSheet>
       _preRecordingText = _textController.text;
 
       if (await speechService.supportsStreamingTranscription()) {
+        _logger.info('Initializing streaming transcriber for input sheet');
         _streamingTranscriber = StreamingTranscriber(
           onTextChanged: (fullText) {
             if (mounted) {
@@ -538,9 +540,11 @@ class _InputSheetState extends State<InputSheet>
           },
         );
         await _streamingTranscriber!.init();
+        _logger.info('Streaming transcriber initialized for input sheet');
       }
 
       _pcmBuffer.clear();
+      _logger.info('Starting PCM audio stream for input sheet');
       final audioStream = await _audioRecorder.startStream(
         const RecordConfig(
           encoder: AudioEncoder.pcm16bits,
@@ -568,7 +572,8 @@ class _InputSheetState extends State<InputSheet>
       _pulseController.repeat(reverse: true);
 
       _updateRecordingDuration();
-    } catch (e) {
+    } catch (e, stackTrace) {
+      _logger.severe('Failed to start input sheet recording', e, stackTrace);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Failed to start recording: $e')),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1681,50 +1681,74 @@ packages:
     dependency: "direct main"
     description:
       name: sherpa_onnx
-      sha256: c10a1052bf03b9e68562e5be7d3a60568738c8356f3607012f0260f88ea11f08
+      sha256: b5a503cedc0605134770015fd4dba00c62f109f8a16630a52ebc04ef99ccbf93
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.36"
-  sherpa_onnx_android:
+    version: "1.13.2"
+  sherpa_onnx_android_arm64:
     dependency: transitive
     description:
-      name: sherpa_onnx_android
-      sha256: "03a70665e83c026ccf4d853fe87d011321bc66810c5ea108ea08a128f95d862a"
+      name: sherpa_onnx_android_arm64
+      sha256: b6aeb7cd5b32c6d1bd209a4bff0f28044d95977620d20e1d926b0c31e0a0725f
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.36"
+    version: "1.13.2"
+  sherpa_onnx_android_armeabi:
+    dependency: transitive
+    description:
+      name: sherpa_onnx_android_armeabi
+      sha256: ab647a0a4ca4b7c31159db1bdfc79b718882a088a2ed9757b340856d626715c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.13.2"
+  sherpa_onnx_android_x86:
+    dependency: transitive
+    description:
+      name: sherpa_onnx_android_x86
+      sha256: df0e8bf68ff564bf8683f285ee3e65fb296ec118dbf6ce60a906bb1b3206120e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.13.2"
+  sherpa_onnx_android_x86_64:
+    dependency: transitive
+    description:
+      name: sherpa_onnx_android_x86_64
+      sha256: f9f63fafde9498bed9de45a0e1d3f2eb4d649ad257e5de30b91d139432750b84
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.13.2"
   sherpa_onnx_ios:
     dependency: transitive
     description:
       name: sherpa_onnx_ios
-      sha256: a7c89d151473ceef7052a9095e2ba3ea4e62b641d000e1a7f4bc6003a1df0390
+      sha256: "46b30fe5db3e0741026e94f09f3515dc60071eb970e12039265e1ba98c4d812d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.36"
+    version: "1.13.2"
   sherpa_onnx_linux:
     dependency: transitive
     description:
       name: sherpa_onnx_linux
-      sha256: ce48bbad9d2ea65bdbbbb2fce435533299402128aa27b2542f9a73c32dec47de
+      sha256: e0b2780d809a5be6cc36b7915bbe25dd15059e357a7f0ac684feb4e6ad4e20b7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.36"
+    version: "1.13.2"
   sherpa_onnx_macos:
     dependency: transitive
     description:
       name: sherpa_onnx_macos
-      sha256: be4f45f30f6683008464f482b1c70c7a422a3312b022073cf43ff80cd1b1ebe2
+      sha256: "8049aae4e290d01ce51267541a770eb5a61c8164d46c1127406557995b054875"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.36"
+    version: "1.13.2"
   sherpa_onnx_windows:
     dependency: transitive
     description:
       name: sherpa_onnx_windows
-      sha256: c436894ec5abb4730481ae59a026f1215c8f2006f2306d63fffe44a95410091a
+      sha256: "428c5fc2fea2d9083555d6281224ab7dba3a33a8fbc013de18ea843cf1236f14"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.36"
+    version: "1.13.2"
   shimmer:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,7 +86,7 @@ dependencies:
   share_plus: ^10.1.4
   file_picker: ^8.1.7
   screenshot: ^3.0.0
-  sherpa_onnx: ^1.12.36
+  sherpa_onnx: 1.13.2
   geolocator: ^14.0.2
 
 dev_dependencies:


### PR DESCRIPTION
## 背景 / 根因

Issue #29 在 Android 真机点击录音后会发生 native `SIGILL` 崩溃。排查日志和反汇编显示：

- 录音权限、模型下载和 VAD 初始化都已经通过；崩溃发生在第一帧音频进入 `VoiceActivityDetector.acceptWaveform()` 时。
- crash 栈落在 `libonnxruntime.so`，旧包 `sherpa_onnx_android 1.12.36` 携带的 ORT 为 `1.23.2`。
- 崩溃指令位于 ORT/KleidiAI SME2 路径；目标设备暴露 SME，但不支持 `sme2`，因此执行 SME2 指令触发 `SIGILL`。

这更像是上游 native runtime 的 CPU feature dispatch 兼容问题，不是 Dart 侧异常、权限问题，也不是 SenseVoice 模型文件损坏。

## 修复方案

- 将 `sherpa_onnx` 从 `^1.12.36` 精确升级到 `1.13.2`。
  - `1.12.37/#3494` 将 Android ORT 升到 `1.24.3`。
  - `1.12.38/#3501` 继续更新 ORT 版本线。
  - `1.12.40/#3522` 拆分 Android ABI 包，但该版本有 `BuildConfig is defined multiple times` 的 release 构建问题（#3557）。
  - `1.13.0/#3559` 修复 ABI split 后的 Android namespace 冲突，所以这里直接落到 `1.13.2`，避免卡在 1.12.40 的构建坑。
- 保留精确 pin，避免 `^` 后续自动跳版本扩大风险。
- 补充录音启动、streaming transcriber 初始化、PCM stream 开始，以及首个 VAD window 的日志，后续排查不再依赖截图猜阶段。

## 兼容性检查

- Dart API 对比：`sherpa_onnx` 1.12.36 与 1.13.2 的 `lib/` 目录逐文件一致；本项目使用的 `VoiceActivityDetector`、`OfflineRecognizer`、`readWave` 等 API 没有签名变化。
- native symbol 对比：新旧 `libsherpa-onnx-c-api.so` 都导出当前使用的 VAD / OfflineRecognizer / ReadWave 相关 C API。
- Android ABI 打包：arm64 / armeabi-v7a / x86_64 split APK 和 debug AAB 均能正确包含对应 ABI 的 sherpa/ORT so。
- iOS：`sherpa_onnx_ios` lock 同步到 1.13.2；podspec 除版本号外无接口性变化。

## 验证

- `flutter pub get --offline`
- `flutter analyze --no-pub lib/data/services/streaming_transcriber.dart lib/ui/main_screen/widgets/input_sheet.dart lib/main.dart`
  - 仅剩 `lib/main.dart` 既有 16 个 info 级 lint，无新增 error。
- `flutter test --no-pub test/ui/main_screen/widgets/input_sheet_test.dart`
- `flutter build apk --debug --flavor globalDev --target-platform android-arm64 --split-per-abi --no-pub`
- 额外兼容性 smoke：
  - `flutter build apk --debug --flavor globalDev --target-platform android-arm --split-per-abi --no-pub`
  - `flutter build apk --debug --flavor globalDev --target-platform android-x64 --split-per-abi --no-pub`
  - `flutter build apk --debug --flavor globalDev --no-pub`
  - `flutter build appbundle --debug --flavor globalDev --no-pub`
  - `flutter build ios --debug --flavor global --no-codesign --no-pub`

## 已知情况

- 当前环境没有再次识别到真机，因此最终录音按钮 smoke test 还需要接上设备后补跑。
- release APK 构建目前被既有 `GeneratedPluginRegistrant` 中 `flutter_native_splash` Java 编译问题挡住，未作为本 PR 的通过项。

Fixes #29
