### PR TITLE
[codex] Add explicit save flow for location context settings

### DIFF
--- a/lib/ui/settings/widgets/location_context_settings_page.dart
+++ b/lib/ui/settings/widgets/location_context_settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:memex/data/services/location_context_service.dart';
 import 'package:memex/domain/models/location_context_config.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/utils/toast_helper.dart';
 import 'package:memex/utils/user_storage.dart';
 
 typedef CurrentLocationContextLoader =
@@ -20,10 +21,14 @@ class LocationContextSettingsPage extends StatefulWidget {
 class _LocationContextSettingsPageState
     extends State<LocationContextSettingsPage> {
   LocationContextConfig _config = const LocationContextConfig();
+  LocationContextConfig _savedConfig = const LocationContextConfig();
   late final TextEditingController _amapKeyController;
   bool _loading = true;
+  bool _saving = false;
   bool _testing = false;
   String? _testResult;
+
+  bool get _hasChanges => !_isSameConfig(_config, _savedConfig);
 
   @override
   void initState() {
@@ -43,14 +48,36 @@ class _LocationContextSettingsPageState
     if (!mounted) return;
     setState(() {
       _config = config;
+      _savedConfig = config;
       _amapKeyController.text = config.amapApiKey;
       _loading = false;
     });
   }
 
-  Future<void> _save(LocationContextConfig config) async {
+  void _updateDraft(LocationContextConfig config) {
     setState(() => _config = config);
-    await UserStorage.saveLocationContextConfig(config);
+  }
+
+  Future<void> _saveChanges() async {
+    if (!_hasChanges || _saving) return;
+    setState(() => _saving = true);
+
+    final config = _config.copyWith(amapApiKey: _amapKeyController.text.trim());
+    try {
+      await UserStorage.saveLocationContextConfig(config);
+      if (!mounted) return;
+      setState(() {
+        _config = config;
+        _savedConfig = config;
+        _saving = false;
+        _amapKeyController.text = config.amapApiKey;
+      });
+      ToastHelper.showSuccess(context, UserStorage.l10n.saveSuccess);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ToastHelper.showError(context, UserStorage.l10n.saveFailed(e));
+    }
   }
 
   Future<void> _testLocation() async {
@@ -85,7 +112,7 @@ class _LocationContextSettingsPageState
     final summary = address?.summary(context.granularity);
     final lines = <String>[
       '${l10n.locationDebugGps}: ${context.status}',
-      '${l10n.locationDebugProvider}: ${_providerLabel(_config.provider)}',
+      '${l10n.locationDebugProvider}: ${_providerLabel(_savedConfig.provider)}',
       '${l10n.locationDebugReverseGeocode}: '
           '${address == null ? l10n.locationDebugUnavailable : l10n.locationDebugOk}',
       '${l10n.locationDebugAgentContext}: '
@@ -130,222 +157,310 @@ class _LocationContextSettingsPageState
     }
   }
 
+  bool _isSameConfig(LocationContextConfig a, LocationContextConfig b) {
+    return a.enabled == b.enabled &&
+        a.provider == b.provider &&
+        a.amapApiKey == b.amapApiKey &&
+        a.granularity == b.granularity &&
+        a.ttlMinutes == b.ttlMinutes;
+  }
+
+  Future<bool> _showDiscardDialog() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: Colors.white,
+        title: Text(UserStorage.l10n.discardChangesTitle),
+        content: Text(UserStorage.l10n.discardChangesMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(UserStorage.l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(
+              UserStorage.l10n.discardButton,
+              style: const TextStyle(color: Colors.red),
+            ),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = UserStorage.l10n;
-    return Scaffold(
-      backgroundColor: const Color(0xFFF7F8FA),
-      appBar: AppBar(
-        title: Text(l10n.locationContextTitle),
-        backgroundColor: AppColors.background,
-        surfaceTintColor: AppColors.background,
-      ),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : ListView(
-              padding: const EdgeInsets.all(16),
-              children: [
-                _section(
-                  child: SwitchListTile(
-                    contentPadding: EdgeInsets.zero,
-                    secondary: const Icon(
-                      Icons.my_location_outlined,
-                      color: AppColors.primary,
+    return PopScope(
+      canPop: !_hasChanges,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        final shouldPop = await _showDiscardDialog();
+        if (shouldPop && context.mounted) {
+          Navigator.of(context).pop(result);
+        }
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFFF7F8FA),
+        appBar: AppBar(
+          title: Text(l10n.locationContextTitle),
+          backgroundColor: AppColors.background,
+          surfaceTintColor: AppColors.background,
+        ),
+        bottomNavigationBar: _loading ? null : _saveBar(),
+        body: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  _section(
+                    child: SwitchListTile(
+                      contentPadding: EdgeInsets.zero,
+                      secondary: const Icon(
+                        Icons.my_location_outlined,
+                        color: AppColors.primary,
+                      ),
+                      title: Text(l10n.locationContextAttachTitle),
+                      subtitle: Text(l10n.locationContextAttachDesc),
+                      value: _config.enabled,
+                      onChanged: (value) =>
+                          _updateDraft(_config.copyWith(enabled: value)),
                     ),
-                    title: Text(l10n.locationContextAttachTitle),
-                    subtitle: Text(l10n.locationContextAttachDesc),
-                    value: _config.enabled,
-                    onChanged: (value) =>
-                        _save(_config.copyWith(enabled: value)),
                   ),
-                ),
-                const SizedBox(height: 16),
-                _section(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        l10n.reverseGeocodingProvider,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      DropdownButtonFormField<GeocodingProvider>(
-                        key: ValueKey(_config.provider),
-                        initialValue: _config.provider,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          isDense: true,
-                        ),
-                        selectedItemBuilder: (_) => [
-                          const Text('OpenStreetMap / Nominatim'),
-                          Text(l10n.amapProviderName),
-                        ],
-                        items: [
-                          const DropdownMenuItem(
-                            value: GeocodingProvider.openStreetMap,
-                            child: Text('OpenStreetMap / Nominatim'),
+                  const SizedBox(height: 16),
+                  _section(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l10n.reverseGeocodingProvider,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
                           ),
-                          DropdownMenuItem(
-                            value: GeocodingProvider.amap,
-                            child: Text(l10n.amapProviderName),
-                          ),
-                        ],
-                        onChanged: (value) {
-                          if (value == null) return;
-                          _save(_config.copyWith(provider: value));
-                        },
-                      ),
-                      if (_config.provider == GeocodingProvider.amap) ...[
+                        ),
                         const SizedBox(height: 12),
-                        TextField(
-                          controller: _amapKeyController,
-                          decoration: InputDecoration(
-                            labelText: l10n.amapApiKey,
-                            border: const OutlineInputBorder(),
+                        DropdownButtonFormField<GeocodingProvider>(
+                          key: ValueKey(_config.provider),
+                          initialValue: _config.provider,
+                          decoration: const InputDecoration(
+                            border: OutlineInputBorder(),
                             isDense: true,
                           ),
-                          onChanged: (value) =>
-                              _save(_config.copyWith(amapApiKey: value.trim())),
+                          selectedItemBuilder: (_) => [
+                            const Text('OpenStreetMap / Nominatim'),
+                            Text(l10n.amapProviderName),
+                          ],
+                          items: [
+                            const DropdownMenuItem(
+                              value: GeocodingProvider.openStreetMap,
+                              child: Text('OpenStreetMap / Nominatim'),
+                            ),
+                            DropdownMenuItem(
+                              value: GeocodingProvider.amap,
+                              child: Text(l10n.amapProviderName),
+                            ),
+                          ],
+                          onChanged: (value) {
+                            if (value == null) return;
+                            _updateDraft(_config.copyWith(provider: value));
+                          },
                         ),
-                        const SizedBox(height: 8),
+                        if (_config.provider == GeocodingProvider.amap) ...[
+                          const SizedBox(height: 12),
+                          TextField(
+                            controller: _amapKeyController,
+                            decoration: InputDecoration(
+                              labelText: l10n.amapApiKey,
+                              border: const OutlineInputBorder(),
+                              isDense: true,
+                            ),
+                            onChanged: (value) => _updateDraft(
+                              _config.copyWith(amapApiKey: value.trim()),
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            l10n.amapGcj02Note,
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey[600],
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  _section(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
                         Text(
-                          l10n.amapGcj02Note,
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: Colors.grey[600],
+                          l10n.contextGranularity,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
-                      ],
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 16),
-                _section(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        l10n.contextGranularity,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      DropdownButtonFormField<LocationContextGranularity>(
-                        key: ValueKey(_config.granularity),
-                        initialValue: _config.granularity,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          isDense: true,
-                        ),
-                        items: [
-                          DropdownMenuItem(
-                            value: LocationContextGranularity.city,
-                            child: Text(l10n.granularityCity),
-                          ),
-                          DropdownMenuItem(
-                            value: LocationContextGranularity.district,
-                            child: Text(l10n.granularityDistrict),
-                          ),
-                          DropdownMenuItem(
-                            value: LocationContextGranularity.neighborhood,
-                            child: Text(l10n.granularityNeighborhood),
-                          ),
-                          DropdownMenuItem(
-                            value: LocationContextGranularity.street,
-                            child: Text(l10n.granularityStreet),
-                          ),
-                          DropdownMenuItem(
-                            value: LocationContextGranularity.full,
-                            child: Text(l10n.granularityFullAddress),
-                          ),
-                        ],
-                        onChanged: (value) {
-                          if (value == null) return;
-                          _save(_config.copyWith(granularity: value));
-                        },
-                      ),
-                      const SizedBox(height: 16),
-                      Text(
-                        l10n.locationFreshness,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      DropdownButtonFormField<int>(
-                        key: ValueKey(_config.ttlMinutes),
-                        initialValue: _config.ttlMinutes,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          isDense: true,
-                        ),
-                        items: [
-                          DropdownMenuItem(
-                            value: 5,
-                            child: Text(l10n.minutesShort(5)),
-                          ),
-                          DropdownMenuItem(
-                            value: 15,
-                            child: Text(l10n.minutesShort(15)),
-                          ),
-                          DropdownMenuItem(
-                            value: 30,
-                            child: Text(l10n.minutesShort(30)),
-                          ),
-                          DropdownMenuItem(
-                            value: 60,
-                            child: Text(l10n.oneHour),
-                          ),
-                        ],
-                        onChanged: (value) {
-                          if (value == null) return;
-                          _save(_config.copyWith(ttlMinutes: value));
-                        },
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 16),
-                _section(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      FilledButton.icon(
-                        onPressed: _testing ? null : _testLocation,
-                        icon: _testing
-                            ? const SizedBox(
-                                width: 16,
-                                height: 16,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  color: Colors.white,
-                                ),
-                              )
-                            : const Icon(Icons.location_searching),
-                        label: Text(l10n.testCurrentLocation),
-                      ),
-                      if (_testResult != null) ...[
                         const SizedBox(height: 12),
-                        SelectableText(
-                          _testResult!,
-                          style: TextStyle(
-                            fontSize: 13,
-                            color: Colors.grey[700],
-                            height: 1.4,
+                        DropdownButtonFormField<LocationContextGranularity>(
+                          key: ValueKey(_config.granularity),
+                          initialValue: _config.granularity,
+                          decoration: const InputDecoration(
+                            border: OutlineInputBorder(),
+                            isDense: true,
+                          ),
+                          items: [
+                            DropdownMenuItem(
+                              value: LocationContextGranularity.city,
+                              child: Text(l10n.granularityCity),
+                            ),
+                            DropdownMenuItem(
+                              value: LocationContextGranularity.district,
+                              child: Text(l10n.granularityDistrict),
+                            ),
+                            DropdownMenuItem(
+                              value: LocationContextGranularity.neighborhood,
+                              child: Text(l10n.granularityNeighborhood),
+                            ),
+                            DropdownMenuItem(
+                              value: LocationContextGranularity.street,
+                              child: Text(l10n.granularityStreet),
+                            ),
+                            DropdownMenuItem(
+                              value: LocationContextGranularity.full,
+                              child: Text(l10n.granularityFullAddress),
+                            ),
+                          ],
+                          onChanged: (value) {
+                            if (value == null) return;
+                            _updateDraft(_config.copyWith(granularity: value));
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          l10n.locationFreshness,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
+                        const SizedBox(height: 12),
+                        DropdownButtonFormField<int>(
+                          key: ValueKey(_config.ttlMinutes),
+                          initialValue: _config.ttlMinutes,
+                          decoration: const InputDecoration(
+                            border: OutlineInputBorder(),
+                            isDense: true,
+                          ),
+                          items: [
+                            DropdownMenuItem(
+                              value: 5,
+                              child: Text(l10n.minutesShort(5)),
+                            ),
+                            DropdownMenuItem(
+                              value: 15,
+                              child: Text(l10n.minutesShort(15)),
+                            ),
+                            DropdownMenuItem(
+                              value: 30,
+                              child: Text(l10n.minutesShort(30)),
+                            ),
+                            DropdownMenuItem(
+                              value: 60,
+                              child: Text(l10n.oneHour),
+                            ),
+                          ],
+                          onChanged: (value) {
+                            if (value == null) return;
+                            _updateDraft(_config.copyWith(ttlMinutes: value));
+                          },
+                        ),
                       ],
-                    ],
+                    ),
                   ),
-                ),
-              ],
+                  const SizedBox(height: 16),
+                  _section(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        FilledButton.icon(
+                          onPressed: _testing ? null : _testLocation,
+                          icon: _testing
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
+                              : const Icon(Icons.location_searching),
+                          label: Text(l10n.testCurrentLocation),
+                        ),
+                        if (_testResult != null) ...[
+                          const SizedBox(height: 12),
+                          SelectableText(
+                            _testResult!,
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: Colors.grey[700],
+                              height: 1.4,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  Widget _saveBar() {
+    final l10n = UserStorage.l10n;
+    final hasChanges = _hasChanges;
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(16, 10, 16, 16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.textSecondary.withValues(alpha: 0.08),
+              blurRadius: 16,
+              offset: const Offset(0, -4),
             ),
+          ],
+        ),
+        child: SizedBox(
+          width: double.infinity,
+          child: FilledButton.icon(
+            onPressed: hasChanges && !_saving ? _saveChanges : null,
+            icon: _saving
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                : Icon(hasChanges ? Icons.save_outlined : Icons.check),
+            label: Text(
+              _saving
+                  ? '${l10n.save}...'
+                  : hasChanges
+                  ? l10n.save
+                  : l10n.saved,
+            ),
+          ),
+        ),
+      ),
     );
   }
 

--- a/test/ui/settings/location_context_settings_page_test.dart
+++ b/test/ui/settings/location_context_settings_page_test.dart
@@ -39,6 +39,57 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  Future<void> selectProvider(
+    WidgetTester tester,
+    GeocodingProvider provider,
+  ) async {
+    final currentLabel = provider == GeocodingProvider.amap
+        ? 'OpenStreetMap / Nominatim'
+        : 'Amap';
+    final targetLabel = provider == GeocodingProvider.amap
+        ? 'Amap'
+        : 'OpenStreetMap / Nominatim';
+
+    await tester.tap(find.text(currentLabel));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(targetLabel).last);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pumpPageFromLauncher(
+    WidgetTester tester, {
+    LocationContextConfig config = const LocationContextConfig(),
+  }) async {
+    SharedPreferences.setMockInitialValues({
+      'language': 'en',
+      'location_context_config': jsonEncode(config.toJson()),
+    });
+    await UserStorage.initL10n();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const LocationContextSettingsPage(),
+                    ),
+                  );
+                },
+                child: const Text('Open settings'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open settings'));
+    await tester.pumpAndSettle();
+  }
+
   testWidgets('updates location context settings from the page', (
     WidgetTester tester,
   ) async {
@@ -56,11 +107,19 @@ void main() {
     expect(find.text('Attach current location to chat'), findsOneWidget);
     expect(find.text('OpenStreetMap / Nominatim'), findsOneWidget);
     expect(find.text('Amap API Key'), findsNothing);
+    expect(find.text('Saved'), findsOneWidget);
 
     await tester.tap(find.byType(SwitchListTile));
     await tester.pumpAndSettle();
     var config = await UserStorage.getLocationContextConfig();
+    expect(config.enabled, isFalse);
+    expect(find.text('Save'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+    config = await UserStorage.getLocationContextConfig();
     expect(config.enabled, isTrue);
+    expect(find.text('Saved'), findsOneWidget);
 
     await tester.tap(find.text('OpenStreetMap / Nominatim'));
     await tester.pumpAndSettle();
@@ -72,6 +131,12 @@ void main() {
     await tester.pumpAndSettle();
 
     config = await UserStorage.getLocationContextConfig();
+    expect(config.provider, GeocodingProvider.openStreetMap);
+    expect(config.amapApiKey, isEmpty);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+    config = await UserStorage.getLocationContextConfig();
     expect(config.provider, GeocodingProvider.amap);
     expect(config.amapApiKey, 'test-amap-key');
 
@@ -82,6 +147,12 @@ void main() {
 
     expect(find.text('Amap API Key'), findsNothing);
     config = await UserStorage.getLocationContextConfig();
+    expect(config.provider, GeocodingProvider.amap);
+    expect(config.amapApiKey, 'test-amap-key');
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+    config = await UserStorage.getLocationContextConfig();
     expect(config.provider, GeocodingProvider.openStreetMap);
     expect(config.amapApiKey, 'test-amap-key');
 
@@ -91,15 +162,129 @@ void main() {
     await tester.pumpAndSettle();
 
     config = await UserStorage.getLocationContextConfig();
+    expect(config.granularity, LocationContextGranularity.neighborhood);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+    config = await UserStorage.getLocationContextConfig();
     expect(config.granularity, LocationContextGranularity.street);
 
+    await tester.scrollUntilVisible(
+      find.text('Location freshness'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
     await tester.tap(find.text('15 minutes'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('30 minutes').last);
     await tester.pumpAndSettle();
 
     config = await UserStorage.getLocationContextConfig();
+    expect(config.ttlMinutes, 15);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+    config = await UserStorage.getLocationContextConfig();
     expect(config.ttlMinutes, 30);
+  });
+
+  testWidgets('complex edits stay draft until explicit save', (
+    WidgetTester tester,
+  ) async {
+    const savedConfig = LocationContextConfig(
+      enabled: true,
+      provider: GeocodingProvider.openStreetMap,
+      granularity: LocationContextGranularity.city,
+      ttlMinutes: 5,
+      amapApiKey: 'saved-key',
+    );
+    await pumpLocationSettingsPage(
+      tester,
+      config: savedConfig,
+      loadCurrentContext: ({bool forceRefresh = false}) async {
+        return CurrentLocationContext(
+          status: 'fresh',
+          source: 'device_gps',
+          updatedAt: DateTime.utc(2026, 5, 15, 10),
+          granularity: LocationContextGranularity.city,
+          reason: 'mock unsaved settings check',
+        );
+      },
+    );
+
+    await selectProvider(tester, GeocodingProvider.amap);
+    await tester.enterText(find.byType(TextField), '  draft-key  ');
+    await tester.pumpAndSettle();
+    await selectProvider(tester, GeocodingProvider.openStreetMap);
+
+    await tester.tap(find.text('City'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Full address candidate').last);
+    await tester.pumpAndSettle();
+
+    var config = await UserStorage.getLocationContextConfig();
+    expect(config.provider, GeocodingProvider.openStreetMap);
+    expect(config.granularity, LocationContextGranularity.city);
+    expect(config.amapApiKey, 'saved-key');
+    expect(find.text('Save'), findsOneWidget);
+
+    await scrollToTestButton(tester);
+    await tester.tap(find.text('Test current location'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Provider: OpenStreetMap / Nominatim'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Reason: mock unsaved settings check'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+    config = await UserStorage.getLocationContextConfig();
+    expect(config.provider, GeocodingProvider.openStreetMap);
+    expect(config.granularity, LocationContextGranularity.full);
+    expect(config.amapApiKey, 'draft-key');
+    expect(find.text('Saved'), findsOneWidget);
+  });
+
+  testWidgets('unsaved changes can be canceled or discarded on back', (
+    WidgetTester tester,
+  ) async {
+    await pumpPageFromLauncher(
+      tester,
+      config: const LocationContextConfig(
+        enabled: false,
+        provider: GeocodingProvider.openStreetMap,
+      ),
+    );
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+    expect(find.text('Save'), findsOneWidget);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.text('Leave this page?'), findsOneWidget);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(find.text('Location Context'), findsOneWidget);
+
+    var config = await UserStorage.getLocationContextConfig();
+    expect(config.enabled, isFalse);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Discard'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Open settings'), findsOneWidget);
+    config = await UserStorage.getLocationContextConfig();
+    expect(config.enabled, isFalse);
   });
 
   testWidgets('renders localized Chinese labels', (WidgetTester tester) async {
@@ -109,6 +294,7 @@ void main() {
     expect(find.text('为对话附加当前位置'), findsOneWidget);
     expect(find.text('逆地理编码服务商'), findsOneWidget);
     expect(find.text('上下文粒度'), findsOneWidget);
+    expect(find.text('已保存'), findsOneWidget);
   });
 
   testWidgets('test button displays a fresh reverse-geocoded location', (


### PR DESCRIPTION
## Background

Location context settings previously saved every control change immediately. That made the state technically persistent, but the interaction lacked an explicit confirmation moment for users.

## Changes

- Keep location context edits as a local draft until the user taps Save.
- Add a bottom save bar that switches between Save and Saved states, with save success/error feedback.
- Guard back navigation with the existing discard-changes dialog when draft edits are pending.
- Keep the test-current-location debug output aligned with the saved provider, so unsaved drafts are not presented as active configuration.
- Expand widget coverage for draft-only edits, saved-state transitions, provider/API-key preservation, discard flow, and location test output.

## Validation

- `flutter analyze --no-pub lib/ui/settings/widgets/location_context_settings_page.dart test/ui/settings/location_context_settings_page_test.dart`
- `flutter test --no-pub test/ui/settings/location_context_settings_page_test.dart`

## Notes

- Ran Memex PR preflight checks: scope is limited to the location context settings page and its widget tests; no generated files or dependency changes were staged.