### PR TITLE
[codex] 添加 PR 规则预检

### DIFF
--- a/.github/workflows/pr-policy-preflight.yml
+++ b/.github/workflows/pr-policy-preflight.yml
@@ -1,0 +1,120 @@
+name: PR Policy Preflight
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  preflight:
+    name: PR Policy Preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out trusted base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Fetch PR ref as data
+        run: |
+          git fetch --no-tags origin \
+            "pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-head"
+
+      - name: Extract PR metadata
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+          pr = event["pull_request"]
+          Path("pr-title.txt").write_text(pr.get("title") or "", encoding="utf-8")
+          Path("pr-body.txt").write_text(pr.get("body") or "", encoding="utf-8")
+          PY
+
+      - name: Run preflight in shadow mode
+        run: |
+          set +e
+          python3 scripts/pr_policy_check.py \
+            --repo-path . \
+            --base "origin/${{ github.event.repository.default_branch }}" \
+            --head "refs/remotes/origin/pr-head" \
+            --pr-title-file pr-title.txt \
+            --pr-body-file pr-body.txt \
+            --output preflight.json \
+            --markdown-output preflight.md \
+            --no-fail-on-decision
+          status="$?"
+          set -e
+
+          if [ -f preflight.md ]; then
+            cat preflight.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "# PR Policy Preflight"
+              echo
+              echo "Preflight did not produce a Markdown report."
+              echo
+              echo "Script exit code: \`${status}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit 0
+
+      - name: Comment preflight result
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MARKER: "<!-- memex-pr-policy-preflight -->"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ ! -f preflight.md ]; then
+            {
+              echo "# PR Policy Preflight"
+              echo
+              echo "Preflight did not produce a report."
+            } > preflight.md
+          fi
+
+          {
+            echo "$MARKER"
+            echo
+            cat preflight.md
+            echo
+            echo "_Shadow mode: this result is informational and does not block merge._"
+          } > preflight-comment.md
+
+          existing_comment_id="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" \
+            | head -n 1)"
+
+          if [ -n "$existing_comment_id" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
+              -f body=@preflight-comment.md
+          else
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -f body=@preflight-comment.md
+          fi
+
+      - name: Upload preflight result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-policy-preflight
+          if-no-files-found: warn
+          path: |
+            preflight.json
+            preflight.md

--- a/docs/pr-policy-preflight.en.md
+++ b/docs/pr-policy-preflight.en.md
@@ -1,0 +1,115 @@
+# PR Policy Preflight Rules
+
+Policy Preflight is a deterministic rule check for pull requests. It does not
+call AI, run Flutter, execute PR code, or decide whether the code is
+semantically correct. It only classifies objective risk signals from PR metadata,
+changed files, and diff content.
+
+In the current shadow phase, Preflight only reports a decision. Its decision is
+not a merge blocker yet.
+
+## Decision Levels
+
+### `reject`
+
+The PR contains an objective policy violation or cannot be safely evaluated.
+The author should rework the PR before it enters the normal merge path.
+
+### `high_risk`
+
+The PR may be valid, but it touches sensitive areas or has enough change volume
+that maintainer review is required.
+
+### `low_risk`
+
+No deterministic rule found a reason to reject the PR or require maintainer
+review. AI review and normal CI can still raise additional concerns.
+
+## Reject Rules
+
+These rules always produce `reject`.
+
+| Rule | How it is checked | Why it rejects |
+| --- | --- | --- |
+| Secret or signing material | Changed file path matches keystore, `.pem`, `.p8`, `.key`, `key.properties`, or credential-like patterns | Secrets and signing material must not enter PR review. |
+| Generated Dart without source | `*.g.dart`, `*.freezed.dart`, or `*.gr.dart` changed without the matching `.dart` source file | Generated output should not be edited by hand. |
+| Policy control deleted | Preflight docs, the preflight script, or CODEOWNERS-style control files are deleted | Review controls should not be weakened silently. |
+| Unsafe workflow pattern | Added workflow content contains `permissions: write-all`, Docker socket mount, privileged container, `curl | bash`, or `wget | sh` | Workflow changes can expose tokens or execute untrusted code. |
+| Preflight collection failure | The script cannot read git refs, changed files, or diff context | A PR that cannot be evaluated should not be treated as low risk. |
+
+## High-Risk Path Rules
+
+These rules produce `high_risk`.
+
+| Path or area | Why it is high risk |
+| --- | --- |
+| `.github/**` | CI, release, and repository automation can change the trust boundary. |
+| `android/**` | Platform permissions, signing, flavors, and packaging can affect release safety. |
+| `ios/**` | Platform permissions, entitlements, signing, and packaging can affect release safety. |
+| `pubspec.yaml`, `pubspec.lock` | Dependency changes can affect build, runtime, and supply-chain risk. |
+| `analysis_options.yaml` | Analyzer/lint changes can weaken code quality checks. |
+| `lib/main.dart`, `lib/dependencies.dart`, `lib/router.dart` | App startup, dependency registration, and navigation are golden paths. |
+| `lib/utils/user_storage.dart` | User identity, locale, storage, LLM config, and preferences are privacy-sensitive. |
+| `lib/data/services/file_system_service.dart` | Workspace paths and local data access are data-integrity sensitive. |
+| `lib/data/services/backup_service.dart` | Backup/restore changes can cause data loss. |
+| `lib/data/services/global_event_bus.dart` | Event routing can affect multiple independent consumers. |
+| `lib/data/services/local_task_executor.dart` | Persistent background tasks must complete and retry correctly. |
+| `lib/data/services/event_bus_service.dart` | UI refresh events can hide or surface stale data. |
+| `lib/data/services/task_handlers/**` | Agent/task processing can trigger slow, persistent, or cross-cutting behavior. |
+| `lib/agent/**` | Agent prompts, tools, skills, and file permissions affect safety boundaries. |
+| Timeline/card rendering factories | Timeline and card rendering are core user-facing golden paths. |
+| Preflight docs/script/control files | Review policy changes need maintainer eyes. |
+
+## High-Risk Structure Rules
+
+These rules also produce `high_risk`.
+
+| Rule | How it is checked | Why it is high risk |
+| --- | --- | --- |
+| Generated Dart with source | Generated file and matching source file both changed | Maintainer should verify code generation was intentional. |
+| Localization pair mismatch | Only one of `lib/l10n/app_en.arb` or `lib/l10n/app_zh.arb` changed | User-facing strings should stay in sync across languages. |
+| Large PR | Changed file count exceeds the low-risk threshold | Broad changes are harder to validate quickly. |
+| Large diff | Total changed lines exceed the low-risk threshold | Large diffs are not suitable for the fast low-risk path. |
+| Large single-file change | One file exceeds the single-file low-risk threshold | Large concentrated changes need human context. |
+| Diff truncated | Diff exceeds the configured byte limit | The reviewer cannot see the full change. |
+| Binary file outside low-risk asset path | Binary file changed outside `assets/icons/**` | Binary content is hard to review from diff. |
+
+## Sensitive Keyword Rules
+
+For selected source and configuration paths, added lines are scanned for
+sensitive keywords. A match produces `high_risk`.
+
+Examples:
+
+- `UserStorage`
+- `FilePermissionManager`
+- `PermissionRule`
+- `GlobalEventBus`
+- `LocalTaskExecutor`
+- `BackupService`
+- workspace path helpers such as `getCardsPath` or `getFactsPath`
+- credential-like identifiers such as `apiKey`, `accessToken`, `secret`,
+  `password`, or `credential`
+- network-related code such as `http`, `dio`, `WebSocket`, or `request(`
+- destructive file operations such as `deleteSync`, `unlinkSync`, or `delete(`
+
+## Warning Rules
+
+Warnings do not change a PR to `high_risk` by themselves.
+
+| Rule | How it is checked | Why it warns |
+| --- | --- | --- |
+| Missing test signal | Production Dart files changed without test files or a clear test plan | The PR may still be fine, but the reviewer should notice the missing evidence. |
+| Missing PR title | PR title is empty | Review context is incomplete. |
+| Missing PR body | PR body is empty | Review context is incomplete. |
+
+## Shadow-Mode Behavior
+
+During shadow mode:
+
+- `low_risk`, `high_risk`, and `reject` are all reported.
+- The workflow exits successfully so the PR is not blocked.
+- Results are written to the workflow summary and uploaded as artifacts.
+
+After calibration, a separate gate can decide how to use the result as a merge
+requirement.

--- a/docs/pr-policy-preflight.zh.md
+++ b/docs/pr-policy-preflight.zh.md
@@ -1,0 +1,108 @@
+# PR 规则预检规则
+
+`Policy Preflight` 是 PR 的确定性规则检查。它不调用 AI，不运行 Flutter，不执行
+PR 代码，也不判断代码语义是否正确。它只根据 PR 元数据、变更文件和 diff 内容识别
+客观风险信号。
+
+当前阶段是 shadow mode，Preflight 只输出判定结果，不把判定作为合并阻塞依据。
+
+## 判定等级
+
+### `reject`
+
+PR 命中了客观策略违规，或者无法安全完成检查。作者应该先 rework，再进入正常合并流程。
+
+### `high_risk`
+
+PR 可能是合理的，但触及敏感区域，或者改动规模已经不适合走低风险快速通道，需要
+maintainer review。
+
+### `low_risk`
+
+没有确定性规则要求打回或人工审核。后续 AI review 和普通 CI 仍然可以提出额外问题。
+
+## 直接打回规则
+
+这些规则命中后判定为 `reject`。
+
+| 规则 | 如何检查 | 为什么打回 |
+| --- | --- | --- |
+| Secret 或签名材料 | 变更路径匹配 keystore、`.pem`、`.p8`、`.key`、`key.properties` 或 credential-like pattern | secrets 和签名材料不应该进入 PR review。 |
+| generated Dart 缺少源文件 | `*.g.dart`、`*.freezed.dart` 或 `*.gr.dart` 变化，但对应 `.dart` 源文件没有变化 | generated output 不应该手工修改。 |
+| 审核控制文件被删除 | 删除 preflight 文档、preflight 脚本或 CODEOWNERS 类控制文件 | 审核控制不应该被静默削弱。 |
+| 危险 workflow 模式 | workflow 新增内容包含 `permissions: write-all`、Docker socket、privileged container、`curl | bash` 或 `wget | sh` | workflow 可能暴露 token 或执行不可信代码。 |
+| Preflight 采集失败 | 脚本无法读取 git refs、changed files 或 diff context | 无法检查的 PR 不能被当作低风险。 |
+
+## 高风险路径规则
+
+这些规则命中后判定为 `high_risk`。
+
+| 路径或区域 | 为什么高风险 |
+| --- | --- |
+| `.github/**` | CI、发布和仓库自动化会改变信任边界。 |
+| `android/**` | 平台权限、签名、flavor、打包会影响发布安全。 |
+| `ios/**` | 平台权限、entitlements、签名、打包会影响发布安全。 |
+| `pubspec.yaml`、`pubspec.lock` | 依赖变化会影响构建、运行时和供应链风险。 |
+| `analysis_options.yaml` | analyzer/lint 变化可能削弱代码质量检查。 |
+| `lib/main.dart`、`lib/dependencies.dart`、`lib/router.dart` | App 启动、依赖注册和导航是黄金链路。 |
+| `lib/utils/user_storage.dart` | 用户身份、locale、存储、LLM 配置和偏好属于隐私敏感边界。 |
+| `lib/data/services/file_system_service.dart` | workspace 路径和本地数据访问影响数据完整性。 |
+| `lib/data/services/backup_service.dart` | backup/restore 变化可能导致数据丢失。 |
+| `lib/data/services/global_event_bus.dart` | event routing 会影响多个独立消费者。 |
+| `lib/data/services/local_task_executor.dart` | 持久后台任务必须正确完成和重试。 |
+| `lib/data/services/event_bus_service.dart` | UI refresh event 可能隐藏或暴露旧数据。 |
+| `lib/data/services/task_handlers/**` | agent/task processing 会触发慢任务、持久任务或跨模块行为。 |
+| `lib/agent/**` | agent prompts、tools、skills、file permissions 会影响安全边界。 |
+| Timeline/card rendering factories | Timeline 和卡片渲染是核心用户链路。 |
+| Preflight 文档、脚本、控制文件 | 审核策略变化需要 maintainer 看一眼。 |
+
+## 高风险结构规则
+
+这些规则也会判定为 `high_risk`。
+
+| 规则 | 如何检查 | 为什么高风险 |
+| --- | --- | --- |
+| generated Dart 和源文件一起变化 | generated file 和对应源文件都发生变化 | maintainer 应确认 codegen 是有意且正确的。 |
+| 本地化文件未成对变化 | 只改了 `lib/l10n/app_en.arb` 或 `lib/l10n/app_zh.arb` 其中一个 | 用户可见文案需要中英文同步。 |
+| 文件数过多 | changed files 超过低风险阈值 | 大范围变更不适合快速通道。 |
+| diff 过大 | 总变更行数超过低风险阈值 | 大 diff 难以快速确认。 |
+| 单文件改动过大 | 单个文件变更行数超过低风险阈值 | 集中大改需要人工上下文。 |
+| diff 被截断 | diff 超过配置的 byte 限制 | reviewer 无法看到完整变更。 |
+| 二进制文件变化 | 二进制文件变化且不在 `assets/icons/**` 低风险路径下 | 二进制内容无法从 diff 中有效 review。 |
+
+## 敏感关键词规则
+
+对选定的源码和配置路径，脚本会扫描新增行里的敏感关键词。命中后判定为 `high_risk`。
+
+例子：
+
+- `UserStorage`
+- `FilePermissionManager`
+- `PermissionRule`
+- `GlobalEventBus`
+- `LocalTaskExecutor`
+- `BackupService`
+- workspace path helper，例如 `getCardsPath` 或 `getFactsPath`
+- credential-like identifier，例如 `apiKey`、`accessToken`、`secret`、`password`、`credential`
+- network-related code，例如 `http`、`dio`、`WebSocket`、`request(`
+- destructive file operation，例如 `deleteSync`、`unlinkSync`、`delete(`
+
+## 警告规则
+
+警告本身不会把 PR 升级成 `high_risk`。
+
+| 规则 | 如何检查 | 为什么警告 |
+| --- | --- | --- |
+| 缺少测试信号 | production Dart 文件变化，但没有测试文件变化，也没有清晰 test plan | PR 可能没问题，但 reviewer 应该看到这个证据缺口。 |
+| 缺少 PR title | PR title 为空 | review context 不完整。 |
+| 缺少 PR body | PR body 为空 | review context 不完整。 |
+
+## Shadow Mode 行为
+
+在 shadow mode 中：
+
+- `low_risk`、`high_risk`、`reject` 都只作为结果输出。
+- workflow 始终成功退出，不阻塞 PR。
+- 结果写入 workflow summary，并作为 artifact 上传。
+
+规则稳定后，可以由单独的 gate 决定如何把结果接入 required check。

--- a/scripts/pr_policy_check.py
+++ b/scripts/pr_policy_check.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Deterministic PR policy preflight for Memex.
+
+This script is intentionally boring: it reads git metadata and diffs, applies
+path/content rules, and emits machine-readable JSON. It does not execute PR
+code, run Flutter, or call an AI model.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from fnmatch import fnmatch
+import json
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+
+DECISION_LOW_RISK = "low_risk"
+DECISION_HIGH_RISK = "high_risk"
+DECISION_REJECT = "reject"
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    status: str
+    path: str
+    old_path: str | None = None
+    additions: int = 0
+    deletions: int = 0
+    binary: bool = False
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str
+    rule_id: str
+    message: str
+    path: str | None = None
+    score: int = 0
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    schema_version: int
+    decision: str
+    risk_score: int
+    compliant: bool
+    findings: list[Finding]
+    metrics: dict[str, int | bool]
+    base_ref: str
+    head_ref: str
+    head_sha: str
+    merge_base: str
+    changed_files: list[ChangedFile]
+
+
+SECRET_PATTERNS = [
+    "*.jks",
+    "*.keystore",
+    "*.p8",
+    "*.pem",
+    "*.key",
+    "*.mobileprovision",
+    "**/key.properties",
+    "**/key-*.properties",
+    "**/*secret*",
+    "**/*credential*",
+    "**/*credentials*",
+]
+
+GENERATED_PATTERNS = [
+    "**/*.g.dart",
+    "**/*.freezed.dart",
+    "**/*.gr.dart",
+]
+
+POLICY_CONTROL_PATTERNS = [
+    "docs/pr-policy-preflight.en.md",
+    "docs/pr-policy-preflight.zh.md",
+    "scripts/pr_policy_check.py",
+    ".github/CODEOWNERS",
+]
+
+HIGH_RISK_PATH_RULES: list[tuple[str, list[str], int, str]] = [
+    ("github-config", [".github/**"], 55, "GitHub configuration or workflow changed."),
+    ("android-platform", ["android/**"], 35, "Android platform, signing, flavor, or permission area changed."),
+    ("ios-platform", ["ios/**"], 35, "iOS platform, signing, entitlement, or permission area changed."),
+    ("dependency-config", ["pubspec.yaml", "pubspec.lock"], 30, "Dart/Flutter dependency configuration changed."),
+    ("analysis-config", ["analysis_options.yaml"], 25, "Analyzer or lint configuration changed."),
+    ("app-entrypoint", ["lib/main.dart", "lib/dependencies.dart", "lib/router.dart"], 40, "App entrypoint, dependency registration, or router changed."),
+    ("user-storage", ["lib/utils/user_storage.dart"], 45, "User settings, identity, locale, storage, or LLM configuration boundary changed."),
+    ("filesystem-storage", ["lib/data/services/file_system_service.dart", "lib/data/services/backup_service.dart"], 45, "Local workspace storage or backup boundary changed."),
+    ("event-task-pipeline", ["lib/data/services/global_event_bus.dart", "lib/data/services/local_task_executor.dart", "lib/data/services/event_bus_service.dart", "lib/data/services/task_handlers/**"], 45, "Event bus, persistent task, or background handler changed."),
+    ("agent-system", ["lib/agent/**"], 45, "Agent, skill, prompt, tool, or file permission area changed."),
+    ("timeline-rendering", ["lib/ui/**/timeline*_screen.dart", "lib/**/native_card_factory*.dart", "lib/**/native_widget_factory*.dart", "lib/**/card_attachment_factory*.dart"], 40, "Timeline orchestration or card rendering changed."),
+    ("review-policy", POLICY_CONTROL_PATTERNS, 35, "Review policy, preflight script, or control file changed."),
+]
+
+HIGH_RISK_KEYWORDS: list[tuple[str, int, str]] = [
+    (r"\bUserStorage\b", 10, "UserStorage reference changed."),
+    (r"\bFilePermissionManager\b", 15, "Agent file permission boundary reference changed."),
+    (r"\bPermissionRule\b", 15, "Agent permission rule reference changed."),
+    (r"\bGlobalEventBus\b", 12, "Global event bus reference changed."),
+    (r"\bLocalTaskExecutor\b", 12, "Persistent task executor reference changed."),
+    (r"\bBackupService\b", 12, "Backup service reference changed."),
+    (r"\bgetCardsPath\b|\bgetFactsPath\b|\bgetWorkspace", 12, "Workspace path reference changed."),
+    (r"\b(apiKey|accessToken|secret|password|credential)s?\b", 15, "Credential-like identifier changed."),
+    (r"\bhttp\b|\bdio\b|\bWebSocket\b|\brequest\(", 10, "Network-related code changed."),
+    (r"\bdeleteSync\b|\bunlinkSync\b|\bdelete\(|\brm\s+-rf\b", 12, "Deletion or destructive file operation changed."),
+]
+
+WORKFLOW_REJECT_PATTERNS: list[tuple[str, str]] = [
+    (r"permissions:\s*write-all", "Workflow grants write-all permissions."),
+    (r"/var/run/docker\.sock", "Workflow mounts the host Docker socket."),
+    (r"privileged:\s*true", "Workflow requests privileged container execution."),
+    (r"curl\b.*\|\s*(bash|sh)", "Workflow pipes downloaded content into a shell."),
+    (r"wget\b.*\|\s*(bash|sh)", "Workflow pipes downloaded content into a shell."),
+]
+
+SENSITIVE_KEYWORD_SCAN_PATTERNS = [
+    ".github/**",
+    "android/**",
+    "ios/**",
+    "lib/**",
+    "pubspec.yaml",
+    "pubspec.lock",
+    "analysis_options.yaml",
+    "scripts/**",
+]
+
+
+def normalize_path(path: str) -> str:
+    normalized = PurePosixPath(path).as_posix()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.lstrip("/")
+
+
+def path_matches(path: str, patterns: Iterable[str]) -> bool:
+    normalized = normalize_path(path)
+    return any(fnmatch(normalized, pattern) for pattern in patterns)
+
+
+def is_test_path(path: str) -> bool:
+    normalized = normalize_path(path)
+    return normalized.startswith("test/") or normalized.startswith("tests/")
+
+
+def run_git(repo: Path, args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return result.stdout
+
+
+def parse_name_status(text: str) -> dict[str, ChangedFile]:
+    files: dict[str, ChangedFile] = {}
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        if status.startswith(("R", "C")) and len(parts) >= 3:
+            files[normalize_path(parts[2])] = ChangedFile(
+                status=status,
+                old_path=normalize_path(parts[1]),
+                path=normalize_path(parts[2]),
+            )
+        elif len(parts) >= 2:
+            files[normalize_path(parts[1])] = ChangedFile(
+                status=status,
+                path=normalize_path(parts[1]),
+            )
+    return files
+
+
+def parse_numstat(text: str) -> dict[str, tuple[int, int, bool]]:
+    stats: dict[str, tuple[int, int, bool]] = {}
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        additions_text, deletions_text, path_text = parts[0], parts[1], parts[-1]
+        binary = additions_text == "-" or deletions_text == "-"
+        additions = 0 if binary else int(additions_text)
+        deletions = 0 if binary else int(deletions_text)
+        stats[normalize_path(path_text)] = (additions, deletions, binary)
+    return stats
+
+
+def collect_changed_files(repo: Path, base_ref: str, head_ref: str) -> tuple[str, str, list[ChangedFile]]:
+    merge_base = run_git(repo, ["merge-base", base_ref, head_ref]).strip()
+    head_sha = run_git(repo, ["rev-parse", head_ref]).strip()
+    name_status = parse_name_status(
+        run_git(repo, ["diff", "--name-status", "--find-renames", f"{merge_base}...{head_ref}"])
+    )
+    numstat = parse_numstat(
+        run_git(repo, ["diff", "--numstat", "--find-renames", f"{merge_base}...{head_ref}"])
+    )
+    changed_files: list[ChangedFile] = []
+    for path, changed_file in sorted(name_status.items()):
+        additions, deletions, binary = numstat.get(path, (0, 0, False))
+        changed_files.append(
+            ChangedFile(
+                status=changed_file.status,
+                old_path=changed_file.old_path,
+                path=changed_file.path,
+                additions=additions,
+                deletions=deletions,
+                binary=binary,
+            )
+        )
+    return merge_base, head_sha, changed_files
+
+
+def collect_diff(repo: Path, merge_base: str, head_ref: str, max_diff_bytes: int) -> tuple[str, bool, int]:
+    diff = run_git(repo, ["diff", "--no-ext-diff", "--find-renames", "--unified=80", f"{merge_base}...{head_ref}"])
+    encoded = diff.encode("utf-8", errors="replace")
+    if len(encoded) <= max_diff_bytes:
+        return diff, False, len(encoded)
+    truncated = encoded[:max_diff_bytes].decode("utf-8", errors="replace")
+    return truncated, True, len(encoded)
+
+
+def generated_source_path(path: str) -> str | None:
+    path = normalize_path(path)
+    for suffix in (".g.dart", ".freezed.dart", ".gr.dart"):
+        if path.endswith(suffix):
+            return f"{path[: -len(suffix)]}.dart"
+    return None
+
+
+def added_lines_by_path(diff: str) -> dict[str, list[str]]:
+    current_path: str | None = None
+    result: dict[str, list[str]] = {}
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current_path = normalize_path(line.removeprefix("+++ b/"))
+            result.setdefault(current_path, [])
+            continue
+        if current_path and line.startswith("+") and not line.startswith("+++"):
+            result[current_path].append(line[1:])
+    return result
+
+
+def has_test_plan(pr_body: str) -> bool:
+    body = pr_body.lower()
+    if "test plan" in body or "测试" in body or "验证" in body:
+        return "not run" not in body and "未运行" not in body
+    return False
+
+
+def evaluate_policy(
+    *,
+    base_ref: str,
+    head_ref: str,
+    head_sha: str,
+    merge_base: str,
+    changed_files: list[ChangedFile],
+    diff: str,
+    diff_truncated: bool,
+    diff_bytes: int,
+    pr_title: str,
+    pr_body: str,
+    max_files_low_risk: int,
+    max_lines_low_risk: int,
+    max_single_file_lines_low_risk: int,
+) -> PreflightResult:
+    findings: list[Finding] = []
+    paths = {file.path for file in changed_files}
+    added_by_path = added_lines_by_path(diff)
+
+    def add(severity: str, rule_id: str, message: str, path: str | None = None, score: int = 0) -> None:
+        findings.append(Finding(severity=severity, rule_id=rule_id, message=message, path=path, score=score))
+
+    for file in changed_files:
+        if path_matches(file.path, SECRET_PATTERNS):
+            add(
+                "reject",
+                "secret-or-signing-material",
+                "Signing material, credentials, or credential-like files cannot enter the normal review path.",
+                file.path,
+                100,
+            )
+
+        if file.status.startswith("D") and path_matches(file.path, POLICY_CONTROL_PATTERNS):
+            add(
+                "reject",
+                "policy-control-deleted",
+                "Review policy, preflight script, or control file was deleted.",
+                file.path,
+                100,
+            )
+
+        if path_matches(file.path, GENERATED_PATTERNS):
+            source_path = generated_source_path(file.path)
+            if source_path and source_path not in paths:
+                add(
+                    "reject",
+                    "generated-file-without-source",
+                    "Generated Dart file changed without the matching source file.",
+                    file.path,
+                    100,
+                )
+            else:
+                add(
+                    "high",
+                    "generated-file",
+                    "Generated Dart file changed; maintainer should verify regeneration.",
+                    file.path,
+                    30,
+                )
+
+        for rule_id, patterns, score, message in HIGH_RISK_PATH_RULES:
+            if path_matches(file.path, patterns):
+                add("high", rule_id, message, file.path, score)
+
+        if file.binary and not file.path.startswith("assets/icons/"):
+            add(
+                "high",
+                "binary-file",
+                "Binary file changed outside the low-risk icon asset path.",
+                file.path,
+                25,
+            )
+
+        single_file_lines = file.additions + file.deletions
+        if single_file_lines > max_single_file_lines_low_risk:
+            add(
+                "high",
+                "large-single-file-change",
+                f"Single file changed {single_file_lines} lines, above low-risk threshold {max_single_file_lines_low_risk}.",
+                file.path,
+                25,
+            )
+
+    if "lib/l10n/app_en.arb" in paths and "lib/l10n/app_zh.arb" not in paths:
+        add("high", "l10n-pair-mismatch", "English ARB changed without matching Chinese ARB update.", "lib/l10n", 25)
+    if "lib/l10n/app_zh.arb" in paths and "lib/l10n/app_en.arb" not in paths:
+        add("high", "l10n-pair-mismatch", "Chinese ARB changed without matching English ARB update.", "lib/l10n", 25)
+
+    total_lines = sum(file.additions + file.deletions for file in changed_files)
+    if len(changed_files) > max_files_low_risk:
+        add(
+            "high",
+            "too-many-files",
+            f"PR changes {len(changed_files)} files, above low-risk threshold {max_files_low_risk}.",
+            score=20,
+        )
+    if total_lines > max_lines_low_risk:
+        add(
+            "high",
+            "too-many-lines",
+            f"PR changes {total_lines} lines, above low-risk threshold {max_lines_low_risk}.",
+            score=20,
+        )
+    if diff_truncated:
+        add(
+            "high",
+            "diff-truncated",
+            "Diff exceeded the configured preflight size limit and was truncated.",
+            score=30,
+        )
+
+    lib_changed = any(path.startswith("lib/") for path in paths)
+    test_changed = any(is_test_path(path) for path in paths)
+    if lib_changed and not test_changed and not has_test_plan(pr_body):
+        add(
+            "warn",
+            "missing-test-signal",
+            "Production Dart files changed without test file changes or a clear test plan in the PR body.",
+            score=10,
+        )
+
+    if not pr_title.strip():
+        add("warn", "missing-pr-title", "PR title is empty.", score=5)
+    if not pr_body.strip():
+        add("warn", "missing-pr-body", "PR body is empty.", score=5)
+
+    for path, added_lines in added_by_path.items():
+        added_text = "\n".join(added_lines)
+        if path_matches(path, [".github/workflows/**"]):
+            for pattern, message in WORKFLOW_REJECT_PATTERNS:
+                if re.search(pattern, added_text, flags=re.IGNORECASE):
+                    add("reject", "unsafe-workflow-pattern", message, path, 100)
+        if path_matches(path, SENSITIVE_KEYWORD_SCAN_PATTERNS):
+            for pattern, score, message in HIGH_RISK_KEYWORDS:
+                if re.search(pattern, added_text, flags=re.IGNORECASE):
+                    add("high", "sensitive-keyword", message, path, score)
+
+    reject = any(finding.severity == "reject" for finding in findings)
+    high = any(finding.severity == "high" for finding in findings)
+    risk_score = sum(finding.score for finding in findings)
+    if reject:
+        decision = DECISION_REJECT
+    elif high:
+        decision = DECISION_HIGH_RISK
+    else:
+        decision = DECISION_LOW_RISK
+
+    metrics: dict[str, int | bool] = {
+        "changed_files": len(changed_files),
+        "lines_added": sum(file.additions for file in changed_files),
+        "lines_deleted": sum(file.deletions for file in changed_files),
+        "total_changed_lines": total_lines,
+        "binary_files": sum(1 for file in changed_files if file.binary),
+        "test_files_changed": sum(1 for path in paths if is_test_path(path)),
+        "lib_files_changed": sum(1 for path in paths if path.startswith("lib/")),
+        "diff_bytes": diff_bytes,
+        "diff_truncated": diff_truncated,
+    }
+
+    return PreflightResult(
+        schema_version=1,
+        decision=decision,
+        risk_score=risk_score,
+        compliant=decision != DECISION_REJECT,
+        findings=findings,
+        metrics=metrics,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        head_sha=head_sha,
+        merge_base=merge_base,
+        changed_files=changed_files,
+    )
+
+
+def result_to_dict(result: PreflightResult) -> dict:
+    data = asdict(result)
+    data["findings"] = [asdict(finding) for finding in result.findings]
+    data["changed_files"] = [asdict(file) for file in result.changed_files]
+    return data
+
+
+def result_to_markdown(result: PreflightResult) -> str:
+    status = {
+        DECISION_LOW_RISK: "LOW RISK",
+        DECISION_HIGH_RISK: "HIGH RISK",
+        DECISION_REJECT: "REJECT",
+    }[result.decision]
+    lines = [
+        "# PR Policy Preflight",
+        "",
+        f"- Decision: `{status}`",
+        f"- Risk score: `{result.risk_score}`",
+        f"- Changed files: `{result.metrics['changed_files']}`",
+        f"- Changed lines: `{result.metrics['total_changed_lines']}`",
+        f"- Diff truncated: `{str(result.metrics['diff_truncated']).lower()}`",
+        "",
+    ]
+    if result.findings:
+        lines.append("## Findings")
+        for finding in result.findings:
+            path = f" `{finding.path}`" if finding.path else ""
+            lines.append(f"- `{finding.severity}` `{finding.rule_id}`{path}: {finding.message}")
+    else:
+        lines.append("No deterministic policy findings.")
+    return "\n".join(lines) + "\n"
+
+
+def write_text(path: Path | None, text: str) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def read_optional_file(path: Path | None) -> str:
+    if path is None:
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run deterministic PR policy preflight.")
+    parser.add_argument("--repo-path", type=Path, default=Path.cwd())
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--pr-title", default="")
+    parser.add_argument("--pr-title-file", type=Path)
+    parser.add_argument("--pr-body", default="")
+    parser.add_argument("--pr-body-file", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument("--max-diff-bytes", type=int, default=240_000)
+    parser.add_argument("--max-files-low-risk", type=int, default=20)
+    parser.add_argument("--max-lines-low-risk", type=int, default=800)
+    parser.add_argument("--max-single-file-lines-low-risk", type=int, default=400)
+    parser.add_argument("--no-fail-on-decision", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_path = args.repo_path.resolve()
+    pr_title = read_optional_file(args.pr_title_file) if args.pr_title_file else args.pr_title
+    pr_body = read_optional_file(args.pr_body_file) if args.pr_body_file else args.pr_body
+
+    try:
+        merge_base, head_sha, changed_files = collect_changed_files(repo_path, args.base, args.head)
+        diff, diff_truncated, diff_bytes = collect_diff(repo_path, merge_base, args.head, args.max_diff_bytes)
+        result = evaluate_policy(
+            base_ref=args.base,
+            head_ref=args.head,
+            head_sha=head_sha,
+            merge_base=merge_base,
+            changed_files=changed_files,
+            diff=diff,
+            diff_truncated=diff_truncated,
+            diff_bytes=diff_bytes,
+            pr_title=pr_title,
+            pr_body=pr_body,
+            max_files_low_risk=args.max_files_low_risk,
+            max_lines_low_risk=args.max_lines_low_risk,
+            max_single_file_lines_low_risk=args.max_single_file_lines_low_risk,
+        )
+    except Exception as exc:  # noqa: BLE001 - CLI boundary should report any failure.
+        fallback = {
+            "schema_version": 1,
+            "decision": DECISION_REJECT,
+            "risk_score": 100,
+            "compliant": False,
+            "findings": [
+                {
+                    "severity": "reject",
+                    "rule_id": "preflight-error",
+                    "message": f"Preflight failed to collect or evaluate PR context: {exc}",
+                    "path": None,
+                    "score": 100,
+                }
+            ],
+            "metrics": {},
+            "base_ref": args.base,
+            "head_ref": args.head,
+        }
+        json_output = json.dumps(fallback, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        markdown_output = "\n".join(
+            [
+                "# PR Policy Preflight",
+                "",
+                "- Decision: `REJECT`",
+                "- Risk score: `100`",
+                "",
+                "Preflight failed to collect or evaluate PR context.",
+                "",
+                f"Error: `{exc}`",
+                "",
+            ]
+        )
+        write_text(args.output, json_output)
+        write_text(args.markdown_output, markdown_output)
+        if not args.output:
+            print(json_output, end="")
+        return 0 if args.no_fail_on_decision else 1
+
+    json_output = json.dumps(result_to_dict(result), ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    markdown_output = result_to_markdown(result)
+    write_text(args.output, json_output)
+    write_text(args.markdown_output, markdown_output)
+    if not args.output:
+        print(json_output, end="")
+
+    if args.no_fail_on_decision:
+        return 0
+    if result.decision == DECISION_LOW_RISK:
+        return 0
+    if result.decision == DECISION_HIGH_RISK:
+        return 2
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Python tests for repository tooling."""

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tooling test package."""

--- a/tests/tools/test_pr_policy_check.py
+++ b/tests/tools/test_pr_policy_check.py
@@ -1,0 +1,90 @@
+import unittest
+
+from scripts.pr_policy_check import (
+    ChangedFile,
+    DECISION_HIGH_RISK,
+    DECISION_LOW_RISK,
+    DECISION_REJECT,
+    evaluate_policy,
+)
+
+
+def run_policy(changed_files, diff="", pr_body="Test plan: not needed for docs."):
+    return evaluate_policy(
+        base_ref="origin/main",
+        head_ref="HEAD",
+        head_sha="abc123",
+        merge_base="base123",
+        changed_files=changed_files,
+        diff=diff,
+        diff_truncated=False,
+        diff_bytes=len(diff.encode()),
+        pr_title="Test PR",
+        pr_body=pr_body,
+        max_files_low_risk=20,
+        max_lines_low_risk=800,
+        max_single_file_lines_low_risk=400,
+    )
+
+
+class PolicyPreflightTest(unittest.TestCase):
+    def test_secret_file_rejects(self):
+        result = run_policy([ChangedFile(status="A", path="android/key.properties")])
+
+        self.assertEqual(result.decision, DECISION_REJECT)
+        self.assertFalse(result.compliant)
+
+    def test_generated_file_without_source_rejects(self):
+        result = run_policy([ChangedFile(status="M", path="lib/db/app_database.g.dart")])
+
+        self.assertEqual(result.decision, DECISION_REJECT)
+
+    def test_generated_file_with_source_is_high_risk(self):
+        result = run_policy(
+            [
+                ChangedFile(status="M", path="lib/db/app_database.dart"),
+                ChangedFile(status="M", path="lib/db/app_database.g.dart"),
+            ]
+        )
+
+        self.assertEqual(result.decision, DECISION_HIGH_RISK)
+        self.assertTrue(result.compliant)
+
+    def test_docs_only_is_low_risk(self):
+        result = run_policy([ChangedFile(status="M", path="docs/readme.md", additions=10)])
+
+        self.assertEqual(result.decision, DECISION_LOW_RISK)
+
+    def test_workflow_change_is_high_risk(self):
+        result = run_policy([ChangedFile(status="M", path=".github/workflows/build.yml")])
+
+        self.assertEqual(result.decision, DECISION_HIGH_RISK)
+
+    def test_unsafe_workflow_pattern_rejects(self):
+        diff = (
+            "diff --git a/.github/workflows/build.yml b/.github/workflows/build.yml\n"
+            "+++ b/.github/workflows/build.yml\n"
+            "+permissions: write-all\n"
+            "+run: curl https://example.com/install.sh | bash\n"
+        )
+        result = run_policy([ChangedFile(status="M", path=".github/workflows/build.yml")], diff=diff)
+
+        self.assertEqual(result.decision, DECISION_REJECT)
+
+    def test_single_l10n_file_is_high_risk(self):
+        result = run_policy([ChangedFile(status="M", path="lib/l10n/app_en.arb")])
+
+        self.assertEqual(result.decision, DECISION_HIGH_RISK)
+
+    def test_production_change_without_test_signal_warns_only(self):
+        result = run_policy(
+            [ChangedFile(status="M", path="lib/ui/example_widget.dart", additions=8)],
+            pr_body="",
+        )
+
+        self.assertEqual(result.decision, DECISION_LOW_RISK)
+        self.assertTrue(any(finding.rule_id == "missing-test-signal" for finding in result.findings))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- 新增 `PR Policy Preflight` GitHub Action，当前为 shadow mode：只输出判断、写入 job summary、更新一条固定 PR comment、上传 artifact，不把 `low_risk/high_risk/reject` 作为阻塞依据。
- 新增 `scripts/pr_policy_check.py`，实现不执行 PR 代码的确定性规则预检。
- 新增中英文规则文档，面向维护者说明哪些规则会导致 `reject`、`high_risk`、`low_risk` 或 warning。
- 新增 Python 单元测试，覆盖 secret/signing、generated file、workflow、l10n、低风险文档等规则。

## Why

先把规则审核从 AI review 中拆出来，作为可解释、可复现的机械预检。当前先空跑收集结果，直接显示在 PR 评论和 workflow summary 里，后续再根据误判情况决定是否接入正式 gate。

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Enhancement
- [x] Documentation
- [ ] Localization
- [ ] Refactor
- [x] Tests

## Risk areas

- [ ] Database schema or migration
- [ ] Local file storage, backup, or restore
- [ ] App lock, security, or privacy boundary
- [ ] Agent orchestration, skills, or background tasks
- [ ] LLM provider configuration or authentication
- [ ] iOS platform behavior
- [ ] Android platform behavior
- [ ] User-facing strings / localization
- [x] None of the above

备注：本 PR 修改了 GitHub workflow 和 preflight 规则本身，按新规则会判为 `high_risk`，这是预期行为；workflow 当前只空跑，不阻塞 PR。

## Screenshots or recordings

不涉及 UI。

## Test plan

- [x] `python3 -m unittest tests.tools.test_pr_policy_check -v`
- [x] `python3 -m py_compile scripts/pr_policy_check.py tests/tools/test_pr_policy_check.py`
- [x] `python3 scripts/pr_policy_check.py --repo-path . --base HEAD~1 --head HEAD --pr-title '添加 PR 规则预检' --pr-body 'Test plan: python3 -m unittest tests.tools.test_pr_policy_check -v' --output /tmp/preflight-self2.json --markdown-output /tmp/preflight-self2.md --no-fail-on-decision`
- [x] Shadow mode error path: invalid base ref returns exit 0 with `reject` report when `--no-fail-on-decision` is set
- [ ] `flutter test`
- [ ] `flutter analyze`
- [x] Not run; reason: 本 PR 只新增文档、GitHub workflow 和 Python 工具脚本，没有修改 Flutter/Dart 业务代码。

## Contributor checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I kept this PR focused on one change.
- [x] I did not edit generated `*.g.dart` files manually.
- [x] I did not add telemetry, hidden network calls, secrets, or signing keys.
- [x] I updated docs or localization when needed.
