### PR TITLE
[codex] 添加首页版本角标

### DIFF
--- a/lib/config/app_flavor.dart
+++ b/lib/config/app_flavor.dart
@@ -29,6 +29,11 @@ class AppFlavor {
   static bool get isStable => _channel == AppChannelType.stable;
   static bool get isEarly => _channel == AppChannelType.early;
   static bool get isDev => _channel == AppChannelType.dev;
+  static String? get homeBadgeLabel => switch (_channel) {
+        AppChannelType.stable => null,
+        AppChannelType.early => 'EARLY',
+        AppChannelType.dev => 'DEV',
+      };
   static String get name => switch ((_current, _channel)) {
         (AppFlavorType.cn, AppChannelType.dev) => 'cnDev',
         (AppFlavorType.global, AppChannelType.dev) => 'globalDev',

--- a/lib/ui/core/widgets/memex_brand_title.dart
+++ b/lib/ui/core/widgets/memex_brand_title.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:memex/config/app_flavor.dart';
+import 'package:memex/ui/core/themes/app_colors.dart';
+
+class MemexBrandTitle extends StatelessWidget {
+  const MemexBrandTitle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final badgeLabel = AppFlavor.homeBadgeLabel;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        RichText(
+          text: TextSpan(
+            children: [
+              TextSpan(
+                text: 'Meme',
+                style: GoogleFonts.bricolageGrotesque(
+                  fontSize: 32,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                  height: 1,
+                  color: AppColors.textPrimary,
+                ),
+              ),
+              TextSpan(
+                text: 'x',
+                style: GoogleFonts.bricolageGrotesque(
+                  fontSize: 32,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                  height: 1,
+                  color: AppColors.primary,
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (badgeLabel != null) ...[
+          const SizedBox(width: 7),
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: _ChannelBadge(label: badgeLabel),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _ChannelBadge extends StatelessWidget {
+  const _ChannelBadge({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(5),
+        border: Border.all(color: AppColors.primary.withValues(alpha: 0.22)),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.inter(
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0,
+          height: 1.1,
+          color: AppColors.primary,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/knowledge/widgets/knowledge_base_screen.dart
+++ b/lib/ui/knowledge/widgets/knowledge_base_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:memex/ui/knowledge/view_models/knowledge_base_viewmodel.dart';
 import 'package:memex/ui/knowledge/widgets/knowledge/knowledge_file_card.dart';
 import 'package:memex/ui/knowledge/widgets/knowledge_search_delegate.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'knowledge_directory_page.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
+import 'package:memex/ui/core/widgets/memex_brand_title.dart';
 
 /// Knowledge base page. Receives [viewModel] from parent (Compass-style).
 class KnowledgeBaseScreen extends StatefulWidget {
@@ -48,30 +48,7 @@ class KnowledgeBaseScreenState extends State<KnowledgeBaseScreen> {
           backgroundColor: const Color(
               0xFFF7F8FA), // Match Timeline, Insights and bottom nav background
           appBar: AppBar(
-            title: RichText(
-              text: TextSpan(
-                children: [
-                  TextSpan(
-                    text: 'Meme',
-                    style: GoogleFonts.bricolageGrotesque(
-                      fontSize: 32,
-                      fontWeight: FontWeight.w800,
-                      letterSpacing: -0.4,
-                      color: const Color(0xFF0A0A0A),
-                    ),
-                  ),
-                  TextSpan(
-                    text: 'x',
-                    style: GoogleFonts.bricolageGrotesque(
-                      fontSize: 32,
-                      fontWeight: FontWeight.w800,
-                      letterSpacing: -0.4,
-                      color: const Color(0xFF5B6CFF),
-                    ),
-                  ),
-                ],
-              ),
-            ),
+            title: const MemexBrandTitle(),
             backgroundColor: const Color(0xFFF7F8FA),
             surfaceTintColor: const Color(0xFFF7F8FA),
             elevation: 0,

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 import 'package:memex/domain/models/timeline_card_model.dart';
 import 'package:memex/db/app_database.dart';
@@ -28,6 +27,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:memex/ui/settings/widgets/model_config_list_page.dart';
 import 'package:memex/ui/settings/widgets/system_authorization_page.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
+import 'package:memex/ui/core/widgets/memex_brand_title.dart';
 import 'package:memex/ui/core/widgets/character_avatar.dart';
 import 'package:memex/ui/character/widgets/persona_avatar_button.dart';
 import 'package:memex/ui/schedule/widgets/schedule_aggregator_screen.dart';
@@ -339,30 +339,14 @@ class TimelineScreenState extends State<TimelineScreen> {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  RichText(
-                    text: TextSpan(
-                      children: [
-                        TextSpan(
-                          text: 'Meme',
-                          style: GoogleFonts.bricolageGrotesque(
-                            fontSize: 32,
-                            fontWeight: FontWeight.w800,
-                            letterSpacing: -0.41,
-                            height: 22 / 32,
-                            color: const Color(0xFF0A0A0A),
-                          ),
-                        ),
-                        TextSpan(
-                          text: 'x',
-                          style: GoogleFonts.bricolageGrotesque(
-                            fontSize: 32,
-                            fontWeight: FontWeight.w800,
-                            letterSpacing: -0.41,
-                            height: 22 / 32,
-                            color: const Color(0xFF5B6CFF),
-                          ),
-                        ),
-                      ],
+                  const Flexible(
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: FittedBox(
+                        fit: BoxFit.scaleDown,
+                        alignment: Alignment.centerLeft,
+                        child: MemexBrandTitle(),
+                      ),
                     ),
                   ),
                   // 4 buttons: chat, notification, companion, user avatar

--- a/test/ui/core/widgets/memex_brand_title_test.dart
+++ b/test/ui/core/widgets/memex_brand_title_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:memex/config/app_flavor.dart';
+import 'package:memex/ui/core/widgets/memex_brand_title.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  tearDown(() {
+    AppFlavor.init('global');
+  });
+
+  testWidgets('hides channel badge for stable builds', (tester) async {
+    AppFlavor.init('global');
+
+    await tester.pumpWidget(const MaterialApp(home: MemexBrandTitle()));
+
+    expect(find.text('EARLY'), findsNothing);
+    expect(find.text('DEV'), findsNothing);
+  });
+
+  testWidgets('shows Early channel badge for early builds', (tester) async {
+    AppFlavor.init('globalEarly');
+
+    await tester.pumpWidget(const MaterialApp(home: MemexBrandTitle()));
+
+    expect(find.text('EARLY'), findsOneWidget);
+    expect(find.text('DEV'), findsNothing);
+  });
+
+  testWidgets('shows Dev channel badge for development builds', (tester) async {
+    AppFlavor.init('cnDev');
+
+    await tester.pumpWidget(const MaterialApp(home: MemexBrandTitle()));
+
+    expect(find.text('DEV'), findsOneWidget);
+    expect(find.text('EARLY'), findsNothing);
+  });
+}


### PR DESCRIPTION
## 变更
- 新增共享的 `MemexBrandTitle`，在首页品牌标题旁按构建 channel 显示小角标。
- 正式版不显示角标，Early/Develop 版本分别显示 `EARLY` / `DEV`。
- 时间线页和知识库页统一复用品牌标题组件，避免两个首页入口显示不一致。
- 补充 widget test 覆盖 stable、early、dev 三种显示逻辑。

## 影响
- 不新增图片或启动图等资源，只用文本 label 标识非正式版本。
- 窄屏时间线标题区域会在空间不足时轻微缩放，避免和右侧操作按钮重叠。

## 验证
- `dart analyze lib/config/app_flavor.dart lib/ui/core/widgets/memex_brand_title.dart test/ui/core/widgets/memex_brand_title_test.dart`
- `env -u http_proxy -u https_proxy -u ws_proxy -u wss_proxy flutter test test/ui/core/widgets/memex_brand_title_test.dart`

备注：全量 `flutter analyze` 目前仍会被仓库既有 warning/info 阻断，本次新增文件的定向分析通过。