### PR TITLE
复用 Early 更新已下载 APK

### DIFF
--- a/lib/data/services/app_update_service.dart
+++ b/lib/data/services/app_update_service.dart
@@ -36,12 +36,11 @@ class AppUpdateSettings {
   }
 
   Map<String, dynamic> toJson() => {
-        'auto_check_enabled': autoCheckEnabled,
-        'wifi_only_downloads': wifiOnlyDownloads,
-        'auto_download_and_install': autoDownloadAndInstall,
-        if (lastCheckAt != null)
-          'last_check_at': lastCheckAt!.toIso8601String(),
-      };
+    'auto_check_enabled': autoCheckEnabled,
+    'wifi_only_downloads': wifiOnlyDownloads,
+    'auto_download_and_install': autoDownloadAndInstall,
+    if (lastCheckAt != null) 'last_check_at': lastCheckAt!.toIso8601String(),
+  };
 
   AppUpdateSettings copyWith({
     bool? autoCheckEnabled,
@@ -120,32 +119,41 @@ class AppUpdateCheckResult {
   const AppUpdateCheckResult._(this.status, [this.update]);
 
   const AppUpdateCheckResult.unsupported()
-      : this._(AppUpdateCheckStatus.unsupported);
+    : this._(AppUpdateCheckStatus.unsupported);
 
   const AppUpdateCheckResult.skippedNotWifi()
-      : this._(AppUpdateCheckStatus.skippedNotWifi);
+    : this._(AppUpdateCheckStatus.skippedNotWifi);
 
   const AppUpdateCheckResult.noUpdate() : this._(AppUpdateCheckStatus.noUpdate);
 
   const AppUpdateCheckResult.updateAvailable(AppUpdateInfo update)
-      : this._(AppUpdateCheckStatus.updateAvailable, update);
+    : this._(AppUpdateCheckStatus.updateAvailable, update);
 }
 
 class AppUpdateDownloadResult {
   final AppUpdateInfo update;
   final String apkPath;
+  final bool reusedExistingFile;
 
   const AppUpdateDownloadResult({
     required this.update,
     required this.apkPath,
+    this.reusedExistingFile = false,
   });
 }
 
-enum AppUpdateInstallStatus {
-  started,
-  permissionRequired,
-  unsupported,
+class AppUpdateCacheInfo {
+  final int fileCount;
+  final int totalBytes;
+
+  const AppUpdateCacheInfo({required this.fileCount, required this.totalBytes});
+
+  static const empty = AppUpdateCacheInfo(fileCount: 0, totalBytes: 0);
+
+  bool get hasFiles => fileCount > 0;
 }
+
+enum AppUpdateInstallStatus { started, permissionRequired, unsupported }
 
 class AppUpdateInstallResult {
   final AppUpdateInstallStatus status;
@@ -197,8 +205,9 @@ abstract class AppUpdatePlatform {
 }
 
 class MethodChannelAppUpdatePlatform implements AppUpdatePlatform {
-  static const MethodChannel _channel =
-      MethodChannel('com.memexlab.memex/app_update');
+  static const MethodChannel _channel = MethodChannel(
+    'com.memexlab.memex/app_update',
+  );
 
   const MethodChannelAppUpdatePlatform();
 
@@ -262,14 +271,14 @@ class AppUpdateService {
     PackageVersionLoader? packageVersionLoader,
     UpdateDirectoryProvider? updateDirectoryProvider,
     Clock? clock,
-  })  : _httpClient = httpClient ?? http.Client(),
-        _platform = platform ?? const MethodChannelAppUpdatePlatform(),
-        _settingsStore = settingsStore ?? AppUpdateSettingsStore(),
-        _environment = environment ?? AppUpdateEnvironment.current(),
-        _packageVersionLoader = packageVersionLoader ?? _loadPackageVersion,
-        _updateDirectoryProvider =
-            updateDirectoryProvider ?? _defaultUpdateDirectory,
-        _clock = clock ?? DateTime.now;
+  }) : _httpClient = httpClient ?? http.Client(),
+       _platform = platform ?? const MethodChannelAppUpdatePlatform(),
+       _settingsStore = settingsStore ?? AppUpdateSettingsStore(),
+       _environment = environment ?? AppUpdateEnvironment.current(),
+       _packageVersionLoader = packageVersionLoader ?? _loadPackageVersion,
+       _updateDirectoryProvider =
+           updateDirectoryProvider ?? _defaultUpdateDirectory,
+       _clock = clock ?? DateTime.now;
 
   static final AppUpdateService instance = AppUpdateService();
   static const String releasesUrl =
@@ -336,18 +345,37 @@ class AppUpdateService {
     AppUpdateInfo update, {
     void Function(int receivedBytes, int totalBytes)? onProgress,
   }) async {
+    final dir = await _updateDirectoryProvider();
+    final fileName = _safeFileName(update.assetName);
+    final targetFile = File(path.join(dir.path, fileName));
+    if (await _isReusableDownloadedApk(targetFile, update)) {
+      final cachedBytes = await targetFile.length();
+      final totalBytes = update.sizeBytes > 0 ? update.sizeBytes : cachedBytes;
+      onProgress?.call(totalBytes, totalBytes);
+      _logger.info(
+        'Reusing downloaded APK for ${update.displayVersion}: '
+        '${targetFile.path}',
+      );
+      return AppUpdateDownloadResult(
+        update: update,
+        apkPath: targetFile.path,
+        reusedExistingFile: true,
+      );
+    }
+
+    if (await targetFile.exists()) {
+      await targetFile.delete();
+    }
+
     final settings = await loadSettings();
     if (settings.wifiOnlyDownloads && !await _platform.isWifiConnected()) {
       throw const AppUpdateWifiRequiredException();
     }
 
-    final dir = await _updateDirectoryProvider();
     if (!await dir.exists()) {
       await dir.create(recursive: true);
     }
 
-    final fileName = _safeFileName(update.assetName);
-    final targetFile = File(path.join(dir.path, fileName));
     final tempFile = File('${targetFile.path}.part');
     if (await tempFile.exists()) {
       await tempFile.delete();
@@ -381,10 +409,47 @@ class AppUpdateService {
     }
     await tempFile.rename(targetFile.path);
 
-    return AppUpdateDownloadResult(
-      update: update,
-      apkPath: targetFile.path,
-    );
+    return AppUpdateDownloadResult(update: update, apkPath: targetFile.path);
+  }
+
+  Future<bool> hasDownloadedUpdate(AppUpdateInfo update) async {
+    final dir = await _updateDirectoryProvider();
+    final fileName = _safeFileName(update.assetName);
+    final targetFile = File(path.join(dir.path, fileName));
+    return _isReusableDownloadedApk(targetFile, update);
+  }
+
+  Future<AppUpdateCacheInfo> getDownloadedUpdateCacheInfo() async {
+    final dir = await _updateDirectoryProvider();
+    if (!await dir.exists()) {
+      return AppUpdateCacheInfo.empty;
+    }
+
+    var fileCount = 0;
+    var totalBytes = 0;
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is! File || !_isUpdateCacheFile(entity)) continue;
+      final stat = await entity.stat();
+      if (stat.type != FileSystemEntityType.file) continue;
+      fileCount += 1;
+      totalBytes += stat.size;
+    }
+    return AppUpdateCacheInfo(fileCount: fileCount, totalBytes: totalBytes);
+  }
+
+  Future<int> clearDownloadedUpdates() async {
+    final dir = await _updateDirectoryProvider();
+    if (!await dir.exists()) {
+      return 0;
+    }
+
+    var deletedCount = 0;
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is! File || !_isUpdateCacheFile(entity)) continue;
+      await entity.delete();
+      deletedCount += 1;
+    }
+    return deletedCount;
   }
 
   Future<AppUpdateInstallResult> installUpdate(String apkPath) async {
@@ -405,8 +470,10 @@ class AppUpdateService {
   }
 
   Future<List<Map<String, dynamic>>> _fetchReleases() async {
-    final response =
-        await _httpClient.get(Uri.parse(releasesUrl), headers: _githubHeaders);
+    final response = await _httpClient.get(
+      Uri.parse(releasesUrl),
+      headers: _githubHeaders,
+    );
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw HttpException(
         'GitHub releases request failed: HTTP ${response.statusCode}',
@@ -450,7 +517,8 @@ class AppUpdateService {
         if (downloadUrl.isEmpty) continue;
 
         final releaseNotes = release['body'] as String? ?? '';
-        final buildNumber = _parseBuildNumber(name) ??
+        final buildNumber =
+            _parseBuildNumber(name) ??
             _parseBuildNumber(releaseNotes) ??
             _parseBuildNumber(tagName);
         if (buildNumber == null || buildNumber <= currentBuildNumber) {
@@ -461,7 +529,8 @@ class AppUpdateService {
           AppUpdateInfo(
             releaseName: release['name'] as String? ?? name,
             tagName: tagName,
-            versionName: _parseVersionName(name) ??
+            versionName:
+                _parseVersionName(name) ??
                 _parseVersionName(releaseNotes) ??
                 _parseVersionName(tagName) ??
                 (tagName.isEmpty ? null : tagName) ??
@@ -471,8 +540,9 @@ class AppUpdateService {
             sizeBytes: (asset['size'] as num?)?.toInt() ?? 0,
             downloadUrl: downloadUrl,
             releaseNotes: releaseNotes,
-            publishedAt:
-                DateTime.tryParse(release['published_at'] as String? ?? ''),
+            publishedAt: DateTime.tryParse(
+              release['published_at'] as String? ?? '',
+            ),
           ),
         );
       }
@@ -499,10 +569,40 @@ class AppUpdateService {
     return Directory(path.join(cacheDir.path, 'updates'));
   }
 
+  Future<bool> _isReusableDownloadedApk(File file, AppUpdateInfo update) async {
+    try {
+      if (!await file.exists()) return false;
+      if (!file.path.toLowerCase().endsWith('.apk')) return false;
+
+      final stat = await file.stat();
+      if (stat.type != FileSystemEntityType.file || stat.size <= 0) {
+        return false;
+      }
+
+      if (update.sizeBytes > 0 && stat.size != update.sizeBytes) {
+        _logger.info(
+          'Discarding cached APK with unexpected size for '
+          '${update.displayVersion}: expected ${update.sizeBytes}, '
+          'found ${stat.size}',
+        );
+        return false;
+      }
+      return true;
+    } catch (e, st) {
+      _logger.warning('Failed to inspect cached APK: ${file.path}', e, st);
+      return false;
+    }
+  }
+
+  static bool _isUpdateCacheFile(File file) {
+    final lowerPath = file.path.toLowerCase();
+    return lowerPath.endsWith('.apk') || lowerPath.endsWith('.apk.part');
+  }
+
   static Map<String, String> get _githubHeaders => const {
-        'Accept': 'application/vnd.github+json',
-        'User-Agent': 'Memex-Early-Updater',
-      };
+    'Accept': 'application/vnd.github+json',
+    'User-Agent': 'Memex-Early-Updater',
+  };
 
   static String _normalize(String value) {
     return value.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
@@ -521,15 +621,18 @@ class AppUpdateService {
   }
 
   static int? _parseBuildNumber(String value) {
-    final versionLineMatch =
-        RegExp(r'Version:\s*[^\s+]+\+(\d+)', caseSensitive: false)
-            .firstMatch(value.trim());
+    final versionLineMatch = RegExp(
+      r'Version:\s*[^\s+]+\+(\d+)',
+      caseSensitive: false,
+    ).firstMatch(value.trim());
     if (versionLineMatch != null) {
       return int.tryParse(versionLineMatch.group(1)!);
     }
 
-    final assetMatch =
-        RegExp(r'_(\d+)\.apk$', caseSensitive: false).firstMatch(value.trim());
+    final assetMatch = RegExp(
+      r'_(\d+)\.apk$',
+      caseSensitive: false,
+    ).firstMatch(value.trim());
     if (assetMatch != null) {
       return int.tryParse(assetMatch.group(1)!);
     }
@@ -542,9 +645,10 @@ class AppUpdateService {
   }
 
   static String? _parseVersionName(String value) {
-    final versionLineMatch =
-        RegExp(r'Version:\s*([^\s+]+)\+\d+', caseSensitive: false)
-            .firstMatch(value.trim());
+    final versionLineMatch = RegExp(
+      r'Version:\s*([^\s+]+)\+\d+',
+      caseSensitive: false,
+    ).firstMatch(value.trim());
     if (versionLineMatch != null) {
       return versionLineMatch.group(1);
     }
@@ -557,8 +661,9 @@ class AppUpdateService {
       return assetMatch.group(1);
     }
 
-    final tagMatch =
-        RegExp(r'v?(\d+(?:\.\d+){1,3})(?:[+_-]\d+)?').firstMatch(value);
+    final tagMatch = RegExp(
+      r'v?(\d+(?:\.\d+){1,3})(?:[+_-]\d+)?',
+    ).firstMatch(value);
     return tagMatch?.group(1);
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1259,6 +1259,9 @@
     }
   },
   "earlyUpdateDownloadingPercent": "Downloading update: {percent}%",
+  "earlyUpdateInstallDownloadedPackage": "Install downloaded package",
+  "earlyUpdateClearDownloadedPackage": "Clear downloaded package",
+  "earlyUpdateClearDownloadedPackageSuccess": "Downloaded update package cleared.",
   "earlyUpdateInstallStarted": "Android installer opened.",
   "earlyUpdateInstallPermissionRequired": "Allow Memex to install unknown apps, then tap download and install again.",
   "@earlyUpdateLastChecked": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_zh.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('zh')
+    Locale('zh'),
   ];
 
   /// No description provided for @timesLabel.
@@ -5000,6 +5000,24 @@ abstract class AppLocalizations {
   /// **'Downloading update: {percent}%'**
   String earlyUpdateDownloadingPercent(Object percent);
 
+  /// No description provided for @earlyUpdateInstallDownloadedPackage.
+  ///
+  /// In en, this message translates to:
+  /// **'Install downloaded package'**
+  String get earlyUpdateInstallDownloadedPackage;
+
+  /// No description provided for @earlyUpdateClearDownloadedPackage.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear downloaded package'**
+  String get earlyUpdateClearDownloadedPackage;
+
+  /// No description provided for @earlyUpdateClearDownloadedPackageSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloaded update package cleared.'**
+  String get earlyUpdateClearDownloadedPackageSuccess;
+
   /// No description provided for @earlyUpdateInstallStarted.
   ///
   /// In en, this message translates to:
@@ -5064,8 +5082,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2759,6 +2759,17 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get earlyUpdateInstallDownloadedPackage =>
+      'Install downloaded package';
+
+  @override
+  String get earlyUpdateClearDownloadedPackage => 'Clear downloaded package';
+
+  @override
+  String get earlyUpdateClearDownloadedPackageSuccess =>
+      'Downloaded update package cleared.';
+
+  @override
   String get earlyUpdateInstallStarted => 'Android installer opened.';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2654,6 +2654,15 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get earlyUpdateInstallDownloadedPackage => '安装已下载包';
+
+  @override
+  String get earlyUpdateClearDownloadedPackage => '清除下载包';
+
+  @override
+  String get earlyUpdateClearDownloadedPackageSuccess => '已清除下载包。';
+
+  @override
   String get earlyUpdateInstallStarted => '已打开 Android 系统安装器。';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1237,6 +1237,9 @@
     }
   },
   "earlyUpdateDownloadingPercent": "正在下载更新：{percent}%",
+  "earlyUpdateInstallDownloadedPackage": "安装已下载包",
+  "earlyUpdateClearDownloadedPackage": "清除下载包",
+  "earlyUpdateClearDownloadedPackageSuccess": "已清除下载包。",
   "earlyUpdateInstallStarted": "已打开 Android 系统安装器。",
   "earlyUpdateInstallPermissionRequired": "请允许 Memex 安装未知来源应用，然后再次点击下载并安装。",
   "@earlyUpdateLastChecked": {

--- a/lib/ui/settings/widgets/early_update_settings_card.dart
+++ b/lib/ui/settings/widgets/early_update_settings_card.dart
@@ -23,8 +23,11 @@ class EarlyUpdateSettingsCard extends StatefulWidget {
 class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
   AppUpdateSettings? _settings;
   AppUpdateInfo? _availableUpdate;
+  AppUpdateCacheInfo _cacheInfo = AppUpdateCacheInfo.empty;
+  bool _availableUpdateDownloaded = false;
   bool _checking = false;
   bool _downloading = false;
+  bool _clearingCache = false;
   int _downloadPercent = 0;
   String? _statusText;
 
@@ -37,9 +40,11 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
   Future<void> _loadSettings() async {
     if (!widget.forceVisible && !widget.service.isSupported) return;
     final settings = await widget.service.loadSettings();
+    final cacheInfo = await widget.service.getDownloadedUpdateCacheInfo();
     if (!mounted) return;
     setState(() {
       _settings = settings;
+      _cacheInfo = cacheInfo;
       _statusText = _lastCheckedText(settings);
     });
   }
@@ -51,7 +56,7 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
   }
 
   Future<void> _checkNow() async {
-    if (_checking || _downloading) return;
+    if (_checking || _downloading || _clearingCache) return;
     setState(() {
       _checking = true;
       _statusText = UserStorage.l10n.earlyUpdateChecking;
@@ -59,20 +64,33 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
 
     try {
       final result = await widget.service.checkForUpdate(manual: true);
-      if (!mounted) return;
       final latestSettings = await widget.service.loadSettings();
+      final latestCacheInfo =
+          await widget.service.getDownloadedUpdateCacheInfo();
+      var availableUpdateDownloaded = false;
+      if (result.status == AppUpdateCheckStatus.updateAvailable) {
+        availableUpdateDownloaded = await widget.service.hasDownloadedUpdate(
+          result.update!,
+        );
+      }
+      if (!mounted) return;
       setState(() {
         _checking = false;
         _settings = latestSettings;
+        _cacheInfo = latestCacheInfo;
+        _availableUpdateDownloaded = availableUpdateDownloaded;
         switch (result.status) {
           case AppUpdateCheckStatus.unsupported:
             _availableUpdate = null;
+            _availableUpdateDownloaded = false;
             _statusText = UserStorage.l10n.earlyUpdateUnsupported;
           case AppUpdateCheckStatus.skippedNotWifi:
             _availableUpdate = null;
+            _availableUpdateDownloaded = false;
             _statusText = UserStorage.l10n.earlyUpdateSkippedMobile;
           case AppUpdateCheckStatus.noUpdate:
             _availableUpdate = null;
+            _availableUpdateDownloaded = false;
             _statusText = UserStorage.l10n.earlyUpdateNoUpdate;
           case AppUpdateCheckStatus.updateAvailable:
             _availableUpdate = result.update;
@@ -87,6 +105,7 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
       if (!mounted) return;
       setState(() {
         _checking = false;
+        _availableUpdateDownloaded = false;
         _statusText = UserStorage.l10n.earlyUpdateCheckFailed(e);
       });
     }
@@ -94,7 +113,7 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
 
   Future<void> _downloadAndInstall() async {
     final update = _availableUpdate;
-    if (update == null || _downloading) return;
+    if (update == null || _downloading || _clearingCache) return;
 
     setState(() {
       _downloading = true;
@@ -111,17 +130,22 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
               ((receivedBytes / totalBytes) * 100).clamp(0, 100).round();
           setState(() {
             _downloadPercent = percent;
-            _statusText =
-                UserStorage.l10n.earlyUpdateDownloadingPercent(percent);
+            _statusText = UserStorage.l10n.earlyUpdateDownloadingPercent(
+              percent,
+            );
           });
         },
       );
 
+      final latestCacheInfo =
+          await widget.service.getDownloadedUpdateCacheInfo();
       final install = await widget.service.installUpdate(download.apkPath);
       if (!mounted) return;
       setState(() {
         _downloading = false;
         _downloadPercent = 100;
+        _cacheInfo = latestCacheInfo;
+        _availableUpdateDownloaded = true;
         _statusText = switch (install.status) {
           AppUpdateInstallStatus.started =>
             UserStorage.l10n.earlyUpdateInstallStarted,
@@ -142,10 +166,41 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
       });
       if (e is AppUpdateWifiRequiredException) {
         ToastHelper.showInfo(
-            context, UserStorage.l10n.earlyUpdateSkippedMobile);
+          context,
+          UserStorage.l10n.earlyUpdateSkippedMobile,
+        );
       } else {
         ToastHelper.showError(context, e);
       }
+    }
+  }
+
+  Future<void> _clearDownloadedPackage() async {
+    if (_checking || _downloading || _clearingCache) return;
+
+    setState(() => _clearingCache = true);
+    try {
+      await widget.service.clearDownloadedUpdates();
+      final latestCacheInfo =
+          await widget.service.getDownloadedUpdateCacheInfo();
+      if (!mounted) return;
+      setState(() {
+        _clearingCache = false;
+        _cacheInfo = latestCacheInfo;
+        _availableUpdateDownloaded = false;
+        _statusText = UserStorage.l10n.earlyUpdateClearDownloadedPackageSuccess;
+      });
+      ToastHelper.showSuccess(
+        context,
+        UserStorage.l10n.earlyUpdateClearDownloadedPackageSuccess,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _clearingCache = false;
+        _statusText = UserStorage.l10n.earlyUpdateCheckFailed(e);
+      });
+      ToastHelper.showError(context, e);
     }
   }
 
@@ -234,9 +289,8 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
             title: UserStorage.l10n.earlyUpdateAutoInstallTitle,
             subtitle: UserStorage.l10n.earlyUpdateAutoInstallDesc,
             value: settings.autoDownloadAndInstall,
-            onChanged: (value) => _saveSettings(
-              settings.copyWith(autoDownloadAndInstall: value),
-            ),
+            onChanged: (value) =>
+                _saveSettings(settings.copyWith(autoDownloadAndInstall: value)),
           ),
           if (_statusText != null) ...[
             const SizedBox(height: 12),
@@ -263,7 +317,9 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
             runSpacing: 10,
             children: [
               OutlinedButton.icon(
-                onPressed: _checking || _downloading ? null : _checkNow,
+                onPressed: _checking || _downloading || _clearingCache
+                    ? null
+                    : _checkNow,
                 icon: _checking
                     ? const SizedBox(
                         width: 16,
@@ -275,10 +331,36 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
               ),
               if (_availableUpdate != null)
                 FilledButton.icon(
-                  onPressed:
-                      _checking || _downloading ? null : _downloadAndInstall,
-                  icon: const Icon(Icons.download, size: 18),
-                  label: Text(UserStorage.l10n.earlyUpdateDownloadAndInstall),
+                  onPressed: _checking || _downloading || _clearingCache
+                      ? null
+                      : _downloadAndInstall,
+                  icon: Icon(
+                    _availableUpdateDownloaded
+                        ? Icons.install_mobile
+                        : Icons.download,
+                    size: 18,
+                  ),
+                  label: Text(
+                    _availableUpdateDownloaded
+                        ? UserStorage.l10n.earlyUpdateInstallDownloadedPackage
+                        : UserStorage.l10n.earlyUpdateDownloadAndInstall,
+                  ),
+                ),
+              if (_cacheInfo.hasFiles)
+                OutlinedButton.icon(
+                  onPressed: _checking || _downloading || _clearingCache
+                      ? null
+                      : _clearDownloadedPackage,
+                  icon: _clearingCache
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.delete_outline, size: 18),
+                  label: Text(
+                    UserStorage.l10n.earlyUpdateClearDownloadedPackage,
+                  ),
                 ),
             ],
           ),
@@ -326,15 +408,11 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
         padding: const EdgeInsets.only(top: 2),
         child: Text(
           subtitle,
-          style: TextStyle(
-            fontSize: 12,
-            color: Colors.grey[600],
-            height: 1.35,
-          ),
+          style: TextStyle(fontSize: 12, color: Colors.grey[600], height: 1.35),
         ),
       ),
       value: value,
-      onChanged: _checking || _downloading ? null : onChanged,
+      onChanged: _checking || _downloading || _clearingCache ? null : onChanged,
     );
   }
 }

--- a/test/data/services/app_update_service_test.dart
+++ b/test/data/services/app_update_service_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:memex/data/services/app_update_service.dart';
+import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -39,10 +40,8 @@ void main() {
         isEarlyChannel: isSupported,
         flavorName: flavorName,
       ),
-      packageVersionLoader: () async => AppPackageVersion(
-        versionName: '1.0.29',
-        buildNumber: currentBuild,
-      ),
+      packageVersionLoader: () async =>
+          AppPackageVersion(versionName: '1.0.29', buildNumber: currentBuild),
       updateDirectoryProvider: () async => tempDir,
       clock: () => DateTime(2026, 5, 15, 10),
     );
@@ -148,52 +147,56 @@ void main() {
   });
 
   group('check/download/install flow', () {
-    test('still checks releases on mobile data when Wi-Fi-only is enabled',
-        () async {
-      platform.wifiConnected = false;
-      final service = buildService(
-        client: MockClient((_) async {
-          return http.Response(
-            jsonEncode([
-              release(
-                assetName: 'memex_globalEarly_1.0.30_113.apk',
-                downloadUrl: 'https://example.com/global.apk',
-              ),
-            ]),
-            200,
-          );
-        }),
-      );
+    test(
+      'still checks releases on mobile data when Wi-Fi-only is enabled',
+      () async {
+        platform.wifiConnected = false;
+        final service = buildService(
+          client: MockClient((_) async {
+            return http.Response(
+              jsonEncode([
+                release(
+                  assetName: 'memex_globalEarly_1.0.30_113.apk',
+                  downloadUrl: 'https://example.com/global.apk',
+                ),
+              ]),
+              200,
+            );
+          }),
+        );
 
-      final result = await service.checkForUpdate(manual: true);
+        final result = await service.checkForUpdate(manual: true);
 
-      expect(result.status, AppUpdateCheckStatus.updateAvailable);
-      final settings = await service.loadSettings();
-      expect(settings.lastCheckAt, DateTime(2026, 5, 15, 10));
-    });
+        expect(result.status, AppUpdateCheckStatus.updateAvailable);
+        final settings = await service.loadSettings();
+        expect(settings.lastCheckAt, DateTime(2026, 5, 15, 10));
+      },
+    );
 
-    test('blocks APK download on mobile data when Wi-Fi-only is enabled',
-        () async {
-      platform.wifiConnected = false;
-      final service = buildService(
-        client: MockClient((_) async => throw StateError('should not fetch')),
-      );
-      const update = AppUpdateInfo(
-        releaseName: 'Early',
-        tagName: 'v1.0.30+113',
-        versionName: '1.0.30',
-        buildNumber: 113,
-        assetName: 'memex_globalEarly_1.0.30_113.apk',
-        sizeBytes: 4,
-        downloadUrl: 'https://example.com/global.apk',
-        releaseNotes: '',
-      );
+    test(
+      'blocks APK download on mobile data when Wi-Fi-only is enabled',
+      () async {
+        platform.wifiConnected = false;
+        final service = buildService(
+          client: MockClient((_) async => throw StateError('should not fetch')),
+        );
+        const update = AppUpdateInfo(
+          releaseName: 'Early',
+          tagName: 'v1.0.30+113',
+          versionName: '1.0.30',
+          buildNumber: 113,
+          assetName: 'memex_globalEarly_1.0.30_113.apk',
+          sizeBytes: 4,
+          downloadUrl: 'https://example.com/global.apk',
+          releaseNotes: '',
+        );
 
-      expect(
-        () => service.downloadUpdate(update),
-        throwsA(isA<AppUpdateWifiRequiredException>()),
-      );
-    });
+        expect(
+          () => service.downloadUpdate(update),
+          throwsA(isA<AppUpdateWifiRequiredException>()),
+        );
+      },
+    );
 
     test('detects an available update from GitHub pre-releases', () async {
       final service = buildService(
@@ -219,55 +222,137 @@ void main() {
       expect(settings.lastCheckAt, DateTime(2026, 5, 15, 10));
     });
 
-    test('downloads APK and delegates install to Android platform channel',
-        () async {
+    test(
+      'downloads APK and delegates install to Android platform channel',
+      () async {
+        final service = buildService(
+          client: MockClient((request) async {
+            expect(request.url.toString(), 'https://example.com/global.apk');
+            return http.Response.bytes(
+              [1, 2, 3, 4],
+              200,
+              headers: {'content-length': '4'},
+            );
+          }),
+        );
+        const update = AppUpdateInfo(
+          releaseName: 'Early',
+          tagName: 'v1.0.30+113',
+          versionName: '1.0.30',
+          buildNumber: 113,
+          assetName: 'memex_globalEarly_1.0.30_113.apk',
+          sizeBytes: 4,
+          downloadUrl: 'https://example.com/global.apk',
+          releaseNotes: '',
+        );
+        final progress = <int>[];
+
+        final download = await service.downloadUpdate(
+          update,
+          onProgress: (received, total) => progress.add(received),
+        );
+        final install = await service.installUpdate(download.apkPath);
+
+        expect(await File(download.apkPath).readAsBytes(), [1, 2, 3, 4]);
+        expect(progress, contains(4));
+        expect(install.status, AppUpdateInstallStatus.started);
+        expect(platform.installedApkPath, download.apkPath);
+      },
+    );
+
+    test('reuses a complete downloaded APK without fetching again', () async {
+      final apk = File(p.join(tempDir.path, _testUpdate.assetName));
+      await apk.writeAsBytes([1, 2, 3, 4]);
+      platform.wifiConnected = false;
       final service = buildService(
-        client: MockClient((request) async {
-          expect(request.url.toString(), 'https://example.com/global.apk');
-          return http.Response.bytes(
-            [1, 2, 3, 4],
-            200,
-            headers: {'content-length': '4'},
-          );
-        }),
-      );
-      const update = AppUpdateInfo(
-        releaseName: 'Early',
-        tagName: 'v1.0.30+113',
-        versionName: '1.0.30',
-        buildNumber: 113,
-        assetName: 'memex_globalEarly_1.0.30_113.apk',
-        sizeBytes: 4,
-        downloadUrl: 'https://example.com/global.apk',
-        releaseNotes: '',
+        client: MockClient((_) async => throw StateError('should not fetch')),
       );
       final progress = <int>[];
 
       final download = await service.downloadUpdate(
-        update,
-        onProgress: (received, total) => progress.add(received),
+        _testUpdate,
+        onProgress: (received, _) => progress.add(received),
       );
-      final install = await service.installUpdate(download.apkPath);
 
+      expect(download.reusedExistingFile, isTrue);
+      expect(download.apkPath, apk.path);
+      expect(progress, [4]);
       expect(await File(download.apkPath).readAsBytes(), [1, 2, 3, 4]);
-      expect(progress, contains(4));
-      expect(install.status, AppUpdateInstallStatus.started);
-      expect(platform.installedApkPath, download.apkPath);
     });
 
-    test('opens unknown-app settings when install permission is missing',
-        () async {
-      platform.canInstall = false;
+    test(
+      'redownloads when cached APK size does not match asset size',
+      () async {
+        final apk = File(p.join(tempDir.path, _testUpdate.assetName));
+        await apk.writeAsBytes([9]);
+        var fetched = false;
+        final service = buildService(
+          client: MockClient((request) async {
+            fetched = true;
+            expect(request.url.toString(), _testUpdate.downloadUrl);
+            return http.Response.bytes(
+              [1, 2, 3, 4],
+              200,
+              headers: {'content-length': '4'},
+            );
+          }),
+        );
+
+        final download = await service.downloadUpdate(_testUpdate);
+
+        expect(fetched, isTrue);
+        expect(download.reusedExistingFile, isFalse);
+        expect(await File(download.apkPath).readAsBytes(), [1, 2, 3, 4]);
+      },
+    );
+
+    test('reports and clears downloaded update cache files', () async {
+      await File(
+        p.join(tempDir.path, 'memex_globalEarly_1.0.30_113.apk'),
+      ).writeAsBytes([1]);
+      await File(
+        p.join(tempDir.path, 'memex_globalEarly_1.0.30_113.apk.part'),
+      ).writeAsBytes([2, 3]);
+      await File(p.join(tempDir.path, 'notes.txt')).writeAsString('keep');
       final service = buildService();
 
-      final result = await service.installUpdate('/tmp/memex.apk');
+      final before = await service.getDownloadedUpdateCacheInfo();
+      final deleted = await service.clearDownloadedUpdates();
+      final after = await service.getDownloadedUpdateCacheInfo();
 
-      expect(result.status, AppUpdateInstallStatus.permissionRequired);
-      expect(platform.openedInstallSettings, isTrue);
-      expect(platform.installedApkPath, isNull);
+      expect(before.fileCount, 2);
+      expect(before.totalBytes, 3);
+      expect(deleted, 2);
+      expect(after.hasFiles, isFalse);
+      expect(await File(p.join(tempDir.path, 'notes.txt')).exists(), isTrue);
     });
+
+    test(
+      'opens unknown-app settings when install permission is missing',
+      () async {
+        platform.canInstall = false;
+        final service = buildService();
+
+        final result = await service.installUpdate('/tmp/memex.apk');
+
+        expect(result.status, AppUpdateInstallStatus.permissionRequired);
+        expect(platform.openedInstallSettings, isTrue);
+        expect(platform.installedApkPath, isNull);
+      },
+    );
   });
 }
+
+const _testUpdate = AppUpdateInfo(
+  releaseName: 'Early',
+  tagName: 'v1.0.30+113',
+  versionName: '1.0.30',
+  buildNumber: 113,
+  assetName: 'memex_globalEarly_1.0.30_113.apk',
+  sizeBytes: 4,
+  downloadUrl: 'https://example.com/global.apk',
+  releaseNotes: '',
+);
 
 Map<String, dynamic> release({
   bool prerelease = true,
@@ -283,11 +368,7 @@ Map<String, dynamic> release({
     'body': body,
     'published_at': '2026-05-15T00:00:00Z',
     'assets': [
-      {
-        'name': assetName,
-        'size': 1234,
-        'browser_download_url': downloadUrl,
-      }
+      {'name': assetName, 'size': 1234, 'browser_download_url': downloadUrl},
     ],
   };
 }

--- a/test/ui/settings/widgets/early_update_settings_card_test.dart
+++ b/test/ui/settings/widgets/early_update_settings_card_test.dart
@@ -32,13 +32,16 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('renders defaults and persists Wi-Fi-only toggle',
-      (tester) async {
+  testWidgets('renders defaults and persists Wi-Fi-only toggle', (
+    tester,
+  ) async {
     final service = FakeWidgetUpdateService();
     await pumpCard(tester, service);
 
     expect(
-        find.text(UserStorage.l10n.earlyUpdateSettingsTitle), findsOneWidget);
+      find.text(UserStorage.l10n.earlyUpdateSettingsTitle),
+      findsOneWidget,
+    );
     expect(find.byType(Switch), findsNWidgets(3));
 
     await tester.tap(find.byType(Switch).at(1));
@@ -48,8 +51,9 @@ void main() {
     expect(settings.wifiOnlyDownloads, isFalse);
   });
 
-  testWidgets('manual check reveals update and download opens installer',
-      (tester) async {
+  testWidgets('manual check reveals update and download opens installer', (
+    tester,
+  ) async {
     final service = FakeWidgetUpdateService(update: testUpdate);
     await pumpCard(tester, service);
 
@@ -60,8 +64,10 @@ void main() {
       find.text(UserStorage.l10n.earlyUpdateFound('1.0.30', 113)),
       findsOneWidget,
     );
-    expect(find.text(UserStorage.l10n.earlyUpdateDownloadAndInstall),
-        findsOneWidget);
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateDownloadAndInstall),
+      findsOneWidget,
+    );
 
     await tester.tap(find.text(UserStorage.l10n.earlyUpdateDownloadAndInstall));
     await tester.pump();
@@ -71,6 +77,44 @@ void main() {
     expect(
       find.text(UserStorage.l10n.earlyUpdateInstallStarted),
       findsOneWidget,
+    );
+  });
+
+  testWidgets('can install cached update package and clear cache', (
+    tester,
+  ) async {
+    final service = FakeWidgetUpdateService(
+      update: testUpdate,
+      cacheInfo: const AppUpdateCacheInfo(fileCount: 1, totalBytes: 4),
+      downloadedUpdateAvailable: true,
+    );
+    await pumpCard(tester, service);
+
+    await tester.tap(find.text(UserStorage.l10n.earlyUpdateCheckNow));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateInstallDownloadedPackage),
+      findsOneWidget,
+    );
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateClearDownloadedPackage),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.text(UserStorage.l10n.earlyUpdateClearDownloadedPackage),
+    );
+    await tester.pumpAndSettle();
+
+    expect(service.cacheCleared, isTrue);
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateClearDownloadedPackageSuccess),
+      findsWidgets,
+    );
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateClearDownloadedPackage),
+      findsNothing,
     );
   });
 }
@@ -87,18 +131,25 @@ const testUpdate = AppUpdateInfo(
 );
 
 class FakeWidgetUpdateService extends AppUpdateService {
-  FakeWidgetUpdateService({this.update})
-      : super(
-          environment: const AppUpdateEnvironment(
-            isAndroid: true,
-            isEarlyChannel: true,
-            flavorName: 'globalEarly',
-          ),
-        );
+  FakeWidgetUpdateService({
+    this.update,
+    AppUpdateCacheInfo? cacheInfo,
+    this.downloadedUpdateAvailable = false,
+  }) : cacheInfo = cacheInfo ?? AppUpdateCacheInfo.empty,
+       super(
+         environment: const AppUpdateEnvironment(
+           isAndroid: true,
+           isEarlyChannel: true,
+           flavorName: 'globalEarly',
+         ),
+       );
 
   final AppUpdateInfo? update;
+  AppUpdateCacheInfo cacheInfo;
+  bool downloadedUpdateAvailable;
   AppUpdateSettings settings = const AppUpdateSettings();
   bool installStarted = false;
+  bool cacheCleared = false;
 
   @override
   bool get isSupported => true;
@@ -129,6 +180,8 @@ class FakeWidgetUpdateService extends AppUpdateService {
     void Function(int receivedBytes, int totalBytes)? onProgress,
   }) async {
     onProgress?.call(4, 4);
+    cacheInfo = const AppUpdateCacheInfo(fileCount: 1, totalBytes: 4);
+    downloadedUpdateAvailable = true;
     return AppUpdateDownloadResult(update: update, apkPath: '/tmp/memex.apk');
   }
 
@@ -136,5 +189,24 @@ class FakeWidgetUpdateService extends AppUpdateService {
   Future<AppUpdateInstallResult> installUpdate(String apkPath) async {
     installStarted = true;
     return const AppUpdateInstallResult(AppUpdateInstallStatus.started);
+  }
+
+  @override
+  Future<bool> hasDownloadedUpdate(AppUpdateInfo update) async {
+    return downloadedUpdateAvailable;
+  }
+
+  @override
+  Future<AppUpdateCacheInfo> getDownloadedUpdateCacheInfo() async {
+    return cacheInfo;
+  }
+
+  @override
+  Future<int> clearDownloadedUpdates() async {
+    cacheCleared = true;
+    final deletedCount = cacheInfo.fileCount;
+    cacheInfo = AppUpdateCacheInfo.empty;
+    downloadedUpdateAvailable = false;
+    return deletedCount;
   }
 }


### PR DESCRIPTION
## 背景

关联 issue：#109

Android Early 渠道的更新流程会从 GitHub pre-release 中找到匹配当前 flavor 的 APK，下载完成后交给 Android 系统安装器处理。之前下载完成后如果用户没有继续安装，下一次发现同一个更新时仍会重新下载。

## 改动

- `AppUpdateService.downloadUpdate()` 下载前先按 release asset 文件名查找本地 APK。
- 使用 GitHub asset size 校验缓存包完整性；完整则直接复用，不再访问网络。
- 缓存包为空或大小不匹配时会丢弃并重新下载，避免坏包被复用。
- 新增 `AppUpdateCacheInfo`、`hasDownloadedUpdate()`、`getDownloadedUpdateCacheInfo()` 和 `clearDownloadedUpdates()`，给设置页提供缓存状态和清理能力。
- Early 更新设置卡片在已有完整包时显示“安装已下载包”，并提供“清除下载包”的兜底入口。
- 补齐中英文文案和服务层 / widget 测试覆盖。

## 用户影响

用户下载 Early APK 后即使临时取消安装，下次也可以直接复用已下载包继续打开系统安装器。“仅 Wi-Fi 下载”不会阻止安装本地已有的完整包；如果安装失败或缓存异常，也可以在设置页手动清理下载包。

## 验证

- `flutter analyze --no-pub lib/data/services/app_update_service.dart lib/ui/settings/widgets/early_update_settings_card.dart test/data/services/app_update_service_test.dart test/ui/settings/widgets/early_update_settings_card_test.dart`
- `env -u http_proxy -u https_proxy -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub --concurrency=1 test/data/services/app_update_service_test.dart test/ui/settings/widgets/early_update_settings_card_test.dart`