### PR TITLE
[codex] Fix schedule labels and briefing order

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1068,6 +1068,7 @@
   "personaChatInputHint": "Type a message...",
   "personaChatEmptyHint": "Send the first message to begin this companion chat",
   "today": "Today",
+  "tomorrow": "Tomorrow",
   "yesterday": "Yesterday",
 
   "showInsightTextTitle": "Show Memex insight comment",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4316,6 +4316,12 @@ abstract class AppLocalizations {
   /// **'Today'**
   String get today;
 
+  /// No description provided for @tomorrow.
+  ///
+  /// In en, this message translates to:
+  /// **'Tomorrow'**
+  String get tomorrow;
+
   /// No description provided for @yesterday.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2369,6 +2369,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get today => 'Today';
 
   @override
+  String get tomorrow => 'Tomorrow';
+
+  @override
   String get yesterday => 'Yesterday';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2283,6 +2283,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get today => '今天';
 
   @override
+  String get tomorrow => '明天';
+
+  @override
   String get yesterday => '昨天';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1046,6 +1046,7 @@
   "personaChatInputHint": "输入消息...",
   "personaChatEmptyHint": "发出第一条消息，让这段陪伴开始",
   "today": "今天",
+  "tomorrow": "明天",
   "yesterday": "昨天",
 
   "showInsightTextTitle": "显示 Memex 洞察评论",

--- a/lib/ui/schedule/models/schedule_day_label.dart
+++ b/lib/ui/schedule/models/schedule_day_label.dart
@@ -1,0 +1,55 @@
+import 'package:intl/intl.dart';
+import 'package:memex/domain/models/schedule_aggregation_model.dart';
+
+class ScheduleDayLabelStrings {
+  const ScheduleDayLabelStrings({
+    required this.yesterday,
+    required this.today,
+    required this.tomorrow,
+    required this.thisWeek,
+    required this.localeName,
+  });
+
+  final String yesterday;
+  final String today;
+  final String tomorrow;
+  final String thisWeek;
+  final String localeName;
+}
+
+String resolveScheduleDayLabel(
+  TimelineDay day, {
+  required DateTime referenceDate,
+  required ScheduleDayLabelStrings labels,
+}) {
+  final storedLabel = day.dayLabel.trim();
+  final dayDate = day.dayDate;
+  if (dayDate == null) {
+    return storedLabel.isNotEmpty ? storedLabel : labels.thisWeek;
+  }
+
+  return switch (scheduleDayOffset(dayDate, referenceDate)) {
+    -1 => labels.yesterday,
+    0 => labels.today,
+    1 => labels.tomorrow,
+    _ =>
+      storedLabel.isNotEmpty && !isRelativeScheduleDayLabel(storedLabel)
+          ? storedLabel
+          : DateFormat.MMMEd(labels.localeName).format(dayDate),
+  };
+}
+
+int scheduleDayOffset(DateTime dayDate, DateTime referenceDate) {
+  final target = DateTime.utc(dayDate.year, dayDate.month, dayDate.day);
+  final reference = DateTime.utc(
+    referenceDate.year,
+    referenceDate.month,
+    referenceDate.day,
+  );
+  return target.difference(reference).inDays;
+}
+
+bool isRelativeScheduleDayLabel(String label) {
+  const relativeLabels = {'today', 'tomorrow', 'yesterday', '今天', '明天', '昨天'};
+  return relativeLabels.contains(label.trim().toLowerCase());
+}

--- a/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
+++ b/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
@@ -31,12 +33,56 @@ class _ScheduleAggregatorScreenBody extends StatefulWidget {
 }
 
 class _ScheduleAggregatorScreenState
-    extends State<_ScheduleAggregatorScreenBody> {
+    extends State<_ScheduleAggregatorScreenBody>
+    with WidgetsBindingObserver {
+  DateTime _relativeDate = DateTime.now();
+  Timer? _dayRefreshTimer;
+
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _scheduleNextDayRefresh();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<ScheduleAggregatorViewModel>().ensureFresh();
+    });
+  }
+
+  @override
+  void dispose() {
+    _dayRefreshTimer?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    _syncRelativeDate();
+    _scheduleNextDayRefresh();
+  }
+
+  void _scheduleNextDayRefresh() {
+    _dayRefreshTimer?.cancel();
+    final now = DateTime.now();
+    final nextDay = DateTime(now.year, now.month, now.day + 1);
+    final delay = nextDay.difference(now) + const Duration(seconds: 1);
+    _dayRefreshTimer = Timer(delay, () {
+      if (!mounted) return;
+      _syncRelativeDate();
+      _scheduleNextDayRefresh();
+    });
+  }
+
+  void _syncRelativeDate() {
+    final now = DateTime.now();
+    if (_relativeDate.year == now.year &&
+        _relativeDate.month == now.month &&
+        _relativeDate.day == now.day) {
+      return;
+    }
+    setState(() {
+      _relativeDate = now;
     });
   }
 
@@ -101,6 +147,7 @@ class _ScheduleAggregatorScreenState
                     onRefresh: _onReload,
                     child: MagazineNarrativeTab(
                       aggregation: vm.aggregation!,
+                      referenceDate: _relativeDate,
                       onTapCardId: _navigateToCard,
                       itemStatuses: itemStatuses,
                       onToggleTask: _toggleTaskCompletion,

--- a/lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart
+++ b/lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:memex/utils/user_storage.dart';
 
 import '../../../../domain/models/schedule_aggregation_model.dart';
+import '../../models/schedule_day_label.dart';
 import '../../models/schedule_item.dart';
 import '../../../core/cards/ui/glass_card.dart';
 
@@ -13,6 +14,7 @@ class MagazineNarrativeTab extends StatefulWidget {
   final void Function(String cardId)? onTapCardId;
   final Map<String, ScheduleItemStatus> itemStatuses;
   final void Function(String cardId)? onToggleTask;
+  final DateTime? referenceDate;
 
   const MagazineNarrativeTab({
     super.key,
@@ -20,6 +22,7 @@ class MagazineNarrativeTab extends StatefulWidget {
     this.onTapCardId,
     this.itemStatuses = const {},
     this.onToggleTask,
+    this.referenceDate,
   });
 
   @override
@@ -65,7 +68,7 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _buildSectionTitle(entry.$2.dayLabel.toUpperCase()),
+              _buildSectionTitle(_resolveDayLabel(entry.$2).toUpperCase()),
               const SizedBox(height: 10),
               ...entry.$2.items.map(
                 (item) =>
@@ -594,6 +597,20 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
     return DateFormat.MMMd(
       UserStorage.l10n.localeName,
     ).add_Hm().format(startTime);
+  }
+
+  String _resolveDayLabel(TimelineDay day) {
+    return resolveScheduleDayLabel(
+      day,
+      referenceDate: widget.referenceDate ?? DateTime.now(),
+      labels: ScheduleDayLabelStrings(
+        yesterday: UserStorage.l10n.yesterday,
+        today: UserStorage.l10n.today,
+        tomorrow: UserStorage.l10n.tomorrow,
+        thisWeek: UserStorage.l10n.scheduleThisWeek,
+        localeName: UserStorage.l10n.localeName,
+      ),
+    );
   }
 
   bool _isTaskItem(TimelineItem item) {

--- a/lib/ui/timeline/models/schedule_briefing_merge.dart
+++ b/lib/ui/timeline/models/schedule_briefing_merge.dart
@@ -1,0 +1,28 @@
+import 'package:memex/domain/models/system_card_constants.dart';
+import 'package:memex/domain/models/timeline_card_model.dart';
+
+List<TimelineCardModel> mergeScheduleBriefingInTimelineOrder({
+  required List<TimelineCardModel> cards,
+  required TimelineCardModel? briefing,
+  required bool hasMore,
+}) {
+  final withoutBriefing =
+      cards.where((card) => card.id != scheduleBriefingCardId).toList();
+  if (briefing == null) return withoutBriefing;
+  if (withoutBriefing.isEmpty) return [briefing];
+
+  final oldestVisibleCard = withoutBriefing.last;
+  if (hasMore && briefing.timestamp.isBefore(oldestVisibleCard.timestamp)) {
+    return withoutBriefing;
+  }
+
+  final merged = [...withoutBriefing, briefing];
+  merged.sort(compareTimelineCardsForFeed);
+  return merged;
+}
+
+int compareTimelineCardsForFeed(TimelineCardModel a, TimelineCardModel b) {
+  final timestampCompare = b.timestamp.compareTo(a.timestamp);
+  if (timestampCompare != 0) return timestampCompare;
+  return b.id.compareTo(a.id);
+}

--- a/lib/ui/timeline/view_models/timeline_viewmodel.dart
+++ b/lib/ui/timeline/view_models/timeline_viewmodel.dart
@@ -10,6 +10,7 @@ import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/card_attachment_service.dart';
 import 'package:memex/ui/card_attachments/card_attachment_data.dart';
+import 'package:memex/ui/timeline/models/schedule_briefing_merge.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/result.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -62,8 +63,12 @@ class TimelineViewModel extends ChangeNotifier {
     return cardsResult.when(
       onOk: (list) async {
         _currentPage = 1;
-        cards = await _withScheduleBriefingCard(list);
-        hasMore = list.length >= pageLimit;
+        final loadedHasMore = list.length >= pageLimit;
+        cards = await _withScheduleBriefingCard(
+          list,
+          hasMoreAfterList: loadedHasMore,
+        );
+        hasMore = loadedHasMore;
         errorMessage = null;
         _startPollingIfNeeded();
         // Load attachments for all cards in parallel
@@ -300,8 +305,12 @@ class TimelineViewModel extends ChangeNotifier {
     result.when(
       onOk: (newCards) async {
         _currentPage++;
-        cards.addAll(newCards);
-        hasMore = newCards.length >= pageLimit;
+        final loadedHasMore = newCards.length >= pageLimit;
+        cards = await _withScheduleBriefingCard(
+          [...cards, ...newCards],
+          hasMoreAfterList: loadedHasMore,
+        );
+        hasMore = loadedHasMore;
         _startPollingIfNeeded();
         await _loadAttachmentsForCards(newCards);
       },
@@ -312,8 +321,9 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   Future<List<TimelineCardModel>> _withScheduleBriefingCard(
-    List<TimelineCardModel> list,
-  ) async {
+    List<TimelineCardModel> list, {
+    required bool hasMoreAfterList,
+  }) async {
     final withoutBriefing =
         list.where((card) => card.id != scheduleBriefingCardId).toList();
     if (!_shouldShowScheduleBriefing) return withoutBriefing;
@@ -321,8 +331,11 @@ class TimelineViewModel extends ChangeNotifier {
     final briefingResult = await _router.fetchScheduleBriefingCard();
     return briefingResult.when(
       onOk: (briefing) {
-        if (briefing == null) return withoutBriefing;
-        return [briefing, ...withoutBriefing];
+        return mergeScheduleBriefingInTimelineOrder(
+          cards: withoutBriefing,
+          briefing: briefing,
+          hasMore: hasMoreAfterList,
+        );
       },
       onError: (e, st) {
         _logger.warning('Failed to load schedule briefing card: $e');
@@ -333,7 +346,10 @@ class TimelineViewModel extends ChangeNotifier {
 
   Future<void> _refreshScheduleBriefingCard() async {
     if (!_shouldShowScheduleBriefing) return;
-    cards = await _withScheduleBriefingCard(cards);
+    cards = await _withScheduleBriefingCard(
+      cards,
+      hasMoreAfterList: hasMore,
+    );
     notifyListeners();
   }
 
@@ -352,8 +368,12 @@ class TimelineViewModel extends ChangeNotifier {
     result.when(
       onOk: (newCards) async {
         _currentPage++;
-        cards.addAll(newCards);
-        hasMore = newCards.length >= pageLimit;
+        final loadedHasMore = newCards.length >= pageLimit;
+        cards = await _withScheduleBriefingCard(
+          [...cards, ...newCards],
+          hasMoreAfterList: loadedHasMore,
+        );
+        hasMore = loadedHasMore;
         await _loadAttachmentsForCards(newCards);
       },
       onError: (_, __) {},

--- a/test/ui/schedule/models/schedule_day_label_test.dart
+++ b/test/ui/schedule/models/schedule_day_label_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
+import 'package:memex/domain/models/schedule_aggregation_model.dart';
+import 'package:memex/ui/schedule/models/schedule_day_label.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('en');
+  });
+
+  group('resolveScheduleDayLabel', () {
+    const labels = ScheduleDayLabelStrings(
+      yesterday: 'Yesterday',
+      today: 'Today',
+      tomorrow: 'Tomorrow',
+      thisWeek: 'This week',
+      localeName: 'en',
+    );
+
+    test('recomputes stale relative labels from day dates', () {
+      final reference = DateTime(2026, 5, 16, 22, 30);
+
+      expect(
+        resolveScheduleDayLabel(
+          TimelineDay(dayLabel: 'Tomorrow', dayDate: DateTime(2026, 5, 16, 8)),
+          referenceDate: reference,
+          labels: labels,
+        ),
+        'Today',
+      );
+      expect(
+        resolveScheduleDayLabel(
+          TimelineDay(
+            dayLabel: 'Today',
+            dayDate: DateTime(2026, 5, 17, 23, 59),
+          ),
+          referenceDate: reference,
+          labels: labels,
+        ),
+        'Tomorrow',
+      );
+      expect(
+        resolveScheduleDayLabel(
+          TimelineDay(dayLabel: '明天', dayDate: DateTime(2026, 5, 15)),
+          referenceDate: reference,
+          labels: labels,
+        ),
+        'Yesterday',
+      );
+    });
+
+    test('preserves custom non-relative labels for distant days', () {
+      final label = resolveScheduleDayLabel(
+        TimelineDay(dayLabel: 'Launch day', dayDate: DateTime(2026, 5, 20)),
+        referenceDate: DateTime(2026, 5, 16),
+        labels: labels,
+      );
+
+      expect(label, 'Launch day');
+    });
+
+    test('formats distant days when stored label is relative or empty', () {
+      final dayDate = DateTime(2026, 5, 20);
+      final expected = DateFormat.MMMEd(labels.localeName).format(dayDate);
+
+      expect(
+        resolveScheduleDayLabel(
+          TimelineDay(dayLabel: 'tomorrow', dayDate: dayDate),
+          referenceDate: DateTime(2026, 5, 16),
+          labels: labels,
+        ),
+        expected,
+      );
+      expect(
+        resolveScheduleDayLabel(
+          TimelineDay(dayLabel: '', dayDate: dayDate),
+          referenceDate: DateTime(2026, 5, 16),
+          labels: labels,
+        ),
+        expected,
+      );
+    });
+
+    test('uses stored or fallback labels when day date is missing', () {
+      expect(
+        resolveScheduleDayLabel(
+          TimelineDay(dayLabel: 'Unscheduled'),
+          referenceDate: DateTime(2026, 5, 16),
+          labels: labels,
+        ),
+        'Unscheduled',
+      );
+      expect(
+        resolveScheduleDayLabel(
+          TimelineDay(dayLabel: '   '),
+          referenceDate: DateTime(2026, 5, 16),
+          labels: labels,
+        ),
+        'This week',
+      );
+    });
+
+    test('supports Chinese relative labels independently of UI locale', () {
+      expect(isRelativeScheduleDayLabel(' 今天 '), isTrue);
+      expect(isRelativeScheduleDayLabel('明天'), isTrue);
+      expect(isRelativeScheduleDayLabel('昨天'), isTrue);
+      expect(isRelativeScheduleDayLabel('Today'), isTrue);
+      expect(isRelativeScheduleDayLabel('launch day'), isFalse);
+    });
+  });
+
+  group('scheduleDayOffset', () {
+    test('compares calendar dates and ignores time-of-day', () {
+      expect(
+        scheduleDayOffset(
+          DateTime(2026, 5, 17, 0, 1),
+          DateTime(2026, 5, 16, 23, 59),
+        ),
+        1,
+      );
+      expect(
+        scheduleDayOffset(
+          DateTime(2026, 5, 16, 23, 59),
+          DateTime(2026, 5, 16, 0, 1),
+        ),
+        0,
+      );
+    });
+
+    test('handles month and year boundaries', () {
+      expect(
+        scheduleDayOffset(DateTime(2027, 1, 1), DateTime(2026, 12, 31)),
+        1,
+      );
+      expect(
+        scheduleDayOffset(DateTime(2026, 12, 31), DateTime(2027, 1, 1)),
+        -1,
+      );
+    });
+  });
+}

--- a/test/ui/schedule/widgets/schedule_widgets_test.dart
+++ b/test/ui/schedule/widgets/schedule_widgets_test.dart
@@ -128,6 +128,126 @@ void main() {
       );
     });
 
+    testWidgets('recomputes relative day labels from day dates', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildHost(
+          MagazineNarrativeTab(
+            referenceDate: DateTime(2026, 5, 16, 8),
+            aggregation: ScheduleAggregationModel(
+              id: 'agg_relative_labels',
+              generatedAt: DateTime(2026, 5, 15, 18),
+              timeRange: TimeRange(
+                from: DateTime(2026, 5, 15),
+                to: DateTime(2026, 5, 22),
+              ),
+              timeline: [
+                TimelineDay(
+                  dayLabel: 'Tomorrow',
+                  dayDate: DateTime(2026, 5, 16),
+                  items: [
+                    TimelineItem(
+                      cardId: 'event-today',
+                      title: 'Today event',
+                      startTime: DateTime(2026, 5, 16, 10),
+                    ),
+                  ],
+                ),
+                TimelineDay(
+                  dayLabel: 'Today',
+                  dayDate: DateTime(2026, 5, 17),
+                  items: [
+                    TimelineItem(
+                      cardId: 'event-tomorrow',
+                      title: 'Tomorrow event',
+                      startTime: DateTime(2026, 5, 17, 10),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('TODAY'), findsOneWidget);
+      expect(find.text('TOMORROW'), findsOneWidget);
+    });
+
+    testWidgets('renders stale relative, custom, and undated section labels', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(420, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final staleFutureDate = DateTime(2026, 5, 20);
+      final staleFutureLabel = DateFormat.MMMEd(
+        UserStorage.l10n.localeName,
+      ).format(staleFutureDate).toUpperCase();
+      final undatedItemLabel = DateFormat.MMMd(
+        UserStorage.l10n.localeName,
+      ).add_Hm().format(DateTime(2026, 5, 22, 16));
+
+      await tester.pumpWidget(
+        buildHost(
+          MagazineNarrativeTab(
+            referenceDate: DateTime(2026, 5, 16, 8),
+            aggregation: ScheduleAggregationModel(
+              id: 'agg_mixed_day_labels',
+              generatedAt: DateTime(2026, 5, 15, 18),
+              timeRange: TimeRange(
+                from: DateTime(2026, 5, 15),
+                to: DateTime(2026, 5, 23),
+              ),
+              timeline: [
+                TimelineDay(
+                  dayLabel: 'Tomorrow',
+                  dayDate: staleFutureDate,
+                  items: [
+                    TimelineItem(
+                      cardId: 'event-future-relative',
+                      title: 'Future stale relative label',
+                      startTime: DateTime(2026, 5, 20, 10),
+                    ),
+                  ],
+                ),
+                TimelineDay(
+                  dayLabel: 'Launch day',
+                  dayDate: DateTime(2026, 5, 21),
+                  items: [
+                    TimelineItem(
+                      cardId: 'event-custom',
+                      title: 'Custom label event',
+                      startTime: DateTime(2026, 5, 21, 11),
+                    ),
+                  ],
+                ),
+                TimelineDay(
+                  dayLabel: '',
+                  items: [
+                    TimelineItem(
+                      cardId: 'event-undated-section',
+                      title: 'Undated section event',
+                      startTime: DateTime(2026, 5, 22, 16),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(staleFutureLabel), findsOneWidget);
+      expect(find.text('TOMORROW'), findsNothing);
+      expect(find.text('LAUNCH DAY'), findsOneWidget);
+      expect(find.text('THIS WEEK'), findsOneWidget);
+      expect(find.text(undatedItemLabel), findsOneWidget);
+    });
+
     testWidgets('handles narrow screens with long hero metadata', (
       tester,
     ) async {

--- a/test/ui/timeline/models/schedule_briefing_merge_test.dart
+++ b/test/ui/timeline/models/schedule_briefing_merge_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/system_card_constants.dart';
+import 'package:memex/domain/models/timeline_card_model.dart';
+import 'package:memex/ui/timeline/models/schedule_briefing_merge.dart';
+
+void main() {
+  group('mergeScheduleBriefingInTimelineOrder', () {
+    test('inserts briefing by timestamp instead of pinning it to the top', () {
+      final merged = mergeScheduleBriefingInTimelineOrder(
+        cards: [
+          _card('new-record', DateTime(2026, 5, 16, 12)),
+          _card('older-record', DateTime(2026, 5, 16, 8)),
+        ],
+        briefing: _briefing(DateTime(2026, 5, 16, 10)),
+        hasMore: false,
+      );
+
+      expect(merged.map((card) => card.id), [
+        'new-record',
+        scheduleBriefingCardId,
+        'older-record',
+      ]);
+    });
+
+    test('keeps briefing hidden when it is older than the loaded page window',
+        () {
+      final merged = mergeScheduleBriefingInTimelineOrder(
+        cards: [
+          _card('noon-record', DateTime(2026, 5, 16, 12)),
+          _card('morning-record', DateTime(2026, 5, 16, 8)),
+        ],
+        briefing: _briefing(DateTime(2026, 5, 15, 20)),
+        hasMore: true,
+      );
+
+      expect(merged.map((card) => card.id), [
+        'noon-record',
+        'morning-record',
+      ]);
+    });
+
+    test('appends old briefing after the final loaded page', () {
+      final merged = mergeScheduleBriefingInTimelineOrder(
+        cards: [
+          _card('noon-record', DateTime(2026, 5, 16, 12)),
+          _card('morning-record', DateTime(2026, 5, 16, 8)),
+        ],
+        briefing: _briefing(DateTime(2026, 5, 15, 20)),
+        hasMore: false,
+      );
+
+      expect(merged.map((card) => card.id), [
+        'noon-record',
+        'morning-record',
+        scheduleBriefingCardId,
+      ]);
+    });
+
+    test('replaces existing briefing copy when refreshed', () {
+      final merged = mergeScheduleBriefingInTimelineOrder(
+        cards: [
+          _card('noon-record', DateTime(2026, 5, 16, 12)),
+          _briefing(DateTime(2026, 5, 16, 10)),
+          _card('morning-record', DateTime(2026, 5, 16, 8)),
+        ],
+        briefing: _briefing(DateTime(2026, 5, 16, 13)),
+        hasMore: false,
+      );
+
+      expect(merged.map((card) => card.id), [
+        scheduleBriefingCardId,
+        'noon-record',
+        'morning-record',
+      ]);
+      expect(merged.first.timestamp, DateTime(2026, 5, 16, 13));
+    });
+
+    test('removes existing briefing when no briefing should be shown', () {
+      final merged = mergeScheduleBriefingInTimelineOrder(
+        cards: [
+          _card('noon-record', DateTime(2026, 5, 16, 12)),
+          _briefing(DateTime(2026, 5, 16, 10)),
+        ],
+        briefing: null,
+        hasMore: false,
+      );
+
+      expect(merged.map((card) => card.id), ['noon-record']);
+    });
+  });
+}
+
+TimelineCardModel _briefing(DateTime timestamp) {
+  return _card(
+    scheduleBriefingCardId,
+    timestamp,
+    templateId: scheduleBriefingTemplateId,
+  );
+}
+
+TimelineCardModel _card(
+  String id,
+  DateTime timestamp, {
+  String templateId = 'classic_card',
+}) {
+  return TimelineCardModel(
+    id: id,
+    timestamp: timestamp,
+    tags: const [],
+    status: 'completed',
+    title: id,
+    uiConfigs: [
+      UiConfig(templateId: templateId, data: const {}),
+    ],
+  );
+}


### PR DESCRIPTION
## Summary

- Recompute schedule day headers from `day_date` at render time so stale Today/Tomorrow labels update across date boundaries.
- Refresh the schedule page relative-date reference when the app resumes or the local day changes.
- Stop auto-pinning the schedule briefing card at the top of the home feed; merge it by timestamp as a normal timeline card.
- Add unit and widget coverage for relative labels, mixed day labels, and briefing-card feed ordering.

## Validation

- `flutter pub get --offline`
- `flutter analyze --no-pub lib/ui/schedule/models/schedule_day_label.dart lib/ui/schedule/widgets/schedule_aggregator_screen.dart lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart test/ui/schedule/models/schedule_day_label_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart`
- `flutter analyze --no-pub lib/ui/timeline/models/schedule_briefing_merge.dart lib/ui/timeline/view_models/timeline_viewmodel.dart test/ui/timeline/models/schedule_briefing_merge_test.dart`
- `env -u http_proxy -u https_proxy -u ws_proxy -u wss_proxy NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 flutter test --no-pub test/ui/schedule/models/schedule_day_label_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart`
- `env -u http_proxy -u https_proxy -u ws_proxy -u wss_proxy NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 flutter test --no-pub test/ui/schedule test/domain/models/schedule_aggregation_model_test.dart`
- `env -u http_proxy -u https_proxy -u ws_proxy -u wss_proxy NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 flutter test --no-pub test/ui/timeline/models/schedule_briefing_merge_test.dart test/ui/schedule test/domain/models/schedule_aggregation_model_test.dart test/data/repositories/get_schedule_briefing_timeline_card_test.dart`