### PR TITLE
[codex] 收敛日程聚合 Agent 执行态

### DIFF
--- a/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart
+++ b/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+
+import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/schedule_refresh_state_service.dart';
+
+const int defaultScheduleAggregationCardLimit = 80;
+
+/// Builds a compact context packet for a fresh schedule aggregation run.
+///
+/// The agent still uses tools for detailed evidence, but this gives each fresh
+/// run a deterministic map of current schedule data instead of relying on prior
+/// LLM conversation history.
+Future<String> buildScheduleAggregationRunContext({
+  required String userId,
+  required String runId,
+  DateTime? now,
+  int scheduleCardLimit = defaultScheduleAggregationCardLimit,
+}) async {
+  final fileSystem = FileSystemService.instance;
+  final generatedAt = now ?? DateTime.now();
+  final from = generatedAt.subtract(const Duration(days: 3));
+  final to = generatedAt.add(const Duration(days: 7));
+
+  final scheduleCards = await queryScheduleCardsForRange(
+    userId: userId,
+    from: from,
+    to: to,
+    limit: scheduleCardLimit,
+  );
+  final latestAggregation = await fileSystem.getLatestScheduleAggregation(
+    userId,
+  );
+  final refreshState = await ScheduleRefreshStateService.instance.read(userId);
+
+  final payload = {
+    'run_id': runId,
+    'generated_at': generatedAt.toIso8601String(),
+    'fresh_execution_state': true,
+    'durable_sources': {
+      'schedule_cards': scheduleCards,
+      'schedule_cards_limit': scheduleCardLimit,
+      'latest_schedule_aggregation': _compactScheduleAggregation(
+        latestAggregation,
+      ),
+      'refresh_state': refreshState.toJson(),
+    },
+    'execution_policy': [
+      'This is a fresh schedule aggregation execution. Do not rely on prior LLM conversation history.',
+      'Use durable workspace data as the source of truth: Cards, Facts, ScheduleAggregations, event log, and injected user memory context.',
+      'Start from schedule_cards for the current refresh window, then inspect source cards with Read or BatchRead when details are needed.',
+      'Use save_schedule_aggregation to persist exactly one current aggregation result.',
+      'Preserve completed task status only when task is_completed is true; card processing status does not mean task completion.',
+    ],
+  };
+
+  return '<schedule_aggregation_run_context>\n'
+      '${const JsonEncoder.withIndent('  ').convert(payload)}\n'
+      '</schedule_aggregation_run_context>';
+}
+
+Map<String, dynamic>? _compactScheduleAggregation(Map<String, dynamic>? value) {
+  if (value == null) return null;
+  final timeline = value['timeline'];
+  return {
+    if (value['id'] != null) 'id': value['id'],
+    if (value['generated_at'] != null) 'generated_at': value['generated_at'],
+    if (value['time_range'] != null) 'time_range': value['time_range'],
+    if (value['hero_item'] != null)
+      'hero_item': _compactHero(value['hero_item']),
+    if (value['editorial_intro'] != null)
+      'editorial_intro': _truncate(value['editorial_intro'].toString(), 360),
+    if (value['quote_blocks'] is List)
+      'quote_block_count': (value['quote_blocks'] as List).length,
+    if (value['conflicts'] is List)
+      'conflict_count': (value['conflicts'] as List).length,
+    if (value['completed'] is List)
+      'completed_count': (value['completed'] as List).length,
+    if (timeline is List) 'timeline_days': timeline.map(_compactDay).toList(),
+  };
+}
+
+Map<String, dynamic> _compactHero(dynamic value) {
+  if (value is! Map) return const {};
+  return {
+    if (value['card_id'] != null) 'card_id': value['card_id'],
+    if (value['title'] != null) 'title': value['title'],
+    if (value['start_time'] != null) 'start_time': value['start_time'],
+    if (value['end_time'] != null) 'end_time': value['end_time'],
+    if (value['priority'] != null) 'priority': value['priority'],
+  };
+}
+
+Map<String, dynamic> _compactDay(dynamic value) {
+  if (value is! Map) return const {};
+  final items = value['items'];
+  return {
+    if (value['day_label'] != null) 'day_label': value['day_label'],
+    if (value['day_date'] != null) 'day_date': value['day_date'],
+    if (items is List) 'item_count': items.length,
+    if (items is List)
+      'item_ids': items.map(_itemId).whereType<String>().toList(),
+  };
+}
+
+String? _itemId(dynamic value) {
+  if (value is! Map) return null;
+  return value['card_id']?.toString();
+}
+
+String _truncate(String value, int maxLength) {
+  if (value.length <= maxLength) return value;
+  return '${value.substring(0, maxLength)}...';
+}

--- a/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_lifecycle.dart
+++ b/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_lifecycle.dart
@@ -1,0 +1,80 @@
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:memex/agent/state_util.dart';
+
+const Duration defaultScheduleAggregationResumeTtl = Duration(hours: 6);
+
+String normalizeScheduleAggregationRunId(String? runId, DateTime now) {
+  final normalized = runId?.trim();
+  if (normalized != null && normalized.isNotEmpty) {
+    return normalized;
+  }
+  return 'manual_${now.microsecondsSinceEpoch}';
+}
+
+String buildScheduleAggregatorSessionId(String userId, String runId) {
+  return 'schedule_aggregator_${safeScheduleAggregatorSessionPart(userId)}_${safeScheduleAggregatorSessionPart(runId)}';
+}
+
+String safeScheduleAggregatorSessionPart(String value) {
+  final safe = value
+      .trim()
+      .replaceAll(RegExp(r'[^A-Za-z0-9_-]+'), '_')
+      .replaceAll(RegExp(r'_+'), '_');
+  if (safe.isEmpty) {
+    return 'unknown';
+  }
+  if (safe.length <= 96) {
+    return safe;
+  }
+  return safe.substring(safe.length - 96);
+}
+
+Future<AgentState> loadOrCreateScheduleAggregatorRunState({
+  required String userId,
+  required String runId,
+  required String sessionId,
+  required DateTime now,
+}) async {
+  final state = await loadOrCreateAgentState(sessionId, {
+    'userId': userId,
+    'scene': 'schedule_aggregation',
+    'sceneId': runId,
+    'run_id': runId,
+  });
+  ensureScheduleAggregatorRunMetadata(
+    state: state,
+    userId: userId,
+    runId: runId,
+    now: now,
+  );
+  return state;
+}
+
+void ensureScheduleAggregatorRunMetadata({
+  required AgentState state,
+  required String userId,
+  required String runId,
+  required DateTime now,
+}) {
+  state.metadata['userId'] = userId;
+  state.metadata['scene'] = 'schedule_aggregation';
+  state.metadata['sceneId'] = runId;
+  state.metadata['run_id'] = runId;
+  state.metadata.putIfAbsent('run_started_at', () => now.toIso8601String());
+}
+
+bool shouldResumeScheduleAggregatorRun(
+  AgentState state,
+  DateTime now,
+  Duration ttl,
+) {
+  if (!state.isRunning) return false;
+  final startedAtValue = state.metadata['run_started_at']?.toString();
+  final startedAt =
+      startedAtValue == null ? null : DateTime.tryParse(startedAtValue);
+  if (startedAt == null) {
+    return true;
+  }
+  final age = now.difference(startedAt);
+  return age.isNegative || age <= ttl;
+}

--- a/lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart
+++ b/lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart
@@ -1,13 +1,14 @@
 import 'dart:io';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
-import 'package:intl/intl.dart';
 import 'package:memex/agent/agent_controller.util.dart';
 import 'package:memex/agent/built_in_tools/file_tools.dart';
 import 'package:memex/agent/built_in_tools/search_event_logs_tool.dart';
 import 'package:memex/agent/common_tools.dart';
 import 'package:memex/agent/memory/memory_management.dart';
 import 'package:memex/agent/agent_system_prompt_helper.dart';
+import 'package:memex/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart';
+import 'package:memex/agent/schedule_aggregator_agent/schedule_aggregation_run_lifecycle.dart';
 import 'package:memex/agent/schedule_aggregator_agent/prompt.dart';
 import 'package:memex/agent/security/file_permission_manager.dart';
 import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart';
@@ -17,6 +18,7 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/utils/user_storage.dart';
 
 final _logger = getLogger('ScheduleAggregatorAgent');
@@ -26,25 +28,16 @@ class ScheduleAggregatorAgent {
     required LLMClient client,
     required ModelConfig modelConfig,
     required String userId,
+    required AgentState state,
   }) async {
     final fileService = FileSystemService.instance;
-
-    final sessionId = "schedule_aggregator_$userId";
-
-    // Load or create agent state
-    final state = await loadOrCreateAgentState(sessionId, {
-      'userId': userId,
-      'scene': 'schedule_aggregation',
-      'sceneId': sessionId,
-    });
+    final sessionId = state.sessionId;
 
     final controller = AgentController();
     addAgentLogger(controller);
     addAgentActivityCollector(controller);
 
-    final skills = [
-      ScheduleAggregationSkill(forceActivate: true),
-    ];
+    final skills = [ScheduleAggregationSkill(forceActivate: true)];
 
     // Ensure output directory exists
     final scheduleAggPath = fileService.getScheduleAggregationsPath(userId);
@@ -58,17 +51,21 @@ class ScheduleAggregatorAgent {
     // Configure File Permission Manager
     final permissionManager = FilePermissionManager(userId, [
       PermissionRule(
-          rootPath: fileService.getWorkspacePath(userId),
-          access: FileAccessType.read),
+        rootPath: fileService.getWorkspacePath(userId),
+        access: FileAccessType.read,
+      ),
       PermissionRule(
-          rootPath: fileService.getCardsPath(userId),
-          access: FileAccessType.read),
+        rootPath: fileService.getCardsPath(userId),
+        access: FileAccessType.read,
+      ),
       PermissionRule(
-          rootPath: fileService.getFactsPath(userId),
-          access: FileAccessType.read),
+        rootPath: fileService.getFactsPath(userId),
+        access: FileAccessType.read,
+      ),
       PermissionRule(
-          rootPath: fileService.getScheduleAggregationsPath(userId),
-          access: FileAccessType.write),
+        rootPath: fileService.getScheduleAggregationsPath(userId),
+        access: FileAccessType.write,
+      ),
     ]);
 
     final fileToolFactory = FileToolFactory(
@@ -86,15 +83,14 @@ class ScheduleAggregatorAgent {
       getCurrentTimeTool,
     ];
 
-    // Memory Management
+    // Memory is read-only for this batch agent. Durable memory can inform the
+    // summary, but schedule aggregation should not write long-term memory.
     final memoryManagement = await MemoryManagement.createDefault(
       userId: userId,
       sourceAgent: 'schedule_aggregator_agent',
     );
-    final memoryManagementPrompt =
-        await memoryManagement.buildMemoryManagementPrompt();
-    final memoryManagementTools = memoryManagement.buildMemoryManagementTools();
-    tools.addAll(memoryManagementTools);
+    final memoryReadOnlyPrompt =
+        await memoryManagement.buildMemoryReadOnlyPrompt();
 
     final userMemory = await memoryManagement.buildMemoryPrompt();
     state.systemReminders["user_memory"] = userMemory;
@@ -112,10 +108,7 @@ class ScheduleAggregatorAgent {
       ),
       tools: tools,
       skills: skills,
-      systemPrompts: [
-        scheduleAggregatorSystemPrompt,
-        memoryManagementPrompt,
-      ],
+      systemPrompts: [scheduleAggregatorSystemPrompt, memoryReadOnlyPrompt],
       disableSubAgents: false,
       controller: controller,
       withGeneralPrinciples: true,
@@ -127,16 +120,29 @@ class ScheduleAggregatorAgent {
     );
 
     _logger.info(
-        'ScheduleAggregatorAgent created, userId: $userId, sessionId: $sessionId');
+      'ScheduleAggregatorAgent created, userId: $userId, sessionId: $sessionId',
+    );
     return agent;
   }
 
-  static Future<bool> updateScheduleAggregation() async {
-    final userId = await UserStorage.getUserId();
-    if (userId == null) {
+  static Future<bool> updateScheduleAggregation({
+    String? userId,
+    String? runId,
+    Duration resumeTtl = defaultScheduleAggregationResumeTtl,
+  }) async {
+    final effectiveUserId = userId ?? await UserStorage.getUserId();
+    if (effectiveUserId == null) {
       throw Exception(
-          'User not logged in, cannot refresh schedule aggregation');
+        'User not logged in, cannot refresh schedule aggregation',
+      );
     }
+
+    final now = DateTime.now();
+    final effectiveRunId = normalizeScheduleAggregationRunId(runId, now);
+    final sessionId = buildScheduleAggregatorSessionId(
+      effectiveUserId,
+      effectiveRunId,
+    );
 
     final resources = await UserStorage.getAgentLLMResources(
       AgentDefinitions.scheduleAggregatorAgent,
@@ -145,37 +151,70 @@ class ScheduleAggregatorAgent {
     final client = resources.client;
     final modelConfig = resources.modelConfig;
 
-    final sessionId = "schedule_aggregator_$userId";
-    final state = await loadOrCreateAgentState(sessionId, {
-      'userId': userId,
-      'scene': 'schedule_aggregation',
-      'sceneId': sessionId,
-    });
+    var state = await loadOrCreateScheduleAggregatorRunState(
+      userId: effectiveUserId,
+      runId: effectiveRunId,
+      sessionId: sessionId,
+      now: now,
+    );
+
+    if (!state.isRunning && state.history.messages.isNotEmpty) {
+      _logger.info(
+        'ScheduleAggregatorAgent completed state residue, sessionId:$sessionId, delete state and restart',
+      );
+      await deleteAgentState(effectiveUserId, sessionId);
+      state = await loadOrCreateScheduleAggregatorRunState(
+        userId: effectiveUserId,
+        runId: effectiveRunId,
+        sessionId: sessionId,
+        now: now,
+      );
+    } else if (state.isRunning &&
+        !shouldResumeScheduleAggregatorRun(state, now, resumeTtl)) {
+      _logger.info(
+        'ScheduleAggregatorAgent stale interrupted run, sessionId:$sessionId, delete state and restart',
+      );
+      await deleteAgentState(effectiveUserId, sessionId);
+      state = await loadOrCreateScheduleAggregatorRunState(
+        userId: effectiveUserId,
+        runId: effectiveRunId,
+        sessionId: sessionId,
+        now: now,
+      );
+    }
 
     final agent = await _createAgent(
       client: client,
       modelConfig: modelConfig,
-      userId: userId,
+      userId: effectiveUserId,
+      state: state,
     );
 
     List<LLMMessage> result = [];
     try {
       if (state.isRunning) {
         _logger.info(
-            "ScheduleAggregatorAgent resume, sessionId:${state.sessionId}");
+          "ScheduleAggregatorAgent resume, sessionId:${state.sessionId}",
+        );
         result = await agent.resume();
       } else {
-        _logger
-            .info("ScheduleAggregatorAgent run, sessionId:${state.sessionId}");
+        _logger.info(
+          "ScheduleAggregatorAgent run, sessionId:${state.sessionId}",
+        );
 
         String inputMessage = "Please update schedule aggregation.";
+        final runContext = await buildScheduleAggregationRunContext(
+          userId: effectiveUserId,
+          runId: effectiveRunId,
+          now: now,
+        );
 
         final messages = [
           UserMessage([
-            TextPart(
-                "<system-reminder>current time is ${DateFormat("yyyy-MM-dd HH:mm:ss").format(DateTime.now())}.</system-reminder>"),
+            TextPart(buildCurrentTimeReminder(now)),
+            TextPart(runContext),
             TextPart(inputMessage),
-          ])
+          ]),
         ];
         _logger.info("ScheduleAggregatorAgent start");
 
@@ -183,12 +222,13 @@ class ScheduleAggregatorAgent {
         try {
           final fileSystem = FileSystemService.instance;
           await fileSystem.eventLogService.logEvent(
-            userId: userId,
+            userId: effectiveUserId,
             eventType: 'agent_execution',
             description: 'Schedule Aggregator Agent started',
             metadata: {
               'agent_name': 'schedule_aggregator_agent',
               'session_id': sessionId,
+              'run_id': effectiveRunId,
               'input': inputMessage,
             },
           );
@@ -200,20 +240,23 @@ class ScheduleAggregatorAgent {
       }
 
       // Post-processing: emit UI refresh event for both fresh runs and resume.
-      EventBusService.instance.emitEvent(ScheduleAggregationUpdatedMessage(
-        aggregationId: sessionId,
-      ));
+      EventBusService.instance.emitEvent(
+        ScheduleAggregationUpdatedMessage(aggregationId: sessionId),
+      );
+      await deleteAgentState(effectiveUserId, sessionId);
     } on AgentException catch (e) {
       if (e.code == AgentExceptionCode.loopDetection) {
-        await deleteAgentState(userId, sessionId);
+        await deleteAgentState(effectiveUserId, sessionId);
         _logger.info(
-            "ScheduleAggregatorAgent loop detection, sessionId:${state.sessionId}, delete state");
+          "ScheduleAggregatorAgent loop detection, sessionId:${state.sessionId}, delete state",
+        );
       }
       rethrow;
     }
 
     _logger.info(
-        "ScheduleAggregatorAgent done, sessionId:${state.sessionId}, result messages length:${result.length}");
+      "ScheduleAggregatorAgent done, sessionId:${state.sessionId}, result messages length:${result.length}",
+    );
     return true;
   }
 }

--- a/lib/data/services/task_handlers/schedule_aggregator_handler.dart
+++ b/lib/data/services/task_handlers/schedule_aggregator_handler.dart
@@ -13,10 +13,14 @@ Future<void> handleScheduleAggregation(
   TaskContext context,
 ) async {
   _logger.info(
-      'Executing handleScheduleAggregation for task ${context.taskId}, bizId: ${context.bizId}');
+    'Executing handleScheduleAggregation for task ${context.taskId}, bizId: ${context.bizId}',
+  );
 
   try {
-    await ScheduleAggregatorAgent.updateScheduleAggregation();
+    await ScheduleAggregatorAgent.updateScheduleAggregation(
+      userId: userId,
+      runId: context.taskId,
+    );
   } catch (e) {
     _logger.severe('Schedule aggregation failed: $e');
     rethrow;

--- a/test/agent/schedule_aggregation_run_context_test.dart
+++ b/test/agent/schedule_aggregation_run_context_test.dart
@@ -1,0 +1,187 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:memex/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/schedule_refresh_state_service.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('buildScheduleAggregationRunContext', () {
+    late Directory tempRoot;
+    late AppDatabase db;
+    const userId = 'schedule_context_user';
+
+    setUp(() async {
+      tempRoot = await Directory.systemTemp.createTemp(
+        'memex_schedule_context_',
+      );
+      await FileSystemService.init(tempRoot.path);
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      AppDatabase.setTestInstance(db);
+      await db.searchDao.createFtsTables();
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('summarizes durable schedule sources for a fresh run', () async {
+      final fileSystem = FileSystemService.instance;
+      await fileSystem.safeWriteCardFile(
+        userId,
+        '2026/05/18.md#ts_1',
+        CardData(
+          factId: '2026/05/18.md#ts_1',
+          title: 'Passport appointment',
+          timestamp:
+              DateTime.utc(2026, 5, 18, 9).millisecondsSinceEpoch ~/ 1000,
+          status: 'completed',
+          tags: const ['schedule'],
+          uiConfigs: const [
+            UiConfig(
+              templateId: 'event',
+              data: {
+                'start_time': '2026-05-18T09:00:00Z',
+                'end_time': '2026-05-18T10:00:00Z',
+                'location': 'Service center',
+              },
+            ),
+          ],
+        ),
+      );
+      await fileSystem.safeWriteCardFile(
+        userId,
+        '2026/05/19.md#ts_2',
+        CardData(
+          factId: '2026/05/19.md#ts_2',
+          title: 'Prepare documents',
+          timestamp:
+              DateTime.utc(2026, 5, 19, 12).millisecondsSinceEpoch ~/ 1000,
+          status: 'completed',
+          tags: const ['todo'],
+          uiConfigs: const [
+            UiConfig(
+              templateId: 'task',
+              data: {
+                'due_date': '2026-05-19T18:00:00Z',
+                'priority': 3,
+                'is_completed': false,
+              },
+            ),
+          ],
+        ),
+      );
+      await fileSystem.safeWriteCardFile(
+        userId,
+        '2026/06/30.md#ts_3',
+        CardData(
+          factId: '2026/06/30.md#ts_3',
+          title: 'Outside current range',
+          timestamp: DateTime.utc(2026, 6, 30).millisecondsSinceEpoch ~/ 1000,
+          status: 'completed',
+          tags: const [],
+          uiConfigs: const [
+            UiConfig(
+              templateId: 'event',
+              data: {'start_time': '2026-06-30T08:00:00Z'},
+            ),
+          ],
+        ),
+      );
+
+      await fileSystem.writeScheduleAggregation(
+        userId,
+        'schedule_agg_2026_05_17',
+        {
+          'id': 'schedule_agg_2026_05_17',
+          'generated_at': '2026-05-17T08:00:00Z',
+          'time_range': {
+            'from': '2026-05-17T00:00:00Z',
+            'to': '2026-05-24T00:00:00Z',
+          },
+          'hero_item': {
+            'card_id': '2026/05/18.md#ts_1',
+            'title': 'Passport appointment',
+            'start_time': '2026-05-18T09:00:00Z',
+          },
+          'editorial_intro': 'Keep documents ready before the appointment.',
+          'conflicts': [
+            {'description': 'Document prep is close to the appointment.'},
+          ],
+          'completed': [
+            {'card_id': 'done-1', 'title': 'Book appointment'},
+          ],
+          'timeline': [
+            {
+              'day_label': 'Monday',
+              'day_date': '2026-05-18',
+              'items': [
+                {'card_id': '2026/05/18.md#ts_1'},
+                {'card_id': '2026/05/19.md#ts_2'},
+              ],
+            },
+          ],
+        },
+      );
+      await ScheduleRefreshStateService.instance.markDirty(
+        userId: userId,
+        reason: 'new schedule card',
+        cardIds: const ['2026/05/19.md#ts_2'],
+        refreshRequested: true,
+      );
+
+      final context = await buildScheduleAggregationRunContext(
+        userId: userId,
+        runId: 'task_123',
+        now: DateTime.utc(2026, 5, 17, 12),
+        scheduleCardLimit: 10,
+      );
+
+      final payload = _decodeContextPayload(context);
+      final sources = payload['durable_sources'] as Map<String, dynamic>;
+      final cards = sources['schedule_cards'] as Map<String, dynamic>;
+      final latest =
+          sources['latest_schedule_aggregation'] as Map<String, dynamic>;
+      final refreshState = sources['refresh_state'] as Map<String, dynamic>;
+
+      expect(payload['run_id'], 'task_123');
+      expect(payload['fresh_execution_state'], isTrue);
+      expect((cards['cards'] as List), hasLength(2));
+      expect(
+        (cards['cards'] as List).map((card) => card['card_id']),
+        containsAll(['2026/05/18.md#ts_1', '2026/05/19.md#ts_2']),
+      );
+      expect(
+        (cards['cards'] as List).map((card) => card['card_id']),
+        isNot(contains('2026/06/30.md#ts_3')),
+      );
+      expect(latest['id'], 'schedule_agg_2026_05_17');
+      expect(latest['conflict_count'], 1);
+      expect(latest['completed_count'], 1);
+      expect(refreshState['is_dirty'], isTrue);
+      expect(refreshState['card_ids'], ['2026/05/19.md#ts_2']);
+      expect(
+        payload['execution_policy'],
+        contains(contains('Do not rely on prior LLM conversation history')),
+      );
+    });
+  });
+}
+
+Map<String, dynamic> _decodeContextPayload(String context) {
+  const openTag = '<schedule_aggregation_run_context>';
+  const closeTag = '</schedule_aggregation_run_context>';
+  final start = context.indexOf(openTag);
+  final end = context.indexOf(closeTag);
+  expect(start, isNot(-1));
+  expect(end, greaterThan(start));
+  return jsonDecode(context.substring(start + openTag.length, end).trim())
+      as Map<String, dynamic>;
+}

--- a/test/agent/schedule_aggregation_run_lifecycle_test.dart
+++ b/test/agent/schedule_aggregation_run_lifecycle_test.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:memex/agent/schedule_aggregator_agent/schedule_aggregation_run_lifecycle.dart';
+import 'package:memex/agent/state_util.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Schedule aggregation run lifecycle', () {
+    test('builds run-scoped session ids with safe path characters', () {
+      final sessionId = buildScheduleAggregatorSessionId(
+        'user@example.com',
+        'task/2026:05:17 refresh',
+      );
+
+      expect(
+        sessionId,
+        'schedule_aggregator_user_example_com_task_2026_05_17_refresh',
+      );
+    });
+
+    test('normalizes missing run id into a manual run id', () {
+      final now = DateTime.fromMicrosecondsSinceEpoch(123456789);
+
+      expect(normalizeScheduleAggregationRunId(' task_1 ', now), 'task_1');
+      expect(normalizeScheduleAggregationRunId(' ', now), 'manual_123456789');
+      expect(normalizeScheduleAggregationRunId(null, now), 'manual_123456789');
+    });
+
+    test('resumes only recent interrupted runs', () {
+      final now = DateTime.utc(2026, 5, 17, 12);
+      const ttl = Duration(hours: 6);
+
+      expect(
+        shouldResumeScheduleAggregatorRun(
+          AgentState(
+            sessionId: 'recent',
+            isRunning: true,
+            metadata: {
+              'run_started_at':
+                  now.subtract(const Duration(hours: 2)).toIso8601String(),
+            },
+          ),
+          now,
+          ttl,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldResumeScheduleAggregatorRun(
+          AgentState(
+            sessionId: 'stale',
+            isRunning: true,
+            metadata: {
+              'run_started_at':
+                  now.subtract(const Duration(hours: 7)).toIso8601String(),
+            },
+          ),
+          now,
+          ttl,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldResumeScheduleAggregatorRun(
+          AgentState(sessionId: 'done', isRunning: false),
+          now,
+          ttl,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'keeps metadata stable when reloading an existing run state',
+      () async {
+        final tempRoot = await Directory.systemTemp.createTemp(
+          'memex_schedule_state_',
+        );
+        addTearDown(() async {
+          if (await tempRoot.exists()) {
+            await tempRoot.delete(recursive: true);
+          }
+        });
+        await FileSystemService.init(tempRoot.path);
+
+        final now = DateTime.utc(2026, 5, 17, 12);
+        final original = await loadOrCreateScheduleAggregatorRunState(
+          userId: 'state_user',
+          runId: 'task_a',
+          sessionId: 'schedule_aggregator_state_user_task_a',
+          now: now,
+        );
+        original.isRunning = true;
+        original.metadata['extra'] = 'kept';
+        await saveAgentState(original);
+
+        final reloaded = await loadOrCreateScheduleAggregatorRunState(
+          userId: 'state_user',
+          runId: 'task_a',
+          sessionId: 'schedule_aggregator_state_user_task_a',
+          now: now.add(const Duration(hours: 1)),
+        );
+
+        expect(reloaded.isRunning, isTrue);
+        expect(reloaded.metadata['run_id'], 'task_a');
+        expect(reloaded.metadata['sceneId'], 'task_a');
+        expect(reloaded.metadata['extra'], 'kept');
+        expect(reloaded.metadata['run_started_at'], now.toIso8601String());
+      },
+    );
+  });
+}

--- a/test/ui/schedule/widgets/schedule_widgets_test.dart
+++ b/test/ui/schedule/widgets/schedule_widgets_test.dart
@@ -90,10 +90,7 @@ void main() {
 
         expect(tappedCards, contains('event-dentist'));
 
-        await tester.scrollUntilVisible(
-          find.text('Done grocery order'),
-          240,
-        );
+        await tester.scrollUntilVisible(find.text('Done grocery order'), 240);
         await tester.pumpAndSettle();
         expect(find.text('Done grocery order'), findsOneWidget);
       },
@@ -151,6 +148,28 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets('renders fresh output from a task-scoped run', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildHost(
+          MagazineNarrativeTab(
+            aggregation: _complexAggregation(
+              heroTitle: 'Run-scoped refresh result',
+              editorialIntro: 'Fresh schedule output from a task-scoped run.',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Run-scoped refresh result'), findsOneWidget);
+      expect(
+        find.text('Fresh schedule output from a task-scoped run.'),
+        findsOneWidget,
+      );
+    });
   });
 
   group('ScheduleBriefingCard', () {
@@ -204,7 +223,11 @@ void main() {
   });
 }
 
-ScheduleAggregationModel _complexAggregation({bool longText = false}) {
+ScheduleAggregationModel _complexAggregation({
+  bool longText = false,
+  String heroTitle = 'Visa renewal',
+  String editorialIntro = 'A heavy week with travel prep and home tasks.',
+}) {
   final location = longText
       ? 'Very long cross-city conference room name with building, floor, wing, and entrance instructions'
       : 'Clinic room 4';
@@ -220,14 +243,14 @@ ScheduleAggregationModel _complexAggregation({bool longText = false}) {
       cardId: 'event-visa',
       title: longText
           ? 'Very long cross-city visa renewal preparation and paperwork deadline'
-          : 'Visa renewal',
+          : heroTitle,
       description: 'Bring photos, passport, and printed forms.',
       startTime: DateTime(2026, 5, 15, 9, 30),
       endTime: DateTime(2026, 5, 15, 11),
       location: location,
       priority: 3,
     ),
-    editorialIntro: 'A heavy week with travel prep and home tasks.',
+    editorialIntro: editorialIntro,
     quoteBlocks: [
       QuoteBlock(
         title: 'Deadline pressure',


### PR DESCRIPTION
## 背景

关联 #103。#103 里讨论的是批处理型 Agent 不应该跨长期周期复用完整 LLM 对话历史。Knowledge Insight 已经完成 run-scoped 生命周期收敛；这次只处理同类遗留里的 ScheduleAggregatorAgent，其他 Agent 先不动。

## 改动

- 将 ScheduleAggregatorAgent 从固定 `schedule_aggregator_$userId` session 改为 `schedule_aggregator_${userId}_${taskId/runId}`。
- `handleScheduleAggregation` 将 `TaskContext.taskId` 传给 Agent，区分同一次任务恢复和下一次刷新。
- 新增日程聚合 run lifecycle helper：6 小时 TTL 内允许恢复同一次 interrupted run；stale running state 删除后重建；completed residue state 删除后重建；成功执行和 loop detection 后删除本次 Agent state。
- 新增 `<schedule_aggregation_run_context>`，fresh run 从 durable state 注入当前窗口内的 temporal cards、最新 schedule aggregation compact summary、schedule refresh dirty state，以及明确的 fresh-run 执行策略。
- ScheduleAggregatorAgent 的 memory 能力改为 read-only prompt，不再注入 `append_memories` 写工具。

## 影响

- 日程聚合刷新不再跨多次业务触发复用长期 LLM history。
- 短期中断仍可在 TTL 内恢复，避免浪费一次正在执行的聚合任务。
- 切换 provider / model 后，下一次新任务不会天然沿用旧 session 的 provider-native replay payload。
- 降低批处理扫描日程资料时误写长期 memory 的风险。

## 验证

- `dart analyze lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart lib/agent/schedule_aggregator_agent/schedule_aggregation_run_lifecycle.dart lib/data/services/task_handlers/schedule_aggregator_handler.dart test/agent/schedule_aggregation_run_context_test.dart test/agent/schedule_aggregation_run_lifecycle_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart`
- `git diff --check`
- `flutter test --no-pub --concurrency=1 -r expanded test/agent/schedule_aggregation_run_context_test.dart test/agent/schedule_aggregation_run_lifecycle_test.dart test/agent/skills/schedule_aggregation_skill_test.dart test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart`

说明：本地在线 `flutter pub get` 在代理下载阶段卡住，改用 `flutter pub get --offline` 生成 package config 后完成验证。
