### PR TITLE
[codex] 统一 PR preflight 汇总评论

### DIFF
--- a/.github/workflows/pr-flutter-quality.yml
+++ b/.github/workflows/pr-flutter-quality.yml
@@ -23,6 +23,33 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Write preflight context
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+          pr = event["pull_request"]
+          context = {
+              "schema_version": 1,
+              "workflow": "PR Flutter Quality",
+              "artifact": "pr-flutter-quality",
+              "pr_number": pr["number"],
+              "head_sha": pr["head"]["sha"],
+              "head_ref": pr["head"]["ref"],
+              "base_sha": pr["base"]["sha"],
+              "base_ref": pr["base"]["ref"],
+              "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+              "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+          }
+          Path("preflight-context.json").write_text(
+              json.dumps(context, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
       - name: Prepare base worktree
         run: |
           git fetch --no-tags origin "${{ github.event.pull_request.base.sha }}"
@@ -70,11 +97,20 @@ jobs:
           exit 0
 
       - name: Check analyzer baseline
-        run: >
-          python3 scripts/compare_flutter_analyze.py
-          --base "$RUNNER_TEMP/flutter-analyze-base.txt"
-          --head "$RUNNER_TEMP/flutter-analyze-head.txt"
-          --summary "$GITHUB_STEP_SUMMARY"
+        id: analyzer_baseline
+        shell: bash
+        run: |
+          set +e
+          python3 scripts/compare_flutter_analyze.py \
+            --base "$RUNNER_TEMP/flutter-analyze-base.txt" \
+            --head "$RUNNER_TEMP/flutter-analyze-head.txt" \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --markdown-output flutter-analyze.md \
+            --json-output flutter-analyze.json
+          status="$?"
+          set -e
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: Run base and PR Flutter tests
         shell: bash
@@ -94,8 +130,150 @@ jobs:
           exit 0
 
       - name: Check test baseline
-        run: >
-          python3 scripts/compare_flutter_test_failures.py
-          --base "$RUNNER_TEMP/flutter-test-base.txt"
-          --head "$RUNNER_TEMP/flutter-test-head.txt"
-          --summary "$GITHUB_STEP_SUMMARY"
+        id: test_baseline
+        shell: bash
+        run: |
+          set +e
+          python3 scripts/compare_flutter_test_failures.py \
+            --base "$RUNNER_TEMP/flutter-test-base.txt" \
+            --head "$RUNNER_TEMP/flutter-test-head.txt" \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --markdown-output flutter-test.md \
+            --json-output flutter-test.json
+          status="$?"
+          set -e
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Build Flutter quality report
+        if: always()
+        shell: bash
+        env:
+          ANALYZER_STATUS: ${{ steps.analyzer_baseline.outputs.status }}
+          TEST_STATUS: ${{ steps.test_baseline.outputs.status }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          def status_label(status: str) -> tuple[str, str, str]:
+              if not status:
+                  return ("INCOMPLETE", "未完成", "incomplete")
+              if status == "0":
+                  return ("PASS", "通过", "passed")
+              return ("FAIL", "失败", "failed")
+
+          analyzer_status = os.environ.get("ANALYZER_STATUS", "")
+          test_status = os.environ.get("TEST_STATUS", "")
+          analyzer_en, analyzer_zh, analyzer_key = status_label(analyzer_status)
+          test_en, test_zh, test_key = status_label(test_status)
+          overall_key = (
+              "passed"
+              if analyzer_key == "passed" and test_key == "passed"
+              else "incomplete"
+              if "incomplete" in {analyzer_key, test_key}
+              else "failed"
+          )
+          overall_en = {
+              "passed": "PASS",
+              "failed": "FAIL",
+              "incomplete": "INCOMPLETE",
+          }[overall_key]
+          overall_zh = {
+              "passed": "通过",
+              "failed": "失败",
+              "incomplete": "未完成",
+          }[overall_key]
+
+          def read_text(path: str, fallback: str) -> str:
+              file = Path(path)
+              if file.exists():
+                  return file.read_text(encoding="utf-8", errors="replace").strip()
+              return fallback
+
+          analyzer_md = read_text(
+              "flutter-analyze.md",
+              "## Flutter Analyzer Baseline\n\nAnalyzer baseline result was not produced.",
+          )
+          test_md = read_text(
+              "flutter-test.md",
+              "## Flutter Test Baseline\n\nFlutter test baseline result was not produced.",
+          )
+
+          markdown = "\n".join(
+              [
+                  "# PR Flutter Quality / Flutter 质量预检",
+                  "",
+                  "## 中文",
+                  "",
+                  f"- 总体：`{overall_zh}`",
+                  f"- Analyzer baseline：`{analyzer_zh}`",
+                  f"- Test baseline：`{test_zh}`",
+                  "",
+                  "## English",
+                  "",
+                  f"- Overall: `{overall_en}`",
+                  f"- Analyzer baseline: `{analyzer_en}`",
+                  f"- Test baseline: `{test_en}`",
+                  "",
+                  analyzer_md,
+                  "",
+                  test_md,
+                  "",
+              ]
+          )
+          Path("flutter-quality.md").write_text(markdown, encoding="utf-8")
+          Path("flutter-quality.json").write_text(
+              json.dumps(
+                  {
+                      "schema_version": 1,
+                      "overall": overall_key,
+                      "analyzer": {
+                          "status": analyzer_key,
+                          "exit_code": analyzer_status,
+                      },
+                      "tests": {
+                          "status": test_key,
+                          "exit_code": test_status,
+                      },
+                  },
+                  ensure_ascii=False,
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload Flutter quality result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-flutter-quality
+          if-no-files-found: warn
+          path: |
+            preflight-context.json
+            flutter-quality.md
+            flutter-quality.json
+            flutter-analyze.md
+            flutter-analyze.json
+            flutter-test.md
+            flutter-test.json
+
+      - name: Fail on Flutter quality regressions
+        if: always()
+        shell: bash
+        env:
+          ANALYZER_STATUS: ${{ steps.analyzer_baseline.outputs.status }}
+          TEST_STATUS: ${{ steps.test_baseline.outputs.status }}
+        run: |
+          status=0
+          if [ -z "$ANALYZER_STATUS" ] || [ "$ANALYZER_STATUS" != "0" ]; then
+            status=1
+          fi
+          if [ -z "$TEST_STATUS" ] || [ "$TEST_STATUS" != "0" ]; then
+            status=1
+          fi
+          exit "$status"

--- a/.github/workflows/pr-policy-preflight.yml
+++ b/.github/workflows/pr-policy-preflight.yml
@@ -6,8 +6,11 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  pull-requests: read
+
+concurrency:
+  group: pr-policy-preflight-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   preflight:
@@ -38,6 +41,22 @@ jobs:
           pr = event["pull_request"]
           Path("pr-title.txt").write_text(pr.get("title") or "", encoding="utf-8")
           Path("pr-body.txt").write_text(pr.get("body") or "", encoding="utf-8")
+          context = {
+              "schema_version": 1,
+              "workflow": "PR Policy Preflight",
+              "artifact": "pr-policy-preflight",
+              "pr_number": pr["number"],
+              "head_sha": pr["head"]["sha"],
+              "head_ref": pr["head"]["ref"],
+              "base_sha": pr["base"]["sha"],
+              "base_ref": pr["base"]["ref"],
+              "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+              "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+          }
+          Path("preflight-context.json").write_text(
+              json.dumps(context, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
           PY
 
       - name: Run preflight in shadow mode
@@ -71,47 +90,6 @@ jobs:
 
           exit 0
 
-      - name: Comment preflight result
-        if: always()
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MARKER: "<!-- memex-pr-policy-preflight -->"
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          if [ ! -f preflight.md ]; then
-            {
-              echo "# PR Policy Preflight / PR 规则预检"
-              echo
-              echo "Preflight did not produce a report."
-              echo
-              echo "Preflight 未生成报告。"
-            } > preflight.md
-          fi
-
-          {
-            echo "$MARKER"
-            echo
-            cat preflight.md
-          } > preflight-comment.md
-
-          existing_comment_id="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" \
-            | head -n 1)"
-          comment_body="$(cat preflight-comment.md)"
-
-          if [ -n "$existing_comment_id" ]; then
-            gh api \
-              --method PATCH \
-              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
-              -f body="$comment_body"
-          else
-            gh api \
-              --method POST \
-              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              -f body="$comment_body"
-          fi
-
       - name: Upload preflight result
         if: always()
         uses: actions/upload-artifact@v4
@@ -119,5 +97,6 @@ jobs:
           name: pr-policy-preflight
           if-no-files-found: warn
           path: |
+            preflight-context.json
             preflight.json
             preflight.md

--- a/.github/workflows/pr-preflight-summary.yml
+++ b/.github/workflows/pr-preflight-summary.yml
@@ -1,0 +1,41 @@
+name: PR Preflight Summary
+
+on:
+  workflow_run:
+    workflows: ["PR Policy Preflight", "PR Flutter Quality"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: pr-preflight-summary-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  summary:
+    name: PR Preflight Summary
+    if: >-
+      ${{
+        github.event.workflow_run.event == 'pull_request' ||
+        github.event.workflow_run.event == 'pull_request_target'
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out trusted default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Upsert combined preflight comment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >
+          python3 scripts/pr_preflight_summary_comment.py
+          --repo "${{ github.repository }}"
+          --trigger-run-id "${{ github.event.workflow_run.id }}"

--- a/scripts/compare_flutter_analyze.py
+++ b/scripts/compare_flutter_analyze.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+import json
 from pathlib import Path
 import re
 import sys
@@ -114,6 +115,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--base", required=True, type=Path)
     parser.add_argument("--head", required=True, type=Path)
     parser.add_argument("--summary", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument("--json-output", type=Path)
     args = parser.parse_args(argv)
 
     base_issues = parse_report(read_report(args.base))
@@ -129,6 +132,27 @@ def main(argv: list[str] | None = None) -> int:
     if args.summary:
         with args.summary.open("a", encoding="utf-8") as handle:
             handle.write(summary)
+    if args.markdown_output:
+        args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_output.write_text(summary, encoding="utf-8")
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "base_count": len(base_issues),
+                    "head_count": len(head_issues),
+                    "new_count": len(new_issues),
+                    "new_issues": [asdict(issue) for issue in new_issues],
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
     if new_issues:
         for issue in new_issues[:50]:

--- a/scripts/compare_flutter_test_failures.py
+++ b/scripts/compare_flutter_test_failures.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+import json
 from pathlib import Path
 import re
 import sys
@@ -102,6 +103,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--base", required=True, type=Path)
     parser.add_argument("--head", required=True, type=Path)
     parser.add_argument("--summary", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument("--json-output", type=Path)
     args = parser.parse_args(argv)
 
     base_failures = parse_failures(read_report(args.base))
@@ -117,6 +120,27 @@ def main(argv: list[str] | None = None) -> int:
     if args.summary:
         with args.summary.open("a", encoding="utf-8") as handle:
             handle.write(summary)
+    if args.markdown_output:
+        args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_output.write_text(summary, encoding="utf-8")
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "base_count": len(base_failures),
+                    "head_count": len(head_failures),
+                    "new_count": len(new_failures),
+                    "new_failures": [asdict(failure) for failure in new_failures],
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
     if new_failures:
         for failure in new_failures[:50]:

--- a/scripts/pr_preflight_summary_comment.py
+++ b/scripts/pr_preflight_summary_comment.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Post one PR comment after all PR preflight workflows finish.
+
+The summary workflow is intentionally data-only: it downloads artifacts produced
+by the two preflight workflows, checks that they belong to the current PR head,
+and upserts a single issue comment. It never executes PR code or artifact
+content.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from io import BytesIO
+import json
+import os
+import sys
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+
+
+COMMENT_MARKER = "<!-- memex-pr-preflight-summary -->"
+LEGACY_COMMENT_MARKER = "<!-- memex-pr-policy-preflight -->"
+API_VERSION = "2022-11-28"
+
+
+@dataclass(frozen=True)
+class Target:
+    key: str
+    workflow_file: str
+    workflow_name: str
+    event: str
+    artifact_name: str
+    markdown_file: str
+    json_file: str
+
+
+@dataclass(frozen=True)
+class TargetResult:
+    target: Target
+    run: dict[str, Any]
+    context: dict[str, Any]
+    files: dict[str, str]
+
+
+TARGETS = [
+    Target(
+        key="policy",
+        workflow_file="pr-policy-preflight.yml",
+        workflow_name="PR Policy Preflight",
+        event="pull_request_target",
+        artifact_name="pr-policy-preflight",
+        markdown_file="preflight.md",
+        json_file="preflight.json",
+    ),
+    Target(
+        key="flutter",
+        workflow_file="pr-flutter-quality.yml",
+        workflow_name="PR Flutter Quality",
+        event="pull_request",
+        artifact_name="pr-flutter-quality",
+        markdown_file="flutter-quality.md",
+        json_file="flutter-quality.json",
+    ),
+]
+
+
+class GitHubClient:
+    def __init__(self, *, repo: str, token: str) -> None:
+        self.repo = repo
+        self.token = token
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.token}",
+            "X-GitHub-Api-Version": API_VERSION,
+            "User-Agent": "memex-pr-preflight-summary",
+        }
+
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        data: dict[str, Any] | None = None,
+        query: dict[str, str | int] | None = None,
+    ) -> Any:
+        if path.startswith("https://"):
+            url = path
+        else:
+            url = f"https://api.github.com/repos/{self.repo}{path}"
+        if query:
+            separator = "&" if "?" in url else "?"
+            url = f"{url}{separator}{urllib.parse.urlencode(query)}"
+        body = None if data is None else json.dumps(data).encode("utf-8")
+        headers = self._headers()
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(url, data=body, headers=headers, method=method)
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read()
+        if not raw:
+            return None
+        return json.loads(raw.decode("utf-8"))
+
+    def request_bytes(self, url: str) -> bytes:
+        request = urllib.request.Request(url, headers=self._headers(), method="GET")
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read()
+
+    def workflow_runs(self, target: Target, *, max_pages: int = 3) -> list[dict[str, Any]]:
+        runs: list[dict[str, Any]] = []
+        for page in range(1, max_pages + 1):
+            data = self.request_json(
+                "GET",
+                f"/actions/workflows/{target.workflow_file}/runs",
+                query={"event": target.event, "per_page": 30, "page": page},
+            )
+            page_runs = data.get("workflow_runs", [])
+            runs.extend(page_runs)
+            if len(page_runs) < 30:
+                break
+        return runs
+
+    def artifact_files(self, *, run_id: int, artifact_name: str) -> dict[str, str] | None:
+        data = self.request_json(
+            "GET",
+            f"/actions/runs/{run_id}/artifacts",
+            query={"per_page": 100},
+        )
+        artifacts = [
+            artifact
+            for artifact in data.get("artifacts", [])
+            if artifact.get("name") == artifact_name and not artifact.get("expired")
+        ]
+        if not artifacts:
+            return None
+
+        artifact = sorted(artifacts, key=lambda item: item.get("created_at", ""), reverse=True)[0]
+        archive = self.request_bytes(artifact["archive_download_url"])
+        files: dict[str, str] = {}
+        with zipfile.ZipFile(BytesIO(archive)) as zip_file:
+            for name in zip_file.namelist():
+                if name.endswith("/"):
+                    continue
+                files[name] = zip_file.read(name).decode("utf-8", errors="replace")
+        return files
+
+    def issue_comments(self, pr_number: int) -> list[dict[str, Any]]:
+        comments: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            data = self.request_json(
+                "GET",
+                f"/issues/{pr_number}/comments",
+                query={"per_page": 100, "page": page},
+            )
+            comments.extend(data)
+            if len(data) < 100:
+                return comments
+            page += 1
+
+    def upsert_comment(self, *, pr_number: int, body: str) -> None:
+        existing = next(
+            (
+                comment
+                for comment in self.issue_comments(pr_number)
+                if COMMENT_MARKER in (comment.get("body") or "")
+                or LEGACY_COMMENT_MARKER in (comment.get("body") or "")
+            ),
+            None,
+        )
+        if existing:
+            self.request_json("PATCH", f"/issues/comments/{existing['id']}", data={"body": body})
+        else:
+            self.request_json("POST", f"/issues/{pr_number}/comments", data={"body": body})
+
+
+def find_file(files: dict[str, str], filename: str) -> str | None:
+    for path, content in files.items():
+        if path.split("/")[-1] == filename:
+            return content
+    return None
+
+
+def load_json_file(files: dict[str, str], filename: str) -> dict[str, Any]:
+    content = find_file(files, filename)
+    if content is None:
+        return {}
+    try:
+        value = json.loads(content)
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def load_context(files: dict[str, str]) -> dict[str, Any]:
+    context = load_json_file(files, "preflight-context.json")
+    if not context.get("pr_number") or not context.get("head_sha"):
+        raise ValueError("preflight-context.json is missing pr_number or head_sha")
+    return context
+
+
+def trigger_context(client: GitHubClient, *, trigger_run_id: int) -> dict[str, Any] | None:
+    for target in TARGETS:
+        files = client.artifact_files(run_id=trigger_run_id, artifact_name=target.artifact_name)
+        if not files:
+            continue
+        try:
+            return load_context(files)
+        except ValueError:
+            continue
+    return None
+
+
+def find_matching_result(
+    client: GitHubClient,
+    *,
+    target: Target,
+    pr_number: int,
+    head_sha: str,
+) -> TargetResult | None:
+    for run in client.workflow_runs(target):
+        if run.get("status") != "completed":
+            continue
+        try:
+            files = client.artifact_files(
+                run_id=int(run["id"]),
+                artifact_name=target.artifact_name,
+            )
+        except (urllib.error.URLError, KeyError, ValueError, zipfile.BadZipFile):
+            continue
+        if not files:
+            continue
+        try:
+            context = load_context(files)
+        except ValueError:
+            continue
+        if int(context["pr_number"]) == pr_number and context["head_sha"] == head_sha:
+            return TargetResult(target=target, run=run, context=context, files=files)
+    return None
+
+
+def current_pr_head(client: GitHubClient, *, pr_number: int) -> str | None:
+    data = client.request_json("GET", f"/pulls/{pr_number}")
+    head = data.get("head") or {}
+    return head.get("sha")
+
+
+def decision_label(decision: str) -> tuple[str, str]:
+    return {
+        "low_risk": ("LOW RISK", "低风险"),
+        "high_risk": ("HIGH RISK", "高风险"),
+        "reject": ("REJECT", "打回"),
+    }.get(decision, (decision.upper() if decision else "UNKNOWN", decision or "未知"))
+
+
+def quality_label(overall: str, conclusion: str) -> tuple[str, str]:
+    if conclusion != "success":
+        return (conclusion.upper() if conclusion else "UNKNOWN", "失败")
+    return {
+        "passed": ("PASS", "通过"),
+        "failed": ("FAIL", "失败"),
+        "incomplete": ("INCOMPLETE", "未完成"),
+    }.get(overall, ("UNKNOWN", "未知"))
+
+
+def limited(text: str, *, max_chars: int = 25000) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "\n\n...truncated in summary comment..."
+
+
+def details(summary: str, body: str) -> str:
+    return "\n".join(
+        [
+            "<details>",
+            f"<summary>{summary}</summary>",
+            "",
+            limited(body.strip()),
+            "",
+            "</details>",
+        ]
+    )
+
+
+def build_comment(*, policy: TargetResult, flutter: TargetResult) -> str:
+    policy_data = load_json_file(policy.files, policy.target.json_file)
+    flutter_data = load_json_file(flutter.files, flutter.target.json_file)
+    policy_md = find_file(policy.files, policy.target.markdown_file) or "Policy preflight report was not produced."
+    flutter_md = find_file(flutter.files, flutter.target.markdown_file) or "Flutter quality report was not produced."
+
+    decision = policy_data.get("decision", "unknown")
+    decision_en, decision_zh = decision_label(decision)
+    flutter_overall = str(flutter_data.get("overall", "unknown"))
+    flutter_en, flutter_zh = quality_label(flutter_overall, str(flutter.run.get("conclusion", "")))
+
+    if decision == "reject":
+        final_zh = "打回：规则预检命中阻断项，需要修复后再进入普通 review。"
+        final_en = "Rejected: policy preflight found a blocking issue."
+    elif str(flutter.run.get("conclusion", "")) != "success" or flutter_overall != "passed":
+        final_zh = "需要修复：Flutter quality 发现新增 analyzer/test 问题或未完整完成。"
+        final_en = "Needs fixes: Flutter quality found new analyzer/test issues or did not complete."
+    elif decision == "high_risk":
+        final_zh = "高风险：质量预检通过，但需要 maintainer 人工 review 后手动合并。"
+        final_en = "High risk: quality passed, but maintainer review is required before manual merge."
+    elif decision == "low_risk":
+        final_zh = "低风险：两个预检均已完成，质量预检通过，可走普通手动合并流程。"
+        final_en = "Low risk: both preflights completed and quality passed; use the normal manual merge flow."
+    else:
+        final_zh = "未确认：预检完成，但 policy 判定不可识别。"
+        final_en = "Unconfirmed: preflights completed, but the policy decision is unknown."
+
+    return "\n\n".join(
+        [
+            COMMENT_MARKER,
+            "# PR Preflight Summary / PR 预检汇总",
+            "## 中文",
+            "\n".join(
+                [
+                    f"- 统一结论：{final_zh}",
+                    f"- Policy preflight：`{decision_zh}`",
+                    f"- Flutter quality：`{flutter_zh}`",
+                    f"- PR head：`{policy.context['head_sha']}`",
+                    f"- Policy run：[{policy.run['id']}]({policy.run['html_url']})",
+                    f"- Flutter run：[{flutter.run['id']}]({flutter.run['html_url']})",
+                ]
+            ),
+            "## English",
+            "\n".join(
+                [
+                    f"- Combined result: {final_en}",
+                    f"- Policy preflight: `{decision_en}`",
+                    f"- Flutter quality: `{flutter_en}`",
+                    f"- PR head: `{policy.context['head_sha']}`",
+                    f"- Policy run: [{policy.run['id']}]({policy.run['html_url']})",
+                    f"- Flutter run: [{flutter.run['id']}]({flutter.run['html_url']})",
+                ]
+            ),
+            details("PR Policy Preflight / PR 规则预检", policy_md),
+            details("PR Flutter Quality / Flutter 质量预检", flutter_md),
+        ]
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Upsert the combined PR preflight comment.")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--trigger-run-id", required=True, type=int)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN is required.", file=sys.stderr)
+        return 1
+
+    client = GitHubClient(repo=args.repo, token=token)
+    context = trigger_context(client, trigger_run_id=args.trigger_run_id)
+    if context is None:
+        print("Trigger run has no known preflight artifact yet; skipping summary.")
+        return 0
+
+    pr_number = int(context["pr_number"])
+    head_sha = str(context["head_sha"])
+    live_head_sha = current_pr_head(client, pr_number=pr_number)
+    if live_head_sha != head_sha:
+        print(
+            f"Skipping stale preflight summary for PR #{pr_number}: "
+            f"artifact head {head_sha}, current head {live_head_sha}."
+        )
+        return 0
+
+    results: dict[str, TargetResult] = {}
+    for target in TARGETS:
+        result = find_matching_result(
+            client,
+            target=target,
+            pr_number=pr_number,
+            head_sha=head_sha,
+        )
+        if result is None:
+            print(
+                f"Waiting for {target.workflow_name} artifact for PR #{pr_number} "
+                f"at {head_sha}."
+            )
+            return 0
+        results[target.key] = result
+
+    body = build_comment(policy=results["policy"], flutter=results["flutter"])
+    if args.dry_run:
+        print(body)
+        return 0
+
+    client.upsert_comment(pr_number=pr_number, body=body)
+    print(f"Updated combined preflight comment for PR #{pr_number}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景

当前 PR Policy Preflight 会在自己完成后立即评论，而 PR Flutter Quality 只写 check summary。这样 reviewer 在 PR 页面上看到的是分散结果，无法等两个 preflight 都完成后再读一条统一结论。

## 变更

- 移除 Policy Preflight 内部即时评论，只保留 trusted base 上的规则检查和 artifact 输出。
- 为 Flutter Quality 输出结构化 artifact，并确保 analyzer baseline 失败后仍继续跑 test baseline，最后统一决定 workflow 是否失败。
- 新增 PR Preflight Summary workflow，监听两个 preflight 的 workflow_run 完成事件。
- 新增汇总脚本：只有同一 PR、同一当前 head SHA 的两个 artifact 都齐了，才 upsert 一条统一 PR 评论。
- 汇总评论会复用旧的 policy preflight marker 评论，避免历史 PR 上出现重复 bot 评论。

## 安全边界

- 执行 PR 代码的 Flutter Quality 仍然跑在 pull_request 上，不拿写评论权限。
- 可写评论的 Summary 只下载并读取 artifact，不执行 PR 分支代码。
- Policy Preflight 继续使用 pull_request_target，但只 checkout trusted default branch，并把 PR ref 当数据读取。

## 验证

- python3 -m py_compile scripts/compare_flutter_analyze.py scripts/compare_flutter_test_failures.py scripts/pr_policy_check.py scripts/pr_preflight_summary_comment.py
- git diff --check --cached
- Ruby YAML parser 校验三个 workflow 文件
- compare 脚本 artifact 输出冒烟测试
- 汇总评论生成逻辑 fake artifact 测试
