### PR TITLE
[codex] 优化自动备份立即备份性能

### DIFF
--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
-import 'package:archive/archive.dart';
+import 'package:archive/archive_io.dart';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
@@ -225,46 +226,18 @@ class BackupService {
         ? outputPath
         : path.join(targetDir.path, '.$fileName.tmp');
 
-    final archive = Archive();
-    final manifestEntries = <Map<String, dynamic>>[];
-
-    // 1. Add workspace files
+    // 1. Prepare source metadata on the main isolate. The expensive file
+    // reads and zip compression run below in a background isolate.
     onProgress?.call('Packing workspace...');
-    await _addDirectoryToArchive(
-      archive,
-      workspacePath,
-      'workspace',
-      manifestEntries: manifestEntries,
-      excludedRootPaths: [
-        path.join(workspacePath, 'Backups'),
-        if (outputDirectory != null) outputDirectory,
-      ],
-    );
 
-    // 2. Add Drift DB file
-    onProgress?.call('Packing database...');
     final dbName = 'memex_local_$userId.sqlite';
     // drift_flutter stores DB in app support directory on iOS, app documents on Android
     final possibleDbPaths = [
       path.join(appDir.path, dbName),
       path.join((await getApplicationSupportDirectory()).path, dbName),
     ];
-    for (final dbPath in possibleDbPaths) {
-      final dbFile = File(dbPath);
-      if (await dbFile.exists()) {
-        final bytes = await dbFile.readAsBytes();
-        _addBytesToArchive(
-          archive,
-          'db/$dbName',
-          bytes,
-          manifestEntries: manifestEntries,
-        );
-        _logger.info('Added DB file: $dbPath (${bytes.length} bytes)');
-        break;
-      }
-    }
 
-    // 3. Add SharedPreferences settings — backup ALL non-internal keys
+    // 2. Add SharedPreferences settings — backup ALL non-internal keys
     onProgress?.call('Packing settings...');
     final prefs = await SharedPreferences.getInstance();
     final settings = <String, dynamic>{};
@@ -276,32 +249,40 @@ class BackupService {
         settings[key] = value;
       }
     }
-    _addBytesToArchive(
-      archive,
-      'settings.json',
-      utf8.encode(jsonEncode(settings)),
-      manifestEntries: manifestEntries,
-    );
 
-    // 4. Add manifest last so it covers every payload entry.
-    final manifest = await _createManifest(
-      createdAt: createdAt,
-      userId: userId,
-      entries: manifestEntries,
-    );
-    _addBytesToArchive(
-      archive,
-      _backupManifestFileName,
-      utf8.encode(jsonEncode(manifest.toJson())),
-    );
+    var appVersion = 'unknown';
+    var buildNumber = '';
+    try {
+      final packageInfo = await PackageInfo.fromPlatform();
+      appVersion = packageInfo.version;
+      buildNumber = packageInfo.buildNumber;
+    } catch (_) {}
 
-    // 5. Write zip. Automatic path writes use temp + rename in the same dir.
+    // 3. Write zip in a background isolate. Automatic path writes use temp +
+    // rename in the same dir.
     onProgress?.call('Compressing...');
-    final zipData = ZipEncoder().encode(archive);
-    final tempFile = File(tempOutputPath);
-    await tempFile.writeAsBytes(zipData, flush: true);
+    final archiveResult = await Isolate.run(
+      () => _writeBackupArchive(
+        workspacePath: workspacePath,
+        excludedWorkspaceRootPaths: [
+          path.join(workspacePath, 'Backups'),
+          if (outputDirectory != null) outputDirectory,
+        ],
+        dbPaths: possibleDbPaths,
+        dbName: dbName,
+        settingsBytes: utf8.encode(jsonEncode(settings)),
+        tempOutputPath: tempOutputPath,
+        createdAt: createdAt,
+        userId: userId,
+        appVersion: appVersion,
+        buildNumber: buildNumber,
+        flavor: AppFlavor.name,
+        platform: Platform.operatingSystem,
+      ),
+    );
 
     if (outputDirectory != null) {
+      final tempFile = File(tempOutputPath);
       final outputFile = File(outputPath);
       if (await outputFile.exists()) {
         await outputFile.delete();
@@ -309,7 +290,10 @@ class BackupService {
       await tempFile.rename(outputPath);
     }
 
-    _logger.info('Backup created: $outputPath (${zipData.length} bytes)');
+    _logger.info(
+      'Backup created: $outputPath '
+      '(${archiveResult.sizeBytes} bytes, ${archiveResult.fileCount} files)',
+    );
     return outputPath;
   }
 
@@ -692,53 +676,6 @@ class BackupService {
     return stats.totalSize;
   }
 
-  /// Recursively add a directory to the archive.
-  static Future<void> _addDirectoryToArchive(
-    Archive archive,
-    String dirPath,
-    String archivePrefix, {
-    required List<Map<String, dynamic>> manifestEntries,
-    List<String> excludedRootPaths = const [],
-  }) async {
-    final dir = Directory(dirPath);
-    if (!await dir.exists()) return;
-
-    await for (final entity in dir.list(recursive: true, followLinks: false)) {
-      if (entity is! File) continue;
-      if (excludedRootPaths.any((root) => _isPathWithin(root, entity.path))) {
-        continue;
-      }
-
-      final relativePath = path.relative(entity.path, from: dirPath);
-      final archivePath = '$archivePrefix/$relativePath';
-      try {
-        final bytes = await entity.readAsBytes();
-        _addBytesToArchive(
-          archive,
-          archivePath,
-          bytes,
-          manifestEntries: manifestEntries,
-        );
-      } catch (e) {
-        _logger.warning('Skipping file ${entity.path}: $e');
-      }
-    }
-  }
-
-  static void _addBytesToArchive(
-    Archive archive,
-    String archivePath,
-    List<int> bytes, {
-    List<Map<String, dynamic>>? manifestEntries,
-  }) {
-    archive.addFile(ArchiveFile(archivePath, bytes.length, bytes));
-    manifestEntries?.add({
-      'path': archivePath,
-      'size': bytes.length,
-      'sha256': sha256.convert(bytes).toString(),
-    });
-  }
-
   static void _validateManifest(Archive archive) {
     final manifestFile = _findArchiveFile(archive, _backupManifestFileName);
     if (manifestFile == null) {
@@ -1065,33 +1002,6 @@ class BackupService {
     );
   }
 
-  static Future<BackupManifest> _createManifest({
-    required DateTime createdAt,
-    required String userId,
-    required List<Map<String, dynamic>> entries,
-  }) async {
-    var appVersion = 'unknown';
-    var buildNumber = '';
-    try {
-      final packageInfo = await PackageInfo.fromPlatform();
-      appVersion = packageInfo.version;
-      buildNumber = packageInfo.buildNumber;
-    } catch (_) {}
-
-    return BackupManifest(
-      format: _backupFormat,
-      formatVersion: 1,
-      backupSchemaVersion: _currentBackupSchemaVersion,
-      createdAt: createdAt.toUtc(),
-      userId: userId,
-      appVersion: appVersion,
-      buildNumber: buildNumber,
-      flavor: AppFlavor.name,
-      platform: Platform.operatingSystem,
-      entries: List<Map<String, dynamic>>.unmodifiable(entries),
-    );
-  }
-
   static Archive _decodeBackup(List<int> bytes) {
     try {
       return ZipDecoder().decodeBytes(bytes);
@@ -1124,6 +1034,157 @@ class BackupService {
   }
 }
 
+Future<_BackupArchiveResult> _writeBackupArchive({
+  required String workspacePath,
+  required List<String> excludedWorkspaceRootPaths,
+  required List<String> dbPaths,
+  required String dbName,
+  required List<int> settingsBytes,
+  required String tempOutputPath,
+  required DateTime createdAt,
+  required String userId,
+  required String appVersion,
+  required String buildNumber,
+  required String flavor,
+  required String platform,
+}) async {
+  final manifestEntries = <Map<String, dynamic>>[];
+  final encoder = ZipFileEncoder();
+  var fileCount = 0;
+
+  try {
+    encoder.create(tempOutputPath, level: ZipFileEncoder.gzip);
+
+    fileCount += await _addDirectoryToBackupArchive(
+      encoder,
+      workspacePath,
+      'workspace',
+      manifestEntries: manifestEntries,
+      excludedRootPaths: excludedWorkspaceRootPaths,
+    );
+
+    for (final dbPath in dbPaths) {
+      final dbFile = File(dbPath);
+      if (!await dbFile.exists()) continue;
+      await _addFileToBackupArchive(
+        encoder,
+        dbFile,
+        'db/$dbName',
+        manifestEntries,
+      );
+      fileCount += 1;
+      break;
+    }
+
+    _addBytesToBackupArchive(
+      encoder,
+      'settings.json',
+      settingsBytes,
+      manifestEntries: manifestEntries,
+    );
+    fileCount += 1;
+
+    final manifest = BackupManifest(
+      format: _backupFormat,
+      formatVersion: 1,
+      backupSchemaVersion: _currentBackupSchemaVersion,
+      createdAt: createdAt.toUtc(),
+      userId: userId,
+      appVersion: appVersion,
+      buildNumber: buildNumber,
+      flavor: flavor,
+      platform: platform,
+      entries: List<Map<String, dynamic>>.unmodifiable(manifestEntries),
+    );
+    _addBytesToBackupArchive(
+      encoder,
+      _backupManifestFileName,
+      utf8.encode(jsonEncode(manifest.toJson())),
+    );
+    fileCount += 1;
+
+    await encoder.close();
+  } catch (_) {
+    try {
+      await encoder.close();
+    } catch (_) {}
+    final tempFile = File(tempOutputPath);
+    if (await tempFile.exists()) {
+      await tempFile.delete();
+    }
+    rethrow;
+  }
+
+  final sizeBytes = await File(tempOutputPath).length();
+  return _BackupArchiveResult(sizeBytes: sizeBytes, fileCount: fileCount);
+}
+
+Future<int> _addDirectoryToBackupArchive(
+  ZipFileEncoder encoder,
+  String dirPath,
+  String archivePrefix, {
+  required List<Map<String, dynamic>> manifestEntries,
+  List<String> excludedRootPaths = const [],
+}) async {
+  final dir = Directory(dirPath);
+  if (!await dir.exists()) return 0;
+
+  var fileCount = 0;
+  await for (final entity in dir.list(recursive: true, followLinks: false)) {
+    if (entity is! File) continue;
+    if (excludedRootPaths.any(
+      (root) => BackupService._isPathWithin(root, entity.path),
+    )) {
+      continue;
+    }
+
+    final relativePath = path.relative(entity.path, from: dirPath);
+    final archivePath = '$archivePrefix/$relativePath';
+    try {
+      await _addFileToBackupArchive(
+        encoder,
+        entity,
+        archivePath,
+        manifestEntries,
+      );
+      fileCount += 1;
+    } catch (e) {
+      BackupService._logger.warning('Skipping file ${entity.path}: $e');
+    }
+  }
+
+  return fileCount;
+}
+
+Future<void> _addFileToBackupArchive(
+  ZipFileEncoder encoder,
+  File file,
+  String archivePath,
+  List<Map<String, dynamic>> manifestEntries,
+) async {
+  final bytes = await file.readAsBytes();
+  _addBytesToBackupArchive(
+    encoder,
+    archivePath,
+    bytes,
+    manifestEntries: manifestEntries,
+  );
+}
+
+void _addBytesToBackupArchive(
+  ZipFileEncoder encoder,
+  String archivePath,
+  List<int> bytes, {
+  List<Map<String, dynamic>>? manifestEntries,
+}) {
+  encoder.addArchiveFile(ArchiveFile(archivePath, bytes.length, bytes));
+  manifestEntries?.add({
+    'path': archivePath,
+    'size': bytes.length,
+    'sha256': sha256.convert(bytes).toString(),
+  });
+}
+
 class _BackupSourceStats {
   final int totalSize;
   final int fileCount;
@@ -1133,5 +1194,15 @@ class _BackupSourceStats {
     required this.totalSize,
     required this.fileCount,
     required this.latestModifiedMs,
+  });
+}
+
+class _BackupArchiveResult {
+  final int sizeBytes;
+  final int fileCount;
+
+  const _BackupArchiveResult({
+    required this.sizeBytes,
+    required this.fileCount,
   });
 }

--- a/lib/ui/settings/widgets/backup_restore_page.dart
+++ b/lib/ui/settings/widgets/backup_restore_page.dart
@@ -12,11 +12,12 @@ import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/toast_helper.dart';
 import 'package:memex/utils/user_storage.dart';
 
-typedef AutoBackupCreator = Future<BackupSnapshot?> Function({
-  String trigger,
-  bool force,
-  void Function(String status)? onProgress,
-});
+typedef AutoBackupCreator =
+    Future<BackupSnapshot?> Function({
+      String trigger,
+      bool force,
+      void Function(String status)? onProgress,
+    });
 
 class BackupRestorePage extends StatefulWidget {
   final bool? isAndroidOverride;
@@ -63,12 +64,15 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     _loadPageData();
   }
 
-  Future<void> _loadPageData() async {
+  Future<void> _loadPageData({bool includeEstimatedSize = true}) async {
     final userId = await UserStorage.getUserId();
-    final size =
-        await (widget.estimateBackupSize ?? BackupService.estimateBackupSize)();
-    final location = await (widget.currentBackupLocationLabel ??
-        BackupService.currentBackupLocationLabel)();
+    final size = includeEstimatedSize
+        ? await (widget.estimateBackupSize ??
+              BackupService.estimateBackupSize)()
+        : null;
+    final location =
+        await (widget.currentBackupLocationLabel ??
+            BackupService.currentBackupLocationLabel)();
     final snapshots =
         await (widget.listStoredBackups ?? BackupService.listStoredBackups)();
     final autoEnabled = userId != null && userId.isNotEmpty
@@ -80,7 +84,9 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
     if (mounted) {
       setState(() {
-        _estimatedSize = _formatBytes(size);
+        if (size != null) {
+          _estimatedSize = _formatBytes(size);
+        }
         _backupLocation = location;
         _storedBackups = snapshots;
         _autoBackupEnabled = autoEnabled;
@@ -165,7 +171,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
           if (mounted) setState(() => _statusText = status);
         },
       );
-      await _loadPageData();
+      await _loadPageData(includeEstimatedSize: false);
 
       if (!mounted) return;
       setState(() {
@@ -395,7 +401,8 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
   @override
   Widget build(BuildContext context) {
-    final isBusy = _isBackingUp ||
+    final isBusy =
+        _isBackingUp ||
         _isRestoring ||
         _isCreatingSnapshot ||
         _isPickingLocation;

--- a/test/ui/settings/widgets/backup_restore_page_test.dart
+++ b/test/ui/settings/widgets/backup_restore_page_test.dart
@@ -88,17 +88,18 @@ void main() {
     await _pumpBackupPage(
       tester,
       listStoredBackups: () async => List<BackupSnapshot>.of(snapshots),
-      createAutoBackup: ({
-        String trigger = 'automatic',
-        bool force = false,
-        void Function(String status)? onProgress,
-      }) async {
-        expect(trigger, 'manual');
-        expect(force, isTrue);
-        onProgress?.call('Compressing...');
-        snapshots.add(snapshot);
-        return snapshot;
-      },
+      createAutoBackup:
+          ({
+            String trigger = 'automatic',
+            bool force = false,
+            void Function(String status)? onProgress,
+          }) async {
+            expect(trigger, 'manual');
+            expect(force, isTrue);
+            onProgress?.call('Compressing...');
+            snapshots.add(snapshot);
+            return snapshot;
+          },
     );
 
     await tester.tap(find.text(UserStorage.l10n.createSnapshotNow));
@@ -113,6 +114,45 @@ void main() {
       find.text(UserStorage.l10n.autoBackupCreated(snapshot.name)),
       findsOneWidget,
     );
+  });
+
+  testWidgets('manual snapshot refresh does not rescan estimated source size', (
+    tester,
+  ) async {
+    var estimateCalls = 0;
+    final snapshot = BackupSnapshot(
+      id: 'manual',
+      name: 'memex_auto_2026-05-15T11-30-00.memex',
+      createdAt: DateTime(2026, 5, 15, 11, 30),
+      sizeBytes: 8,
+      filePath: '/tmp/memex_auto_2026-05-15T11-30-00.memex',
+    );
+    final snapshots = <BackupSnapshot>[];
+
+    await _pumpBackupPage(
+      tester,
+      estimateBackupSize: () async {
+        estimateCalls += 1;
+        return 42;
+      },
+      listStoredBackups: () async => List<BackupSnapshot>.of(snapshots),
+      createAutoBackup:
+          ({
+            String trigger = 'automatic',
+            bool force = false,
+            void Function(String status)? onProgress,
+          }) async {
+            snapshots.add(snapshot);
+            return snapshot;
+          },
+    );
+
+    expect(estimateCalls, 1);
+
+    await tester.tap(find.text(UserStorage.l10n.createSnapshotNow));
+    await _scrollUntilVisible(tester, find.text(snapshot.name));
+
+    expect(estimateCalls, 1);
   });
 
   testWidgets('shows Android backup location picker menu', (tester) async {
@@ -135,6 +175,7 @@ void main() {
 Future<void> _pumpBackupPage(
   WidgetTester tester, {
   bool isAndroid = false,
+  Future<int> Function()? estimateBackupSize,
   Future<List<BackupSnapshot>> Function()? listStoredBackups,
   AutoBackupCreator? createAutoBackup,
 }) async {
@@ -144,7 +185,7 @@ Future<void> _pumpBackupPage(
       supportedLocales: AppLocalizations.supportedLocales,
       home: BackupRestorePage(
         isAndroidOverride: isAndroid,
-        estimateBackupSize: () async => 0,
+        estimateBackupSize: estimateBackupSize ?? () async => 0,
         currentBackupLocationLabel: () async => '/tmp/Backups',
         listStoredBackups: listStoredBackups ?? () async => const [],
         createAutoBackup: createAutoBackup,


### PR DESCRIPTION
Closes #116

## 背景

自动备份里的“立即备份”是用户主动等待结果的操作。原流程会在主 isolate 中完成 workspace 文件读取、checksum 计算和 ZIP 压缩，数据量稍大时容易让设置页出现明显卡顿。

## 修改内容

- 将 `BackupService.createBackup()` 中较重的文件打包、manifest checksum 计算和 ZIP 写入移动到后台 isolate 执行，主 isolate 只负责收集用户、路径、设置和版本等轻量上下文。
- 改用 `ZipFileEncoder` 逐项写入备份文件，避免先构建完整内存 `Archive` 再一次性同步 `ZipEncoder().encode(...)`。
- 保留现有 `.memex` manifest 结构、checksum 校验、临时文件重命名和恢复兼容逻辑。
- “立即备份”完成后只刷新备份位置、已保存备份列表和状态，不再额外重新扫描估算备份大小。
- 增加 widget 测试，覆盖手动快照完成后不会重复触发大小估算扫描。

## 用户影响

点击“立即备份”后，压缩阶段不再长时间占用 UI 线程，页面加载态和状态反馈会更稳定；同时备份文件格式和恢复路径保持不变。

## 验证

- `flutter test --no-pub test/data/services/backup_service_test.dart`
- `flutter test --no-pub test/ui/settings/widgets/backup_restore_page_test.dart`
- `flutter analyze --no-pub lib/data/services/backup_service.dart lib/ui/settings/widgets/backup_restore_page.dart test/ui/settings/widgets/backup_restore_page_test.dart`

本地验证前使用清理代理变量的环境恢复了 `.dart_tool/package_config.json`，避免 `flutter_tester` 受本机 proxy 环境影响。
