### PR TITLE
[codex] 修复 preflight artifact 下载重定向

### DIFF
--- a/scripts/pr_preflight_summary_comment.py
+++ b/scripts/pr_preflight_summary_comment.py
@@ -68,6 +68,11 @@ TARGETS = [
 ]
 
 
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
 class GitHubClient:
     def __init__(self, *, repo: str, token: str) -> None:
         self.repo = repo
@@ -108,8 +113,26 @@ class GitHubClient:
         return json.loads(raw.decode("utf-8"))
 
     def request_bytes(self, url: str) -> bytes:
+        opener = urllib.request.build_opener(NoRedirectHandler)
         request = urllib.request.Request(url, headers=self._headers(), method="GET")
-        with urllib.request.urlopen(request, timeout=60) as response:
+        try:
+            response = opener.open(request, timeout=60)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in {301, 302, 303, 307, 308}:
+                raise
+            redirect_url = exc.headers.get("Location")
+            if not redirect_url:
+                raise
+            # Artifact downloads redirect to a short-lived object-storage URL.
+            # Fetch the signed URL without GitHub's Authorization header.
+            request = urllib.request.Request(
+                urllib.parse.urljoin(url, redirect_url),
+                headers={"User-Agent": "memex-pr-preflight-summary"},
+                method="GET",
+            )
+            with urllib.request.urlopen(request, timeout=60) as response:
+                return response.read()
+        with response:
             return response.read()
 
     def workflow_runs(self, target: Target, *, max_pages: int = 3) -> list[dict[str, Any]]:


### PR DESCRIPTION
## 背景

合并 #115 后，`PR Preflight Summary` workflow 在下载 preflight artifact 时失败。失败 job：

- https://github.com/memex-lab/memex/actions/runs/25995215647/job/76408428177

日志里报错：

```text
urllib.error.HTTPError: HTTP Error 401: Server failed to authenticate the request.
```

## 根因

`archive_download_url` 首跳是 GitHub API，需要 `GITHUB_TOKEN`。但该 URL 会 302 到短期对象存储 URL；Python `urllib` 自动跟随重定向时把 GitHub `Authorization: Bearer ...` header 也带到了对象存储，导致对象存储拒绝这个请求。

## 变更

- artifact 下载改成手动处理 redirect。
- GitHub API 首跳继续带 token。
- 跳转后的短期对象存储 URL 用无 Authorization header 的请求下载。

## 验证

- `python3 -m py_compile scripts/pr_preflight_summary_comment.py`
- `git diff --check`
- 使用真实 trigger run artifact dry-run：
  - `GITHUB_TOKEN="$(gh auth token)" python3 scripts/pr_preflight_summary_comment.py --repo memex-lab/memex --trigger-run-id 25995110227 --dry-run`
  - dry-run 成功生成完整汇总评论，未写入 GitHub。
