### PR TITLE
[codex] 添加失败对话上下文清理入口

### DIFF
--- a/lib/agent/state_util.dart
+++ b/lib/agent/state_util.dart
@@ -4,6 +4,9 @@ import 'dart:io';
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/data/services/file_system_service.dart';
 
+typedef AgentStateMatcher =
+    bool Function(String sessionId, Map<String, dynamic> metadata);
+
 Future<AgentState> loadOrCreateAgentState(
   String sessionId,
   Map<String, dynamic>? initialMetadata,
@@ -146,6 +149,58 @@ Future<void> deleteAgentState(String userId, String sessionId) async {
   final stateDir = Directory(stateDirPath);
   final storage = FileStateStorage(stateDir);
   await storage.delete(sessionId);
+}
+
+Future<List<String>> deleteAgentStatesWhere(
+  String userId,
+  AgentStateMatcher shouldDelete,
+) async {
+  final stateDirPath = await FileSystemService.instance.getAgentStateDirectory(
+    userId,
+  );
+  final stateDir = Directory(stateDirPath);
+  if (!await stateDir.exists()) {
+    return const [];
+  }
+
+  final storage = FileStateStorage(stateDir);
+  final deletedSessionIds = <String>[];
+  await for (final entity in stateDir.list(followLinks: false)) {
+    if (entity is! File) continue;
+
+    final filename = entity.uri.pathSegments.last;
+    if (!filename.endsWith('.json')) continue;
+
+    final sessionId = filename.substring(0, filename.length - 5);
+    final metadata = await _readAgentStateMetadata(entity);
+    if (!shouldDelete(sessionId, metadata)) continue;
+
+    await storage.delete(sessionId);
+    deletedSessionIds.add(sessionId);
+  }
+  return deletedSessionIds;
+}
+
+Future<Map<String, dynamic>> _readAgentStateMetadata(File file) async {
+  try {
+    final content = await file.readAsString();
+    final decoded = jsonDecode(content);
+    if (decoded is! Map<String, dynamic>) {
+      return const {};
+    }
+    final metadata = decoded['metadata'];
+    if (metadata is Map<String, dynamic>) {
+      return metadata;
+    }
+    if (metadata is Map) {
+      return Map<String, dynamic>.from(metadata);
+    }
+  } catch (_) {
+    // Corrupt state files are left alone here. They can still be removed by a
+    // broader data clear, but this targeted action should only delete known
+    // Insight/Schedule conversation contexts.
+  }
+  return const {};
 }
 
 /// Resolve the session ID for a character agent.

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -71,6 +71,7 @@ import 'package:memex/data/repositories/get_knowledge_insight_detail.dart';
 import 'package:memex/data/repositories/chat.dart' as chat_endpoint;
 import 'package:memex/data/services/llm_call_record_service.dart';
 import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/agent/state_util.dart';
 import 'package:memex/agent/skills/knowledge_insight/native_widgets.dart';
 import 'package:memex/utils/result.dart';
 import 'package:memex/domain/models/system_event.dart';
@@ -780,6 +781,21 @@ class MemexRouter {
       _logger.severe('Failed to clear data locally: $e');
       rethrow;
     }
+  }
+
+  Future<int> clearFailedAgentConversationContexts() async {
+    await _ensureInitialized();
+    final userId = await UserStorage.getUserId();
+    if (userId == null) throw Exception('User not logged in');
+
+    final deleted = await deleteAgentStatesWhere(userId, (sessionId, metadata) {
+      final scene = metadata['scene']?.toString();
+      return scene == 'insight' || scene == 'schedule_aggregation';
+    });
+    _logger.info(
+      'Cleared ${deleted.length} failed agent conversation context(s): $deleted',
+    );
+    return deleted.length;
   }
 
   // Native widget IDs are now dynamically loaded from nativeWidgets definition

--- a/lib/data/services/settings_registry.dart
+++ b/lib/data/services/settings_registry.dart
@@ -232,11 +232,13 @@ class SettingsRegistry {
             pageBuilder: (_) => DebugSettingsPage(
               onClearToken: () async {},
               onClearData: () async {},
+              onClearFailedAgentContexts: () async {},
               onReprocessCards: () async {},
               onReprocessComments: () async {},
               onReprocessKnowledgeBase: () async {},
               onRebuildSearchIndex: () async {},
               isClearingData: false,
+              isClearingFailedAgentContexts: false,
               isReprocessingCards: false,
               isReprocessingComments: false,
               isReprocessingKnowledgeBase: false,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -56,6 +56,12 @@
   "clearData": "Clear data",
   "confirmClearDataMessage": "Clear data?",
   "confirmClearDataKeepFactsMessage": "Only the Facts directory (raw input) will be kept. All other workspace directories (Cards, Discoveries, KnowledgeInsights, PKM, _System, etc.) will be deleted.\n\nThis action cannot be undone!",
+  "clearFailedAgentContexts": "Clear failed conversation context",
+  "confirmClearFailedAgentContextsMessage": "Clear the saved conversation context for Insight and Schedule agents? This is useful after changing models when previous agent messages are no longer compatible. Facts, cards, knowledge, memories, and model settings will not be deleted.",
+  "failedAgentContextsCleared": "Cleared {count} saved conversation context(s)",
+  "@failedAgentContextsCleared": { "placeholders": { "count": {} } },
+  "clearFailedAgentContextsFailed": "Failed to clear conversation context: {error}",
+  "@clearFailedAgentContextsFailed": { "placeholders": { "error": {} } },
   "dataClearedSuccess": "Data cleared successfully",
   "@clearDataFailed": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -314,6 +314,30 @@ abstract class AppLocalizations {
   /// **'Only the Facts directory (raw input) will be kept. All other workspace directories (Cards, Discoveries, KnowledgeInsights, PKM, _System, etc.) will be deleted.\n\nThis action cannot be undone!'**
   String get confirmClearDataKeepFactsMessage;
 
+  /// No description provided for @clearFailedAgentContexts.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear failed conversation context'**
+  String get clearFailedAgentContexts;
+
+  /// No description provided for @confirmClearFailedAgentContextsMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear the saved conversation context for Insight and Schedule agents? This is useful after changing models when previous agent messages are no longer compatible. Facts, cards, knowledge, memories, and model settings will not be deleted.'**
+  String get confirmClearFailedAgentContextsMessage;
+
+  /// No description provided for @failedAgentContextsCleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Cleared {count} saved conversation context(s)'**
+  String failedAgentContextsCleared(Object count);
+
+  /// No description provided for @clearFailedAgentContextsFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to clear conversation context: {error}'**
+  String clearFailedAgentContextsFailed(Object error);
+
   /// No description provided for @dataClearedSuccess.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -131,6 +131,23 @@ class AppLocalizationsEn extends AppLocalizations {
       'Only the Facts directory (raw input) will be kept. All other workspace directories (Cards, Discoveries, KnowledgeInsights, PKM, _System, etc.) will be deleted.\n\nThis action cannot be undone!';
 
   @override
+  String get clearFailedAgentContexts => 'Clear failed conversation context';
+
+  @override
+  String get confirmClearFailedAgentContextsMessage =>
+      'Clear the saved conversation context for Insight and Schedule agents? This is useful after changing models when previous agent messages are no longer compatible. Facts, cards, knowledge, memories, and model settings will not be deleted.';
+
+  @override
+  String failedAgentContextsCleared(Object count) {
+    return 'Cleared $count saved conversation context(s)';
+  }
+
+  @override
+  String clearFailedAgentContextsFailed(Object error) {
+    return 'Failed to clear conversation context: $error';
+  }
+
+  @override
   String get dataClearedSuccess => 'Data cleared successfully';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -126,6 +126,23 @@ class AppLocalizationsZh extends AppLocalizations {
       '将仅保留 Facts 目录（原始记录），删除工作区内其他所有目录（Cards、Discoveries、KnowledgeInsights、PKM、_System 等）。\n\n此操作不可恢复！';
 
   @override
+  String get clearFailedAgentContexts => '清除失败的对话上下文';
+
+  @override
+  String get confirmClearFailedAgentContextsMessage =>
+      '清除 Insight 和 Schedule Agent 已保存的对话上下文？这适用于切换模型后，旧的 agent 消息与新模型 API 不兼容的情况。Facts、卡片、知识库、记忆和模型配置不会被删除。';
+
+  @override
+  String failedAgentContextsCleared(Object count) {
+    return '已清除 $count 个已保存的对话上下文';
+  }
+
+  @override
+  String clearFailedAgentContextsFailed(Object error) {
+    return '清除对话上下文失败: $error';
+  }
+
+  @override
   String get dataClearedSuccess => '数据清除成功';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -56,6 +56,12 @@
   "clearData": "清除数据",
   "confirmClearDataMessage": "确定要清除数据吗？\n",
   "confirmClearDataKeepFactsMessage": "将仅保留 Facts 目录（原始记录），删除工作区内其他所有目录（Cards、Discoveries、KnowledgeInsights、PKM、_System 等）。\n\n此操作不可恢复！",
+  "clearFailedAgentContexts": "清除失败的对话上下文",
+  "confirmClearFailedAgentContextsMessage": "清除 Insight 和 Schedule Agent 已保存的对话上下文？这适用于切换模型后，旧的 agent 消息与新模型 API 不兼容的情况。Facts、卡片、知识库、记忆和模型配置不会被删除。",
+  "failedAgentContextsCleared": "已清除 {count} 个已保存的对话上下文",
+  "@failedAgentContextsCleared": { "placeholders": { "count": {} } },
+  "clearFailedAgentContextsFailed": "清除对话上下文失败: {error}",
+  "@clearFailedAgentContextsFailed": { "placeholders": { "error": {} } },
   "dataClearedSuccess": "数据清除成功",
   "@clearDataFailed": {
     "placeholders": {

--- a/lib/ui/settings/widgets/debug_settings_page.dart
+++ b/lib/ui/settings/widgets/debug_settings_page.dart
@@ -14,11 +14,13 @@ import 'package:memex/utils/toast_helper.dart';
 class DebugSettingsPage extends StatelessWidget {
   final Future<void> Function() onClearToken;
   final Future<void> Function() onClearData;
+  final Future<void> Function() onClearFailedAgentContexts;
   final Future<void> Function() onReprocessCards;
   final Future<void> Function() onReprocessComments;
   final Future<void> Function() onReprocessKnowledgeBase;
   final Future<void> Function() onRebuildSearchIndex;
   final bool isClearingData;
+  final bool isClearingFailedAgentContexts;
   final bool isReprocessingCards;
   final bool isReprocessingComments;
   final bool isReprocessingKnowledgeBase;
@@ -28,11 +30,13 @@ class DebugSettingsPage extends StatelessWidget {
     super.key,
     required this.onClearToken,
     required this.onClearData,
+    required this.onClearFailedAgentContexts,
     required this.onReprocessCards,
     required this.onReprocessComments,
     required this.onReprocessKnowledgeBase,
     required this.onRebuildSearchIndex,
     required this.isClearingData,
+    required this.isClearingFailedAgentContexts,
     required this.isReprocessingCards,
     required this.isReprocessingComments,
     required this.isReprocessingKnowledgeBase,
@@ -203,6 +207,14 @@ class DebugSettingsPage extends StatelessWidget {
             title: UserStorage.l10n.clearData,
             onTap: onClearData,
             isLoading: isClearingData,
+          ),
+          const SizedBox(height: 12),
+          _buildFunctionTab(
+            context: context,
+            icon: Icons.psychology_alt_outlined,
+            title: UserStorage.l10n.clearFailedAgentContexts,
+            onTap: onClearFailedAgentContexts,
+            isLoading: isClearingFailedAgentContexts,
           ),
           const SizedBox(height: 12),
           _buildFunctionTab(

--- a/lib/ui/settings/widgets/personal_center_screen.dart
+++ b/lib/ui/settings/widgets/personal_center_screen.dart
@@ -36,6 +36,7 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
   bool _isReprocessingComments = false;
   bool _isReprocessingKnowledgeBase = false;
   bool _isRebuildingSearchIndex = false;
+  bool _isClearingFailedAgentContexts = false;
   bool _showAuthBadge = false;
   String? _userAvatar;
 
@@ -666,6 +667,53 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
     }
   }
 
+  Future<void> _clearFailedAgentContexts() async {
+    if (_isClearingFailedAgentContexts) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(UserStorage.l10n.clearFailedAgentContexts),
+        content: Text(UserStorage.l10n.confirmClearFailedAgentContextsMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(UserStorage.l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: Text(UserStorage.l10n.confirmClear),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    setState(() => _isClearingFailedAgentContexts = true);
+    try {
+      final deletedCount =
+          await _memexRouter.clearFailedAgentConversationContexts();
+      if (!mounted) return;
+      ToastHelper.showSuccessWithKey(
+        _scaffoldMessengerKey,
+        UserStorage.l10n.failedAgentContextsCleared(deletedCount),
+      );
+    } catch (e) {
+      _logger.severe('Error clearing failed agent contexts: $e', e);
+      if (!mounted) return;
+      ToastHelper.showErrorWithKey(
+        _scaffoldMessengerKey,
+        UserStorage.l10n.clearFailedAgentContextsFailed(e),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isClearingFailedAgentContexts = false);
+      }
+    }
+  }
+
   Future<void> _clearData() async {
     if (_isClearingData) return;
 
@@ -977,6 +1025,8 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                                   builder: (context) => DebugSettingsPage(
                                     onClearToken: () async => _clearToken(),
                                     onClearData: () async => _clearData(),
+                                    onClearFailedAgentContexts: () async =>
+                                        _clearFailedAgentContexts(),
                                     onReprocessCards: () async =>
                                         _reprocessCards(),
                                     onReprocessComments: () async =>
@@ -991,6 +1041,8 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                                         _isReprocessingComments,
                                     isReprocessingKnowledgeBase:
                                         _isReprocessingKnowledgeBase,
+                                    isClearingFailedAgentContexts:
+                                        _isClearingFailedAgentContexts,
                                     isRebuildingSearchIndex:
                                         _isRebuildingSearchIndex,
                                   ),

--- a/test/agent/state_util_test.dart
+++ b/test/agent/state_util_test.dart
@@ -116,5 +116,51 @@ void main() {
       final message = loaded.history.messages.single as ModelMessage;
       expect(message.thought, ' ');
     });
+
+    test('deletes only agent states matching metadata predicate', () async {
+      final insightState = AgentState(
+        sessionId: 'knowledge_insight_state',
+        metadata: {'userId': userId, 'scene': 'insight'},
+      );
+      final scheduleState = AgentState(
+        sessionId: 'schedule_aggregator_state',
+        metadata: {'userId': userId, 'scene': 'schedule_aggregation'},
+      );
+      final pkmState = AgentState(
+        sessionId: 'pkm_state',
+        metadata: {'userId': userId, 'scene': 'pkm'},
+      );
+      await saveAgentState(insightState);
+      await saveAgentState(scheduleState);
+      await saveAgentState(pkmState);
+
+      final deleted = await deleteAgentStatesWhere(userId, (
+        sessionId,
+        metadata,
+      ) {
+        final scene = metadata['scene'];
+        return scene == 'insight' || scene == 'schedule_aggregation';
+      });
+
+      expect(
+        deleted,
+        unorderedEquals([
+          'knowledge_insight_state',
+          'schedule_aggregator_state',
+        ]),
+      );
+
+      final stateDirPath =
+          await FileSystemService.instance.getAgentStateDirectory(userId);
+      expect(
+        await File('$stateDirPath/knowledge_insight_state.json').exists(),
+        isFalse,
+      );
+      expect(
+        await File('$stateDirPath/schedule_aggregator_state.json').exists(),
+        isFalse,
+      );
+      expect(await File('$stateDirPath/pkm_state.json').exists(), isTrue);
+    });
   });
 }

--- a/test/ui/settings/widgets/debug_settings_page_test.dart
+++ b/test/ui/settings/widgets/debug_settings_page_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/settings/widgets/debug_settings_page.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'language': 'en'});
+    await UserStorage.initL10n();
+  });
+
+  testWidgets('clears failed agent contexts from debugging page', (
+    tester,
+  ) async {
+    var clearCount = 0;
+
+    await _pumpDebugPage(
+      tester,
+      onClearFailedAgentContexts: () async {
+        clearCount += 1;
+      },
+    );
+
+    final clearButton = find.text(UserStorage.l10n.clearFailedAgentContexts);
+    await tester.scrollUntilVisible(
+      clearButton,
+      250,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(clearButton, findsOneWidget);
+
+    await tester.tap(clearButton);
+    await tester.pump();
+
+    expect(clearCount, 1);
+  });
+
+  testWidgets('disables clear failed contexts while loading', (tester) async {
+    var clearCount = 0;
+
+    await _pumpDebugPage(
+      tester,
+      isClearingFailedAgentContexts: true,
+      onClearFailedAgentContexts: () async {
+        clearCount += 1;
+      },
+    );
+
+    final clearButton = find.text(UserStorage.l10n.clearFailedAgentContexts);
+    await tester.scrollUntilVisible(
+      clearButton,
+      250,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    await tester.tap(clearButton);
+    await tester.pump();
+
+    expect(clearCount, 0);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}
+
+Future<void> _pumpDebugPage(
+  WidgetTester tester, {
+  Future<void> Function()? onClearFailedAgentContexts,
+  bool isClearingFailedAgentContexts = false,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: DebugSettingsPage(
+        onClearToken: () async {},
+        onClearData: () async {},
+        onClearFailedAgentContexts: onClearFailedAgentContexts ?? () async {},
+        onReprocessCards: () async {},
+        onReprocessComments: () async {},
+        onReprocessKnowledgeBase: () async {},
+        onRebuildSearchIndex: () async {},
+        isClearingData: false,
+        isClearingFailedAgentContexts: isClearingFailedAgentContexts,
+        isReprocessingCards: false,
+        isReprocessingComments: false,
+        isReprocessingKnowledgeBase: false,
+        isRebuildingSearchIndex: false,
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## 背景

Closes #119
Related #103

Insight 和 Schedule Aggregator 现在都已经按 run-scoped session 执行：正常完成后会删除对应 `AgentState`，失败或中断时才会短期保留，方便 resume。这个生命周期比长期复用完整 LLM 历史更安全，但在模型切换、provider 切换，或模型 API 对历史消息结构不兼容时，失败残留的 `AgentState.history` 仍可能让后续 resume 继续失败。

这个 PR 给 Debugging 页面补一个手动急救入口，用来清掉 Insight / Schedule 失败后残留的对话上下文，而不是让用户通过清空更大范围的数据目录绕过问题。

## 改动

- 在 Debugging 页面新增「清除失败的对话上下文」入口，并加确认弹窗与成功/失败 toast。
- 在 `MemexRouter` 暴露受限清理方法，只删除当前用户下 `scene == insight` 或 `scene == schedule_aggregation` 的 Agent state。
- 在 `state_util` 增加按 metadata predicate 删除 state 文件的工具函数。
- 补齐中英文文案和生成的 l10n 接口。
- 增加 state 工具单测和 Debugging 页面 widget test。

## 边界

这个入口只清理失败/中断后残留的 agent 对话上下文，不删除：

- Facts 原始输入
- Cards 时间线卡片
- PKM / KnowledgeInsights / ScheduleAggregations
- 长期 Memory
- 模型配置或用户设置

## 验证

- `flutter test --no-pub test/agent/state_util_test.dart test/agent/schedule_aggregation_run_lifecycle_test.dart test/ui/settings/widgets/debug_settings_page_test.dart`
- `dart analyze lib/agent/state_util.dart lib/data/repositories/memex_router.dart lib/ui/settings/widgets/debug_settings_page.dart lib/ui/settings/widgets/personal_center_screen.dart test/agent/state_util_test.dart test/ui/settings/widgets/debug_settings_page_test.dart`
- `flutter analyze --no-pub --no-fatal-infos` 可运行，但当前 main 仍有既有 warning/info（本 PR 未新增 touched-file analyzer 问题）