### PR TITLE
[codex] 修复 preflight summary 评论权限失败

### DIFF
--- a/.github/workflows/pr-preflight-summary.yml
+++ b/.github/workflows/pr-preflight-summary.yml
@@ -9,7 +9,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: pr-preflight-summary-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}

--- a/scripts/pr_preflight_summary_comment.py
+++ b/scripts/pr_preflight_summary_comment.py
@@ -73,6 +73,19 @@ class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
         return None
 
 
+class GitHubApiError(RuntimeError):
+    def __init__(self, *, method: str, path: str, status: int, body: str) -> None:
+        self.method = method
+        self.path = path
+        self.status = status
+        self.body = body.strip()
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        details = f": {self.body}" if self.body else ""
+        return f"GitHub API {self.method} {self.path} failed with HTTP {self.status}{details}"
+
+
 class GitHubClient:
     def __init__(self, *, repo: str, token: str) -> None:
         self.repo = repo
@@ -106,8 +119,17 @@ class GitHubClient:
         if data is not None:
             headers["Content-Type"] = "application/json"
         request = urllib.request.Request(url, data=body, headers=headers, method=method)
-        with urllib.request.urlopen(request, timeout=30) as response:
-            raw = response.read()
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as exc:
+            error_body = exc.read().decode("utf-8", errors="replace")
+            raise GitHubApiError(
+                method=method,
+                path=path,
+                status=exc.code,
+                body=error_body,
+            ) from exc
         if not raw:
             return None
         return json.loads(raw.decode("utf-8"))
@@ -422,7 +444,12 @@ def main(argv: list[str] | None = None) -> int:
         print(body)
         return 0
 
-    client.upsert_comment(pr_number=pr_number, body=body)
+    try:
+        client.upsert_comment(pr_number=pr_number, body=body)
+    except GitHubApiError as exc:
+        print(f"::warning::Could not update combined preflight comment for PR #{pr_number}. {exc}")
+        return 0
+
     print(f"Updated combined preflight comment for PR #{pr_number}.")
     return 0
 

--- a/tests/tools/test_pr_preflight_summary_comment.py
+++ b/tests/tools/test_pr_preflight_summary_comment.py
@@ -1,0 +1,34 @@
+from io import BytesIO
+import unittest
+from unittest import mock
+import urllib.error
+
+from scripts.pr_preflight_summary_comment import (
+    GitHubApiError,
+    GitHubClient,
+)
+
+
+class PreflightSummaryCommentTest(unittest.TestCase):
+    def test_request_json_preserves_github_error_body(self):
+        response = BytesIO(b'{"message":"Resource not accessible by integration"}')
+        error = urllib.error.HTTPError(
+            "https://api.github.com/repos/memex-lab/memex/issues/120/comments",
+            403,
+            "Forbidden",
+            {},
+            response,
+        )
+        client = GitHubClient(repo="memex-lab/memex", token="token")
+
+        with mock.patch("urllib.request.urlopen", side_effect=error):
+            with self.assertRaises(GitHubApiError) as context:
+                client.request_json("POST", "/issues/120/comments", data={"body": "x"})
+
+        self.assertEqual(context.exception.status, 403)
+        self.assertIn("Resource not accessible by integration", str(context.exception))
+        self.assertIn("POST /issues/120/comments", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

这次失败的 run 是 `PR Preflight Summary`，不是 Flutter quality 本身。日志显示 summary workflow 在创建合并预检评论时调用 GitHub API 返回 `HTTP 403: Forbidden`，导致整个 summary job 失败。

## 改动

- 将 `pr-preflight-summary.yml` 的 `pull-requests` 权限从 `read` 调整为 `write`，和它要更新 PR comment 的行为对齐。
- `scripts/pr_preflight_summary_comment.py` 捕获 GitHub API 的 HTTP error，并保留 GitHub 返回的错误 body，方便后续判断真实原因。
- 如果只是 summary comment 更新失败，脚本降级为 workflow warning 并返回成功，避免非阻塞的汇总评论把真正的 PR gate 打红。
- 增加单测覆盖 403 错误 body 保留逻辑。

## 验证

- `python3 -m unittest tests.tools.test_pr_preflight_summary_comment tests.tools.test_compare_flutter_analyze tests.tools.test_compare_flutter_test_failures tests.tools.test_pr_policy_check -v`
- `python3 -m py_compile scripts/pr_preflight_summary_comment.py scripts/compare_flutter_analyze.py scripts/compare_flutter_test_failures.py scripts/pr_policy_check.py tests/tools/test_pr_preflight_summary_comment.py`
- `git diff --check`
- 使用 `--dry-run` 对失败 run 的触发 run `25996033164` 生成 summary comment，确认 artifact 读取和内容组装正常。

## 说明

这次不会改变 Policy Preflight 或 Flutter Quality 的判定逻辑。Summary comment 是展示层，失败时应该提示 warning，而不应该让 PR 质量门禁失败。
