### PR TITLE
[codex] 为 preflight summary 增加简短详情

### DIFF
--- a/scripts/pr_preflight_summary_comment.py
+++ b/scripts/pr_preflight_summary_comment.py
@@ -314,6 +314,70 @@ def quality_label(overall: str, conclusion: str) -> tuple[str, str]:
     }.get(overall, ("UNKNOWN", "未知"))
 
 
+def policy_detail(policy_data: dict[str, Any]) -> tuple[str, str]:
+    findings = policy_data.get("findings", [])
+    if not isinstance(findings, list):
+        findings = []
+    reject_count = sum(1 for item in findings if isinstance(item, dict) and item.get("severity") == "reject")
+    high_count = sum(1 for item in findings if isinstance(item, dict) and item.get("severity") == "high")
+    warn_count = sum(1 for item in findings if isinstance(item, dict) and item.get("severity") == "warn")
+    decision = str(policy_data.get("decision", "unknown"))
+
+    if decision == "reject":
+        return (
+            f"Found {reject_count} blocking policy issue(s); fix them before normal review.",
+            f"命中 {reject_count} 条打回规则，需要修复后再进入普通 review。",
+        )
+    if decision == "high_risk":
+        warning_part_en = f" and {warn_count} warning(s)" if warn_count else ""
+        warning_part_zh = f"，另有 {warn_count} 条警告" if warn_count else ""
+        return (
+            f"Found {high_count} high-risk policy signal(s){warning_part_en}; maintainer review is required.",
+            f"命中 {high_count} 条高风险规则{warning_part_zh}，需要 maintainer 人工确认。",
+        )
+    if decision == "low_risk":
+        if warn_count:
+            return (
+                f"No blocking or high-risk policy signal; {warn_count} warning(s) remain for review context.",
+                f"未命中打回或高风险规则，仅有 {warn_count} 条警告供 review 参考。",
+            )
+        return (
+            "No blocking, high-risk, or warning policy signal was found.",
+            "未命中打回、高风险或警告规则。",
+        )
+    return (
+        "Policy decision is unknown; check the detailed report below.",
+        "Policy 判定不可识别，请查看下方详情。",
+    )
+
+
+def flutter_detail(
+    *,
+    flutter_data: dict[str, Any],
+    analyzer_data: dict[str, Any],
+    test_data: dict[str, Any],
+    conclusion: str,
+) -> tuple[str, str]:
+    overall = str(flutter_data.get("overall", "unknown"))
+    analyzer_new = int(analyzer_data.get("new_count") or 0)
+    test_new = int(test_data.get("new_count") or 0)
+
+    if conclusion == "success" and overall == "passed":
+        return (
+            "Analyzer and test baselines found no newly introduced issue.",
+            "Analyzer 和 test baseline 均未发现新增问题。",
+        )
+    if analyzer_new or test_new:
+        return (
+            f"Found {analyzer_new} new analyzer issue(s) and {test_new} new test failure(s).",
+            f"发现 {analyzer_new} 个新增 analyzer 问题和 {test_new} 个新增失败测试。",
+        )
+    return (
+        "Flutter quality did not complete successfully; check the detailed report below.",
+        "Flutter quality 未完整通过，请查看下方详情。",
+    )
+
+
 def limited(text: str, *, max_chars: int = 25000) -> str:
     if len(text) <= max_chars:
         return text
@@ -336,18 +400,28 @@ def details(summary: str, body: str) -> str:
 def build_comment(*, policy: TargetResult, flutter: TargetResult) -> str:
     policy_data = load_json_file(policy.files, policy.target.json_file)
     flutter_data = load_json_file(flutter.files, flutter.target.json_file)
+    analyzer_data = load_json_file(flutter.files, "flutter-analyze.json")
+    test_data = load_json_file(flutter.files, "flutter-test.json")
     policy_md = find_file(policy.files, policy.target.markdown_file) or "Policy preflight report was not produced."
     flutter_md = find_file(flutter.files, flutter.target.markdown_file) or "Flutter quality report was not produced."
 
     decision = policy_data.get("decision", "unknown")
     decision_en, decision_zh = decision_label(decision)
     flutter_overall = str(flutter_data.get("overall", "unknown"))
-    flutter_en, flutter_zh = quality_label(flutter_overall, str(flutter.run.get("conclusion", "")))
+    flutter_conclusion = str(flutter.run.get("conclusion", ""))
+    flutter_en, flutter_zh = quality_label(flutter_overall, flutter_conclusion)
+    policy_detail_en, policy_detail_zh = policy_detail(policy_data)
+    flutter_detail_en, flutter_detail_zh = flutter_detail(
+        flutter_data=flutter_data,
+        analyzer_data=analyzer_data,
+        test_data=test_data,
+        conclusion=flutter_conclusion,
+    )
 
     if decision == "reject":
         final_zh = "打回：规则预检命中阻断项，需要修复后再进入普通 review。"
         final_en = "Rejected: policy preflight found a blocking issue."
-    elif str(flutter.run.get("conclusion", "")) != "success" or flutter_overall != "passed":
+    elif flutter_conclusion != "success" or flutter_overall != "passed":
         final_zh = "需要修复：Flutter quality 发现新增 analyzer/test 问题或未完整完成。"
         final_en = "Needs fixes: Flutter quality found new analyzer/test issues or did not complete."
     elif decision == "high_risk":
@@ -368,8 +442,8 @@ def build_comment(*, policy: TargetResult, flutter: TargetResult) -> str:
             "\n".join(
                 [
                     f"- 统一结论：{final_zh}",
-                    f"- Policy preflight：`{decision_zh}`",
-                    f"- Flutter quality：`{flutter_zh}`",
+                    f"- Policy preflight：`{decision_zh}`。{policy_detail_zh}",
+                    f"- Flutter quality：`{flutter_zh}`。{flutter_detail_zh}",
                     f"- PR head：`{policy.context['head_sha']}`",
                     f"- Policy run：[{policy.run['id']}]({policy.run['html_url']})",
                     f"- Flutter run：[{flutter.run['id']}]({flutter.run['html_url']})",
@@ -379,8 +453,8 @@ def build_comment(*, policy: TargetResult, flutter: TargetResult) -> str:
             "\n".join(
                 [
                     f"- Combined result: {final_en}",
-                    f"- Policy preflight: `{decision_en}`",
-                    f"- Flutter quality: `{flutter_en}`",
+                    f"- Policy preflight: `{decision_en}`. {policy_detail_en}",
+                    f"- Flutter quality: `{flutter_en}`. {flutter_detail_en}",
                     f"- PR head: `{policy.context['head_sha']}`",
                     f"- Policy run: [{policy.run['id']}]({policy.run['html_url']})",
                     f"- Flutter run: [{flutter.run['id']}]({flutter.run['html_url']})",

--- a/tests/tools/test_pr_preflight_summary_comment.py
+++ b/tests/tools/test_pr_preflight_summary_comment.py
@@ -6,6 +6,9 @@ import urllib.error
 from scripts.pr_preflight_summary_comment import (
     GitHubApiError,
     GitHubClient,
+    TARGETS,
+    TargetResult,
+    build_comment,
 )
 
 
@@ -28,6 +31,52 @@ class PreflightSummaryCommentTest(unittest.TestCase):
         self.assertEqual(context.exception.status, 403)
         self.assertIn("Resource not accessible by integration", str(context.exception))
         self.assertIn("POST /issues/120/comments", str(context.exception))
+
+    def test_build_comment_includes_one_sentence_details(self):
+        context = {
+            "pr_number": 120,
+            "head_sha": "abc123",
+        }
+        policy = TargetResult(
+            target=TARGETS[0],
+            run={"id": 1, "html_url": "https://example.com/policy", "conclusion": "success"},
+            context=context,
+            files={
+                "preflight.json": """
+                {
+                  "decision": "low_risk",
+                  "findings": [
+                    {"severity": "warn", "rule_id": "missing-test-signal"}
+                  ]
+                }
+                """,
+                "preflight.md": "policy details",
+            },
+        )
+        flutter = TargetResult(
+            target=TARGETS[1],
+            run={"id": 2, "html_url": "https://example.com/flutter", "conclusion": "success"},
+            context=context,
+            files={
+                "flutter-quality.json": """
+                {
+                  "overall": "passed",
+                  "analyzer": {"status": "passed"},
+                  "tests": {"status": "passed"}
+                }
+                """,
+                "flutter-analyze.json": '{"new_count": 0}',
+                "flutter-test.json": '{"new_count": 0}',
+                "flutter-quality.md": "flutter details",
+            },
+        )
+
+        comment = build_comment(policy=policy, flutter=flutter)
+
+        self.assertIn("Policy preflight：`低风险`。未命中打回或高风险规则，仅有 1 条警告供 review 参考。", comment)
+        self.assertIn("Flutter quality：`通过`。Analyzer 和 test baseline 均未发现新增问题。", comment)
+        self.assertIn("Policy preflight: `LOW RISK`. No blocking or high-risk policy signal; 1 warning(s) remain", comment)
+        self.assertIn("Flutter quality: `PASS`. Analyzer and test baselines found no newly introduced issue.", comment)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

当前 `PR Preflight Summary` 里 `Policy preflight` 和 `Flutter quality` 两行只显示状态，例如 `低风险` / `通过`，需要点开详情才知道为什么。

## 改动

- 为 `Policy preflight` 状态行增加一句简短解释：
  - 低风险：说明未命中打回/高风险规则，以及是否仅有 warning。
  - 高风险：说明命中的高风险规则数量，以及是否还有 warning。
  - 打回：说明命中的阻断规则数量。
- 为 `Flutter quality` 状态行增加一句简短解释：
  - 通过：说明 analyzer/test baseline 均无新增问题。
  - 失败：说明新增 analyzer issue / test failure 数量，或提示查看详情。
- 英文区同步增加同等信息。
- 增加单测覆盖 summary comment 中的一句话详情。

## 示例

```text
- Policy preflight：`低风险`。未命中打回、高风险或警告规则。
- Flutter quality：`通过`。Analyzer 和 test baseline 均未发现新增问题。
```

## 验证

- `python3 -m unittest tests.tools.test_pr_preflight_summary_comment tests.tools.test_compare_flutter_analyze tests.tools.test_compare_flutter_test_failures tests.tools.test_pr_policy_check -v`
- `python3 -m py_compile scripts/pr_preflight_summary_comment.py tests/tools/test_pr_preflight_summary_comment.py`
- `git diff --check`
- 使用 `--dry-run` 生成真实历史 run 的 summary comment，确认输出格式符合预期。
