### PR TITLE
[codex] 支持删除历史备份

### DIFF
--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -575,6 +575,31 @@ class BackupService {
     }
   }
 
+  /// Delete a stored automatic/safety backup snapshot.
+  static Future<void> deleteStoredBackup(BackupSnapshot snapshot) async {
+    if (snapshot.isAndroidDocument) {
+      await _deleteAndroidDocument(snapshot.documentUri!);
+      return;
+    }
+
+    final filePath = snapshot.filePath;
+    if (filePath == null || filePath.isEmpty) {
+      throw Exception('Backup snapshot has no deletable source');
+    }
+
+    final normalizedPath = _normalizeFilePath(filePath);
+    if (!isMemexBackupFile(normalizedPath)) {
+      throw const InvalidBackupFileException(
+        'Invalid backup file. Please select a .memex file.',
+      );
+    }
+
+    final file = File(normalizedPath);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
   /// List automatic/safety backups from both the platform default directory and
   /// the user's Android SAF directory, if configured.
   static Future<List<BackupSnapshot>> listStoredBackups() async {
@@ -926,13 +951,17 @@ class BackupService {
       final documentUri = snapshot.documentUri;
       if (documentUri == null) continue;
       try {
-        await _backupStorageChannel.invokeMethod<void>('deleteDocument', {
-          'documentUri': documentUri,
-        });
+        await _deleteAndroidDocument(documentUri);
       } catch (e) {
         _logger.warning('Failed to delete old Android backup $documentUri: $e');
       }
     }
+  }
+
+  static Future<void> _deleteAndroidDocument(String documentUri) async {
+    await _backupStorageChannel.invokeMethod<void>('deleteDocument', {
+      'documentUri': documentUri,
+    });
   }
 
   static Future<BackupFileInfo> inspectBackup(String backupFilePath) async {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -846,6 +846,26 @@
   "noStoredBackups": "Automatic backups will appear here after the first snapshot.",
   "refresh": "Refresh",
   "restoreThisBackup": "Restore this backup",
+  "deleteThisBackup": "Delete this backup",
+  "confirmDeleteBackup": "Delete backup?",
+  "@confirmDeleteBackupMessage": {
+    "placeholders": {
+      "fileName": {}
+    }
+  },
+  "confirmDeleteBackupMessage": "Delete {fileName}? This removes the stored backup file and cannot be undone.",
+  "@backupDeleted": {
+    "placeholders": {
+      "fileName": {}
+    }
+  },
+  "backupDeleted": "Backup deleted: {fileName}",
+  "@backupDeleteFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "backupDeleteFailed": "Could not delete backup: {error}",
   "creatingSafetySnapshot": "Creating safety snapshot...",
   "@autoBackupCreated": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3404,6 +3404,36 @@ abstract class AppLocalizations {
   /// **'Restore this backup'**
   String get restoreThisBackup;
 
+  /// No description provided for @deleteThisBackup.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete this backup'**
+  String get deleteThisBackup;
+
+  /// No description provided for @confirmDeleteBackup.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete backup?'**
+  String get confirmDeleteBackup;
+
+  /// No description provided for @confirmDeleteBackupMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete {fileName}? This removes the stored backup file and cannot be undone.'**
+  String confirmDeleteBackupMessage(Object fileName);
+
+  /// No description provided for @backupDeleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Backup deleted: {fileName}'**
+  String backupDeleted(Object fileName);
+
+  /// No description provided for @backupDeleteFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not delete backup: {error}'**
+  String backupDeleteFailed(Object error);
+
   /// No description provided for @creatingSafetySnapshot.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1860,6 +1860,27 @@ class AppLocalizationsEn extends AppLocalizations {
   String get restoreThisBackup => 'Restore this backup';
 
   @override
+  String get deleteThisBackup => 'Delete this backup';
+
+  @override
+  String get confirmDeleteBackup => 'Delete backup?';
+
+  @override
+  String confirmDeleteBackupMessage(Object fileName) {
+    return 'Delete $fileName? This removes the stored backup file and cannot be undone.';
+  }
+
+  @override
+  String backupDeleted(Object fileName) {
+    return 'Backup deleted: $fileName';
+  }
+
+  @override
+  String backupDeleteFailed(Object error) {
+    return 'Could not delete backup: $error';
+  }
+
+  @override
   String get creatingSafetySnapshot => 'Creating safety snapshot...';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1797,6 +1797,27 @@ class AppLocalizationsZh extends AppLocalizations {
   String get restoreThisBackup => '恢复此备份';
 
   @override
+  String get deleteThisBackup => '删除此备份';
+
+  @override
+  String get confirmDeleteBackup => '删除备份？';
+
+  @override
+  String confirmDeleteBackupMessage(Object fileName) {
+    return '删除 $fileName？这会移除已保存的备份文件，且无法撤销。';
+  }
+
+  @override
+  String backupDeleted(Object fileName) {
+    return '备份已删除：$fileName';
+  }
+
+  @override
+  String backupDeleteFailed(Object error) {
+    return '无法删除备份：$error';
+  }
+
+  @override
   String get creatingSafetySnapshot => '正在创建安全快照...';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -846,6 +846,26 @@
   "noStoredBackups": "创建第一个自动快照后会显示在这里。",
   "refresh": "刷新",
   "restoreThisBackup": "恢复此备份",
+  "deleteThisBackup": "删除此备份",
+  "confirmDeleteBackup": "删除备份？",
+  "@confirmDeleteBackupMessage": {
+    "placeholders": {
+      "fileName": {}
+    }
+  },
+  "confirmDeleteBackupMessage": "删除 {fileName}？这会移除已保存的备份文件，且无法撤销。",
+  "@backupDeleted": {
+    "placeholders": {
+      "fileName": {}
+    }
+  },
+  "backupDeleted": "备份已删除：{fileName}",
+  "@backupDeleteFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "backupDeleteFailed": "无法删除备份：{error}",
   "creatingSafetySnapshot": "正在创建安全快照...",
   "@autoBackupCreated": {
     "placeholders": {

--- a/lib/ui/settings/widgets/backup_restore_page.dart
+++ b/lib/ui/settings/widgets/backup_restore_page.dart
@@ -12,12 +12,13 @@ import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/toast_helper.dart';
 import 'package:memex/utils/user_storage.dart';
 
-typedef AutoBackupCreator =
-    Future<BackupSnapshot?> Function({
-      String trigger,
-      bool force,
-      void Function(String status)? onProgress,
-    });
+typedef AutoBackupCreator = Future<BackupSnapshot?> Function({
+  String trigger,
+  bool force,
+  void Function(String status)? onProgress,
+});
+
+typedef StoredBackupDeleter = Future<void> Function(BackupSnapshot snapshot);
 
 class BackupRestorePage extends StatefulWidget {
   final bool? isAndroidOverride;
@@ -25,6 +26,7 @@ class BackupRestorePage extends StatefulWidget {
   final Future<String> Function()? currentBackupLocationLabel;
   final Future<List<BackupSnapshot>> Function()? listStoredBackups;
   final AutoBackupCreator? createAutoBackup;
+  final StoredBackupDeleter? deleteStoredBackup;
   final Future<void> Function()? useDefaultBackupDirectory;
   final Future<AndroidBackupDirectory?> Function()? pickAndroidBackupDirectory;
 
@@ -35,6 +37,7 @@ class BackupRestorePage extends StatefulWidget {
     this.currentBackupLocationLabel,
     this.listStoredBackups,
     this.createAutoBackup,
+    this.deleteStoredBackup,
     this.useDefaultBackupDirectory,
     this.pickAndroidBackupDirectory,
   });
@@ -51,6 +54,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
   bool _isRestoring = false;
   bool _isCreatingSnapshot = false;
   bool _isPickingLocation = false;
+  String? _deletingBackupId;
   bool _autoBackupEnabled = false;
   String _statusText = '';
   String _estimatedSize = '';
@@ -68,11 +72,10 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     final userId = await UserStorage.getUserId();
     final size = includeEstimatedSize
         ? await (widget.estimateBackupSize ??
-              BackupService.estimateBackupSize)()
+            BackupService.estimateBackupSize)()
         : null;
-    final location =
-        await (widget.currentBackupLocationLabel ??
-            BackupService.currentBackupLocationLabel)();
+    final location = await (widget.currentBackupLocationLabel ??
+        BackupService.currentBackupLocationLabel)();
     final snapshots =
         await (widget.listStoredBackups ?? BackupService.listStoredBackups)();
     final autoEnabled = userId != null && userId.isNotEmpty
@@ -313,6 +316,62 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     );
   }
 
+  Future<void> _deleteStoredBackup(BackupSnapshot snapshot) async {
+    if (_deletingBackupId != null) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: Colors.white,
+        title: Text(UserStorage.l10n.confirmDeleteBackup),
+        content: Text(
+          UserStorage.l10n.confirmDeleteBackupMessage(snapshot.name),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(UserStorage.l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: Text(UserStorage.l10n.delete),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    setState(() {
+      _deletingBackupId = snapshot.id;
+      _statusText = '';
+    });
+
+    try {
+      await (widget.deleteStoredBackup ?? BackupService.deleteStoredBackup)(
+        snapshot,
+      );
+      await _loadPageData(includeEstimatedSize: false);
+      if (!mounted) return;
+      setState(() {
+        _deletingBackupId = null;
+        _statusText = UserStorage.l10n.backupDeleted(snapshot.name);
+      });
+    } catch (e, stack) {
+      _logger.warning('Failed to delete backup ${snapshot.name}: $e', e, stack);
+      if (mounted) {
+        setState(() {
+          _deletingBackupId = null;
+          _statusText = '';
+        });
+        ToastHelper.showError(
+          context,
+          UserStorage.l10n.backupDeleteFailed(e.toString()),
+        );
+      }
+    }
+  }
+
   Future<bool?> _confirmRestore({BackupFileInfo? backupInfo}) {
     return showDialog<bool>(
       context: context,
@@ -401,11 +460,11 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
   @override
   Widget build(BuildContext context) {
-    final isBusy =
-        _isBackingUp ||
+    final isBusy = _isBackingUp ||
         _isRestoring ||
         _isCreatingSnapshot ||
-        _isPickingLocation;
+        _isPickingLocation ||
+        _deletingBackupId != null;
 
     return Scaffold(
       appBar: AppBar(
@@ -626,7 +685,9 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
                 snapshot: snapshot,
                 dateText: _formatDateTime(snapshot.createdAt),
                 sizeText: _formatBytes(snapshot.sizeBytes),
+                isDeleting: _deletingBackupId == snapshot.id,
                 onRestore: isBusy ? null : () => _restoreStoredBackup(snapshot),
+                onDelete: isBusy ? null : () => _deleteStoredBackup(snapshot),
               ),
             ),
         ],
@@ -767,13 +828,17 @@ class _StoredBackupTile extends StatelessWidget {
   final BackupSnapshot snapshot;
   final String dateText;
   final String sizeText;
+  final bool isDeleting;
   final VoidCallback? onRestore;
+  final VoidCallback? onDelete;
 
   const _StoredBackupTile({
     required this.snapshot,
     required this.dateText,
     required this.sizeText,
+    required this.isDeleting,
     required this.onRestore,
+    required this.onDelete,
   });
 
   @override
@@ -809,10 +874,29 @@ class _StoredBackupTile extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
             style: const TextStyle(fontSize: 12),
           ),
-          trailing: IconButton(
-            tooltip: l10n.restoreThisBackup,
-            onPressed: onRestore,
-            icon: const Icon(Icons.restore_outlined),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                key: ValueKey('backup-restore-${snapshot.id}'),
+                tooltip: l10n.restoreThisBackup,
+                onPressed: onRestore,
+                icon: const Icon(Icons.restore_outlined),
+              ),
+              IconButton(
+                key: ValueKey('backup-delete-${snapshot.id}'),
+                tooltip: l10n.deleteThisBackup,
+                onPressed: onDelete,
+                color: const Color(0xFFDC2626),
+                icon: isDeleting
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.delete_outline),
+              ),
+            ],
           ),
         ),
       ),

--- a/test/data/services/backup_service_test.dart
+++ b/test/data/services/backup_service_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/backup_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/db/app_database.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:path/path.dart' as p;
 // ignore: depend_on_referenced_packages
@@ -45,6 +46,7 @@ void main() {
 
   tearDown(() async {
     _clearPathProviderChannelMock();
+    _clearBackupStorageChannelMock();
     PathProviderPlatform.instance = originalPathProvider;
     if (await tempDir.exists()) {
       await tempDir.delete(recursive: true);
@@ -197,6 +199,101 @@ void main() {
     expect(safetyFiles, isNotEmpty);
   });
 
+  test('deleteStoredBackup removes only the selected local snapshot', () async {
+    final backupDir = await BackupService.resolveDefaultBackupDirectory();
+    final target = File(
+      p.join(backupDir.path, 'memex_auto_2026-05-15T10-00-00.memex'),
+    );
+    final keepAuto = File(
+      p.join(backupDir.path, 'memex_auto_2026-05-16T10-00-00.memex'),
+    );
+    final keepSafety = File(
+      p.join(
+        backupDir.path,
+        'memex_safety_before_restore_2026-05-16T11-00-00.memex',
+      ),
+    );
+    final ignoredText = File(p.join(backupDir.path, 'notes.txt'));
+
+    await target.writeAsBytes([1]);
+    await keepAuto.writeAsBytes([2]);
+    await keepSafety.writeAsBytes([3]);
+    await ignoredText.writeAsString('not a backup');
+
+    final snapshots = await BackupService.listStoredBackups();
+    final targetSnapshot = snapshots.firstWhere(
+      (snapshot) => snapshot.name == p.basename(target.path),
+    );
+
+    await BackupService.deleteStoredBackup(targetSnapshot);
+
+    expect(await target.exists(), isFalse);
+    expect(await keepAuto.exists(), isTrue);
+    expect(await keepSafety.exists(), isTrue);
+    expect(await ignoredText.exists(), isTrue);
+
+    final remainingNames = (await BackupService.listStoredBackups())
+        .map((snapshot) => snapshot.name)
+        .toSet();
+    expect(remainingNames, isNot(contains(p.basename(target.path))));
+    expect(remainingNames, contains(p.basename(keepAuto.path)));
+    expect(remainingNames, contains(p.basename(keepSafety.path)));
+  });
+
+  test('deleteStoredBackup delegates Android document deletion', () async {
+    final deletedUris = <String>[];
+    _mockBackupStorageChannel((call) async {
+      if (call.method == 'deleteDocument') {
+        deletedUris.add((call.arguments as Map)['documentUri'] as String);
+      }
+      return null;
+    });
+
+    await BackupService.deleteStoredBackup(
+      BackupSnapshot(
+        id: 'content://backups/auto',
+        name: 'memex_auto_2026-05-16T10-00-00.memex',
+        createdAt: DateTime(2026, 5, 16, 10),
+        sizeBytes: 12,
+        documentUri: 'content://backups/auto',
+      ),
+    );
+
+    expect(deletedUris, ['content://backups/auto']);
+  });
+
+  test('restore leaves stored backup history files untouched', () async {
+    final backupDir = await BackupService.resolveDefaultBackupDirectory();
+    final historyAuto = File(
+      p.join(backupDir.path, 'memex_auto_2026-05-15T10-00-00.memex'),
+    );
+    final historySafety = File(
+      p.join(
+        backupDir.path,
+        'memex_safety_before_restore_2026-05-16T11-00-00.memex',
+      ),
+    );
+    await historyAuto.writeAsBytes([1, 2, 3]);
+    await historySafety.writeAsBytes([4, 5, 6]);
+
+    final exportedDir = Directory(p.join(tempDir.path, 'ExportedBackups'));
+    final backupPath = await BackupService.createBackup(
+      outputDirectory: exportedDir.path,
+    );
+
+    try {
+      await BackupService.restoreBackup(backupPath);
+    } finally {
+      if (AppDatabase.isInitialized) {
+        await AppDatabase.instance.close();
+      }
+    }
+
+    expect(await historyAuto.exists(), isTrue);
+    expect(await historySafety.exists(), isTrue);
+    expect(await File(backupPath).exists(), isTrue);
+  });
+
   group('inspectBackup', () {
     test('reads backup manifest metadata', () async {
       final file = await _writeBackup(
@@ -273,28 +370,46 @@ void main() {
 void _mockPathProviderChannel(String rootPath) {
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(
-    const MethodChannel('plugins.flutter.io/path_provider'),
-    (call) async {
-      switch (call.method) {
-        case 'getTemporaryDirectory':
-        case 'getApplicationDocumentsDirectory':
-        case 'getApplicationSupportDirectory':
-        case 'getExternalStorageDirectory':
-          return rootPath;
-        case 'getExternalStorageDirectories':
-          return <String>[rootPath];
-      }
-      return null;
-    },
-  );
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (call) async {
+          switch (call.method) {
+            case 'getTemporaryDirectory':
+            case 'getApplicationDocumentsDirectory':
+            case 'getApplicationSupportDirectory':
+            case 'getExternalStorageDirectory':
+              return rootPath;
+            case 'getExternalStorageDirectories':
+              return <String>[rootPath];
+          }
+          return null;
+        },
+      );
 }
 
 void _clearPathProviderChannelMock() {
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(
-    const MethodChannel('plugins.flutter.io/path_provider'),
-    null,
-  );
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        null,
+      );
+}
+
+void _mockBackupStorageChannel(
+  Future<dynamic> Function(MethodCall call) handler,
+) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('com.memexlab.memex/backup_storage'),
+        handler,
+      );
+}
+
+void _clearBackupStorageChannelMock() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('com.memexlab.memex/backup_storage'),
+        null,
+      );
 }
 
 class FakePathProviderPlatform extends PathProviderPlatform

--- a/test/ui/settings/widgets/backup_restore_page_test.dart
+++ b/test/ui/settings/widgets/backup_restore_page_test.dart
@@ -73,6 +73,90 @@ void main() {
     },
   );
 
+  testWidgets('deletes one backup from a mixed history after confirmation', (
+    tester,
+  ) async {
+    const oldAutoName = 'memex_auto_2026-05-14T10-00-00.memex';
+    const latestAutoName = 'memex_auto_2026-05-15T10-00-00.memex';
+    const safetyName = 'memex_safety_before_restore_2026-05-15T10-05-00.memex';
+    final oldAutoSnapshot = BackupSnapshot(
+      id: 'old-auto',
+      name: oldAutoName,
+      createdAt: DateTime(2026, 5, 14, 10),
+      sizeBytes: 3,
+      filePath: '/tmp/$oldAutoName',
+    );
+    final latestAutoSnapshot = BackupSnapshot(
+      id: 'android-latest-auto',
+      name: latestAutoName,
+      createdAt: DateTime(2026, 5, 15, 10),
+      sizeBytes: 5 * 1024 * 1024,
+      documentUri: 'content://backups/latest',
+    );
+    final safetySnapshot = BackupSnapshot(
+      id: 'local-safety',
+      name: safetyName,
+      createdAt: DateTime(2026, 5, 15, 10, 5),
+      sizeBytes: 8,
+      filePath: '/tmp/$safetyName',
+    );
+    final snapshots = <BackupSnapshot>[
+      safetySnapshot,
+      latestAutoSnapshot,
+      oldAutoSnapshot,
+    ];
+    final deletedIds = <String>[];
+
+    await _pumpBackupPage(
+      tester,
+      listStoredBackups: () async => List<BackupSnapshot>.of(snapshots),
+      deleteStoredBackup: (snapshot) async {
+        deletedIds.add(snapshot.id);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        snapshots.removeWhere((item) => item.id == snapshot.id);
+      },
+    );
+
+    await _scrollUntilVisible(tester, find.text(oldAutoName));
+    await tester.tap(find.byKey(const ValueKey('backup-delete-old-auto')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text(UserStorage.l10n.confirmDeleteBackup), findsOneWidget);
+    expect(
+      find.text(UserStorage.l10n.confirmDeleteBackupMessage(oldAutoName)),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text(UserStorage.l10n.cancel));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(deletedIds, isEmpty);
+    expect(find.text(oldAutoName), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('backup-delete-old-auto')));
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.text(UserStorage.l10n.delete));
+    await tester.pump();
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    });
+    await tester.pumpAndSettle();
+
+    expect(deletedIds, ['old-auto']);
+    expect(find.text(oldAutoName), findsNothing);
+    expect(find.text(latestAutoName), findsOneWidget);
+    expect(find.text(safetyName), findsOneWidget);
+
+    await _scrollUntilVisible(
+      tester,
+      find.text(UserStorage.l10n.backupDeleted(oldAutoName)),
+    );
+    expect(
+      find.text(UserStorage.l10n.backupDeleted(oldAutoName)),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('manual snapshot button refreshes list and status', (
     tester,
   ) async {
@@ -178,6 +262,7 @@ Future<void> _pumpBackupPage(
   Future<int> Function()? estimateBackupSize,
   Future<List<BackupSnapshot>> Function()? listStoredBackups,
   AutoBackupCreator? createAutoBackup,
+  StoredBackupDeleter? deleteStoredBackup,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -189,6 +274,7 @@ Future<void> _pumpBackupPage(
         currentBackupLocationLabel: () async => '/tmp/Backups',
         listStoredBackups: listStoredBackups ?? () async => const [],
         createAutoBackup: createAutoBackup,
+        deleteStoredBackup: deleteStoredBackup,
       ),
     ),
   );


### PR DESCRIPTION
## 背景

自动备份页已经能展示历史快照，但用户无法手动删除不再需要的历史备份。与此同时，恢复流程会覆盖当前数据，需要明确验证它不会误删或覆盖自动备份历史文件。

## 改动

- 在 `BackupService` 增加 `deleteStoredBackup`，支持删除本地 `.memex` 快照和 Android SAF document 快照。
- 在“已保存备份”列表增加删除按钮、删除确认弹窗、删除中状态、删除成功/失败反馈，并在删除后刷新列表。
- 补齐中英文备份删除相关本地化文案。
- 增加复杂 widget test：混合本地自动备份、Android 备份和安全快照，覆盖取消删除、确认删除、只移除目标项和状态提示。
- 增加 BackupService UT：本地删除只删目标文件、Android 删除走平台 channel、恢复流程保留历史备份文件。

## 恢复设计复核

当前设计是合理的：恢复会覆盖 settings、workspace 和 DB，但不会删除历史备份文件。默认历史备份位于 app-managed `Backups/` 目录，`restoreBackup` 只消费 archive 中的 `settings.json`、`workspace/` 和 `db/`，不会扫描或清理备份目录；这一点已通过新增 UT 固化。

需要注意的是，Android 自选备份目录的偏好属于 settings，恢复后“当前备份位置”可能跟随备份中的设置变化，但这不会删除原目录里的历史备份文件。

## 验证

- `env -u http_proxy -u https_proxy -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 flutter test --no-pub test/data/services/backup_service_test.dart test/ui/settings/widgets/backup_restore_page_test.dart`
- `env -u http_proxy -u https_proxy -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 dart analyze lib/data/services/backup_service.dart lib/ui/settings/widgets/backup_restore_page.dart test/data/services/backup_service_test.dart test/ui/settings/widgets/backup_restore_page_test.dart`

补充：全量 `flutter analyze --no-pub` 仍会被仓库既有 analyzer warning/info 卡住，本次触及的文件单独 analyze 无新增问题。