### PR TITLE
[codex] 修复 FileSystemService root 切换缓存

### DIFF
--- a/lib/agent/built_in_tools/file_tools.dart
+++ b/lib/agent/built_in_tools/file_tools.dart
@@ -7,7 +7,7 @@ import 'package:path/path.dart' as p;
 
 // Helper to access services
 final _fileOpService = FileOperationService.instance;
-final _fileSystem = FileSystemService.instance;
+FileSystemService get _fileSystem => FileSystemService.instance;
 
 class FileToolFactory {
   final FilePermissionManager permissionManager;

--- a/lib/agent/built_in_tools/search_event_logs_tool.dart
+++ b/lib/agent/built_in_tools/search_event_logs_tool.dart
@@ -5,8 +5,6 @@ import 'package:memex/data/services/file_system_service.dart';
 ///
 /// Allows agents to query historical events to understand context
 Tool buildSearchEventLogsTool() {
-  final fileService = FileSystemService.instance;
-
   return Tool(
     name: 'search_workspace_event_logs',
     description:
@@ -74,6 +72,7 @@ A list of events sorted by time (newest first), each containing:
       final effectiveOffset = (offset ?? 0).clamp(0, 10000);
 
       try {
+        final fileService = FileSystemService.instance;
         final userId = AgentCallToolContext.current!.state.metadata['userId'];
         final events = await fileService.eventLogService.searchEvents(
           userId: userId,

--- a/lib/agent/persona_agent/persona_agent.dart
+++ b/lib/agent/persona_agent/persona_agent.dart
@@ -12,7 +12,7 @@ class PersonaAgent {
   final Logger _logger = getLogger('PersonaAgent');
   final GeminiClient client;
   final ModelConfig modelConfig;
-  final FileSystemService _fileService = FileSystemService.instance;
+  FileSystemService get _fileService => FileSystemService.instance;
   final CharacterService _characterService = CharacterService.instance;
 
   PersonaAgent({

--- a/lib/agent/skills/manage_pkm/pkm_skill.dart
+++ b/lib/agent/skills/manage_pkm/pkm_skill.dart
@@ -31,7 +31,6 @@ class PkmSkill extends Skill {
         );
 
   static List<Tool> _buildTools(List<bool>? stopAfterUpdateCardInsightRef) {
-    final fileService = FileSystemService.instance;
     final logger = getLogger('PkmAgent');
 
     return [
@@ -47,6 +46,7 @@ class PkmSkill extends Skill {
                 "update_timeline_card_insight must be called within an agent execution context.");
           }
           final userId = context.state.metadata['userId'] as String;
+          final fileService = FileSystemService.instance;
 
           final factInfo =
               await fileService.extractFactContentFromFile(userId, fact_id);

--- a/lib/agent/skills/manage_timeline_card/save_template_tool.dart
+++ b/lib/agent/skills/manage_timeline_card/save_template_tool.dart
@@ -8,7 +8,7 @@ import 'dart:convert';
 
 class SaveTemplateTool {
   final Logger _logger = getLogger('SaveTemplateTool');
-  final FileSystemService _fileService = FileSystemService.instance;
+  FileSystemService get _fileService => FileSystemService.instance;
 
   Future<String> tool({
     required String templateId,

--- a/lib/data/repositories/card.dart
+++ b/lib/data/repositories/card.dart
@@ -11,7 +11,7 @@ import 'package:memex/data/services/card_renderer.dart';
 import 'package:memex/utils/token_usage_utils.dart';
 
 final _logger = getLogger('CardDetailEndpoint');
-final _fileSystemService = FileSystemService.instance;
+FileSystemService get _fileSystemService => FileSystemService.instance;
 
 /// Get card detail
 /// Maps to backend GET /cards/detail

--- a/lib/data/repositories/chat.dart
+++ b/lib/data/repositories/chat.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 final _logger = getLogger('ChatEndpoint');
-final _fileSystemService = FileSystemService.instance;
+FileSystemService get _fileSystemService => FileSystemService.instance;
 
 /// Get chat session list
 ///

--- a/lib/data/repositories/get_knowledge_insight_detail.dart
+++ b/lib/data/repositories/get_knowledge_insight_detail.dart
@@ -8,7 +8,7 @@ import 'package:memex/data/services/html_templates.dart';
 import 'package:memex/agent/skills/knowledge_insight/native_widgets.dart';
 
 final _logger = getLogger('GetKnowledgeInsightDetailEndpoint');
-final _fileSystemService = FileSystemService.instance;
+FileSystemService get _fileSystemService => FileSystemService.instance;
 
 class KnowledgeInsightNotFoundException implements Exception {
   final String insightId;

--- a/lib/data/repositories/health.dart
+++ b/lib/data/repositories/health.dart
@@ -4,7 +4,7 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/api_exception.dart';
 
 final _logger = getLogger('HealthEndpoint');
-final _fileSystemService = FileSystemService.instance;
+FileSystemService get _fileSystemService => FileSystemService.instance;
 
 Future<bool> reportDailyHealthSummaryEndpoint(
     Map<String, Map<String, dynamic>> dailySummary) async {

--- a/lib/data/repositories/pin_insight.dart
+++ b/lib/data/repositories/pin_insight.dart
@@ -3,7 +3,7 @@ import 'package:memex/utils/user_storage.dart';
 import 'package:memex/data/services/file_system_service.dart';
 
 final _logger = getLogger('PinInsightEndpoint');
-final _fileSystemService = FileSystemService.instance;
+FileSystemService get _fileSystemService => FileSystemService.instance;
 
 /// Pin Knowledge Insight card
 ///

--- a/lib/data/repositories/pkm.dart
+++ b/lib/data/repositories/pkm.dart
@@ -7,7 +7,7 @@ import 'package:memex/data/services/api_exception.dart';
 import 'package:path/path.dart' as p;
 
 final _logger = getLogger('PkmEndpoint');
-final _fileSystemService = FileSystemService.instance;
+FileSystemService get _fileSystemService => FileSystemService.instance;
 
 /// English → Chinese mapping for PARA root categories.
 const _paraCategoryMapping = <String, String>{

--- a/lib/data/repositories/post_comment.dart
+++ b/lib/data/repositories/post_comment.dart
@@ -15,7 +15,7 @@ import 'package:memex/domain/models/system_event.dart';
 import 'package:memex/utils/time_context.dart';
 
 final _logger = Logger('PostCommentEndpoint');
-final _fileSystemService = FileSystemService.instance;
+FileSystemService get _fileSystemService => FileSystemService.instance;
 
 /// Post comment (AI reply handled async)
 ///

--- a/lib/data/repositories/submit_input.dart
+++ b/lib/data/repositories/submit_input.dart
@@ -9,7 +9,7 @@ import 'package:memex/data/services/location_context_service.dart';
 import 'package:memex/domain/models/system_event.dart';
 
 final _logger = getLogger('SubmitInputEndpoint');
-final _fileSystem = FileSystemService.instance;
+FileSystemService get _fileSystem => FileSystemService.instance;
 final _lock = Lock();
 
 /// Submit input locally

--- a/lib/data/repositories/update_card_ui_config.dart
+++ b/lib/data/repositories/update_card_ui_config.dart
@@ -6,7 +6,7 @@ import 'package:memex/domain/models/system_event.dart';
 import 'package:memex/data/services/file_system_service.dart';
 
 final _logger = getLogger('UpdateCardUiConfigEndpoint');
-final _fileSystemService = FileSystemService.instance;
+FileSystemService get _fileSystemService => FileSystemService.instance;
 
 /// Update card UI config data
 ///

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -34,7 +34,7 @@ class ChatService {
   ChatService._internal();
 
   final Logger _logger = getLogger('ChatService');
-  final FileSystemService _fileService = FileSystemService.instance;
+  FileSystemService get _fileService => FileSystemService.instance;
   final Uuid _uuid = const Uuid();
 
   /// Send a message and get a stream of events.

--- a/lib/data/services/llm_call_record_service.dart
+++ b/lib/data/services/llm_call_record_service.dart
@@ -16,11 +16,11 @@ import 'base_file_service.dart';
 /// Records token usage and related info for all LLM calls.
 /// Supports storage by scene (raw input, insight generation, discovery generation, etc.).
 class LLMCallRecordService {
-  final FileSystemService _fileSystem;
   final BaseFileService _baseService = BaseFileService();
   final Logger _logger = getLogger('LLMCallRecordService');
   final _lock = Lock();
   final _uuid = const Uuid();
+  FileSystemService get _fileSystem => FileSystemService.instance;
 
   static LLMCallRecordService? _instance;
   static LLMCallRecordService get instance {
@@ -28,7 +28,7 @@ class LLMCallRecordService {
     return _instance!;
   }
 
-  LLMCallRecordService._() : _fileSystem = FileSystemService.instance;
+  LLMCallRecordService._();
 
   /// Returns the directory path for LLM call records.
   String _getLLMCallsPath(String userId) {

--- a/test/data/repositories/filesystem_root_switch_test.dart
+++ b/test/data/repositories/filesystem_root_switch_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/submit_input.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FileSystemService root switching', () {
+    late Directory rootA;
+    late Directory rootB;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await UserStorage.initL10n();
+      rootA = await Directory.systemTemp.createTemp('memex_root_a_');
+      rootB = await Directory.systemTemp.createTemp('memex_root_b_');
+    });
+
+    tearDown(() async {
+      await LocalAssetServer.stopServer();
+      if (await rootA.exists()) {
+        await rootA.delete(recursive: true);
+      }
+      if (await rootB.exists()) {
+        await rootB.delete(recursive: true);
+      }
+    });
+
+    test('submitInput resolves the active root at call time', () async {
+      const userA = 'root_switch_a';
+      const userB = 'root_switch_b';
+
+      await FileSystemService.init(rootA.path);
+      await submitInput(userA, [
+        {'type': 'text', 'text': 'note written into root A'},
+      ]);
+
+      await FileSystemService.init(rootB.path);
+      final result = await submitInput(userB, [
+        {'type': 'text', 'text': 'note written into root B'},
+      ]);
+
+      final factId = result['fact_id'] as String;
+      final factPath = factId.split('#').first;
+      final rootBFact = p.join(
+        FileSystemService.instance.getFactsPath(userB),
+        factPath,
+      );
+      final rootBCard = FileSystemService.instance.getCardPath(userB, factId);
+
+      expect(File(rootBFact).readAsStringSync(), contains('root B'));
+      expect(File(rootBCard).existsSync(), isTrue);
+      expect(await _rootContains(rootA, 'note written into root B'), isFalse);
+    });
+  });
+}
+
+Future<bool> _rootContains(Directory root, String needle) async {
+  await for (final entity in root.list(recursive: true)) {
+    if (entity is File &&
+        await entity.readAsString().then(
+              (content) => content.contains(needle),
+              onError: (_) => false,
+            )) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## 背景

修复 #124。部分 repository、service 和 agent tool 在模块加载或单例构造时捕获了 `FileSystemService.instance`，当切换用户、切换 workspace storage 或 restore backup 重新 `FileSystemService.init(dataRoot)` 后，旧引用仍可能把读写落到旧 root。

## 修改

- 将相关模块级/实例级 `FileSystemService.instance` 缓存改为 getter 或工具执行时解析。
- 覆盖 submit、card、chat、PKM、comment、health、insight pin/detail、LLM call record、文件工具和模板工具等入口。
- 新增 root switch 回归测试，验证先写 root A、再切到 root B 后，`submitInput` 的 Fact/Card 只写入当前 root。

## 验证

- `flutter test --no-pub --concurrency=1 test/data/repositories/filesystem_root_switch_test.dart test/ui/main_screen/widgets/input_sheet_test.dart`
- `flutter analyze --no-pub --no-fatal-infos ...`（仅剩既有 info 级命名/const 提示）