### PR TITLE
[codex] 修复 Agent 工具失败状态传播

### DIFF
--- a/lib/agent/built_in_tools/search_event_logs_tool.dart
+++ b/lib/agent/built_in_tools/search_event_logs_tool.dart
@@ -125,7 +125,7 @@ A list of events sorted by time (newest first), each containing:
 
         return buffer.toString();
       } catch (e) {
-        return 'Error searching event logs: $e';
+        throw StateError('Error searching event logs: $e');
       }
     },
   );

--- a/lib/agent/skills/ask_clarification/ask_clarification_skill.dart
+++ b/lib/agent/skills/ask_clarification/ask_clarification_skill.dart
@@ -195,7 +195,7 @@ ${UserStorage.l10n.userLanguageInstruction}
             );
           } catch (e, st) {
             _logger.severe('Failed to create clarification request', e, st);
-            return AgentToolResult(content: TextPart('Error: $e'));
+            rethrow;
           }
         },
       ),
@@ -222,7 +222,7 @@ ${UserStorage.l10n.userLanguageInstruction}
             return AgentToolResult(content: TextPart(buffer.toString()));
           } catch (e, st) {
             _logger.severe('Failed to list clarification requests', e, st);
-            return AgentToolResult(content: TextPart('Error: $e'));
+            rethrow;
           }
         },
       ),
@@ -258,7 +258,7 @@ ${UserStorage.l10n.userLanguageInstruction}
           } catch (e, st) {
             _logger.severe(
                 'Failed to list recent clarification requests', e, st);
-            return AgentToolResult(content: TextPart('Error: $e'));
+            rethrow;
           }
         },
       ),

--- a/lib/agent/skills/comment_agent/tools/comment_tools.dart
+++ b/lib/agent/skills/comment_agent/tools/comment_tools.dart
@@ -45,7 +45,7 @@ class CommentToolFactory {
       },
       executable: (String content, String? reply_to_id) async {
         if (content.isEmpty) {
-          return "Error: Comment content cannot be empty.";
+          throw ArgumentError('Comment content cannot be empty.');
         }
 
         try {
@@ -72,7 +72,7 @@ class CommentToolFactory {
           );
 
           if (updatedCardData == null) {
-            return "Error: Card not found: $cardId";
+            throw StateError('Card not found: $cardId');
           }
 
           // Log event
@@ -129,8 +129,9 @@ class CommentToolFactory {
             content: TextPart("Comment saved successfully."),
             stopFlag: true,
           );
-        } catch (e) {
-          return "Error saving comment: $e";
+        } catch (e, st) {
+          getLogger('CommentTool').severe('Error saving comment', e, st);
+          rethrow;
         }
       },
     );

--- a/lib/agent/skills/comment_agent/tools/memory_tools.dart
+++ b/lib/agent/skills/comment_agent/tools/memory_tools.dart
@@ -37,7 +37,7 @@ Usage:
       },
       executable: (List<dynamic>? labels) async {
         final characterId = _targetId;
-        if (characterId == null) return 'Error: No default character set.';
+        if (characterId == null) throw StateError('No default character set.');
         return CharacterMemoryService.instance.readMemoryEntries(
           userId: userId,
           characterId: characterId,
@@ -88,7 +88,7 @@ Usage:
         bool? replace_all,
       ]) async {
         final characterId = _targetId;
-        if (characterId == null) return 'Error: No default character set.';
+        if (characterId == null) throw StateError('No default character set.');
         return CharacterMemoryService.instance.editMemoryEntry(
           userId: userId,
           characterId: characterId,
@@ -134,7 +134,7 @@ Usage:
         num? salience,
       ]) async {
         final characterId = _targetId;
-        if (characterId == null) return 'Error: No default character set.';
+        if (characterId == null) throw StateError('No default character set.');
         return CharacterMemoryService.instance.writeMemoryEntry(
           userId: userId,
           characterId: characterId,
@@ -162,7 +162,7 @@ Usage:
       },
       executable: (String label) async {
         final characterId = _targetId;
-        if (characterId == null) return 'Error: No default character set.';
+        if (characterId == null) throw StateError('No default character set.');
         return CharacterMemoryService.instance.removeMemoryEntry(
           userId: userId,
           characterId: characterId,
@@ -209,7 +209,7 @@ Use this when compressed checkpoints or memory entries are too vague and you nee
         String? thread_id,
       ]) async {
         final characterId = _targetId;
-        if (characterId == null) return 'Error: No default character set.';
+        if (characterId == null) throw StateError('No default character set.');
         CharacterMemoryScene? sceneFilter;
         if (scene != null && scene.trim().isNotEmpty) {
           for (final candidate in CharacterMemoryScene.values) {
@@ -219,7 +219,7 @@ Use this when compressed checkpoints or memory entries are too vague and you nee
             }
           }
           if (sceneFilter == null) {
-            return 'Error: scene must be "chat" or "comment".';
+            throw ArgumentError('scene must be "chat" or "comment".');
           }
         }
         return CharacterMemoryService.instance.searchTimelineEvents(

--- a/lib/agent/skills/companion_agent/tools/action_message_tools.dart
+++ b/lib/agent/skills/companion_agent/tools/action_message_tools.dart
@@ -36,7 +36,7 @@ Do NOT put dialogue or spoken words in this tool.''',
       executable: (String action) async {
         final trimmed = action.trim();
         if (trimmed.isEmpty) {
-          return 'Error: action text cannot be empty.';
+          throw ArgumentError('action text cannot be empty.');
         }
         // Wrap in asterisks if not already wrapped.
         final wrapped = (trimmed.startsWith('*') && trimmed.endsWith('*'))
@@ -55,7 +55,7 @@ Do NOT put dialogue or spoken words in this tool.''',
           );
           return 'Action message sent.';
         } catch (e) {
-          return 'Error sending action message: $e';
+          throw StateError('Error sending action message: $e');
         }
       },
     );

--- a/lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart
+++ b/lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart
@@ -102,9 +102,9 @@ Tool buildGetExistsKnowledgeInsightCardsTool() {
           return "No existing knowledge insight cards found.";
         }
         return jsonEncode(cards);
-      } catch (e) {
-        logger.warning('Failed to get knowledge insight data: $e');
-        return "Error: $e";
+      } catch (e, st) {
+        logger.warning('Failed to get knowledge insight data', e, st);
+        rethrow;
       }
     },
   );
@@ -134,12 +134,12 @@ Tool buildDeleteKnowledgeInsightCardTool() {
             await fileSystem.deleteKnowledgeInsightCard(userId, cardId);
         if (success) {
           return "Card $cardId deleted successfully.";
-        } else {
-          return "Failed to delete card $cardId (File not found or error).";
         }
-      } catch (e) {
-        logger.warning('Failed to delete knowledge insight card: $e');
-        return "Error: $e";
+        throw StateError(
+            "Failed to delete card $cardId (File not found or error).");
+      } catch (e, st) {
+        logger.warning('Failed to delete knowledge insight card', e, st);
+        rethrow;
       }
     },
   );
@@ -170,9 +170,9 @@ Tool buildDeleteKnowledgeInsightTagsTool() {
         final tagList = tags.cast<String>();
         await fileSystem.deleteInsightTags(userId, tagList);
         return "Successfully deleted tags: ${tagList.join(', ')}";
-      } catch (e) {
-        logger.warning('Failed to delete insight tags: $e');
-        return "Error: $e";
+      } catch (e, st) {
+        logger.warning('Failed to delete insight tags', e, st);
+        rethrow;
       }
     },
   );
@@ -226,7 +226,8 @@ Tool buildSaveKnowledgeInsightCardsTool() {
               !availableTemplateIds.contains(chart.templateId))
           .toList();
       if (notSupportedTemplateIds.isNotEmpty) {
-        return "Error: Template IDs ${notSupportedTemplateIds.map((t) => t.templateId).join(", ")} do not exist. Please check available templates using 'get_available_insight_card_templates' tool.";
+        throw ArgumentError(
+            "Template IDs ${notSupportedTemplateIds.map((t) => t.templateId).join(", ")} do not exist. Please check available templates using 'get_available_insight_card_templates' tool.");
       }
 
       // Validate data against schema
@@ -236,7 +237,8 @@ Tool buildSaveKnowledgeInsightCardsTool() {
               nativeWidgets.firstWhere((w) => w.id == chart.templateId);
           final error = widgetDef.validator(chart.data!);
           if (error != null) {
-            return "Error: Validation failed for card (id: ${chart.id}, template: ${chart.templateId}): $error";
+            throw ArgumentError(
+                "Validation failed for card (id: ${chart.id}, template: ${chart.templateId}): $error");
           }
         }
       }
@@ -249,12 +251,14 @@ Tool buildSaveKnowledgeInsightCardsTool() {
         // Actually, for 'add', it MUST be provided.
         if (chart.type == 'add') {
           if (chart.relatedFacts == null || chart.relatedFacts!.isEmpty) {
-            return "Error: `related_facts` is REQUIRED and must not be empty for new insight cards (id: ${chart.id}). Please provide at least one related fact ID.";
+            throw ArgumentError(
+                "`related_facts` is REQUIRED and must not be empty for new insight cards (id: ${chart.id}). Please provide at least one related fact ID.");
           }
         } else if (chart.type == 'update') {
           // For updates, if provided, it must be non-empty
           if (chart.relatedFacts != null && chart.relatedFacts!.isEmpty) {
-            return "Error: `related_facts` cannot be set to empty (id: ${chart.id}). Please provide valid related fact IDs or omit the field to keep existing facts.";
+            throw ArgumentError(
+                "`related_facts` cannot be set to empty (id: ${chart.id}). Please provide valid related fact IDs or omit the field to keep existing facts.");
           }
         }
       }

--- a/lib/agent/skills/manage_pkm/pkm_skill.dart
+++ b/lib/agent/skills/manage_pkm/pkm_skill.dart
@@ -84,11 +84,8 @@ class PkmSkill extends Skill {
           if (updatedCardData == null) {
             logger.warning(
                 "Card file not found for fact_id: $fact_id, maybe it has been deleted");
-            return AgentToolResult(
-              content: TextPart(
-                  Prompts.pkmAgentUpdateCardInsightErrorCardNotFound(fact_id)),
-              stopFlag: stopFlag,
-            );
+            throw StateError(
+                Prompts.pkmAgentUpdateCardInsightErrorCardNotFound(fact_id));
           }
 
           // Notify detail page to refresh after insight update

--- a/lib/agent/skills/manage_system_action/system_action_skill.dart
+++ b/lib/agent/skills/manage_system_action/system_action_skill.dart
@@ -108,9 +108,9 @@ The current time is provided dynamically in your agent's state/reminders. Always
               content: TextPart(
                   "Successfully created calendar event '$title' (Action ID: $actionId)."),
             );
-          } catch (e) {
-            _logger.severe("Failed to create_calendar_event: $e");
-            return AgentToolResult(content: TextPart("Error: $e"));
+          } catch (e, st) {
+            _logger.severe("Failed to create_calendar_event", e, st);
+            rethrow;
           }
         },
       ),
@@ -163,9 +163,9 @@ The current time is provided dynamically in your agent's state/reminders. Always
               content: TextPart(
                   "Successfully created reminder '$title' (Action ID: $actionId)."),
             );
-          } catch (e) {
-            _logger.severe("Failed to create_reminder: $e");
-            return AgentToolResult(content: TextPart("Error: $e"));
+          } catch (e, st) {
+            _logger.severe("Failed to create_reminder", e, st);
+            rethrow;
           }
         },
       ),
@@ -190,9 +190,9 @@ The current time is provided dynamically in your agent's state/reminders. Always
                   "- ID: ${a.id} | Type: ${a.actionType} | Status: ${a.status} | Data: ${a.actionData}");
             }
             return AgentToolResult(content: TextPart(buffer.toString()));
-          } catch (e) {
-            _logger.severe("Failed to get_recent_actions: $e");
-            return AgentToolResult(content: TextPart("Error: $e"));
+          } catch (e, st) {
+            _logger.severe("Failed to get_recent_actions", e, st);
+            rethrow;
           }
         },
       ),
@@ -220,14 +220,11 @@ The current time is provided dynamically in your agent's state/reminders. Always
                 content: TextPart(
                     "Successfully cancelled action with ID: $action_id"),
               );
-            } else {
-              return AgentToolResult(
-                content: TextPart("Action with ID $action_id not found."),
-              );
             }
-          } catch (e) {
-            _logger.severe("Failed to cancel_action: $e");
-            return AgentToolResult(content: TextPart("Error: $e"));
+            throw StateError("Action with ID $action_id not found.");
+          } catch (e, st) {
+            _logger.severe("Failed to cancel_action", e, st);
+            rethrow;
           }
         },
       ),

--- a/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
@@ -344,10 +344,8 @@ class TimelineCardSkill extends Skill {
             );
 
             if (updatedCardData == null) {
-              return AgentToolResult(
-                content: TextPart(
-                    "Card file not found for fact_id: $fact_id, maybe it has been deleted"),
-              );
+              throw StateError(
+                  "Card file not found for fact_id: $fact_id, maybe it has been deleted");
             }
 
             // Log event
@@ -379,9 +377,7 @@ class TimelineCardSkill extends Skill {
             );
           } catch (e, stack) {
             logger.severe("SaveTimelineCard failed", e, stack);
-            return AgentToolResult(
-              content: TextPart("Failed to save timeline card: $e"),
-            );
+            rethrow;
           }
         },
       ),

--- a/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
+++ b/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
@@ -189,7 +189,7 @@ Tool buildGetScheduleCardsTool() {
         return jsonEncode(result);
       } catch (e) {
         logger.severe('Failed to get schedule cards: $e');
-        return "Error: $e";
+        throw Exception('Failed to get schedule cards: $e');
       }
     },
   );

--- a/test/agent/agent_tool_error_result_test.dart
+++ b/test/agent/agent_tool_error_result_test.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/built_in_tools/search_event_logs_tool.dart';
+import 'package:memex/agent/skills/comment_agent/tools/comment_tools.dart';
+import 'package:memex/agent/skills/comment_agent/tools/memory_tools.dart';
+import 'package:memex/agent/skills/manage_timeline_card/timeline_card_skill.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('agent tool error results', () {
+    late Directory tempRoot;
+    late String userId;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await UserStorage.initL10n();
+      userId = 'tool_error_${DateTime.now().microsecondsSinceEpoch}';
+      await UserStorage.saveUser(userId);
+
+      tempRoot = await Directory.systemTemp.createTemp('memex_tool_error_');
+      await FileSystemService.init(tempRoot.path);
+    });
+
+    tearDown(() async {
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('save_timeline_card missing fact is marked as a tool error', () async {
+      final tool = TimelineCardSkill(
+        forceActivate: true,
+        stopAfterSuccessSaveCard: true,
+      ).tools!.singleWhere((tool) => tool.name == 'save_timeline_card');
+
+      final result = await _runToolCall(
+        tool: tool,
+        arguments: {
+          'fact_id': '2026/05/18.md#ts_999',
+          'title': 'Missing source fact',
+          'ui_configs': [
+            {
+              'template_id': 'article',
+              'data': {'body': 'A card without a persisted source fact.'},
+            },
+          ],
+        },
+        metadata: {'userId': userId},
+      );
+
+      expect(result.isError, isTrue);
+      expect(_text(result), contains('Error executing save_timeline_card'));
+      expect(_text(result), contains('fact id: 2026/05/18.md#ts_999'));
+    });
+
+    test('SaveComment invalid input is marked as a tool error', () async {
+      final tool = CommentToolFactory(
+        userId: userId,
+        cardId: '2026/05/18.md#ts_missing',
+      ).buildSaveCommentTool();
+
+      final result = await _runToolCall(
+        tool: tool,
+        arguments: {
+          'content': '',
+          'reply_to_id': null,
+        },
+        metadata: {'userId': userId},
+      );
+
+      expect(result.isError, isTrue);
+      expect(_text(result), contains('Error executing SaveComment'));
+      expect(_text(result), contains('Comment content cannot be empty'));
+    });
+
+    test('MemoryRead without a default character is marked as a tool error',
+        () async {
+      final tool = MemoryToolFactory(userId: userId).buildMemoryReadTool();
+
+      final result = await _runToolCall(
+        tool: tool,
+        arguments: {'labels': null},
+        metadata: {'userId': userId},
+      );
+
+      expect(result.isError, isTrue);
+      expect(_text(result), contains('Error executing MemoryRead'));
+      expect(_text(result), contains('No default character set'));
+    });
+
+    test('search_workspace_event_logs failures are marked as tool errors',
+        () async {
+      final result = await _runToolCall(
+        tool: buildSearchEventLogsTool(),
+        arguments: {
+          'from_time': '2026-05-18T00:00:00+08:00',
+          'limit': 10,
+          'offset': 0,
+          'to_time': null,
+        },
+      );
+
+      expect(result.isError, isTrue);
+      expect(_text(result),
+          contains('Error executing search_workspace_event_logs'));
+    });
+  });
+}
+
+Future<FunctionExecutionResult> _runToolCall({
+  required Tool tool,
+  required Map<String, dynamic> arguments,
+  Map<String, dynamic> metadata = const {},
+}) async {
+  final client = _SingleToolCallClient(
+    toolName: tool.name,
+    arguments: arguments,
+  );
+  final state = AgentState(
+    sessionId: 'tool_error_test_${DateTime.now().microsecondsSinceEpoch}',
+    metadata: Map<String, dynamic>.from(metadata),
+  );
+  final agent = StatefulAgent(
+    name: 'tool_error_test_agent',
+    client: client,
+    modelConfig: ModelConfig(model: 'test-model'),
+    state: state,
+    tools: [tool],
+    withGeneralPrinciples: false,
+    maxTurns: 3,
+  );
+
+  await agent.run([UserMessage.text('run the tool')], useStream: false);
+
+  final resultMessage =
+      state.history.messages.whereType<FunctionExecutionResultMessage>().single;
+  return resultMessage.results.single;
+}
+
+String _text(FunctionExecutionResult result) {
+  return result.content
+      .whereType<TextPart>()
+      .map((part) => part.text)
+      .join('\n');
+}
+
+class _SingleToolCallClient extends LLMClient {
+  _SingleToolCallClient({
+    required this.toolName,
+    required this.arguments,
+  });
+
+  final String toolName;
+  final Map<String, dynamic> arguments;
+  var _callCount = 0;
+
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    _callCount += 1;
+    if (_callCount == 1) {
+      return ModelMessage(
+        model: modelConfig.model,
+        stopReason: 'tool_calls',
+        functionCalls: [
+          FunctionCall(
+            id: 'call_1',
+            name: toolName,
+            arguments: jsonEncode(arguments),
+          ),
+        ],
+      );
+    }
+    return ModelMessage(
+      model: modelConfig.model,
+      stopReason: 'stop',
+      textOutput: 'done',
+    );
+  }
+
+  @override
+  Future<Stream<StreamingMessage>> stream(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    throw UnsupportedError('Streaming is not used by this test client.');
+  }
+}


### PR DESCRIPTION
## 背景
修复 #125。`dart_agent_core` 只有在 tool executable 抛异常时才会把 `FunctionExecutionResult.isError` 标记为 `true`；此前 `save_timeline_card` 等工具把失败包装成普通文本返回，导致 Card Agent 和其他依赖工具历史的流程误判为成功。

## 修改
- `save_timeline_card` 失败时改为抛异常，不再返回普通 `AgentToolResult`。
- 系统排查并修复同类工具：评论保存、角色记忆、clarification、system action、schedule 查询、knowledge insight、PKM insight、companion action message、event log search。
- 保留正常空结果为普通返回，例如“没有近期 action / 没有匹配事件”。
- 新增完整 agent 执行链路单测，断言失败工具在 `FunctionExecutionResultMessage` 中标记为 `isError=true`。

## 验证
- `flutter test --no-pub --concurrency=1 test/agent/agent_tool_error_result_test.dart test/agent/comment_tool_factory_test.dart test/ui/main_screen/widgets/input_sheet_test.dart`
- `flutter analyze --no-pub --no-fatal-infos ...`（仅剩既有 tool 参数命名 info 提示）