### PR TITLE
[codex] 修复 Card Agent 完成态校验

### DIFF
--- a/lib/agent/card_agent/card_agent.dart
+++ b/lib/agent/card_agent/card_agent.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:memex/agent/agent_controller.util.dart';
 import 'package:memex/agent/card_agent/prompts.dart';
 import 'package:memex/agent/memory/memory_management.dart';
@@ -9,6 +11,74 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/agent/agent_cache_helper.dart';
 import 'package:memex/utils/user_storage.dart';
+
+class CardRunCompletionEvidence {
+  final String factId;
+  final bool requireSaveToolCall;
+  final bool hasMatchingSuccessfulSaveToolCall;
+  final bool cardExists;
+  final String? cardPath;
+  final String? persistedFactId;
+  final String? status;
+  final bool hasTitle;
+  final bool hasUiConfigs;
+  final String? failureReason;
+
+  const CardRunCompletionEvidence({
+    required this.factId,
+    required this.requireSaveToolCall,
+    required this.hasMatchingSuccessfulSaveToolCall,
+    required this.cardExists,
+    this.cardPath,
+    this.persistedFactId,
+    this.status,
+    required this.hasTitle,
+    required this.hasUiConfigs,
+    this.failureReason,
+  });
+
+  bool get isComplete {
+    final saveToolSatisfied =
+        !requireSaveToolCall || hasMatchingSuccessfulSaveToolCall;
+    return saveToolSatisfied &&
+        cardExists &&
+        persistedFactId == factId &&
+        status == 'completed' &&
+        hasTitle &&
+        hasUiConfigs;
+  }
+
+  List<String> get missingRequirements {
+    final missing = <String>[];
+    if (requireSaveToolCall && !hasMatchingSuccessfulSaveToolCall) {
+      missing.add('matching_successful_save_timeline_card_tool_call');
+    }
+    if (!cardExists) missing.add('card_file_exists');
+    if (persistedFactId != factId) missing.add('persisted_fact_id_matches');
+    if (status != 'completed') missing.add('status_completed');
+    if (!hasTitle) missing.add('title_present');
+    if (!hasUiConfigs) missing.add('ui_configs_present');
+    return missing;
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'fact_id': factId,
+      'require_save_tool_call': requireSaveToolCall,
+      'has_matching_successful_save_tool_call':
+          hasMatchingSuccessfulSaveToolCall,
+      'card_exists': cardExists,
+      'card_path': cardPath,
+      'persisted_fact_id': persistedFactId,
+      'status': status,
+      'has_title': hasTitle,
+      'has_ui_configs': hasUiConfigs,
+      'failure_reason': failureReason,
+      'is_complete': isComplete,
+      'missing_requirements': missingRequirements,
+    };
+  }
+}
 
 class CardAgent {
   static final Logger _logger = Logger('CardAgent');
@@ -75,7 +145,7 @@ class CardAgent {
 
   /// Static method to run the agent with user message
   /// This method handles responseId caching and agent initialization internally
-  static Future<void> runWithContent({
+  static Future<CardRunCompletionEvidence> runWithContent({
     required LLMClient client,
     required ModelConfig modelConfig,
     required String userId,
@@ -177,11 +247,20 @@ $instruction
 
       if (runCount > maxRetries) break;
 
-      final check = _checkCardRunComplete(agent.state.history.messages);
-      if (check) break;
+      final completionEvidence = await inspectCardRunCompletion(
+        userId: userId,
+        factId: factId,
+        messages: agent.state.history.messages,
+      );
+      if (completionEvidence.isComplete) {
+        _logger.info(
+            'Card Agent completed for $factId: ${completionEvidence.toJson()}');
+        return completionEvidence;
+      }
 
       final reminderText =
-          '- Call save_timeline_card to save the Timeline Card (this call is required to complete the task)';
+          '- Call save_timeline_card to save the Timeline Card (this call is required to complete the task)\n'
+          '- Current persisted card check failed: ${completionEvidence.missingRequirements.join(', ')}';
       messagesToRun = [
         UserMessage([
           TextPart(
@@ -189,14 +268,63 @@ $instruction
         ])
       ];
     }
+
+    final completionEvidence = await inspectCardRunCompletion(
+      userId: userId,
+      factId: factId,
+      messages: agent.state.history.messages,
+    );
+    if (completionEvidence.isComplete) {
+      _logger.info(
+          'Card Agent completed for $factId: ${completionEvidence.toJson()}');
+      return completionEvidence;
+    }
+    throw StateError(
+      'Card Agent did not produce a completed card for $factId. '
+      'Evidence: ${jsonEncode(completionEvidence.toJson())}',
+    );
   }
 
-  /// Returns true if history contains a successful save_timeline_card call.
-  static bool _checkCardRunComplete(List<LLMMessage> messages) {
+  /// Inspect both tool history and the persisted card file before considering
+  /// the Card Agent task complete.
+  static Future<CardRunCompletionEvidence> inspectCardRunCompletion({
+    required String userId,
+    required String factId,
+    List<LLMMessage> messages = const [],
+    bool requireSaveToolCall = true,
+  }) async {
+    final fileSystem = FileSystemService.instance;
+    final card = await fileSystem.readCardFile(userId, factId);
+    final cardPath = fileSystem.getCardPath(userId, factId);
+    return CardRunCompletionEvidence(
+      factId: factId,
+      requireSaveToolCall: requireSaveToolCall,
+      hasMatchingSuccessfulSaveToolCall:
+          _hasMatchingSuccessfulSaveToolCall(messages, factId),
+      cardExists: card != null,
+      cardPath: cardPath,
+      persistedFactId: card?.factId,
+      status: card?.status,
+      hasTitle: (card?.title?.trim().isNotEmpty ?? false),
+      hasUiConfigs: card?.uiConfigs.isNotEmpty ?? false,
+      failureReason: card?.failureReason,
+    );
+  }
+
+  static bool _hasMatchingSuccessfulSaveToolCall(
+    List<LLMMessage> messages,
+    String factId,
+  ) {
     for (final msg in messages) {
       if (msg is! FunctionExecutionResultMessage) continue;
       for (final r in msg.results) {
-        if (!r.isError && r.name == 'save_timeline_card') return true;
+        if (r.isError || r.name != 'save_timeline_card') continue;
+        try {
+          final arguments = jsonDecode(r.arguments) as Map<String, dynamic>;
+          if (arguments['fact_id'] == factId) return true;
+        } catch (_) {
+          // Ignore malformed historical arguments.
+        }
       }
     }
     return false;

--- a/lib/agent/card_agent/rule_based_card_matcher.dart
+++ b/lib/agent/card_agent/rule_based_card_matcher.dart
@@ -32,7 +32,7 @@ CardData applyRuleBasedTemplate({
   final title = _deriveTitle(pureText);
 
   return card.copyWith(
-    status: 'processing',
+    status: 'completed',
     title: title.isEmpty ? null : title,
     uiConfigs: [UiConfig(templateId: templateId, data: data)],
   );

--- a/lib/data/services/task_handlers/card_agent_handler.dart
+++ b/lib/data/services/task_handlers/card_agent_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:logging/logging.dart';
 import 'package:memex/agent/card_agent/card_agent.dart';
 import 'package:memex/agent/card_agent/rule_based_card_matcher.dart';
@@ -25,7 +27,7 @@ final Logger _logger = getLogger('CardAgentHandler');
 /// executes the CardAgent. It mimics the backend's `_process_with_card_agent`.
 ///
 /// [dryRun] - If true, the agent will run but tools will skip side-effects.
-Future<void> processWithCardAgent({
+Future<CardRunCompletionEvidence> processWithCardAgent({
   required String userId,
   required String factId,
   required String contentText,
@@ -51,7 +53,18 @@ Future<void> processWithCardAgent({
         factId: factId,
         combinedText: contentText,
       );
-      return;
+      final evidence = await CardAgent.inspectCardRunCompletion(
+        userId: userId,
+        factId: factId,
+        requireSaveToolCall: false,
+      );
+      if (!evidence.isComplete) {
+        throw StateError(
+          'Rule-based card generation did not produce a completed card for '
+          '$factId. Evidence: ${jsonEncode(evidence.toJson())}',
+        );
+      }
+      return evidence;
     }
 
     // 1. Get LLM Config
@@ -92,7 +105,7 @@ Future<void> processWithCardAgent({
     );
 
     // 4. Run Agent
-    await CardAgent.runWithContent(
+    final completionEvidence = await CardAgent.runWithContent(
       client: client,
       modelConfig: resources.modelConfig,
       userId: userId,
@@ -101,6 +114,7 @@ Future<void> processWithCardAgent({
     );
 
     _logger.info('Card Agent task completed for $factId');
+    return completionEvidence;
   } catch (e, stack) {
     _logger.severe('Error in processWithCardAgent', e, stack);
     rethrowIfNonRetryable(e);
@@ -192,7 +206,7 @@ Future<void> handleCardAgentImpl(
     }
 
     // 3. Call re-usable process function
-    await processWithCardAgent(
+    final completionEvidence = await processWithCardAgent(
       userId: userId,
       factId: factId,
       contentText: combinedText,
@@ -200,6 +214,11 @@ Future<void> handleCardAgentImpl(
       inputDateTime: inputDateTime,
       locationContextReminder: locationContextReminder,
       dryRun: false,
+    );
+
+    await LocalTaskExecutor.instance.updateTaskResult(
+      taskContext.taskId,
+      jsonEncode({'card_completion_evidence': completionEvidence.toJson()}),
     );
 
     _logger.info("Card Agent task completed successfully for $factId");

--- a/test/agent/card_agent_completion_test.dart
+++ b/test/agent/card_agent_completion_test.dart
@@ -1,0 +1,178 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/card_agent/card_agent.dart';
+import 'package:memex/agent/card_agent/rule_based_card_matcher.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('CardAgent completion evidence', () {
+    late Directory tempRoot;
+    late String userId;
+    const factId = '2026/05/18.md#ts_1';
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await UserStorage.initL10n();
+      userId = 'card_completion_${DateTime.now().microsecondsSinceEpoch}';
+      await UserStorage.saveUser(userId);
+
+      tempRoot = await Directory.systemTemp.createTemp('memex_card_done_');
+      await FileSystemService.init(tempRoot.path);
+    });
+
+    tearDown(() async {
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('successful save tool alone is not enough when card file is missing',
+        () async {
+      final evidence = await CardAgent.inspectCardRunCompletion(
+        userId: userId,
+        factId: factId,
+        messages: [_saveToolMessage(factId: factId)],
+      );
+
+      expect(evidence.hasMatchingSuccessfulSaveToolCall, isTrue);
+      expect(evidence.cardExists, isFalse);
+      expect(evidence.isComplete, isFalse);
+      expect(evidence.missingRequirements, contains('card_file_exists'));
+      expect(evidence.missingRequirements, contains('status_completed'));
+    });
+
+    test('completed card with matching save tool is complete', () async {
+      await _writeCard(
+        userId: userId,
+        factId: factId,
+        status: 'completed',
+      );
+
+      final evidence = await CardAgent.inspectCardRunCompletion(
+        userId: userId,
+        factId: factId,
+        messages: [_saveToolMessage(factId: factId)],
+      );
+
+      expect(evidence.isComplete, isTrue);
+      expect(evidence.toJson()['is_complete'], isTrue);
+      expect(evidence.missingRequirements, isEmpty);
+    });
+
+    test('processing card is incomplete even after a save tool call', () async {
+      await _writeCard(
+        userId: userId,
+        factId: factId,
+        status: 'processing',
+      );
+
+      final evidence = await CardAgent.inspectCardRunCompletion(
+        userId: userId,
+        factId: factId,
+        messages: [_saveToolMessage(factId: factId)],
+      );
+
+      expect(evidence.isComplete, isFalse);
+      expect(evidence.status, 'processing');
+      expect(evidence.missingRequirements, contains('status_completed'));
+    });
+
+    test('save tool call must target the same fact id', () async {
+      await _writeCard(
+        userId: userId,
+        factId: factId,
+        status: 'completed',
+      );
+
+      final evidence = await CardAgent.inspectCardRunCompletion(
+        userId: userId,
+        factId: factId,
+        messages: [_saveToolMessage(factId: '2026/05/18.md#ts_2')],
+      );
+
+      expect(evidence.cardExists, isTrue);
+      expect(evidence.hasMatchingSuccessfulSaveToolCall, isFalse);
+      expect(evidence.isComplete, isFalse);
+      expect(
+        evidence.missingRequirements,
+        contains('matching_successful_save_timeline_card_tool_call'),
+      );
+    });
+
+    test('rule-based fallback writes a completed card', () async {
+      const initial = CardData(
+        factId: factId,
+        timestamp: 1000,
+        status: 'processing',
+        tags: [],
+        uiConfigs: [],
+      );
+      final card = applyRuleBasedTemplate(
+        card: initial,
+        combinedText: 'A quiet but complete rule-based memory.',
+        imageUrls: const [],
+        audioUrl: null,
+      );
+      await FileSystemService.instance.safeWriteCardFile(userId, factId, card);
+
+      final evidence = await CardAgent.inspectCardRunCompletion(
+        userId: userId,
+        factId: factId,
+        requireSaveToolCall: false,
+      );
+
+      expect(card.status, 'completed');
+      expect(evidence.isComplete, isTrue);
+      expect(evidence.requireSaveToolCall, isFalse);
+    });
+  });
+}
+
+FunctionExecutionResultMessage _saveToolMessage({
+  required String factId,
+  bool isError = false,
+}) {
+  return FunctionExecutionResultMessage(
+    results: [
+      FunctionExecutionResult(
+        id: 'call_1',
+        name: 'save_timeline_card',
+        isError: isError,
+        arguments: jsonEncode({'fact_id': factId}),
+        content: [TextPart('saved')],
+      ),
+    ],
+  );
+}
+
+Future<void> _writeCard({
+  required String userId,
+  required String factId,
+  required String status,
+}) async {
+  await FileSystemService.instance.safeWriteCardFile(
+    userId,
+    factId,
+    CardData(
+      factId: factId,
+      timestamp: 1000,
+      status: status,
+      tags: const [],
+      title: 'Completion fixture',
+      uiConfigs: const [
+        UiConfig(
+          templateId: 'snippet',
+          data: {'text': 'completion fixture'},
+        ),
+      ],
+    ),
+  );
+}

--- a/test/ui/core/cards/classic_card_status_test.dart
+++ b/test/ui/core/cards/classic_card_status_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/core/cards/templates/classic_card.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  testWidgets('failed classic card exposes the failure reason sheet',
+      (tester) async {
+    const failureReason =
+        'Card Agent did not produce a completed persisted card.';
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ClassicCard(
+            data: {
+              'content': 'A card waiting for recovery.',
+              'status': 'failed',
+              'failure_reason': failureReason,
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(failureReason), findsNothing);
+
+    await tester.tap(find.text(UserStorage.l10n.failedStatus));
+    await tester.pumpAndSettle();
+
+    expect(find.text(failureReason), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 背景
修复 #126。Card Agent 之前只要历史里出现一次非错误的 `save_timeline_card` 工具结果就认为完成，但这不能证明对应 card 文件已经真实落盘、状态为 completed，尤其会被工具失败普通返回、历史残留或落盘异常误导。

## 修改
- 新增 `CardRunCompletionEvidence`，同时记录工具调用和实际 card 文件状态。
- Card Agent 重试条件改为校验：匹配 fact_id 的成功保存工具调用、card 文件存在、persisted fact_id 匹配、status 为 completed、title 和 ui_configs 齐全。
- 重试 reminder 会带上缺失项；最终失败会抛出包含 evidence JSON 的错误，交给 task failure handler 标记失败。
- `handleCardAgentImpl` 将完成证据写入 task result，便于后续排查。
- 修复 rule-based fallback 写入后仍保持 processing 的问题，使无 LLM 配置时也产生 completed card。
- 新增单元测试覆盖“只有工具历史不算完成”、processing card 不算完成、fact_id 不匹配不算完成、rule-based fallback 完成态；新增 widget test 覆盖失败卡片展示失败原因。

## 验证
- `flutter test --no-pub --concurrency=1 test/agent/card_agent_completion_test.dart test/ui/core/cards/classic_card_status_test.dart test/ui/main_screen/widgets/input_sheet_test.dart`
- `flutter analyze --no-pub --no-fatal-infos lib/agent/card_agent/card_agent.dart lib/agent/card_agent/rule_based_card_matcher.dart lib/data/services/task_handlers/card_agent_handler.dart test/agent/card_agent_completion_test.dart test/ui/core/cards/classic_card_status_test.dart`