### PR TITLE
[codex] 兼容时间线卡片工具的字符串数组参数

### DIFF
--- a/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/agent/prompts.dart';
@@ -156,11 +158,11 @@ class TimelineCardSkill extends Skill {
         },
         executable: (String fact_id,
             String title,
-            List ui_configs,
+            dynamic ui_configs,
             String? address,
             String? user_mark_address,
             String? content_creation_date,
-            List? tags) async {
+            dynamic tags) async {
           final fileService = FileSystemService.instance;
 
           // Access context
@@ -181,13 +183,16 @@ class TimelineCardSkill extends Skill {
             if (title.isEmpty) {
               throw ArgumentError("title is required");
             }
+            final uiConfigsList =
+                _normalizeListArgument(ui_configs, 'ui_configs');
+
             // ui_configs: must be array, each element must be dict with valid template_id and data
-            if (ui_configs.isEmpty) {
+            if (uiConfigsList.isEmpty) {
               throw ArgumentError("ui_configs must be provided and non-empty.");
             }
             final List<Map<String, dynamic>> finalUiConfigs = [];
-            for (var i = 0; i < ui_configs.length; i++) {
-              final raw = ui_configs[i];
+            for (var i = 0; i < uiConfigsList.length; i++) {
+              final raw = uiConfigsList[i];
               if (raw is! Map) {
                 throw ArgumentError(
                     "ui_configs[$i] must be an object (Map), got ${raw.runtimeType}.");
@@ -245,8 +250,10 @@ class TimelineCardSkill extends Skill {
             final tagNames = <String>[];
             final newTagsToCreate = <Map<String, dynamic>>[];
 
-            if (tags != null) {
-              for (var tagObj in tags) {
+            final tagsList =
+                tags == null ? null : _normalizeListArgument(tags, 'tags');
+            if (tagsList != null) {
+              for (var tagObj in tagsList) {
                 final extractMap = Map<String, dynamic>.from(tagObj as Map);
                 var tagName = (extractMap['name'] as String?)?.trim() ?? '';
 
@@ -382,5 +389,30 @@ class TimelineCardSkill extends Skill {
         },
       ),
     ];
+  }
+
+  static List<dynamic> _normalizeListArgument(dynamic value, String name) {
+    if (value is List) {
+      return value;
+    }
+    if (value is String) {
+      final trimmed = value.trim();
+      if (trimmed.isEmpty) {
+        throw ArgumentError('$name must be a non-empty array.');
+      }
+      try {
+        final decoded = jsonDecode(trimmed);
+        if (decoded is List) {
+          return decoded;
+        }
+        throw ArgumentError(
+            '$name must be an array or a JSON-encoded array string.');
+      } on FormatException catch (e) {
+        throw ArgumentError('$name must be valid JSON when passed as a string: '
+            '${e.message}');
+      }
+    }
+    throw ArgumentError(
+        '$name must be an array or a JSON-encoded array string, got ${value.runtimeType}.');
   }
 }

--- a/test/agent/agent_tool_error_result_test.dart
+++ b/test/agent/agent_tool_error_result_test.dart
@@ -62,6 +62,137 @@ void main() {
       expect(_text(result), contains('fact id: 2026/05/18.md#ts_999'));
     });
 
+    test('save_timeline_card accepts JSON-encoded list arguments', () async {
+      final tool = TimelineCardSkill(
+        forceActivate: true,
+        stopAfterSuccessSaveCard: true,
+      ).tools!.singleWhere((tool) => tool.name == 'save_timeline_card');
+      final date = DateTime(2026, 5, 18);
+      const factId = '2026/05/18.md#ts_3';
+      await FileSystemService.instance.appendToDailyFactFile(
+        userId,
+        date,
+        '## <id:ts_3> 11:35:17 "{}"\n\nMorning Memex project notes.',
+      );
+
+      final result = await _runToolCall(
+        tool: tool,
+        arguments: {
+          'fact_id': factId,
+          'title': 'Memex project notes',
+          'ui_configs': jsonEncode([
+            {
+              'template_id': 'article',
+              'data': {
+                'title': 'Memex project notes',
+                'body': 'Morning Memex project notes.',
+              },
+            },
+          ]),
+          'tags': jsonEncode([
+            {'name': 'Project'},
+            {'name': 'Emotion'},
+          ]),
+        },
+        metadata: {'userId': userId},
+      );
+
+      final card = await FileSystemService.instance.readCardFile(
+        userId,
+        factId,
+      );
+
+      expect(result.isError, isFalse);
+      expect(card?.title, 'Memex project notes');
+      expect(card?.uiConfigs.single.templateId, 'article');
+      expect(card?.tags, ['Project', 'Emotion']);
+    });
+
+    test('save_timeline_card still accepts native list arguments', () async {
+      final tool = TimelineCardSkill(
+        forceActivate: true,
+        stopAfterSuccessSaveCard: true,
+      ).tools!.singleWhere((tool) => tool.name == 'save_timeline_card');
+      final date = DateTime(2026, 5, 18);
+      const factId = '2026/05/18.md#ts_4';
+      await FileSystemService.instance.appendToDailyFactFile(
+        userId,
+        date,
+        '## <id:ts_4> 11:42:00 "{}"\n\nNative list tool args.',
+      );
+
+      final result = await _runToolCall(
+        tool: tool,
+        arguments: {
+          'fact_id': factId,
+          'title': 'Native list args',
+          'ui_configs': [
+            {
+              'template_id': 'article',
+              'data': {'body': 'Native list tool args.'},
+            },
+          ],
+          'tags': [
+            {'name': 'Knowledge'},
+          ],
+        },
+        metadata: {'userId': userId},
+      );
+
+      final card = await FileSystemService.instance.readCardFile(
+        userId,
+        factId,
+      );
+
+      expect(result.isError, isFalse);
+      expect(card?.uiConfigs.single.templateId, 'article');
+      expect(card?.tags, ['Knowledge']);
+    });
+
+    test('save_timeline_card rejects malformed JSON list strings', () async {
+      final tool = TimelineCardSkill(
+        forceActivate: true,
+        stopAfterSuccessSaveCard: true,
+      ).tools!.singleWhere((tool) => tool.name == 'save_timeline_card');
+
+      final result = await _runToolCall(
+        tool: tool,
+        arguments: {
+          'fact_id': '2026/05/18.md#ts_5',
+          'title': 'Malformed list args',
+          'ui_configs': '[{"template_id":"article"',
+        },
+        metadata: {'userId': userId},
+      );
+
+      expect(result.isError, isTrue);
+      expect(_text(result), contains('ui_configs must be valid JSON'));
+    });
+
+    test('save_timeline_card rejects JSON strings that are not arrays',
+        () async {
+      final tool = TimelineCardSkill(
+        forceActivate: true,
+        stopAfterSuccessSaveCard: true,
+      ).tools!.singleWhere((tool) => tool.name == 'save_timeline_card');
+
+      final result = await _runToolCall(
+        tool: tool,
+        arguments: {
+          'fact_id': '2026/05/18.md#ts_6',
+          'title': 'Wrong list shape',
+          'ui_configs': jsonEncode({
+            'template_id': 'article',
+            'data': {'body': 'This should have been wrapped in a list.'},
+          }),
+        },
+        metadata: {'userId': userId},
+      );
+
+      expect(result.isError, isTrue);
+      expect(_text(result), contains('ui_configs must be an array'));
+    });
+
     test('SaveComment invalid input is marked as a tool error', () async {
       final tool = CommentToolFactory(
         userId: userId,


### PR DESCRIPTION
## 背景

Closes #134。

`save_timeline_card` 的 `ui_configs`、`tags` 等字段在 schema 中声明为 array，但 LLM 工具调用在复杂嵌套参数上偶尔会把数组序列化成 JSON 字符串。原实现直接用 `List` 作为回调入参，导致参数绑定阶段抛出类型错误，工具内部校验和可读错误都无法执行。

## 改动

- 将 `save_timeline_card` 的列表型入参改为先以 `dynamic` 接收。
- 新增列表参数归一化逻辑，支持原生 `List` 和 JSON-encoded array string。
- 对 malformed JSON、解码后不是 array 的字符串返回明确 `ArgumentError`。
- 扩充 agent 工具错误测试，覆盖原生数组、JSON 字符串数组、坏 JSON、非数组 JSON 字符串等场景。

## 影响

这个改动只发生在工具边界，不改变卡片模板校验、tag 校验、文件写入流程，也不会放宽业务数据结构要求。它主要提升 LLM tool calling 参数漂移时的容错能力和错误可恢复性。

## 验证

- `flutter test --no-pub test/agent/agent_tool_error_result_test.dart`
- `dart analyze lib/agent/skills/manage_timeline_card/timeline_card_skill.dart test/agent/agent_tool_error_result_test.dart`
  - 仅剩该工具原有 snake_case 工具参数名 info。