### PR TITLE
[codex] 收敛 PKM skip prompt 引导

### DIFF
--- a/lib/agent/pkm_agent/prompts.dart
+++ b/lib/agent/pkm_agent/prompts.dart
@@ -10,7 +10,6 @@ const pkmAgentSystemPrompt =
 # Current Objectives
 - Understand diverse daily user raw inputs, extract all information from them, and organize them into the knowledge base.
 - Analyze and identify meaningful trends, patterns, associations, suggestions, or discoveries related to current user raw input based on the knowledge base.
-- Respect explicit non-persistence requests. If the user says not to save, remember, persist, write long-term memory, or affect existing knowledge, this instruction takes priority over the default knowledge organization task.
 - Optional: When encountering structural issues or receiving relevant `<system-reminder>` feedback about the P.A.R.A. knowledge base, you are empowered to act proactively. In addition to organizing the current input, you can also execute the "P.A.R.A. Maintenance Task" to optimize and refactor the knowledge base structure when you deem it appropriate.
 
 # System Reminder

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -136,15 +136,8 @@ Bad Examples:
 - **Language:** $fileLanguageInstruction
 
 # Non-Persistent Inputs
-User intent has priority over the default P.A.R.A. organization workflow. If the current raw input explicitly says not to save, remember, persist, write long-term memory, write into the knowledge base, or affect/modify existing knowledge, do not create, edit, move, or remove P.A.R.A. files for this input.
-
-For these inputs, call `skip_pkm_organization` as the completion action instead of writing P.A.R.A. files or forcing a timeline insight update. Use one of these reasons:
-- `explicit_user_opt_out`: the user explicitly says not to remember, persist, save, write long-term memory, or affect existing knowledge.
-- `temporary_state`: the input is explicitly framed as temporary, only today's state, or a short-lived condition.
-- `low_signal_noise`: the input is a test, noise, or too low-signal for durable organization.
-- `duplicate_existing_memory`: the input adds no durable information beyond existing knowledge.
-
-Examples that should use `skip_pkm_organization`: "只是试一下，不要记", "不要写成长记忆", "这只是今天状态，不要写成长记忆", "临时提醒，不要长期保存", "不要影响某某项目/规则".
+If the current raw input explicitly asks not to persist this input or not to modify existing knowledge, call `skip_pkm_organization` instead of writing P.A.R.A. files for this input.
+Use this only for explicit non-persistence or no-op requests; otherwise follow the normal organization workflow.
 
 # Card Insights:
 Use the `update_timeline_card_insight` tool to update the insight section of the corresponding Timeline Card. This tool call must be included in your final message for the **New Raw Input Organization Task**, as it marks the completion of that specific workflow.

--- a/test/agent/pkm_agent_skip_completion_test.dart
+++ b/test/agent/pkm_agent_skip_completion_test.dart
@@ -203,9 +203,10 @@ void main() {
       );
 
       expect(prompt, contains('skip_pkm_organization'));
-      expect(prompt, contains('explicit_user_opt_out'));
-      expect(prompt, contains('不要写成长记忆'));
-      expect(prompt, contains('不要影响某某项目/规则'));
+      expect(prompt, contains('explicitly asks not to persist'));
+      expect(prompt, contains('Use this only for explicit'));
+      expect(prompt, isNot(contains('不要写成长记忆')));
+      expect(prompt, isNot(contains('不要影响某某项目/规则')));
     });
 
     test('skip tool parameters expose enum reason and evidence fields', () {


### PR DESCRIPTION
## 背景

跟进 #138：PKM skip/no-op 出口已经合入，但 prompt 里的行为引导偏重，容易让模型过度保守。

## 变更

- 移除 `pkmAgentSystemPrompt` 里的全局非持久化优先级描述。
- 将 `pkmSkillSystemPrompt` 的 `Non-Persistent Inputs` 从长段说明、reason 枚举解释和中文例子，收敛为两句最小工具使用条件。
- 更新测试，明确 prompt 仍暴露 `skip_pkm_organization`，但不再包含“不要写成长记忆 / 不要影响某某项目/规则”等强示例。

## 验证

- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub --concurrency=1 test/agent/pkm_agent_skip_completion_test.dart`
- `git diff --cached --check`
