### PR TITLE
[codex] Harden ChatAgent temporal context

### DIFF
--- a/lib/agent/built_in_tools/search_event_logs_tool.dart
+++ b/lib/agent/built_in_tools/search_event_logs_tool.dart
@@ -1,5 +1,6 @@
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/utils/time_context.dart';
 
 /// Build a tool for searching event logs
 ///
@@ -38,7 +39,8 @@ Returns:
 A list of events sorted by time (newest first), each containing:
 - event_type: Type of event
 - description: Human-readable description
-- event_time: When the event occurred
+- local_time: When the event occurred in the user's local timezone, including explicit UTC offset
+- raw_event_time: Original stored timestamp
 - file_path: File path (for file operations)
 - metadata: Additional context
 ''',
@@ -67,7 +69,7 @@ A list of events sorted by time (newest first), each containing:
       'required': ['from_time'],
     },
     executable:
-        (String from_time, int? limit, int? offset, String? to_time) async {
+        (String fromTime, int? limit, int? offset, String? toTime) async {
       final effectiveLimit = (limit ?? 50).clamp(1, 200);
       final effectiveOffset = (offset ?? 0).clamp(0, 10000);
 
@@ -76,56 +78,78 @@ A list of events sorted by time (newest first), each containing:
         final userId = AgentCallToolContext.current!.state.metadata['userId'];
         final events = await fileService.eventLogService.searchEvents(
           userId: userId,
-          fromTime: from_time,
+          fromTime: fromTime,
           offset: effectiveOffset,
           limit: effectiveLimit,
-          toTime: to_time,
+          toTime: toTime,
         );
 
         if (events.isEmpty) {
           return 'No events found matching the criteria.';
         }
 
-        // Format events for display
-        final buffer = StringBuffer();
-        buffer.writeln('Found ${events.length} events:');
-        buffer.writeln();
-
-        for (var i = 0; i < events.length; i++) {
-          final event = events[i];
-          buffer.writeln('--- Event ${i + 1} ---');
-          buffer.writeln('Time: ${event['event_time']}');
-          buffer.writeln('Type: ${event['event_type']}');
-          buffer.writeln('Description: ${event['description']}');
-
-          if (event['file_path'] != null) {
-            buffer.writeln('File: ${event['file_path']}');
-          }
-
-          if (event['metadata'] != null) {
-            buffer.writeln('Metadata: ${event['metadata']}');
-          }
-
-          buffer.writeln();
-        }
-
-        // Add smart pagination hint
-        if (events.length == effectiveLimit) {
-          buffer.writeln(
-              '⚠️ Returned exactly $effectiveLimit events (the limit).');
-          buffer.writeln('There might be more events available. To see more:');
-          buffer.writeln(
-              '- Use offset=${effectiveOffset + effectiveLimit} to see next page');
-          buffer.writeln('- Or increase limit (max: 200) to see more at once');
-        } else {
-          buffer.writeln(
-              'Showing all ${events.length} events matching the criteria.');
-        }
-
-        return buffer.toString();
+        return renderEventLogSearchResultsForAgent(
+          events,
+          effectiveLimit: effectiveLimit,
+          effectiveOffset: effectiveOffset,
+        );
       } catch (e) {
         throw StateError('Error searching event logs: $e');
       }
     },
   );
+}
+
+String renderEventLogSearchResultsForAgent(
+  List<Map<String, dynamic>> events, {
+  required int effectiveLimit,
+  required int effectiveOffset,
+}) {
+  final buffer = StringBuffer();
+  buffer.writeln('Found ${events.length} events:');
+  buffer.writeln();
+
+  for (var i = 0; i < events.length; i++) {
+    final event = events[i];
+    final localTime = event['event_time_local'] as String? ??
+        formatLocalDateTimeWithZoneOrNull(event['event_time']) ??
+        'Unknown';
+    buffer.writeln('--- Event ${i + 1} ---');
+    buffer.writeln('Local Time: $localTime');
+    if (event['event_time_unix_seconds'] != null) {
+      buffer.writeln('Unix Seconds: ${event['event_time_unix_seconds']}');
+    }
+    if (event['event_time'] != null) {
+      buffer.writeln('Raw Time: ${event['event_time']}');
+    }
+    buffer.writeln('Type: ${event['event_type']}');
+    buffer.writeln('Description: ${event['description']}');
+
+    if (event['file_path'] != null) {
+      buffer.writeln('File: ${event['file_path']}');
+    }
+
+    if (event['metadata'] != null) {
+      buffer.writeln('Metadata: ${event['metadata']}');
+    }
+
+    buffer.writeln();
+  }
+
+  if (events.length == effectiveLimit) {
+    buffer.writeln(
+      '⚠️ Returned exactly $effectiveLimit events (the limit).',
+    );
+    buffer.writeln('There might be more events available. To see more:');
+    buffer.writeln(
+      '- Use offset=${effectiveOffset + effectiveLimit} to see next page',
+    );
+    buffer.writeln('- Or increase limit (max: 200) to see more at once');
+  } else {
+    buffer.writeln(
+      'Showing all ${events.length} events matching the criteria.',
+    );
+  }
+
+  return buffer.toString();
 }

--- a/lib/data/repositories/chat.dart
+++ b/lib/data/repositories/chat.dart
@@ -4,6 +4,7 @@ import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/api_exception.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
@@ -111,8 +112,16 @@ Future<List<Map<String, dynamic>>> fetchChatSessionsEndpoint({
           'title': sessionData['title'] as String? ?? 'New chat',
           'created_at': sessionData['created_at'] as String? ??
               DateTime.now().toIso8601String(),
+          'created_at_local': sessionData['created_at_local'] as String? ??
+              formatLocalDateTimeWithZoneOrNull(sessionData['created_at']),
+          'created_at_unix_seconds': sessionData['created_at_unix_seconds'] ??
+              unixSecondsFromDateTimeOrNull(sessionData['created_at']),
           'updated_at': sessionData['updated_at'] as String? ??
               DateTime.now().toIso8601String(),
+          'updated_at_local': sessionData['updated_at_local'] as String? ??
+              formatLocalDateTimeWithZoneOrNull(sessionData['updated_at']),
+          'updated_at_unix_seconds': sessionData['updated_at_unix_seconds'] ??
+              unixSecondsFromDateTimeOrNull(sessionData['updated_at']),
           'message_count': messages.length,
           'last_message_preview': lastMessagePreview,
           'is_quick_query': sessionData['is_quick_query'] == true,
@@ -143,7 +152,8 @@ Future<List<Map<String, dynamic>>> fetchChatSessionsEndpoint({
 /// Returns:
 ///   Map<String, dynamic>: session detail (session_id, agent_name, title, created_at, updated_at, messages)
 Future<Map<String, dynamic>> fetchChatSessionDetailEndpoint(
-    String sessionId) async {
+  String sessionId,
+) async {
   _logger.info('fetchChatSessionDetail called: sessionId=$sessionId');
 
   try {
@@ -173,8 +183,16 @@ Future<Map<String, dynamic>> fetchChatSessionDetailEndpoint(
       'title': sessionData['title'] as String? ?? 'New chat',
       'created_at': sessionData['created_at'] as String? ??
           DateTime.now().toIso8601String(),
+      'created_at_local': sessionData['created_at_local'] as String? ??
+          formatLocalDateTimeWithZoneOrNull(sessionData['created_at']),
+      'created_at_unix_seconds': sessionData['created_at_unix_seconds'] ??
+          unixSecondsFromDateTimeOrNull(sessionData['created_at']),
       'updated_at': sessionData['updated_at'] as String? ??
           DateTime.now().toIso8601String(),
+      'updated_at_local': sessionData['updated_at_local'] as String? ??
+          formatLocalDateTimeWithZoneOrNull(sessionData['updated_at']),
+      'updated_at_unix_seconds': sessionData['updated_at_unix_seconds'] ??
+          unixSecondsFromDateTimeOrNull(sessionData['updated_at']),
       'messages': messages,
       if (sessionData['total_usage'] != null)
         'total_usage': sessionData['total_usage'],
@@ -247,8 +265,20 @@ Future<List<Map<String, dynamic>>> _getSessionMessages(
   final messages = sessionData['messages'] as List<dynamic>? ?? [];
   return messages.map((msg) {
     if (msg is Map<String, dynamic>) {
-      return msg;
+      return _withLocalTimestampFallback(msg);
     }
     return <String, dynamic>{};
   }).toList();
+}
+
+Map<String, dynamic> _withLocalTimestampFallback(Map<String, dynamic> msg) {
+  final result = Map<String, dynamic>.from(msg);
+  if (result['local_time'] == null) {
+    final parsed = tryParseDateTime(result['timestamp']);
+    if (parsed != null) {
+      result['local_time'] = formatLocalDateTimeWithZone(parsed);
+      result['unix_seconds'] ??= unixSecondsFromDateTime(parsed);
+    }
+  }
+  return result;
 }

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -61,17 +61,20 @@ class ChatService {
     }
 
     String finalSessionId = sessionId ?? '';
+    final userMessageTime = DateTime.now();
 
     // 1. Session Management
     try {
       if (finalSessionId.isEmpty) {
         finalSessionId = await _createSession(
-            userId,
-            agentName,
-            [
-              {'type': 'text', 'text': message},
-            ],
-            isQuickQuery: isQuickQuery);
+          userId,
+          agentName,
+          [
+            {'type': 'text', 'text': message},
+          ],
+          isQuickQuery: isQuickQuery,
+          createdAt: userMessageTime,
+        );
       }
 
       // Notify UI of the active session ID immediately
@@ -87,6 +90,7 @@ class ChatService {
         ],
         refs: refs,
         isQuickQuery: isQuickQuery,
+        timestamp: userMessageTime,
       );
 
       // Log chat event
@@ -101,6 +105,8 @@ class ChatService {
             'scene_id': sceneId,
             'session_id': finalSessionId,
             'message': message,
+            'message_local_time': formatLocalDateTimeWithZone(userMessageTime),
+            'message_unix_seconds': unixSecondsFromDateTime(userMessageTime),
             'has_refs': refs != null && refs.isNotEmpty,
             'is_quick_query': isQuickQuery,
           },
@@ -336,7 +342,8 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
 
     userMessages.add(
       UserMessage([
-        TextPart(buildCurrentTimeReminder(DateTime.now())),
+        TextPart(buildCurrentTimeReminder(userMessageTime)),
+        TextPart(buildMessageTimePrefix(userMessageTime)),
         TextPart(message),
       ]),
     );
@@ -452,6 +459,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
       }
 
       // Save AI response with usage stats
+      final responseTime = DateTime.now();
       final sessionTotalUsage = await _addMessageToSession(
         userId,
         sessionId,
@@ -468,6 +476,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
           'total_tokens': totalTokens,
           'total_cost': totalCost,
         },
+        timestamp: responseTime,
       );
 
       // Emit Token Usage (Cumulative if available, else current turn)
@@ -611,12 +620,13 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
     String? agentName,
     List<Map<String, dynamic>> initialContent, {
     bool isQuickQuery = false,
+    DateTime? createdAt,
   }) async {
     final uuidStr = _uuid.v4();
     final sessionId = agentName != null && agentName.isNotEmpty
         ? '${agentName}_$uuidStr'
         : uuidStr;
-    final now = DateTime.now();
+    final now = createdAt ?? DateTime.now();
 
     String? title;
     for (final item in initialContent) {
@@ -632,7 +642,11 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
       'agent_name': agentName,
       'title': title ?? 'New Chat',
       'created_at': now.toIso8601String(),
+      'created_at_local': formatLocalDateTimeWithZone(now),
+      'created_at_unix_seconds': unixSecondsFromDateTime(now),
       'updated_at': now.toIso8601String(),
+      'updated_at_local': formatLocalDateTimeWithZone(now),
+      'updated_at_unix_seconds': unixSecondsFromDateTime(now),
       'is_quick_query': isQuickQuery,
       'messages': <dynamic>[],
     };
@@ -653,6 +667,7 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
     Map<String, dynamic>? usage,
     List<Map<String, String>>? refs,
     bool? isQuickQuery,
+    DateTime? timestamp,
   }) async {
     final sessionFile = _getSessionFilePath(userId, sessionId);
     if (!await sessionFile.exists()) return null;
@@ -660,16 +675,22 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
     final fileContent = await sessionFile.readAsString();
     final doc = loadYaml(fileContent);
     final sessionData = jsonDecode(jsonEncode(doc)) as Map<String, dynamic>;
+    _backfillSessionTimeContext(sessionData);
 
+    final messageTime = timestamp ?? DateTime.now();
     final messageDict = {
       'role': role,
       'content': content,
       if (usage != null) 'usage': usage,
       if (refs != null) 'refs': refs,
-      'timestamp': DateTime.now().toIso8601String(),
+      'timestamp': messageTime.toIso8601String(),
+      'local_time': formatLocalDateTimeWithZone(messageTime),
+      'unix_seconds': unixSecondsFromDateTime(messageTime),
     };
 
     final messages = (sessionData['messages'] as List<dynamic>? ?? [])
+        .map(_backfillMessageTimeContext)
+        .toList()
       ..add(messageDict);
     sessionData['messages'] = messages;
 
@@ -704,7 +725,10 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
       sessionData['is_quick_query'] = isQuickQuery;
     }
 
-    sessionData['updated_at'] = DateTime.now().toIso8601String();
+    final updatedAt = DateTime.now();
+    sessionData['updated_at'] = updatedAt.toIso8601String();
+    sessionData['updated_at_local'] = formatLocalDateTimeWithZone(updatedAt);
+    sessionData['updated_at_unix_seconds'] = unixSecondsFromDateTime(updatedAt);
 
     await _fileService.writeYamlFile(sessionFile.path, sessionData);
     return sessionData['total_usage'] as Map<String, dynamic>?;
@@ -713,5 +737,46 @@ When the user disputes content you generated (such as Cards, PKM entries, or Ass
   File _getSessionFilePath(String userId, String sessionId) {
     final sessionsPath = _fileService.getChatSessionsPath(userId);
     return File(p.join(sessionsPath, '$sessionId.yaml'));
+  }
+
+  void _backfillSessionTimeContext(Map<String, dynamic> sessionData) {
+    final createdAt = tryParseDateTime(sessionData['created_at']);
+    if (createdAt != null) {
+      sessionData['created_at_local'] ??= formatLocalDateTimeWithZone(
+        createdAt,
+      );
+      sessionData['created_at_unix_seconds'] ??= unixSecondsFromDateTime(
+        createdAt,
+      );
+    }
+
+    final updatedAt = tryParseDateTime(sessionData['updated_at']);
+    if (updatedAt != null) {
+      sessionData['updated_at_local'] ??= formatLocalDateTimeWithZone(
+        updatedAt,
+      );
+      sessionData['updated_at_unix_seconds'] ??= unixSecondsFromDateTime(
+        updatedAt,
+      );
+    }
+  }
+
+  dynamic _backfillMessageTimeContext(dynamic message) {
+    if (message is! Map<String, dynamic>) {
+      return message;
+    }
+
+    final parsed = tryParseDateTime(message['timestamp']);
+    if (parsed == null) {
+      return message;
+    }
+
+    return {
+      ...message,
+      'local_time':
+          message['local_time'] ?? formatLocalDateTimeWithZone(parsed),
+      'unix_seconds':
+          message['unix_seconds'] ?? unixSecondsFromDateTime(parsed),
+    };
   }
 }

--- a/lib/data/services/event_log_service.dart
+++ b/lib/data/services/event_log_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:path/path.dart' as path;
 import 'package:logging/logging.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
 
 import 'package:synchronized/synchronized.dart';
 
@@ -72,6 +73,8 @@ class EventLogService {
           'event_type': eventType,
           'description': description,
           'event_time': now.toIso8601String(),
+          'event_time_local': formatLocalDateTimeWithZone(now),
+          'event_time_unix_seconds': unixSecondsFromDateTime(now),
           'user_id': userId,
           if (filePath != null) 'file_path': filePath,
           if (metadata != null) 'metadata': metadata,

--- a/lib/data/services/task_handlers/custom_agent_task_handler.dart
+++ b/lib/data/services/task_handlers/custom_agent_task_handler.dart
@@ -14,9 +14,9 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/domain/models/custom_agent_config.dart';
-import 'package:memex/domain/models/event_bus_message.dart';
 import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
 import 'package:memex/utils/user_storage.dart';
 
 final Logger _logger = getLogger('CustomAgentTaskHandler');
@@ -78,14 +78,17 @@ const _audioExtensions = {
 /// in serialized event content. Matches both Chinese and English labels:
 ///   `![图片](fs://xxx)` / `![image](fs://xxx)` → image
 ///   `[音频](fs://xxx)` / `[audio](fs://xxx)` → audio
-final _mediaRefPattern =
-    RegExp(r'(?:!\[(?:图片|image)\]|\[(?:音频|audio)\])\(fs://([^)]+)\)');
+final _mediaRefPattern = RegExp(
+  r'(?:!\[(?:图片|image)\]|\[(?:音频|audio)\])\(fs://([^)]+)\)',
+);
 
 /// Extract media references from the event XML string and build multimodal
 /// [UserContentPart] list. This is generic — works for any event type whose
 /// serialized content contains `![image](fs://file)` or `[audio](fs://file)`.
 Future<List<UserContentPart>> _buildAssetPartsFromXml(
-    String userId, String eventXml) async {
+  String userId,
+  String eventXml,
+) async {
   final matches = _mediaRefPattern.allMatches(eventXml);
   if (matches.isEmpty) return const [];
 
@@ -134,7 +137,8 @@ Future<void> _handleCustomAgentTask(
 ) async {
   final agentName = config.agentName;
   _logger.info(
-      'Running custom agent "$agentName" for event ${payload['event_type']}');
+    'Running custom agent "$agentName" for event ${payload['event_type']}',
+  );
 
   final agentIdForLLM = config.llmConfigKey ?? AgentDefinitions.chatAgent;
   final resources = await UserStorage.getAgentLLMResources(
@@ -153,8 +157,10 @@ Future<void> _handleCustomAgentTask(
     'sceneId': nowStr,
   });
 
-  final skillAbsPath = FileSystemService.instance
-      .resolveSkillPath(userId, config.skillDirectoryPath);
+  final skillAbsPath = FileSystemService.instance.resolveSkillPath(
+    userId,
+    config.skillDirectoryPath,
+  );
 
   final workingDirAbsPath = await FileSystemService.instance
       .resolveWorkingDirectory(userId, config.workingDirectory);
@@ -258,14 +264,19 @@ Future<void> _createChatSession({
   // Don't overwrite if it already exists (e.g. retry scenario).
   if (sessionFile.existsSync()) return;
 
-  final now = DateTime.now().toIso8601String();
+  final now = DateTime.now();
+  final nowIso = now.toIso8601String();
+  final nowLocal = formatLocalDateTimeWithZone(now);
+  final nowUnixSeconds = unixSecondsFromDateTime(now);
   final messages = <Map<String, dynamic>>[
     {
       'role': 'user',
       'content': [
         {'type': 'text', 'text': userText},
       ],
-      'timestamp': now,
+      'timestamp': nowIso,
+      'local_time': nowLocal,
+      'unix_seconds': nowUnixSeconds,
     },
     if (aiResponse != null)
       {
@@ -273,7 +284,9 @@ Future<void> _createChatSession({
         'content': [
           {'type': 'text', 'text': aiResponse},
         ],
-        'timestamp': now,
+        'timestamp': nowIso,
+        'local_time': nowLocal,
+        'unix_seconds': nowUnixSeconds,
       },
   ];
 
@@ -281,16 +294,21 @@ Future<void> _createChatSession({
     'session_id': sessionId,
     'agent_name': agentName,
     'title': agentName,
-    'created_at': now,
-    'updated_at': now,
+    'created_at': nowIso,
+    'created_at_local': nowLocal,
+    'created_at_unix_seconds': nowUnixSeconds,
+    'updated_at': nowIso,
+    'updated_at_local': nowLocal,
+    'updated_at_unix_seconds': nowUnixSeconds,
     'messages': messages,
     'is_custom_agent': true,
   };
 
   try {
     await fs.writeYamlFile(sessionFile.path, sessionData);
-    _logger
-        .info('Created chat session for custom agent "$agentName": $sessionId');
+    _logger.info(
+      'Created chat session for custom agent "$agentName": $sessionId',
+    );
   } catch (e) {
     _logger.warning('Failed to create chat session file: $e');
   }
@@ -347,13 +365,15 @@ Future<void> _createResultCard({
   }
 
   // Notify the timeline UI.
-  EventBusService.instance.emitEvent(CardAddedMessage(
-    id: factId,
-    html: '',
-    timestamp: timestampSec,
-    tags: [agentName],
-    status: status,
-    title: title,
-    uiConfigs: [uiConfig],
-  ));
+  EventBusService.instance.emitEvent(
+    CardAddedMessage(
+      id: factId,
+      html: '',
+      timestamp: timestampSec,
+      tags: [agentName],
+      status: status,
+      title: title,
+      uiConfigs: [uiConfig],
+    ),
+  );
 }

--- a/lib/utils/time_context.dart
+++ b/lib/utils/time_context.dart
@@ -7,8 +7,30 @@ DateTime? tryParseUnixSeconds(dynamic value) {
   return null;
 }
 
+DateTime? tryParseDateTime(dynamic value) {
+  if (value is DateTime) {
+    return value;
+  }
+  if (value is String && value.trim().isNotEmpty) {
+    return DateTime.tryParse(value);
+  }
+  return null;
+}
+
 DateTime dateTimeFromUnixSeconds(dynamic value, {DateTime? fallback}) {
   return tryParseUnixSeconds(value) ?? fallback ?? DateTime.now();
+}
+
+int unixSecondsFromDateTime(DateTime dateTime) {
+  return dateTime.millisecondsSinceEpoch ~/ 1000;
+}
+
+int? unixSecondsFromDateTimeOrNull(dynamic value) {
+  final dateTime = tryParseDateTime(value);
+  if (dateTime == null) {
+    return null;
+  }
+  return unixSecondsFromDateTime(dateTime);
 }
 
 String formatTimeZoneOffset(Duration offset) {
@@ -24,6 +46,14 @@ String formatLocalDateTimeWithZone(DateTime dateTime) {
   final formatted = DateFormat('yyyy-MM-dd HH:mm:ss').format(local);
   return '$formatted ${formatTimeZoneOffset(local.timeZoneOffset)} '
       '(${local.timeZoneName})';
+}
+
+String? formatLocalDateTimeWithZoneOrNull(dynamic value) {
+  final dateTime = tryParseDateTime(value);
+  if (dateTime == null) {
+    return null;
+  }
+  return formatLocalDateTimeWithZone(dateTime);
 }
 
 String buildCurrentTimeReminder(DateTime dateTime) {

--- a/test/agent/built_in_tools/search_event_logs_tool_test.dart
+++ b/test/agent/built_in_tools/search_event_logs_tool_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/built_in_tools/search_event_logs_tool.dart';
+
+void main() {
+  group('renderEventLogSearchResultsForAgent', () {
+    test('uses stored local time and unix seconds when available', () {
+      final output = renderEventLogSearchResultsForAgent(
+        [
+          {
+            'event_type': 'user_chat',
+            'description': 'User sent message to agent',
+            'event_time': '2026-04-28T12:00:46.000Z',
+            'event_time_local': '2026-04-28 20:00:46 +08:00 (CST)',
+            'event_time_unix_seconds': 1777387246,
+            'metadata': {'session_id': 's1'},
+          },
+        ],
+        effectiveLimit: 10,
+        effectiveOffset: 0,
+      );
+
+      expect(output, contains('Local Time: 2026-04-28 20:00:46 +08:00 (CST)'));
+      expect(output, contains('Unix Seconds: 1777387246'));
+      expect(output, contains('Raw Time: 2026-04-28T12:00:46.000Z'));
+      expect(output, contains('Metadata: {session_id: s1}'));
+    });
+
+    test('falls back to raw event_time for legacy events', () {
+      final output = renderEventLogSearchResultsForAgent(
+        [
+          {
+            'event_type': 'user_chat',
+            'description': 'Legacy chat event',
+            'event_time': '2026-04-28T20:00:46.000',
+          },
+        ],
+        effectiveLimit: 10,
+        effectiveOffset: 0,
+      );
+
+      expect(output, contains('Local Time: 2026-04-28 20:00:46'));
+      expect(output, contains('Raw Time: 2026-04-28T20:00:46.000'));
+    });
+
+    test('keeps rendering useful output when legacy time is malformed', () {
+      final output = renderEventLogSearchResultsForAgent(
+        [
+          {
+            'event_type': 'user_chat',
+            'description': 'Malformed timestamp event',
+            'event_time': 'not-a-date',
+          },
+        ],
+        effectiveLimit: 10,
+        effectiveOffset: 0,
+      );
+
+      expect(output, contains('Local Time: Unknown'));
+      expect(output, contains('Raw Time: not-a-date'));
+      expect(output, contains('Malformed timestamp event'));
+    });
+
+    test('includes pagination hint only when the page is full', () {
+      final fullPageOutput = renderEventLogSearchResultsForAgent(
+        [
+          {'event_type': 'user_chat', 'description': 'first'},
+          {'event_type': 'user_chat', 'description': 'second'},
+        ],
+        effectiveLimit: 2,
+        effectiveOffset: 4,
+      );
+
+      final partialPageOutput = renderEventLogSearchResultsForAgent(
+        [
+          {'event_type': 'user_chat', 'description': 'only'},
+        ],
+        effectiveLimit: 2,
+        effectiveOffset: 0,
+      );
+
+      expect(fullPageOutput, contains('offset=6'));
+      expect(partialPageOutput, contains('Showing all 1 events'));
+      expect(partialPageOutput, isNot(contains('offset=')));
+    });
+  });
+}

--- a/test/data/repositories/chat_session_time_context_test.dart
+++ b/test/data/repositories/chat_session_time_context_test.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/chat.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('chat session time context', () {
+    const userId = 'chat-time-test-user';
+    late Directory tempDir;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await UserStorage.initL10n();
+      await UserStorage.saveUser(userId);
+      tempDir = await Directory.systemTemp.createTemp(
+        'memex_chat_time_context_test_',
+      );
+      await FileSystemService.init(tempDir.path);
+    });
+
+    tearDown(() async {
+      await LocalAssetServer.stopServer();
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('hydrates local time fields for legacy session detail', () async {
+      await _writeSession(
+        userId: userId,
+        sessionId: 'legacy-session',
+        data: {
+          'session_id': 'legacy-session',
+          'agent_name': 'memex_agent',
+          'title': 'Legacy Session',
+          'created_at': '2026-04-28T20:00:46.000',
+          'updated_at': '2026-04-28T20:05:00.000',
+          'messages': [
+            {
+              'role': 'user',
+              'content': [
+                {'type': 'text', 'text': '今天晚上聊过什么？'},
+              ],
+              'timestamp': '2026-04-28T20:00:46.000',
+            },
+            {
+              'role': 'ai',
+              'content': [
+                {'type': 'text', 'text': '这是一个坏时间戳。'},
+              ],
+              'timestamp': 'not-a-date',
+            },
+          ],
+        },
+      );
+
+      final detail = await fetchChatSessionDetailEndpoint('legacy-session');
+      final messages = detail['messages'] as List<dynamic>;
+      final firstMessage = messages.first as Map<String, dynamic>;
+      final secondMessage = messages.last as Map<String, dynamic>;
+
+      expect(detail['created_at_local'], contains('2026-04-28 20:00:46'));
+      expect(detail['updated_at_local'], contains('2026-04-28 20:05:00'));
+      expect(detail['created_at_unix_seconds'], isA<int>());
+      expect(firstMessage['local_time'], contains('2026-04-28 20:00:46'));
+      expect(firstMessage['unix_seconds'], isA<int>());
+      expect(secondMessage.containsKey('local_time'), isFalse);
+      expect(secondMessage.containsKey('unix_seconds'), isFalse);
+    });
+
+    test('preserves existing local time fields in session messages', () async {
+      await _writeSession(
+        userId: userId,
+        sessionId: 'preserved-session',
+        data: {
+          'session_id': 'preserved-session',
+          'agent_name': 'memex_agent',
+          'title': 'Preserved Session',
+          'created_at': '2026-04-28T20:00:46.000',
+          'created_at_local': 'already-local-created',
+          'created_at_unix_seconds': 111,
+          'updated_at': '2026-04-28T20:05:00.000',
+          'updated_at_local': 'already-local-updated',
+          'updated_at_unix_seconds': 222,
+          'messages': [
+            {
+              'role': 'user',
+              'content': [
+                {'type': 'text', 'text': 'preserve me'},
+              ],
+              'timestamp': '2026-04-28T20:00:46.000',
+              'local_time': 'already-local-message',
+              'unix_seconds': 333,
+            },
+          ],
+        },
+      );
+
+      final detail = await fetchChatSessionDetailEndpoint('preserved-session');
+      final message =
+          (detail['messages'] as List<dynamic>).single as Map<String, dynamic>;
+
+      expect(detail['created_at_local'], 'already-local-created');
+      expect(detail['created_at_unix_seconds'], 111);
+      expect(detail['updated_at_local'], 'already-local-updated');
+      expect(detail['updated_at_unix_seconds'], 222);
+      expect(message['local_time'], 'already-local-message');
+      expect(message['unix_seconds'], 333);
+    });
+
+    test('adds local time fallback to chat session list rows', () async {
+      await _writeSession(
+        userId: userId,
+        sessionId: 'memex_agent_list-session',
+        data: {
+          'session_id': 'memex_agent_list-session',
+          'agent_name': 'memex_agent',
+          'title': 'List Session',
+          'created_at': '2026-04-28T20:00:46.000',
+          'updated_at': '2026-04-28T20:05:00.000',
+          'messages': [
+            {
+              'role': 'user',
+              'content': [
+                {'type': 'text', 'text': 'preview text'},
+              ],
+              'timestamp': '2026-04-28T20:00:46.000',
+            },
+          ],
+        },
+      );
+
+      final sessions = await fetchChatSessionsEndpoint(
+        agentName: 'memex_agent',
+        limit: 10,
+      );
+
+      expect(sessions, hasLength(1));
+      expect(sessions.single['created_at_local'], contains('2026-04-28'));
+      expect(sessions.single['updated_at_local'], contains('2026-04-28'));
+      expect(sessions.single['last_message_preview'], 'preview text');
+    });
+  });
+}
+
+Future<void> _writeSession({
+  required String userId,
+  required String sessionId,
+  required Map<String, dynamic> data,
+}) async {
+  final sessionPath = p.join(
+    FileSystemService.instance.getChatSessionsPath(userId),
+    '$sessionId.yaml',
+  );
+  await FileSystemService.instance.writeYamlFile(sessionPath, data);
+}

--- a/test/data/services/event_log_service_test.dart
+++ b/test/data/services/event_log_service_test.dart
@@ -1,0 +1,174 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/event_log_service.dart';
+
+void main() {
+  group('EventLogService', () {
+    test('stores agent-readable local time with explicit timezone', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'memex_event_log_service_test_',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final service = EventLogService(dataRoot: tempDir.path);
+      final fromTime =
+          DateTime.now().subtract(const Duration(minutes: 1)).toIso8601String();
+
+      await service.logEvent(
+        userId: 'test-user',
+        eventType: 'user_chat',
+        description: 'User sent message to agent',
+      );
+
+      final events = await service.searchEvents(
+        userId: 'test-user',
+        fromTime: fromTime,
+        offset: 0,
+        limit: 10,
+      );
+
+      expect(events, hasLength(1));
+      expect(
+        events.single['event_time_local'],
+        matches(RegExp(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [+-]\d{2}:\d{2}')),
+      );
+      expect(events.single['event_time_unix_seconds'], isA<int>());
+    });
+
+    test('searches legacy log lines without local-time fields', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'memex_event_log_service_test_',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final service = EventLogService(dataRoot: tempDir.path);
+      final logFile = File(
+        service.getEventLogPath('test-user', DateTime(2026, 4, 28)),
+      );
+      await logFile.parent.create(recursive: true);
+      await logFile.writeAsString(
+        '${jsonEncode({
+              'event_type': 'user_chat',
+              'description': 'legacy chat event',
+              'event_time': '2026-04-28T20:00:46.000',
+              'user_id': 'test-user',
+            })}\n',
+      );
+
+      final events = await service.searchEvents(
+        userId: 'test-user',
+        fromTime: '2026-04-28T00:00:00.000',
+        offset: 0,
+        limit: 10,
+        toTime: '2026-04-28T23:59:59.000',
+      );
+
+      expect(events, hasLength(1));
+      expect(events.single['description'], 'legacy chat event');
+      expect(events.single.containsKey('event_time_local'), isFalse);
+    });
+
+    test('applies event type, time range, and pagination filters', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'memex_event_log_service_test_',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final service = EventLogService(dataRoot: tempDir.path);
+      final logFile = File(
+        service.getEventLogPath('test-user', DateTime(2026, 4, 28)),
+      );
+      await logFile.parent.create(recursive: true);
+      await logFile.writeAsString(
+        [
+          {
+            'event_type': 'user_chat',
+            'description': 'older chat',
+            'event_time': '2026-04-28T08:00:00.000',
+            'user_id': 'test-user',
+          },
+          {
+            'event_type': 'file_modified',
+            'description': 'not a chat',
+            'event_time': '2026-04-28T12:00:00.000',
+            'user_id': 'test-user',
+          },
+          {
+            'event_type': 'user_chat',
+            'description': 'newer chat',
+            'event_time': '2026-04-28T20:00:00.000',
+            'user_id': 'test-user',
+          },
+          {
+            'event_type': 'user_chat',
+            'description': 'outside range',
+            'event_time': '2026-04-29T09:00:00.000',
+            'user_id': 'test-user',
+          },
+        ].map(jsonEncode).join('\n'),
+      );
+
+      final events = await service.searchEvents(
+        userId: 'test-user',
+        fromTime: '2026-04-28T00:00:00.000',
+        offset: 1,
+        limit: 1,
+        toTime: '2026-04-28T23:59:59.000',
+        eventType: 'user_chat',
+      );
+
+      expect(events, hasLength(1));
+      expect(events.single['description'], 'older chat');
+    });
+
+    test('ignores malformed json lines while keeping valid events', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'memex_event_log_service_test_',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final service = EventLogService(dataRoot: tempDir.path);
+      final logFile = File(
+        service.getEventLogPath('test-user', DateTime(2026, 4, 28)),
+      );
+      await logFile.parent.create(recursive: true);
+      await logFile.writeAsString(
+        'not-json\n'
+        '${jsonEncode({
+              'event_type': 'user_chat',
+              'description': 'valid event',
+              'event_time': '2026-04-28T20:00:46.000',
+              'user_id': 'test-user',
+            })}\n',
+      );
+
+      final events = await service.searchEvents(
+        userId: 'test-user',
+        fromTime: '2026-04-28T00:00:00.000',
+        offset: 0,
+        limit: 10,
+      );
+
+      expect(events, hasLength(1));
+      expect(events.single['description'], 'valid event');
+    });
+  });
+}

--- a/test/utils/time_context_test.dart
+++ b/test/utils/time_context_test.dart
@@ -10,12 +10,56 @@ void main() {
       expect(parsed!.millisecondsSinceEpoch, 1777377646000);
     });
 
+    test('rounds fractional Unix seconds to milliseconds', () {
+      final parsed = tryParseUnixSeconds(1.234);
+
+      expect(parsed, isNotNull);
+      expect(parsed!.millisecondsSinceEpoch, 1234);
+    });
+
+    test('rejects non numeric Unix seconds', () {
+      expect(tryParseUnixSeconds('1777377646'), isNull);
+      expect(tryParseUnixSeconds(null), isNull);
+    });
+
+    test('parses ISO date strings for local context decoration', () {
+      final parsed = tryParseDateTime('2026-04-28T20:00:46.000');
+
+      expect(parsed, isNotNull);
+      expect(parsed!.year, 2026);
+      expect(parsed.month, 4);
+      expect(parsed.day, 28);
+    });
+
+    test('rejects blank and malformed ISO date strings', () {
+      expect(tryParseDateTime(''), isNull);
+      expect(tryParseDateTime('not-a-date'), isNull);
+      expect(formatLocalDateTimeWithZoneOrNull('not-a-date'), isNull);
+    });
+
+    test('converts date time to truncated Unix seconds', () {
+      final seconds = unixSecondsFromDateTime(
+        DateTime.fromMillisecondsSinceEpoch(1777377646999),
+      );
+
+      expect(seconds, 1777377646);
+    });
+
+    test('converts parseable date time values to Unix seconds', () {
+      expect(
+        unixSecondsFromDateTimeOrNull('2026-04-28T20:00:46.999'),
+        unixSecondsFromDateTime(DateTime(2026, 4, 28, 20, 0, 46, 999)),
+      );
+      expect(unixSecondsFromDateTimeOrNull('not-a-date'), isNull);
+    });
+
     test('formats timezone offsets with sign and minutes', () {
       expect(formatTimeZoneOffset(const Duration(hours: 8)), '+08:00');
       expect(
         formatTimeZoneOffset(const Duration(hours: -5, minutes: -30)),
         '-05:30',
       );
+      expect(formatTimeZoneOffset(Duration.zero), '+00:00');
     });
 
     test('formats local date time with explicit timezone context', () {
@@ -25,6 +69,25 @@ void main() {
 
       expect(formatted, contains('2026-04-28 20:00:46'));
       expect(formatted, matches(RegExp(r'[+-]\d{2}:\d{2}')));
+    });
+
+    test('builds message time prefix with explicit timezone context', () {
+      final prefix = buildMessageTimePrefix(DateTime(2026, 4, 28, 20, 0, 46));
+
+      expect(prefix, startsWith('<message_time>'));
+      expect(prefix, contains('2026-04-28 20:00:46'));
+      expect(prefix, matches(RegExp(r'[+-]\d{2}:\d{2}')));
+    });
+
+    test('builds current time reminder with local-time label', () {
+      final reminder = buildCurrentTimeReminder(
+        DateTime(2026, 4, 28, 20, 0, 46),
+      );
+
+      expect(reminder, startsWith('<system-reminder>'));
+      expect(reminder, contains('Current Local Time:'));
+      expect(reminder, contains('2026-04-28 20:00:46'));
+      expect(reminder, endsWith('</system-reminder>\n\n'));
     });
   });
 }


### PR DESCRIPTION
## 背景

Fixes #28。

#45 已经给多个 Agent 补过本地时间锚点，但这次复现路径更像是普通 ChatAgent 在引用历史聊天或 event log 时仍会看到裸 ISO 时间戳。模型如果把这些时间按 UTC 或无时区日期理解，就可能把当天晚上的对话说成“昨天”或前一天。

## 改动

- ChatService 当前用户消息除了 `Current Local Time` 外，增加 `<message_time>`，并用同一个发送时刻作为锚点。
- ChatSessions 新写入 `created_at_local` / `updated_at_local` / message `local_time`，以及对应 Unix seconds。
- 继续旧会话时，回填旧 session / message 的本地时间字段，避免历史 YAML 继续只暴露裸 ISO。
- Chat session list/detail 读取旧 YAML 时提供本地时间和 Unix seconds fallback。
- EventLogService 新日志增加 `event_time_local` 和 `event_time_unix_seconds`。
- `search_workspace_event_logs` 输出优先展示明确本地时间，旧日志 fallback 到 raw `event_time` 解析；坏时间戳输出 `Unknown`，不误导模型。
- 自定义 Agent 生成的 ChatSession 也写入本地时间字段。

## 测试

- `flutter pub get --offline`
- `flutter test --no-pub test/utils/time_context_test.dart test/data/services/event_log_service_test.dart test/agent/built_in_tools/search_event_logs_tool_test.dart test/data/repositories/chat_session_time_context_test.dart`
- `dart analyze lib/utils/time_context.dart lib/data/services/event_log_service.dart lib/agent/built_in_tools/search_event_logs_tool.dart lib/data/services/chat_service.dart lib/data/services/task_handlers/custom_agent_task_handler.dart lib/data/repositories/chat.dart test/utils/time_context_test.dart test/data/services/event_log_service_test.dart test/agent/built_in_tools/search_event_logs_tool_test.dart test/data/repositories/chat_session_time_context_test.dart`
- `git diff --check`

## 说明

全量 `flutter analyze --no-pub` 仍返回非 0，为仓库既有 info 级噪音；本次 touched paths 的 targeted analyze 无问题。
