### PR TITLE
优化自动备份位置展示

### DIFF
--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -41,6 +41,22 @@ class AndroidBackupDirectory {
   });
 }
 
+enum BackupLocationKind { fileSystem, androidTree, iosICloud, iosAppDocuments }
+
+/// Current automatic backup location, split into a concise label and the
+/// underlying path/URI for copyable details.
+class BackupLocationInfo {
+  final BackupLocationKind kind;
+  final String label;
+  final String detail;
+
+  const BackupLocationInfo({
+    required this.kind,
+    required this.label,
+    required this.detail,
+  });
+}
+
 /// A restorable .memex snapshot stored by the automatic backup system.
 class BackupSnapshot {
   final String id;
@@ -663,12 +679,52 @@ class BackupService {
 
   /// Human-readable current automatic backup location.
   static Future<String> currentBackupLocationLabel() async {
+    final info = await currentBackupLocationInfo();
+    return info.label;
+  }
+
+  /// Current automatic backup location with full path/URI details.
+  static Future<BackupLocationInfo> currentBackupLocationInfo() async {
     final userId = await UserStorage.getUserId();
     if (Platform.isAndroid && userId != null && userId.isNotEmpty) {
+      final treeUri = await UserStorage.getAndroidBackupTreeUri(userId);
       final name = await UserStorage.getAndroidBackupTreeName(userId);
-      if (name != null && name.isNotEmpty) return name;
+      if (treeUri != null && treeUri.isNotEmpty) {
+        return BackupLocationInfo(
+          kind: BackupLocationKind.androidTree,
+          label: name != null && name.isNotEmpty ? name : treeUri,
+          detail: treeUri,
+        );
+      }
     }
-    return (await resolveDefaultBackupDirectory()).path;
+
+    if (Platform.isIOS) {
+      final iCloudDocumentsPath =
+          await UserStorage.resolveICloudDocumentsPath();
+      if (iCloudDocumentsPath != null && iCloudDocumentsPath.isNotEmpty) {
+        final backupDir = await _ensureBackupDirectory(iCloudDocumentsPath);
+        return BackupLocationInfo(
+          kind: BackupLocationKind.iosICloud,
+          label: backupDir.path,
+          detail: backupDir.path,
+        );
+      }
+
+      final appDir = await getApplicationDocumentsDirectory();
+      final backupDir = await _ensureBackupDirectory(appDir.path);
+      return BackupLocationInfo(
+        kind: BackupLocationKind.iosAppDocuments,
+        label: backupDir.path,
+        detail: backupDir.path,
+      );
+    }
+
+    final backupDir = await resolveDefaultBackupDirectory();
+    return BackupLocationInfo(
+      kind: BackupLocationKind.fileSystem,
+      label: backupDir.path,
+      detail: backupDir.path,
+    );
   }
 
   /// Resolve the app-managed default backup directory.
@@ -685,6 +741,10 @@ class BackupService {
       rootPath = (await getApplicationDocumentsDirectory()).path;
     }
 
+    return _ensureBackupDirectory(rootPath);
+  }
+
+  static Future<Directory> _ensureBackupDirectory(String rootPath) async {
     final dir = Directory(path.join(rootPath, 'Backups'));
     if (!await dir.exists()) {
       await dir.create(recursive: true);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -828,6 +828,20 @@
   "autoBackupDescription": "When enabled, Memex creates at most one local snapshot per day after startup or when returning to the foreground.",
   "backupSensitiveSettingsHint": "Backups include settings and model provider keys. Keep backup files somewhere you trust.",
   "backupLocation": "Location",
+  "backupLocationDetails": "Location details",
+  "backupLocationSummary": "Shown in app",
+  "backupLocationFullPath": "Full path",
+  "backupLocationUri": "Folder access URI",
+  "copyBackupLocationPath": "Copy path",
+  "backupLocationCopied": "Backup location copied",
+  "androidBackupLocationSelected": "Selected folder: {folderName}",
+  "@androidBackupLocationSelected": {
+    "placeholders": {
+      "folderName": {}
+    }
+  },
+  "iosICloudBackupLocation": "iCloud Drive > Memex > Backups",
+  "iosAppDocumentsBackupLocation": "Files > On My iPhone > Memex > Backups",
   "autoBackupStatus": "Status",
   "noAutoBackupYet": "No automatic backup yet",
   "@lastBackupAt": {
@@ -837,7 +851,7 @@
   },
   "lastBackupAt": "Last backup: {time}",
   "createSnapshotNow": "Back up now",
-  "backupLocationMenu": "Location",
+  "backupLocationMenu": "Change location",
   "defaultBackupLocation": "Default backup folder",
   "defaultBackupLocationAndroidDesc": "Use Memex's app-specific external files folder. No storage permission needed.",
   "chooseBackupLocation": "Choose backup folder",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_zh.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('zh'),
+    Locale('zh')
   ];
 
   /// No description provided for @timesLabel.
@@ -3326,6 +3326,60 @@ abstract class AppLocalizations {
   /// **'Location'**
   String get backupLocation;
 
+  /// No description provided for @backupLocationDetails.
+  ///
+  /// In en, this message translates to:
+  /// **'Location details'**
+  String get backupLocationDetails;
+
+  /// No description provided for @backupLocationSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'Shown in app'**
+  String get backupLocationSummary;
+
+  /// No description provided for @backupLocationFullPath.
+  ///
+  /// In en, this message translates to:
+  /// **'Full path'**
+  String get backupLocationFullPath;
+
+  /// No description provided for @backupLocationUri.
+  ///
+  /// In en, this message translates to:
+  /// **'Folder access URI'**
+  String get backupLocationUri;
+
+  /// No description provided for @copyBackupLocationPath.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy path'**
+  String get copyBackupLocationPath;
+
+  /// No description provided for @backupLocationCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'Backup location copied'**
+  String get backupLocationCopied;
+
+  /// No description provided for @androidBackupLocationSelected.
+  ///
+  /// In en, this message translates to:
+  /// **'Selected folder: {folderName}'**
+  String androidBackupLocationSelected(Object folderName);
+
+  /// No description provided for @iosICloudBackupLocation.
+  ///
+  /// In en, this message translates to:
+  /// **'iCloud Drive > Memex > Backups'**
+  String get iosICloudBackupLocation;
+
+  /// No description provided for @iosAppDocumentsBackupLocation.
+  ///
+  /// In en, this message translates to:
+  /// **'Files > On My iPhone > Memex > Backups'**
+  String get iosAppDocumentsBackupLocation;
+
   /// No description provided for @autoBackupStatus.
   ///
   /// In en, this message translates to:
@@ -3353,7 +3407,7 @@ abstract class AppLocalizations {
   /// No description provided for @backupLocationMenu.
   ///
   /// In en, this message translates to:
-  /// **'Location'**
+  /// **'Change location'**
   String get backupLocationMenu;
 
   /// No description provided for @defaultBackupLocation.
@@ -5142,9 +5196,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1816,6 +1816,36 @@ class AppLocalizationsEn extends AppLocalizations {
   String get backupLocation => 'Location';
 
   @override
+  String get backupLocationDetails => 'Location details';
+
+  @override
+  String get backupLocationSummary => 'Shown in app';
+
+  @override
+  String get backupLocationFullPath => 'Full path';
+
+  @override
+  String get backupLocationUri => 'Folder access URI';
+
+  @override
+  String get copyBackupLocationPath => 'Copy path';
+
+  @override
+  String get backupLocationCopied => 'Backup location copied';
+
+  @override
+  String androidBackupLocationSelected(Object folderName) {
+    return 'Selected folder: $folderName';
+  }
+
+  @override
+  String get iosICloudBackupLocation => 'iCloud Drive > Memex > Backups';
+
+  @override
+  String get iosAppDocumentsBackupLocation =>
+      'Files > On My iPhone > Memex > Backups';
+
+  @override
   String get autoBackupStatus => 'Status';
 
   @override
@@ -1830,7 +1860,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get createSnapshotNow => 'Back up now';
 
   @override
-  String get backupLocationMenu => 'Location';
+  String get backupLocationMenu => 'Change location';
 
   @override
   String get defaultBackupLocation => 'Default backup folder';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1755,6 +1755,36 @@ class AppLocalizationsZh extends AppLocalizations {
   String get backupLocation => '位置';
 
   @override
+  String get backupLocationDetails => '位置详情';
+
+  @override
+  String get backupLocationSummary => '应用中显示';
+
+  @override
+  String get backupLocationFullPath => '完整路径';
+
+  @override
+  String get backupLocationUri => '文件夹授权 URI';
+
+  @override
+  String get copyBackupLocationPath => '复制路径';
+
+  @override
+  String get backupLocationCopied => '备份位置已复制';
+
+  @override
+  String androidBackupLocationSelected(Object folderName) {
+    return '已选文件夹：$folderName';
+  }
+
+  @override
+  String get iosICloudBackupLocation => 'iCloud 云盘 > Memex > Backups';
+
+  @override
+  String get iosAppDocumentsBackupLocation =>
+      '文件 > 我的 iPhone > Memex > Backups';
+
+  @override
   String get autoBackupStatus => '状态';
 
   @override
@@ -1769,7 +1799,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get createSnapshotNow => '立即备份';
 
   @override
-  String get backupLocationMenu => '位置';
+  String get backupLocationMenu => '更改位置';
 
   @override
   String get defaultBackupLocation => '默认备份文件夹';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -828,6 +828,20 @@
   "autoBackupDescription": "开启后，Memex 会在启动或回到前台时检查，每天最多创建一次本地时间点快照。",
   "backupSensitiveSettingsHint": "备份包含设置和模型服务商密钥，请只保存到你信任的位置。",
   "backupLocation": "位置",
+  "backupLocationDetails": "位置详情",
+  "backupLocationSummary": "应用中显示",
+  "backupLocationFullPath": "完整路径",
+  "backupLocationUri": "文件夹授权 URI",
+  "copyBackupLocationPath": "复制路径",
+  "backupLocationCopied": "备份位置已复制",
+  "androidBackupLocationSelected": "已选文件夹：{folderName}",
+  "@androidBackupLocationSelected": {
+    "placeholders": {
+      "folderName": {}
+    }
+  },
+  "iosICloudBackupLocation": "iCloud 云盘 > Memex > Backups",
+  "iosAppDocumentsBackupLocation": "文件 > 我的 iPhone > Memex > Backups",
   "autoBackupStatus": "状态",
   "noAutoBackupYet": "还没有自动备份",
   "@lastBackupAt": {
@@ -837,7 +851,7 @@
   },
   "lastBackupAt": "上次备份：{time}",
   "createSnapshotNow": "立即备份",
-  "backupLocationMenu": "位置",
+  "backupLocationMenu": "更改位置",
   "defaultBackupLocation": "默认备份文件夹",
   "defaultBackupLocationAndroidDesc": "使用 Memex 的应用专属外部目录，不需要存储权限。",
   "chooseBackupLocation": "选择备份文件夹",

--- a/lib/ui/settings/widgets/backup_restore_page.dart
+++ b/lib/ui/settings/widgets/backup_restore_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
@@ -23,6 +24,7 @@ typedef StoredBackupDeleter = Future<void> Function(BackupSnapshot snapshot);
 class BackupRestorePage extends StatefulWidget {
   final bool? isAndroidOverride;
   final Future<int> Function()? estimateBackupSize;
+  final Future<BackupLocationInfo> Function()? currentBackupLocationInfo;
   final Future<String> Function()? currentBackupLocationLabel;
   final Future<List<BackupSnapshot>> Function()? listStoredBackups;
   final AutoBackupCreator? createAutoBackup;
@@ -34,6 +36,7 @@ class BackupRestorePage extends StatefulWidget {
     super.key,
     this.isAndroidOverride,
     this.estimateBackupSize,
+    this.currentBackupLocationInfo,
     this.currentBackupLocationLabel,
     this.listStoredBackups,
     this.createAutoBackup,
@@ -58,7 +61,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
   bool _autoBackupEnabled = false;
   String _statusText = '';
   String _estimatedSize = '';
-  String _backupLocation = '';
+  BackupLocationInfo? _backupLocationInfo;
   DateTime? _lastAutoBackupAt;
   List<BackupSnapshot> _storedBackups = const [];
 
@@ -74,8 +77,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         ? await (widget.estimateBackupSize ??
             BackupService.estimateBackupSize)()
         : null;
-    final location = await (widget.currentBackupLocationLabel ??
-        BackupService.currentBackupLocationLabel)();
+    final location = await _resolveBackupLocationInfo();
     final snapshots =
         await (widget.listStoredBackups ?? BackupService.listStoredBackups)();
     final autoEnabled = userId != null && userId.isNotEmpty
@@ -90,7 +92,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         if (size != null) {
           _estimatedSize = _formatBytes(size);
         }
-        _backupLocation = location;
+        _backupLocationInfo = location;
         _storedBackups = snapshots;
         _autoBackupEnabled = autoEnabled;
         _lastAutoBackupAt = lastAutoBackupAt;
@@ -111,6 +113,23 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     return DateFormat.yMd(
       UserStorage.l10n.localeName,
     ).add_Hm().format(dateTime);
+  }
+
+  Future<BackupLocationInfo> _resolveBackupLocationInfo() async {
+    if (widget.currentBackupLocationInfo != null) {
+      return widget.currentBackupLocationInfo!();
+    }
+
+    if (widget.currentBackupLocationLabel != null) {
+      final label = await widget.currentBackupLocationLabel!();
+      return BackupLocationInfo(
+        kind: BackupLocationKind.fileSystem,
+        label: label,
+        detail: label,
+      );
+    }
+
+    return BackupService.currentBackupLocationInfo();
   }
 
   Future<void> _createBackup() async {
@@ -241,6 +260,133 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         ),
       ),
     );
+  }
+
+  Future<void> _showBackupLocationDetails() async {
+    final info = _backupLocationInfo;
+    if (info == null) return;
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        final bottomPadding = MediaQuery.viewInsetsOf(sheetContext).bottom;
+        final detailLabel = info.kind == BackupLocationKind.androidTree
+            ? UserStorage.l10n.backupLocationUri
+            : UserStorage.l10n.backupLocationFullPath;
+
+        return SafeArea(
+          child: SingleChildScrollView(
+            padding: EdgeInsets.fromLTRB(20, 0, 20, 24 + bottomPadding),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        UserStorage.l10n.backupLocationDetails,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.textPrimary,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: UserStorage.l10n.close,
+                      onPressed: () => Navigator.of(sheetContext).pop(),
+                      icon: const Icon(Icons.close),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                _detailLabel(UserStorage.l10n.backupLocationSummary),
+                const SizedBox(height: 6),
+                Text(
+                  _formatBackupLocationSummary(info),
+                  style: const TextStyle(
+                    fontSize: 14,
+                    color: AppColors.textPrimary,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(height: 18),
+                _detailLabel(detailLabel),
+                const SizedBox(height: 6),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppColors.background,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: AppColors.textSecondary.withValues(alpha: 0.12),
+                    ),
+                  ),
+                  child: SelectableText(
+                    info.detail,
+                    key: const ValueKey('backup-location-detail-value'),
+                    style: const TextStyle(
+                      fontSize: 13,
+                      color: AppColors.textPrimary,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: () => _copyBackupLocation(info.detail),
+                        icon: const Icon(Icons.copy_outlined, size: 18),
+                        label: Text(UserStorage.l10n.copyBackupLocationPath),
+                      ),
+                    ),
+                    if (widget.isAndroid) ...[
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: ElevatedButton.icon(
+                          onPressed: () {
+                            Navigator.of(sheetContext).pop();
+                            _showBackupLocationMenu();
+                          },
+                          icon: const Icon(
+                            Icons.folder_open_outlined,
+                            size: 18,
+                          ),
+                          label: Text(UserStorage.l10n.backupLocationMenu),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _detailLabel(String label) {
+    return Text(
+      label,
+      style: const TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+        color: AppColors.textSecondary,
+      ),
+    );
+  }
+
+  Future<void> _copyBackupLocation(String value) async {
+    await Clipboard.setData(ClipboardData(text: value));
+    if (!mounted) return;
+    ToastHelper.showSuccess(context, UserStorage.l10n.backupLocationCopied);
   }
 
   Future<void> _pickAndroidBackupLocation() async {
@@ -597,7 +743,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
             ),
           ),
           const SizedBox(height: 14),
-          _infoRow(UserStorage.l10n.backupLocation, _backupLocation),
+          _backupLocationRow(),
           const SizedBox(height: 8),
           _infoRow(UserStorage.l10n.autoBackupStatus, lastBackupText),
           const SizedBox(height: 16),
@@ -795,6 +941,71 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
       ),
       child: child,
     );
+  }
+
+  Widget _backupLocationRow() {
+    final info = _backupLocationInfo;
+    final summary = info == null ? '' : _formatBackupLocationSummary(info);
+
+    return Semantics(
+      button: info != null,
+      child: InkWell(
+        key: const ValueKey('backup-location-row'),
+        onTap: info == null ? null : _showBackupLocationDetails,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                width: 96,
+                child: Text(
+                  UserStorage.l10n.backupLocation,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: AppColors.textSecondary,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  summary,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: AppColors.textPrimary,
+                    height: 1.35,
+                  ),
+                ),
+              ),
+              if (info != null) ...[
+                const SizedBox(width: 8),
+                const Icon(
+                  Icons.info_outline,
+                  size: 16,
+                  color: AppColors.textSecondary,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatBackupLocationSummary(BackupLocationInfo info) {
+    switch (info.kind) {
+      case BackupLocationKind.androidTree:
+        return UserStorage.l10n.androidBackupLocationSelected(info.label);
+      case BackupLocationKind.iosICloud:
+        return UserStorage.l10n.iosICloudBackupLocation;
+      case BackupLocationKind.iosAppDocuments:
+        return UserStorage.l10n.iosAppDocumentsBackupLocation;
+      case BackupLocationKind.fileSystem:
+        return info.label;
+    }
   }
 
   Widget _infoRow(String label, String value) {

--- a/test/ui/settings/widgets/backup_restore_page_test.dart
+++ b/test/ui/settings/widgets/backup_restore_page_test.dart
@@ -254,12 +254,95 @@ void main() {
     expect(find.text(UserStorage.l10n.defaultBackupLocation), findsOneWidget);
     expect(find.text(UserStorage.l10n.chooseBackupLocation), findsOneWidget);
   });
+
+  testWidgets('opens copyable full backup location details', (tester) async {
+    const fullPath =
+        '/very/long/device/path/that/does/not/fit/in/two/lines/Memex/Backups';
+
+    await _pumpBackupPage(
+      tester,
+      currentBackupLocationInfo: () async => const BackupLocationInfo(
+        kind: BackupLocationKind.fileSystem,
+        label: fullPath,
+        detail: fullPath,
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('backup-location-row')));
+    await tester.pumpAndSettle();
+
+    expect(find.text(UserStorage.l10n.backupLocationDetails), findsOneWidget);
+    expect(find.text(UserStorage.l10n.backupLocationFullPath), findsOneWidget);
+    final detail = tester.widget<SelectableText>(
+      find.byKey(const ValueKey('backup-location-detail-value')),
+    );
+    expect(detail.data, fullPath);
+    expect(find.text(UserStorage.l10n.copyBackupLocationPath), findsOneWidget);
+  });
+
+  testWidgets('shows iOS Files label with full sandbox path in details', (
+    tester,
+  ) async {
+    const fullPath =
+        '/private/var/mobile/Library/Mobile Documents/iCloud~com~memexlab~memex/Documents/Backups';
+
+    await _pumpBackupPage(
+      tester,
+      currentBackupLocationInfo: () async => const BackupLocationInfo(
+        kind: BackupLocationKind.iosICloud,
+        label: fullPath,
+        detail: fullPath,
+      ),
+    );
+
+    expect(find.text(UserStorage.l10n.iosICloudBackupLocation), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('backup-location-row')));
+    await tester.pumpAndSettle();
+
+    final detail = tester.widget<SelectableText>(
+      find.byKey(const ValueKey('backup-location-detail-value')),
+    );
+    expect(detail.data, fullPath);
+  });
+
+  testWidgets('shows Android SAF folder name and URI details', (tester) async {
+    const treeUri =
+        'content://com.android.externalstorage.documents/tree/'
+        'primary%3ADownload%2FMemexBackups';
+
+    await _pumpBackupPage(
+      tester,
+      isAndroid: true,
+      currentBackupLocationInfo: () async => const BackupLocationInfo(
+        kind: BackupLocationKind.androidTree,
+        label: 'MemexBackups',
+        detail: treeUri,
+      ),
+    );
+
+    expect(
+      find.text(UserStorage.l10n.androidBackupLocationSelected('MemexBackups')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('backup-location-row')));
+    await tester.pumpAndSettle();
+
+    expect(find.text(UserStorage.l10n.backupLocationUri), findsOneWidget);
+    expect(find.text(UserStorage.l10n.backupLocationMenu), findsWidgets);
+    final detail = tester.widget<SelectableText>(
+      find.byKey(const ValueKey('backup-location-detail-value')),
+    );
+    expect(detail.data, treeUri);
+  });
 }
 
 Future<void> _pumpBackupPage(
   WidgetTester tester, {
   bool isAndroid = false,
   Future<int> Function()? estimateBackupSize,
+  Future<BackupLocationInfo> Function()? currentBackupLocationInfo,
   Future<List<BackupSnapshot>> Function()? listStoredBackups,
   AutoBackupCreator? createAutoBackup,
   StoredBackupDeleter? deleteStoredBackup,
@@ -271,6 +354,7 @@ Future<void> _pumpBackupPage(
       home: BackupRestorePage(
         isAndroidOverride: isAndroid,
         estimateBackupSize: estimateBackupSize ?? () async => 0,
+        currentBackupLocationInfo: currentBackupLocationInfo,
         currentBackupLocationLabel: () async => '/tmp/Backups',
         listStoredBackups: listStoredBackups ?? () async => const [],
         createAutoBackup: createAutoBackup,


### PR DESCRIPTION
## 背景

Closes #140

自动备份页原先只在设置卡片中展示位置文本，长路径会被截断；Android SAF 自定义目录也只展示文件夹名，无法查看完整授权 URI。iOS 上如果直接暴露沙盒路径，也不符合用户在“文件”App 中查找备份的心智。

## 改动

- 为自动备份位置增加 `BackupLocationInfo`，区分主展示文案和完整路径/URI。
- 备份页位置行改为可点击摘要，点击后打开位置详情 bottom sheet，可查看并复制完整路径或 Android SAF URI。
- 为 iOS iCloud / 本机文稿位置提供更贴近“文件”App 的展示文案，同时保留完整沙盒路径在详情中。
- 补充中英文 ARB 文案并更新生成的本地化代码。
- 增加 widget tests 覆盖完整路径详情、iOS 展示和 Android SAF URI 展示。

## 验证

- `flutter pub get --offline`
- `flutter test --no-pub test/ui/settings/widgets/backup_restore_page_test.dart`
- `dart analyze lib/data/services/backup_service.dart lib/ui/settings/widgets/backup_restore_page.dart test/ui/settings/widgets/backup_restore_page_test.dart`
- `git diff --check upstream/main...HEAD`

## 说明

- 普通文件系统位置在主界面仍显示路径摘要；完整路径始终可在详情中查看和复制。
- Android 自定义目录使用 SAF 授权，详情展示的是 `content://` URI，而不是伪造本地文件路径。