### PR TITLE
[codex] 收敛卡片定位提示规则

### DIFF
--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -65,6 +65,7 @@ Example: An image of a receipt should use the `transaction` template, not a gene
 4. **Save**: Call `save_timeline_card` to persist the card.
 
 Important: If the user uses the `#xxx` format in raw input (e.g., `#work`, `#health`), this represents a user-specified tag that must be set. You must ensure these tags are correctly set in the card's tags property.
+Important: The top-level card address describes where the recorded moment actually happened. For tasks, todos, reminders, plans, wishes, future destinations, or places the user merely wants to go to, omit the top-level address even if a place is mentioned in the raw input.
 Important: $instruction
 ''';
 

--- a/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
@@ -120,7 +120,7 @@ class TimelineCardSkill extends Skill {
             'address': {
               'type': 'string',
               'description':
-                  'Location information for where the card happened. If raw input explicitly names a place, use that. If raw input describes an immediate present-time event, check-in, photo capture, or daily activity and current_location_context is available, use its location_summary or full_address_candidate as a conservative default. Do not use current_location_context for memories, plans, remote events, or when raw input names a conflicting place. Do not be too specific. Use the format "City · Specific Location" (e.g., Beijing · Chaoyang Park) if possible, otherwise just the specific location name is fine.'
+                  'Location information for where the recorded card actually happened. Use raw input named places only when they are the actual occurrence, check-in, visit, photo capture, or activity location. For tasks, todos, reminders, plans, wishes, future destinations, or places the user merely wants to go to, omit address even if a place is mentioned. If raw input describes an immediate present-time event, check-in, photo capture, or daily activity and current_location_context is available, use its location_summary or full_address_candidate as a conservative default. Do not use current_location_context for memories, plans, remote events, or when raw input names a conflicting place. Do not be too specific. Use the format "City · Specific Location" (e.g., Beijing · Chaoyang Park) if possible, otherwise just the specific location name is fine.'
             },
             'user_mark_address': {
               'type': 'string',

--- a/test/agent/agent_tool_error_result_test.dart
+++ b/test/agent/agent_tool_error_result_test.dart
@@ -62,6 +62,24 @@ void main() {
       expect(_text(result), contains('fact id: 2026/05/18.md#ts_999'));
     });
 
+    test('save_timeline_card address schema excludes future destinations', () {
+      final tool = TimelineCardSkill(
+        forceActivate: true,
+        stopAfterSuccessSaveCard: true,
+      ).tools!.singleWhere((tool) => tool.name == 'save_timeline_card');
+      final parameters = Map<String, dynamic>.from(tool.parameters as Map);
+      final properties =
+          Map<String, dynamic>.from(parameters['properties'] as Map);
+      final address =
+          Map<String, dynamic>.from(properties['address'] as Map);
+      final description = address['description'] as String;
+
+      expect(description, contains('where the recorded card actually happened'));
+      expect(description, contains('tasks, todos, reminders, plans'));
+      expect(description, contains('future destinations'));
+      expect(description, contains('omit address'));
+    });
+
     test('save_timeline_card accepts JSON-encoded list arguments', () async {
       final tool = TimelineCardSkill(
         forceActivate: true,


### PR DESCRIPTION
## Summary
- Clarify that the top-level card address is only for where the recorded moment actually happened.
- Narrow the `save_timeline_card.address` tool schema so todos, reminders, plans, wishes, and future destinations omit `address`.
- Add a regression test that locks the future-destination guidance into the tool schema.

## Root Cause
The previous address guidance said to use a place whenever raw input explicitly named one. That let Card Agent treat a future target place, such as “北京二环附近” in a todo, as the card occurrence location.

## Validation
- `flutter pub get --offline`
- `flutter analyze --no-pub --no-fatal-infos lib/agent/prompts.dart lib/agent/skills/manage_timeline_card/timeline_card_skill.dart test/agent/agent_tool_error_result_test.dart`
  - Passes with existing `non_constant_identifier_names` info for tool callback parameters like `fact_id` / `ui_configs`.
- `flutter test --no-pub test/agent/agent_tool_error_result_test.dart`

## Scope
No data/schema migration or runtime guard in this PR; this is intentionally a prompt/tool-schema tightening only.