### PR TITLE
[codex] Fix duplicate timeline placeholder cards

### DIFF
--- a/lib/ui/timeline/view_models/timeline_viewmodel.dart
+++ b/lib/ui/timeline/view_models/timeline_viewmodel.dart
@@ -18,6 +18,60 @@ import 'package:memex/utils/command.dart';
 
 enum TimelineViewMode { timeline, insight }
 
+/// Upserts a card into a timeline list by stable card id.
+///
+/// New local submissions and card-added events can describe the same fact, so
+/// the in-memory list must be idempotent even when multiple sources race.
+@visibleForTesting
+List<TimelineCardModel> upsertTimelineCardById(
+  List<TimelineCardModel> cards,
+  TimelineCardModel card,
+) {
+  return [card, ...cards.where((existing) => existing.id != card.id)];
+}
+
+/// Replaces all existing copies of [updatedCard] while preserving the first
+/// loaded position. If the card is not currently visible, the list is unchanged.
+@visibleForTesting
+List<TimelineCardModel> replaceTimelineCardById(
+  List<TimelineCardModel> cards,
+  TimelineCardModel updatedCard,
+) {
+  var inserted = false;
+  var found = false;
+  final next = <TimelineCardModel>[];
+
+  for (final card in cards) {
+    if (card.id != updatedCard.id) {
+      next.add(card);
+      continue;
+    }
+
+    found = true;
+    if (!inserted) {
+      next.add(updatedCard);
+      inserted = true;
+    }
+  }
+
+  return found ? next : cards;
+}
+
+/// Keeps the first occurrence of each card id, preserving timeline order.
+@visibleForTesting
+List<TimelineCardModel> dedupeTimelineCardsById(List<TimelineCardModel> cards) {
+  final seen = <String>{};
+  final next = <TimelineCardModel>[];
+
+  for (final card in cards) {
+    if (seen.add(card.id)) {
+      next.add(card);
+    }
+  }
+
+  return next;
+}
+
 /// ViewModel for the Timeline page. Holds cards, tags, loading state, and
 /// delegates data access to [MemexRouter]. Call [init] once after creation.
 class TimelineViewModel extends ChangeNotifier {
@@ -255,7 +309,7 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   void addCard(TimelineCardModel card) {
-    cards.insert(0, card);
+    cards = upsertTimelineCardById(cards, card);
     isSubmitting = false;
     if (card.status == 'processing') {
       _startPollingIfNeeded();
@@ -264,10 +318,7 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   void updateCard(TimelineCardModel updatedCard) {
-    final index = cards.indexWhere((c) => c.id == updatedCard.id);
-    if (index != -1) {
-      cards[index] = updatedCard;
-    }
+    cards = replaceTimelineCardById(cards, updatedCard);
     _checkAndStopPollingIfNeeded();
     notifyListeners();
   }
@@ -324,8 +375,9 @@ class TimelineViewModel extends ChangeNotifier {
     List<TimelineCardModel> list, {
     required bool hasMoreAfterList,
   }) async {
-    final withoutBriefing =
-        list.where((card) => card.id != scheduleBriefingCardId).toList();
+    final withoutBriefing = dedupeTimelineCardsById(
+      list,
+    ).where((card) => card.id != scheduleBriefingCardId).toList();
     if (!_shouldShowScheduleBriefing) return withoutBriefing;
 
     final briefingResult = await _router.fetchScheduleBriefingCard();

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -1041,7 +1041,8 @@ class TimelineScreenState extends State<TimelineScreen> {
           final card = entry.card;
           final cardIndex = entry.cardIndex;
           final isDemoTarget = _isDemoTargetCard(vm.cards, cardIndex);
-          return _TimelineEntryItem(
+          return TimelineEntryItem(
+            key: ValueKey(card.id),
             card: card,
             isDemoTarget: isDemoTarget,
             attachments: vm.attachments[card.id] ?? const [],
@@ -1124,13 +1125,14 @@ bool _isDemoTargetCard(List<TimelineCardModel> cards, int index) {
   return index == firstUserCardIndex;
 }
 
-class _TimelineEntryItem extends StatefulWidget {
+class TimelineEntryItem extends StatefulWidget {
   final TimelineCardModel card;
   final VoidCallback onTap;
   final bool isDemoTarget;
   final List<CardAttachmentData> attachments;
 
-  const _TimelineEntryItem({
+  const TimelineEntryItem({
+    super.key,
     required this.card,
     required this.onTap,
     required this.attachments,
@@ -1138,10 +1140,10 @@ class _TimelineEntryItem extends StatefulWidget {
   });
 
   @override
-  State<_TimelineEntryItem> createState() => _TimelineEntryItemState();
+  State<TimelineEntryItem> createState() => _TimelineEntryItemState();
 }
 
-class _TimelineEntryItemState extends State<_TimelineEntryItem> {
+class _TimelineEntryItemState extends State<TimelineEntryItem> {
   bool _isClassicMode = false;
 
   void _toggleClassicMode() {

--- a/test/ui/timeline/view_models/timeline_viewmodel_test.dart
+++ b/test/ui/timeline/view_models/timeline_viewmodel_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/timeline_card_model.dart';
+import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
+
+void main() {
+  group('timeline card idempotency helpers', () {
+    test('upsert inserts a new local card at the top', () {
+      final existing = [
+        _card('2026/05/18.md#ts_1', title: 'older'),
+        _card('2026/05/18.md#ts_2', title: 'oldest'),
+      ];
+
+      final result = upsertTimelineCardById(
+        existing,
+        _card('2026/05/18.md#ts_3', title: 'new'),
+      );
+
+      expect(result.map((card) => card.id), [
+        '2026/05/18.md#ts_3',
+        '2026/05/18.md#ts_1',
+        '2026/05/18.md#ts_2',
+      ]);
+    });
+
+    test(
+      'upsert replaces a duplicate local submission instead of appending',
+      () {
+        final existing = [
+          _card(
+            '2026/05/18.md#ts_1',
+            title: 'stale processing copy',
+            status: 'processing',
+          ),
+          _card('2026/05/18.md#ts_0', title: 'older'),
+        ];
+
+        final result = upsertTimelineCardById(
+          existing,
+          _card(
+            '2026/05/18.md#ts_1',
+            title: 'fresh processing copy',
+            status: 'processing',
+          ),
+        );
+
+        expect(result, hasLength(2));
+        expect(result.first.id, '2026/05/18.md#ts_1');
+        expect(result.first.title, 'fresh processing copy');
+        expect(
+          result.where((card) => card.id == '2026/05/18.md#ts_1'),
+          hasLength(1),
+        );
+      },
+    );
+
+    test(
+      'update collapses duplicate processing copies in their first position',
+      () {
+        final existing = [
+          _card('2026/05/18.md#ts_0', title: 'newer neighbor'),
+          _card(
+            '2026/05/18.md#ts_1',
+            title: 'processing copy A',
+            status: 'processing',
+          ),
+          _card(
+            '2026/05/18.md#ts_1',
+            title: 'processing copy B',
+            status: 'processing',
+          ),
+          _card('2026/05/18.md#ts_2', title: 'older neighbor'),
+        ];
+
+        final result = replaceTimelineCardById(
+          existing,
+          _card(
+            '2026/05/18.md#ts_1',
+            title: 'completed result',
+            status: 'completed',
+          ),
+        );
+
+        expect(result.map((card) => card.title), [
+          'newer neighbor',
+          'completed result',
+          'older neighbor',
+        ]);
+        expect(
+          result.where((card) => card.id == '2026/05/18.md#ts_1'),
+          hasLength(1),
+        );
+      },
+    );
+
+    test('update leaves unloaded cards out of the current filtered list', () {
+      final existing = [_card('2026/05/18.md#ts_0', title: 'visible card')];
+
+      final result = replaceTimelineCardById(
+        existing,
+        _card('2026/05/18.md#ts_9', title: 'hidden card'),
+      );
+
+      expect(result, same(existing));
+      expect(result.map((card) => card.title), ['visible card']);
+    });
+
+    test(
+      'dedupe keeps the already loaded page copy across pagination overlap',
+      () {
+        final result = dedupeTimelineCardsById([
+          _card('2026/05/18.md#ts_3', title: 'top'),
+          _card('2026/05/18.md#ts_2', title: 'page one boundary'),
+          _card('2026/05/18.md#ts_2', title: 'page two duplicate'),
+          _card('2026/05/18.md#ts_1', title: 'older'),
+        ]);
+
+        expect(result.map((card) => card.title), [
+          'top',
+          'page one boundary',
+          'older',
+        ]);
+        expect(
+          result.where((card) => card.id == '2026/05/18.md#ts_2'),
+          hasLength(1),
+        );
+      },
+    );
+  });
+}
+
+TimelineCardModel _card(
+  String id, {
+  required String title,
+  String status = 'completed',
+}) {
+  return TimelineCardModel(
+    id: id,
+    timestamp: DateTime(2026, 5, 18, 12),
+    tags: const [],
+    status: status,
+    title: title,
+    uiConfigs: [
+      UiConfig(templateId: 'classic_card', data: {'content': title}),
+    ],
+  );
+}

--- a/test/ui/timeline/widgets/timeline_entry_dedupe_test.dart
+++ b/test/ui/timeline/widgets/timeline_entry_dedupe_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/timeline_card_model.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
+import 'package:memex/ui/timeline/widgets/timeline_screen.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'language': 'en'});
+    await UserStorage.initL10n();
+  });
+
+  testWidgets(
+    'renders one processing entry after duplicate submission upsert',
+    (tester) async {
+      final cards = upsertTimelineCardById(
+        [
+          _card(
+            '2026/05/18.md#ts_1',
+            content: 'stale processing copy',
+            status: 'processing',
+          ),
+          _card('2026/05/18.md#ts_0', content: 'older neighbor'),
+        ],
+        _card(
+          '2026/05/18.md#ts_1',
+          content: 'fresh processing copy',
+          status: 'processing',
+        ),
+      );
+
+      await tester.pumpWidget(_FeedHost(cards: cards));
+      await tester.pump();
+
+      expect(find.byType(TimelineEntryItem), findsNWidgets(2));
+      expect(find.byKey(const ValueKey('2026/05/18.md#ts_1')), findsOneWidget);
+      expect(find.text('fresh processing copy'), findsOneWidget);
+      expect(find.text('stale processing copy'), findsNothing);
+      expect(find.text('older neighbor'), findsOneWidget);
+    },
+  );
+
+  testWidgets('renders one completed entry after duplicate processing update', (
+    tester,
+  ) async {
+    final cards = replaceTimelineCardById(
+      [
+        _card(
+          '2026/05/18.md#ts_1',
+          content: 'processing copy A',
+          status: 'processing',
+        ),
+        _card(
+          '2026/05/18.md#ts_1',
+          content: 'processing copy B',
+          status: 'processing',
+        ),
+      ],
+      _card(
+        '2026/05/18.md#ts_1',
+        content: 'completed result',
+        status: 'completed',
+      ),
+    );
+
+    await tester.pumpWidget(_FeedHost(cards: cards));
+    await tester.pump();
+
+    expect(find.byType(TimelineEntryItem), findsOneWidget);
+    expect(find.byKey(const ValueKey('2026/05/18.md#ts_1')), findsOneWidget);
+    expect(find.text('completed result'), findsOneWidget);
+    expect(find.text('processing copy A'), findsNothing);
+    expect(find.text('processing copy B'), findsNothing);
+  });
+}
+
+class _FeedHost extends StatelessWidget {
+  const _FeedHost({required this.cards});
+
+  final List<TimelineCardModel> cards;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: ListView(
+          children: [
+            for (final card in cards)
+              TimelineEntryItem(
+                key: ValueKey(card.id),
+                card: card,
+                attachments: const [],
+                onTap: () {},
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+TimelineCardModel _card(
+  String id, {
+  required String content,
+  String status = 'completed',
+}) {
+  return TimelineCardModel(
+    id: id,
+    timestamp: DateTime(2026, 5, 18, 12),
+    tags: const [],
+    status: status,
+    title: content,
+    uiConfigs: [
+      UiConfig(templateId: 'classic_card', data: {'content': content}),
+    ],
+  );
+}


### PR DESCRIPTION
## Summary
- Fixes #143 by making the in-memory timeline list idempotent by `TimelineCardModel.id`.
- Upserts locally submitted/card-added cards instead of blindly inserting duplicates.
- Collapses duplicate processing copies when card updates arrive, while keeping unloaded filtered-list cards hidden.
- Adds a stable key to timeline entries and focused unit/widget coverage for duplicate submission, update, and pagination overlap cases.

## Root Cause
A newly submitted card can enter the TimelineViewModel from more than one local UI/update path while it is still in `processing` state. `addCard()` always inserted at index 0, so two copies of the same fact id could be visible until a later refresh or completed card update rebuilt the list from storage.

## Validation
- `dart pub get --offline --no-example`
- `flutter test --no-pub test/ui/timeline`
- `dart analyze lib/ui/timeline/view_models/timeline_viewmodel.dart lib/ui/timeline/widgets/timeline_screen.dart test/ui/timeline/view_models/timeline_viewmodel_test.dart test/ui/timeline/widgets/timeline_entry_dedupe_test.dart` (passes with existing info-level `timeline_screen.dart` warnings for deprecated `withOpacity` and one existing async-context lint)
- `git diff --cached --check`
