### PR TITLE
[codex] Group schedule subtasks in agenda cards

### DIFF
--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -771,6 +771,9 @@ timeline:
         type: "event" | "task" | "routine" | "duration" | "procedure"
         priority: 1-3 (optional)
         description: "Brief description" (optional)
+        subtasks: (task cards only, optional; preserve source subtasks, do not invent)
+          - title: "Subtask title"
+            completed: true | false
 completed:
   - card_id: "original card fact_id"
     title: "Completed item title"
@@ -785,6 +788,7 @@ conflicts:
 - Hero Item: The single most important upcoming event (not necessarily the closest). Choose based on priority, impact, and user context.
 - Quote Blocks: Urgent deadlines, time conflicts, or important reminders. Max 2 items.
 - Timeline: Group by day. Max 7 days. Preserve original card IDs for navigation.
+- Task Subtasks: If a source task card has `subtasks`, include them on that task's timeline item with each original title and completion state. Do not split one task card into multiple timeline cards, and do not invent subtasks for cards that do not have them.
 - Completed: Separate section, faded but acknowledged.
 - Conflicts: Detect overlapping events and highlight them.
 

--- a/lib/agent/schedule_aggregator_agent/prompt.dart
+++ b/lib/agent/schedule_aggregator_agent/prompt.dart
@@ -27,6 +27,8 @@ You are the Schedule Aggregator, a specialized agent with the `update_schedule_a
   card processing status. For task cards, only `is_completed: true` means the
   user's task is done. If `is_completed` is absent or false, keep the task
   pending even if the AI card generation has finished.
+- If a task card includes `subtasks`, preserve them in the timeline output as
+  the task's `subtasks` list. Do not invent subtasks for unrelated cards.
 
 ## Language Consistency Rule (CRITICAL)
 - Respect User Language: If user's input is Chinese, output MUST be Chinese

--- a/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart
+++ b/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart
@@ -51,6 +51,7 @@ Future<String> buildScheduleAggregationRunContext({
       'Start from schedule_cards for the current refresh window, then inspect source cards with Read or BatchRead when details are needed.',
       'Use save_schedule_aggregation to persist exactly one current aggregation result.',
       'Preserve completed task status only when task is_completed is true; card processing status does not mean task completion.',
+      'When a task card has subtasks, preserve those subtasks on the timeline item; do not invent subtasks for independent cards.',
     ],
   };
 

--- a/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
+++ b/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
@@ -141,7 +141,7 @@ Tool buildGetScheduleCardsTool() {
   return Tool(
     name: 'get_schedule_cards',
     description:
-        'Query temporal cards (events, tasks, routines, durations, procedures) within a date range. Returns structured card data including title, normalized start_time, status, and template type. Task due_date is exposed as start_time when start_time is absent.',
+        'Query temporal cards (events, tasks, routines, durations, procedures) within a date range. Returns structured card data including title, normalized start_time, status, template type, and task subtasks. Task due_date is exposed as start_time when start_time is absent.',
     parameters: {
       'type': 'object',
       'properties': {

--- a/lib/domain/models/schedule_aggregation_model.dart
+++ b/lib/domain/models/schedule_aggregation_model.dart
@@ -32,8 +32,9 @@ class ScheduleAggregationModel {
       id: _parseString(yaml['id']),
       generatedAt: _parseDateTime(yaml['generated_at']),
       version: _parseInt(yaml['version']) ?? 1,
-      timeRange:
-          TimeRange.fromYaml(yaml['time_range'] as Map<String, dynamic>? ?? {}),
+      timeRange: TimeRange.fromYaml(
+        yaml['time_range'] as Map<String, dynamic>? ?? {},
+      ),
       heroItem: yaml['hero_item'] != null
           ? HeroItem.fromYaml(yaml['hero_item'] as Map<String, dynamic>)
           : null,
@@ -46,24 +47,26 @@ class ScheduleAggregationModel {
   }
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'generated_at': generatedAt.toIso8601String(),
-        'version': version,
-        'time_range': timeRange.toJson(),
-        if (heroItem != null) 'hero_item': heroItem!.toJson(),
-        'editorial_intro': editorialIntro,
-        'quote_blocks': quoteBlocks.map((e) => e.toJson()).toList(),
-        'timeline': timeline.map((e) => e.toJson()).toList(),
-        'completed': completed.map((e) => e.toJson()).toList(),
-        'conflicts': conflicts.map((e) => e.toJson()).toList(),
-      };
+    'id': id,
+    'generated_at': generatedAt.toIso8601String(),
+    'version': version,
+    'time_range': timeRange.toJson(),
+    if (heroItem != null) 'hero_item': heroItem!.toJson(),
+    'editorial_intro': editorialIntro,
+    'quote_blocks': quoteBlocks.map((e) => e.toJson()).toList(),
+    'timeline': timeline.map((e) => e.toJson()).toList(),
+    'completed': completed.map((e) => e.toJson()).toList(),
+    'conflicts': conflicts.map((e) => e.toJson()).toList(),
+  };
 
   static DateTime _parseDateTime(dynamic value) {
     return _parseDateTimeNullable(value) ?? DateTime.now();
   }
 
   static List<T> _parseList<T>(
-      dynamic value, T Function(Map<String, dynamic>) parser) {
+    dynamic value,
+    T Function(Map<String, dynamic>) parser,
+  ) {
     if (value == null) return [];
     if (value is! List) return [];
     return value
@@ -87,9 +90,9 @@ class TimeRange {
   }
 
   Map<String, dynamic> toJson() => {
-        'from': _formatDate(from),
-        'to': _formatDate(to),
-      };
+    'from': _formatDate(from),
+    'to': _formatDate(to),
+  };
 
   static DateTime _parseDate(dynamic value) {
     if (value == null) return DateTime.now();
@@ -135,14 +138,14 @@ class HeroItem {
   }
 
   Map<String, dynamic> toJson() => {
-        'card_id': cardId,
-        'title': title,
-        if (description != null) 'description': description,
-        if (startTime != null) 'start_time': startTime!.toIso8601String(),
-        if (endTime != null) 'end_time': endTime!.toIso8601String(),
-        if (location != null) 'location': location,
-        if (priority != null) 'priority': priority,
-      };
+    'card_id': cardId,
+    'title': title,
+    if (description != null) 'description': description,
+    if (startTime != null) 'start_time': startTime!.toIso8601String(),
+    if (endTime != null) 'end_time': endTime!.toIso8601String(),
+    if (location != null) 'location': location,
+    if (priority != null) 'priority': priority,
+  };
 }
 
 class QuoteBlock {
@@ -168,11 +171,11 @@ class QuoteBlock {
   }
 
   Map<String, dynamic> toJson() => {
-        'title': title,
-        'content': content,
-        'priority': priority,
-        if (relatedCardId != null) 'related_card_id': relatedCardId,
-      };
+    'title': title,
+    'content': content,
+    'priority': priority,
+    if (relatedCardId != null) 'related_card_id': relatedCardId,
+  };
 }
 
 class TimelineDay {
@@ -180,11 +183,7 @@ class TimelineDay {
   final DateTime? dayDate;
   final List<TimelineItem> items;
 
-  TimelineDay({
-    required this.dayLabel,
-    this.dayDate,
-    this.items = const [],
-  });
+  TimelineDay({required this.dayLabel, this.dayDate, this.items = const []});
 
   factory TimelineDay.fromYaml(Map<String, dynamic> yaml) {
     return TimelineDay(
@@ -195,10 +194,10 @@ class TimelineDay {
   }
 
   Map<String, dynamic> toJson() => {
-        'day_label': dayLabel,
-        if (dayDate != null) 'day_date': _formatDate(dayDate!),
-        'items': items.map((e) => e.toJson()).toList(),
-      };
+    'day_label': dayLabel,
+    if (dayDate != null) 'day_date': _formatDate(dayDate!),
+    'items': items.map((e) => e.toJson()).toList(),
+  };
 
   static String _formatDate(DateTime date) {
     return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
@@ -213,6 +212,7 @@ class TimelineItem {
   final String type;
   final int? priority;
   final String? description;
+  final List<ScheduleSubtask> subtasks;
 
   TimelineItem({
     required this.cardId,
@@ -222,6 +222,7 @@ class TimelineItem {
     this.type = 'event',
     this.priority,
     this.description,
+    this.subtasks = const [],
   });
 
   factory TimelineItem.fromYaml(Map<String, dynamic> yaml) {
@@ -233,18 +234,47 @@ class TimelineItem {
       type: _parseString(yaml['type'], fallback: 'event'),
       priority: _parseInt(yaml['priority']),
       description: _parseNullableString(yaml['description']),
+      subtasks: _parseList(
+        yaml['subtasks'],
+        ScheduleSubtask.fromYaml,
+      ).where((subtask) => subtask.title.trim().isNotEmpty).toList(),
     );
   }
 
   Map<String, dynamic> toJson() => {
-        'card_id': cardId,
-        'title': title,
-        'status': status,
-        if (startTime != null) 'start_time': startTime!.toIso8601String(),
-        'type': type,
-        if (priority != null) 'priority': priority,
-        if (description != null) 'description': description,
-      };
+    'card_id': cardId,
+    'title': title,
+    'status': status,
+    if (startTime != null) 'start_time': startTime!.toIso8601String(),
+    'type': type,
+    if (priority != null) 'priority': priority,
+    if (description != null) 'description': description,
+    if (subtasks.isNotEmpty)
+      'subtasks': subtasks.map((e) => e.toJson()).toList(),
+  };
+}
+
+class ScheduleSubtask {
+  final String title;
+  final bool completed;
+
+  const ScheduleSubtask({required this.title, this.completed = false});
+
+  factory ScheduleSubtask.fromYaml(Map<String, dynamic> yaml) {
+    return ScheduleSubtask(
+      title: _parseString(yaml['title']),
+      completed: _parseBool(yaml['completed']) ?? false,
+    );
+  }
+
+  ScheduleSubtask copyWith({String? title, bool? completed}) {
+    return ScheduleSubtask(
+      title: title ?? this.title,
+      completed: completed ?? this.completed,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {'title': title, 'completed': completed};
 }
 
 class CompletedItem {
@@ -252,11 +282,7 @@ class CompletedItem {
   final String title;
   final DateTime? completedAt;
 
-  CompletedItem({
-    required this.cardId,
-    required this.title,
-    this.completedAt,
-  });
+  CompletedItem({required this.cardId, required this.title, this.completedAt});
 
   factory CompletedItem.fromYaml(Map<String, dynamic> yaml) {
     return CompletedItem(
@@ -267,25 +293,23 @@ class CompletedItem {
   }
 
   Map<String, dynamic> toJson() => {
-        'card_id': cardId,
-        'title': title,
-        if (completedAt != null) 'completed_at': completedAt!.toIso8601String(),
-      };
+    'card_id': cardId,
+    'title': title,
+    if (completedAt != null) 'completed_at': completedAt!.toIso8601String(),
+  };
 }
 
 class Conflict {
   final String description;
   final List<String> itemIds;
 
-  Conflict({
-    required this.description,
-    this.itemIds = const [],
-  });
+  Conflict({required this.description, this.itemIds = const []});
 
   factory Conflict.fromYaml(Map<String, dynamic> yaml) {
     return Conflict(
       description: _parseString(yaml['description']),
-      itemIds: (yaml['item_ids'] as List?)
+      itemIds:
+          (yaml['item_ids'] as List?)
               ?.map((item) => item.toString())
               .toList() ??
           [],
@@ -293,9 +317,9 @@ class Conflict {
   }
 
   Map<String, dynamic> toJson() => {
-        'description': description,
-        'item_ids': itemIds,
-      };
+    'description': description,
+    'item_ids': itemIds,
+  };
 }
 
 DateTime? _parseDateTimeNullable(dynamic value) {
@@ -334,6 +358,20 @@ int? _parseInt(dynamic value) {
       'high' || 'urgent' || '重要' || '高' => 3,
       'medium' || 'normal' || '中' => 2,
       'low' || '低' => 1,
+      _ => null,
+    };
+  }
+  return null;
+}
+
+bool? _parseBool(dynamic value) {
+  if (value == null) return null;
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    return switch (value.toLowerCase().trim()) {
+      'true' || 'yes' || 'y' || '1' || 'done' || 'completed' => true,
+      'false' || 'no' || 'n' || '0' || 'pending' || 'todo' => false,
       _ => null,
     };
   }

--- a/lib/ui/schedule/models/schedule_item.dart
+++ b/lib/ui/schedule/models/schedule_item.dart
@@ -22,6 +22,7 @@ class ScheduleItem {
   final int? priority; // 1-3, 3 = highest
   final String sourceType;
   final List<RelatedEvent> relatedEvents;
+  final List<ScheduleSubtask> subtasks;
 
   ScheduleItem({
     required this.id,
@@ -37,6 +38,7 @@ class ScheduleItem {
     this.priority,
     this.sourceType = 'event',
     this.relatedEvents = const [],
+    this.subtasks = const [],
   });
 
   ScheduleItem copyWith({
@@ -50,6 +52,7 @@ class ScheduleItem {
     List<String>? tags,
     int? priority,
     String? sourceType,
+    List<ScheduleSubtask>? subtasks,
     bool clearCompletedAt = false,
   }) {
     return ScheduleItem(
@@ -66,6 +69,7 @@ class ScheduleItem {
       priority: priority ?? this.priority,
       sourceType: sourceType ?? this.sourceType,
       relatedEvents: relatedEvents,
+      subtasks: subtasks ?? this.subtasks,
     );
   }
 
@@ -93,26 +97,30 @@ class ScheduleItem {
               priority: _normalizePriority(item.priority),
               sourceType: item.sourceType,
               relatedEvents: item.relatedEvents,
+              subtasks: item.subtasks,
             );
       final existing = itemsById[id];
-      itemsById[id] =
-          existing == null ? normalized : _merge(existing, normalized);
+      itemsById[id] = existing == null
+          ? normalized
+          : _merge(existing, normalized);
     }
 
     if (aggregation.heroItem != null) {
       final hero = aggregation.heroItem!;
-      upsert(ScheduleItem(
-        id: hero.cardId,
-        title: hero.title,
-        type: ScheduleItemType.event,
-        status: ScheduleItemStatus.pending,
-        startTime: hero.startTime,
-        endTime: hero.endTime,
-        location: hero.location,
-        description: hero.description,
-        priority: _normalizePriority(hero.priority),
-        sourceType: 'event',
-      ));
+      upsert(
+        ScheduleItem(
+          id: hero.cardId,
+          title: hero.title,
+          type: ScheduleItemType.event,
+          status: ScheduleItemStatus.pending,
+          startTime: hero.startTime,
+          endTime: hero.endTime,
+          location: hero.location,
+          description: hero.description,
+          priority: _normalizePriority(hero.priority),
+          sourceType: 'event',
+        ),
+      );
     }
 
     for (final day in aggregation.timeline) {
@@ -130,14 +138,16 @@ class ScheduleItem {
           completedAt: completedItem.completedAt,
         );
       } else {
-        upsert(ScheduleItem(
-          id: id,
-          title: completedItem.title,
-          type: ScheduleItemType.todo,
-          status: ScheduleItemStatus.completed,
-          completedAt: completedItem.completedAt,
-          sourceType: 'task',
-        ));
+        upsert(
+          ScheduleItem(
+            id: id,
+            title: completedItem.title,
+            type: ScheduleItemType.todo,
+            status: ScheduleItemStatus.completed,
+            completedAt: completedItem.completedAt,
+            sourceType: 'task',
+          ),
+        );
       }
     }
 
@@ -155,33 +165,43 @@ class ScheduleItem {
     return items;
   }
 
-  static ScheduleItem _fromTimelineItem(
-    TimelineItem item,
-    DateTime? dayDate,
-  ) {
+  static ScheduleItem _fromTimelineItem(TimelineItem item, DateTime? dayDate) {
     final sourceType = item.type;
     final itemType = _parseType(sourceType);
     final startTime = item.startTime ?? dayDate;
+    final parsedStatus = _parseStatus(item.status);
     return ScheduleItem(
       id: item.cardId,
       title: item.title,
       type: itemType,
-      status: _parseStatus(item.status),
+      status: itemType == ScheduleItemType.todo
+          ? deriveTodoStatus(item.subtasks, fallback: parsedStatus)
+          : parsedStatus,
       startTime: startTime,
       description: item.description,
       priority: _normalizePriority(item.priority),
       sourceType: sourceType,
+      subtasks: item.subtasks,
     );
   }
 
   static ScheduleItem _merge(ScheduleItem base, ScheduleItem incoming) {
-    final status = _higherPriorityStatus(base.status, incoming.status);
-    final type =
-        incoming.type == ScheduleItemType.todo ? incoming.type : base.type;
+    final type = incoming.type == ScheduleItemType.todo
+        ? incoming.type
+        : base.type;
+    final subtasks = base.subtasks.isNotEmpty
+        ? base.subtasks
+        : incoming.subtasks;
+    final status = type == ScheduleItemType.todo
+        ? deriveTodoStatus(
+            subtasks,
+            fallback: _higherPriorityStatus(base.status, incoming.status),
+          )
+        : _higherPriorityStatus(base.status, incoming.status);
     final sourceType =
         base.sourceType == 'event' && incoming.sourceType != 'event'
-            ? incoming.sourceType
-            : base.sourceType;
+        ? incoming.sourceType
+        : base.sourceType;
     return base.copyWith(
       type: type,
       status: status,
@@ -193,7 +213,30 @@ class ScheduleItem {
       tags: base.tags.isNotEmpty ? base.tags : incoming.tags,
       priority: _normalizePriority(base.priority ?? incoming.priority),
       sourceType: sourceType,
+      subtasks: subtasks,
     );
+  }
+
+  static ScheduleItemStatus deriveTodoStatus(
+    List<ScheduleSubtask> subtasks, {
+    required ScheduleItemStatus fallback,
+  }) {
+    if (fallback == ScheduleItemStatus.completed || subtasks.isEmpty) {
+      return fallback;
+    }
+
+    final completedCount = subtasks
+        .where((subtask) => subtask.completed)
+        .length;
+    if (completedCount == subtasks.length) {
+      return ScheduleItemStatus.completed;
+    }
+    if (completedCount > 0) {
+      return ScheduleItemStatus.inProgress;
+    }
+    return fallback == ScheduleItemStatus.overdue
+        ? ScheduleItemStatus.overdue
+        : ScheduleItemStatus.pending;
   }
 
   static ScheduleItemType _parseType(String value) {
@@ -210,8 +253,7 @@ class ScheduleItem {
       'completed' || 'done' => ScheduleItemStatus.completed,
       'in_progress' ||
       'inprogress' ||
-      'active' =>
-        ScheduleItemStatus.inProgress,
+      'active' => ScheduleItemStatus.inProgress,
       'overdue' => ScheduleItemStatus.overdue,
       _ => ScheduleItemStatus.pending,
     };

--- a/lib/ui/schedule/view_models/schedule_aggregator_view_model.dart
+++ b/lib/ui/schedule/view_models/schedule_aggregator_view_model.dart
@@ -28,14 +28,12 @@ String _localizedOrFallback(
 
 typedef ScheduleAggregationLoader = Future<ScheduleAggregationModel?>
     Function();
-typedef ScheduleAggregationFreshnessChecker = Future<bool> Function({
-  Duration? maxAge,
-});
+typedef ScheduleAggregationFreshnessChecker = Future<bool> Function(
+    {Duration? maxAge});
 typedef ScheduleAggregationRefresher = Future<Result<void>> Function();
 typedef ScheduleRefreshStateLoader = Future<ScheduleRefreshState> Function();
 typedef ScheduleCardDetailFetcher = Future<CardDetailModel> Function(
-  String cardId,
-);
+    String cardId);
 typedef ScheduleCardUiConfigUpdater = Future<bool> Function(
   String cardId,
   int configIndex,
@@ -91,6 +89,7 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
   ScheduleRefreshState _refreshState = ScheduleRefreshState.clean();
   Completer<void>? _pendingRefreshCompletion;
   final Map<String, ScheduleItemStatus> _statusOverrides = {};
+  final Map<String, List<ScheduleSubtask>> _subtaskOverrides = {};
 
   ScheduleAggregationModel? get aggregation => _aggregation;
   bool get isLoading => _isLoading;
@@ -101,14 +100,24 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
   List<ScheduleItem> get items {
     if (_aggregation == null) return const [];
     return ScheduleItem.fromAggregation(_aggregation!).map((item) {
+      final subtasks = _subtaskOverrides[item.id];
       final status = _statusOverrides[item.id];
-      if (status == null) return item;
+      if (status == null && subtasks == null) return item;
+      final effectiveSubtasks = subtasks ?? item.subtasks;
+      final effectiveStatus = status ??
+          (subtasks == null
+              ? item.status
+              : ScheduleItem.deriveTodoStatus(
+                  effectiveSubtasks,
+                  fallback: item.status,
+                ));
       return item.copyWith(
-        status: status,
-        completedAt: status == ScheduleItemStatus.completed
+        status: effectiveStatus,
+        subtasks: effectiveSubtasks,
+        completedAt: effectiveStatus == ScheduleItemStatus.completed
             ? item.completedAt ?? DateTime.now()
             : item.completedAt,
-        clearCompletedAt: status != ScheduleItemStatus.completed,
+        clearCompletedAt: effectiveStatus != ScheduleItemStatus.completed,
       );
     }).toList();
   }
@@ -131,6 +140,7 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
       _aggregation = await _loadAggregation();
       _refreshState = await _loadRefreshState();
       _statusOverrides.clear();
+      _subtaskOverrides.clear();
       _error = null;
     } catch (e) {
       _logger.severe('Failed to load schedule aggregation: $e');
@@ -197,22 +207,48 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
     final nextStatus = item.status == ScheduleItemStatus.completed
         ? ScheduleItemStatus.pending
         : ScheduleItemStatus.completed;
-    _applyStatusOverride(item.id, nextStatus);
+    final nextCompleted = nextStatus == ScheduleItemStatus.completed;
+    final previousStatusOverride = _statusOverrides[item.id];
+    final previousSubtaskOverride = _subtaskOverrides[item.id];
+    final optimisticSubtasks = item.subtasks.isEmpty
+        ? null
+        : item.subtasks
+            .map((subtask) => subtask.copyWith(completed: nextCompleted))
+            .toList();
+    _applyTaskOverride(
+      item.id,
+      status: nextStatus,
+      subtasks: optimisticSubtasks,
+    );
 
     try {
       final detail = await _fetchCardDetail(item.id);
-      final configIndex =
-          detail.uiConfigs.indexWhere((config) => config.templateId == 'task');
+      final configIndex = _findTaskConfigIndex(detail);
 
       if (configIndex < 0) {
         throw Exception('No task ui_config found for ${item.id}');
       }
 
-      final success = await _updateCardUiConfig(
-        item.id,
-        configIndex,
-        {'is_completed': nextStatus == ScheduleItemStatus.completed},
-      );
+      final taskData = detail.uiConfigs[configIndex].data;
+      final updates = <String, dynamic>{'is_completed': nextCompleted};
+      final rawSubtasks = taskData['subtasks'];
+      if (item.subtasks.isNotEmpty) {
+        if (rawSubtasks is! List ||
+            rawSubtasks.length != item.subtasks.length) {
+          throw Exception('Task card subtasks are stale for ${item.id}');
+        }
+        updates['subtasks'] = _setRawSubtasksCompletion(
+          rawSubtasks,
+          nextCompleted,
+        );
+      } else if (_canBulkUpdateSubtasks(rawSubtasks)) {
+        updates['subtasks'] = _setRawSubtasksCompletion(
+          rawSubtasks as List,
+          nextCompleted,
+        );
+      }
+
+      final success = await _updateCardUiConfig(item.id, configIndex, updates);
 
       if (!success) {
         throw Exception('Failed to update task card');
@@ -220,7 +256,71 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
       _error = null;
     } catch (e) {
       _logger.warning('Failed to toggle schedule item ${item.id}: $e');
-      _statusOverrides[item.id] = item.status;
+      _restoreTaskOverrides(
+        item.id,
+        previousStatusOverride,
+        previousSubtaskOverride,
+      );
+      _error = _localizedOrFallback(
+        (l10n) => l10n.scheduleTaskUpdateFailed,
+        'Failed to update task',
+      );
+      notifyListeners();
+    }
+  }
+
+  Future<void> toggleSubtask(ScheduleItem item, int subtaskIndex) async {
+    if (item.type != ScheduleItemType.todo) return;
+    if (subtaskIndex < 0 || subtaskIndex >= item.subtasks.length) return;
+
+    final previousStatusOverride = _statusOverrides[item.id];
+    final previousSubtaskOverride = _subtaskOverrides[item.id];
+    final nextSubtasks = item.subtasks.toList();
+    final currentSubtask = nextSubtasks[subtaskIndex];
+    nextSubtasks[subtaskIndex] = currentSubtask.copyWith(
+      completed: !currentSubtask.completed,
+    );
+    final nextStatus = ScheduleItem.deriveTodoStatus(
+      nextSubtasks,
+      fallback: item.status,
+    );
+    _applyTaskOverride(item.id, status: nextStatus, subtasks: nextSubtasks);
+
+    try {
+      final detail = await _fetchCardDetail(item.id);
+      final configIndex = _findTaskConfigIndex(detail);
+
+      if (configIndex < 0) {
+        throw Exception('No task ui_config found for ${item.id}');
+      }
+
+      final rawSubtasks = detail.uiConfigs[configIndex].data['subtasks'];
+      if (rawSubtasks is! List) {
+        throw Exception('Task card has no subtask list for ${item.id}');
+      }
+
+      final updatedRawSubtasks = _toggleRawSubtask(rawSubtasks, subtaskIndex);
+      final completedSubtasks = _countCompletedRawSubtasks(updatedRawSubtasks);
+      final isCompleted = updatedRawSubtasks.isNotEmpty &&
+          completedSubtasks == updatedRawSubtasks.length;
+      final success = await _updateCardUiConfig(item.id, configIndex, {
+        'subtasks': updatedRawSubtasks,
+        'is_completed': isCompleted,
+      });
+
+      if (!success) {
+        throw Exception('Failed to update task card');
+      }
+      _error = null;
+    } catch (e) {
+      _logger.warning(
+        'Failed to toggle schedule subtask $subtaskIndex for ${item.id}: $e',
+      );
+      _restoreTaskOverrides(
+        item.id,
+        previousStatusOverride,
+        previousSubtaskOverride,
+      );
       _error = _localizedOrFallback(
         (l10n) => l10n.scheduleTaskUpdateFailed,
         'Failed to update task',
@@ -259,9 +359,33 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void _applyStatusOverride(String itemId, ScheduleItemStatus status) {
+  void _applyTaskOverride(
+    String itemId, {
+    required ScheduleItemStatus status,
+    List<ScheduleSubtask>? subtasks,
+  }) {
     _statusOverrides[itemId] = status;
+    if (subtasks != null) {
+      _subtaskOverrides[itemId] = subtasks;
+    }
     notifyListeners();
+  }
+
+  void _restoreTaskOverrides(
+    String itemId,
+    ScheduleItemStatus? statusOverride,
+    List<ScheduleSubtask>? subtaskOverride,
+  ) {
+    if (statusOverride == null) {
+      _statusOverrides.remove(itemId);
+    } else {
+      _statusOverrides[itemId] = statusOverride;
+    }
+    if (subtaskOverride == null) {
+      _subtaskOverrides.remove(itemId);
+    } else {
+      _subtaskOverrides[itemId] = subtaskOverride;
+    }
   }
 
   void _setLoading(bool value) {
@@ -288,4 +412,68 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
     }
     super.dispose();
   }
+}
+
+int _findTaskConfigIndex(CardDetailModel detail) {
+  return detail.uiConfigs.indexWhere((config) => config.templateId == 'task');
+}
+
+bool _canBulkUpdateSubtasks(dynamic rawSubtasks) {
+  return rawSubtasks is List &&
+      rawSubtasks.isNotEmpty &&
+      rawSubtasks.every((subtask) => subtask is Map);
+}
+
+List<Map<String, dynamic>> _setRawSubtasksCompletion(
+  List<dynamic> rawSubtasks,
+  bool completed,
+) {
+  return rawSubtasks
+      .map(
+        (subtask) => {
+          ...Map<String, dynamic>.from(subtask as Map),
+          'completed': completed,
+        },
+      )
+      .toList();
+}
+
+List<Map<String, dynamic>> _toggleRawSubtask(
+  List<dynamic> rawSubtasks,
+  int subtaskIndex,
+) {
+  if (subtaskIndex >= rawSubtasks.length) {
+    throw Exception('Subtask index out of bounds: $subtaskIndex');
+  }
+  final updated = <Map<String, dynamic>>[];
+  for (final entry in rawSubtasks.indexed) {
+    final value = entry.$2;
+    if (value is! Map) {
+      throw Exception('Malformed subtask at index ${entry.$1}');
+    }
+    final subtask = Map<String, dynamic>.from(value);
+    if (entry.$1 == subtaskIndex) {
+      subtask['completed'] = !_parseCompletedBool(subtask['completed']);
+    }
+    updated.add(subtask);
+  }
+  return updated;
+}
+
+int _countCompletedRawSubtasks(List<Map<String, dynamic>> subtasks) {
+  return subtasks
+      .where((subtask) => _parseCompletedBool(subtask['completed']))
+      .length;
+}
+
+bool _parseCompletedBool(dynamic value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    return switch (value.toLowerCase().trim()) {
+      'true' || 'yes' || 'y' || '1' || 'done' || 'completed' => true,
+      _ => false,
+    };
+  }
+  return false;
 }

--- a/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
+++ b/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
@@ -115,6 +115,13 @@ class _ScheduleAggregatorScreenState
     vm.toggleCompletion(vm.items[index]);
   }
 
+  void _toggleSubtask(String cardId, int subtaskIndex) {
+    final vm = context.read<ScheduleAggregatorViewModel>();
+    final index = vm.items.indexWhere((item) => item.id == cardId);
+    if (index < 0) return;
+    vm.toggleSubtask(vm.items[index], subtaskIndex);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -139,8 +146,13 @@ class _ScheduleAggregatorScreenState
                     return _buildRefreshableState(_buildEmptyState(vm.error));
                   }
 
+                  final items = vm.items;
                   final itemStatuses = {
-                    for (final item in vm.items) item.id: item.status,
+                    for (final item in items) item.id: item.status,
+                  };
+                  final itemSubtasks = {
+                    for (final item in items)
+                      if (item.subtasks.isNotEmpty) item.id: item.subtasks,
                   };
 
                   return RefreshIndicator(
@@ -151,6 +163,8 @@ class _ScheduleAggregatorScreenState
                       onTapCardId: _navigateToCard,
                       itemStatuses: itemStatuses,
                       onToggleTask: _toggleTaskCompletion,
+                      itemSubtasks: itemSubtasks,
+                      onToggleSubtask: _toggleSubtask,
                     ),
                   );
                 },

--- a/lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart
+++ b/lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart
@@ -13,7 +13,9 @@ class MagazineNarrativeTab extends StatefulWidget {
   final ScheduleAggregationModel aggregation;
   final void Function(String cardId)? onTapCardId;
   final Map<String, ScheduleItemStatus> itemStatuses;
+  final Map<String, List<ScheduleSubtask>> itemSubtasks;
   final void Function(String cardId)? onToggleTask;
+  final void Function(String cardId, int subtaskIndex)? onToggleSubtask;
   final DateTime? referenceDate;
 
   const MagazineNarrativeTab({
@@ -21,7 +23,9 @@ class MagazineNarrativeTab extends StatefulWidget {
     required this.aggregation,
     this.onTapCardId,
     this.itemStatuses = const {},
+    this.itemSubtasks = const {},
     this.onToggleTask,
+    this.onToggleSubtask,
     this.referenceDate,
   });
 
@@ -30,6 +34,9 @@ class MagazineNarrativeTab extends StatefulWidget {
 }
 
 class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
+  static const int _collapsedSubtaskCount = 3;
+  final Set<String> _expandedTaskIds = {};
+
   @override
   Widget build(BuildContext context) {
     return _buildAgentMode(widget.aggregation);
@@ -279,8 +286,9 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
 
   Widget _buildAgentReminderRow(QuoteBlock block) {
     final isHighPriority = block.priority == 'high';
-    final accentColor =
-        isHighPriority ? const Color(0xFFD97706) : const Color(0xFF64748B);
+    final accentColor = isHighPriority
+        ? const Color(0xFFD97706)
+        : const Color(0xFF64748B);
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -359,10 +367,12 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
   }
 
   Widget _buildAgentTimelineCard(TimelineItem item, {DateTime? dayDate}) {
-    final status =
-        widget.itemStatuses[item.cardId] ?? _parseStatus(item.status);
-    final isCompleted = status == ScheduleItemStatus.completed;
     final isTask = _isTaskItem(item);
+    final subtasks = isTask
+        ? _resolveSubtasks(item)
+        : const <ScheduleSubtask>[];
+    final status = _resolveStatus(item, subtasks);
+    final isCompleted = status == ScheduleItemStatus.completed;
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 14),
@@ -380,18 +390,19 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
                     color: isCompleted
                         ? const Color(0xFF99A1AF)
                         : item.priority == 3
-                            ? const Color(0xFFF43F5E)
-                            : const Color(0xFF5B6CFF),
+                        ? const Color(0xFFF43F5E)
+                        : const Color(0xFF5B6CFF),
                     shape: BoxShape.circle,
                     border: Border.all(color: Colors.white, width: 2),
                     boxShadow: [
                       BoxShadow(
-                        color: (isCompleted
-                                ? const Color(0xFF99A1AF)
-                                : item.priority == 3
+                        color:
+                            (isCompleted
+                                    ? const Color(0xFF99A1AF)
+                                    : item.priority == 3
                                     ? const Color(0xFFF43F5E)
                                     : const Color(0xFF5B6CFF))
-                            .withValues(alpha: 0.3),
+                                .withValues(alpha: 0.3),
                         blurRadius: 6,
                       ),
                     ],
@@ -411,7 +422,7 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
                     Row(
                       children: [
                         if (isTask) ...[
-                          _buildTaskCompletionCircle(item.cardId, isCompleted),
+                          _buildTaskCompletionCircle(item.cardId, status),
                           const SizedBox(width: 10),
                         ],
                         Expanded(
@@ -471,6 +482,12 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
                       ),
+                    ],
+                    if (isTask && subtasks.isNotEmpty) ...[
+                      const SizedBox(height: 10),
+                      _buildSubtaskProgress(item.cardId, subtasks, status),
+                      const SizedBox(height: 8),
+                      _buildSubtaskList(item.cardId, subtasks, isCompleted),
                     ],
                   ],
                 ),
@@ -544,7 +561,9 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
     );
   }
 
-  Widget _buildTaskCompletionCircle(String cardId, bool isCompleted) {
+  Widget _buildTaskCompletionCircle(String cardId, ScheduleItemStatus status) {
+    final isCompleted = status == ScheduleItemStatus.completed;
+    final isInProgress = status == ScheduleItemStatus.inProgress;
     return GestureDetector(
       key: ValueKey('schedule_task_toggle_$cardId'),
       onTap: () => widget.onToggleTask?.call(cardId),
@@ -557,14 +576,152 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
           shape: BoxShape.circle,
           color: isCompleted ? const Color(0xFF5B6CFF) : Colors.transparent,
           border: Border.all(
-            color:
-                isCompleted ? const Color(0xFF5B6CFF) : const Color(0xFFCBD5E1),
+            color: isCompleted
+                ? const Color(0xFF5B6CFF)
+                : const Color(0xFFCBD5E1),
             width: 2,
           ),
         ),
         child: isCompleted
             ? const Icon(Icons.check, size: 13, color: Colors.white)
+            : isInProgress
+            ? Container(
+                width: 8,
+                height: 8,
+                decoration: const BoxDecoration(
+                  color: Color(0xFF5B6CFF),
+                  shape: BoxShape.circle,
+                ),
+              )
             : null,
+      ),
+    );
+  }
+
+  Widget _buildSubtaskProgress(
+    String cardId,
+    List<ScheduleSubtask> subtasks,
+    ScheduleItemStatus status,
+  ) {
+    final completed = subtasks.where((subtask) => subtask.completed).length;
+    final progress = subtasks.isEmpty ? 0.0 : completed / subtasks.length;
+    final canExpand = subtasks.length > _collapsedSubtaskCount;
+    final isExpanded = _expandedTaskIds.contains(cardId);
+
+    return Row(
+      children: [
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: LinearProgressIndicator(
+              minHeight: 4,
+              value: progress,
+              backgroundColor: const Color(0xFFE2E8F0),
+              valueColor: AlwaysStoppedAnimation<Color>(
+                status == ScheduleItemStatus.completed
+                    ? const Color(0xFF99A1AF)
+                    : const Color(0xFF5B6CFF),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Text(
+          '$completed/${subtasks.length}',
+          style: const TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            color: Color(0xFF64748B),
+          ),
+        ),
+        if (canExpand) ...[
+          const SizedBox(width: 4),
+          GestureDetector(
+            key: ValueKey('schedule_subtasks_expand_$cardId'),
+            onTap: () {
+              setState(() {
+                if (isExpanded) {
+                  _expandedTaskIds.remove(cardId);
+                } else {
+                  _expandedTaskIds.add(cardId);
+                }
+              });
+            },
+            behavior: HitTestBehavior.opaque,
+            child: Padding(
+              padding: const EdgeInsets.all(3),
+              child: Icon(
+                isExpanded
+                    ? Icons.keyboard_arrow_up_rounded
+                    : Icons.keyboard_arrow_down_rounded,
+                size: 18,
+                color: const Color(0xFF64748B),
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildSubtaskList(
+    String cardId,
+    List<ScheduleSubtask> subtasks,
+    bool parentCompleted,
+  ) {
+    final visibleSubtasks = _visibleSubtasks(cardId, subtasks);
+    return Column(
+      children: [
+        for (final entry in visibleSubtasks)
+          _buildSubtaskRow(cardId, entry, parentCompleted),
+      ],
+    );
+  }
+
+  Widget _buildSubtaskRow(
+    String cardId,
+    _IndexedSubtask entry,
+    bool parentCompleted,
+  ) {
+    final subtask = entry.subtask;
+    final isCompleted = parentCompleted || subtask.completed;
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(
+        children: [
+          GestureDetector(
+            key: ValueKey('schedule_subtask_toggle_${cardId}_${entry.index}'),
+            onTap: () => widget.onToggleSubtask?.call(cardId, entry.index),
+            behavior: HitTestBehavior.opaque,
+            child: Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Icon(
+                isCompleted
+                    ? Icons.check_box_rounded
+                    : Icons.check_box_outline_blank_rounded,
+                size: 18,
+                color: isCompleted
+                    ? const Color(0xFF99A1AF)
+                    : const Color(0xFF64748B),
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              subtask.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                height: 1.3,
+                color: isCompleted
+                    ? const Color(0xFF99A1AF)
+                    : const Color(0xFF334155),
+                decoration: isCompleted ? TextDecoration.lineThrough : null,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -618,16 +775,54 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
     return type == 'task' || type == 'todo';
   }
 
+  List<ScheduleSubtask> _resolveSubtasks(TimelineItem item) {
+    return widget.itemSubtasks[item.cardId] ?? item.subtasks;
+  }
+
+  ScheduleItemStatus _resolveStatus(
+    TimelineItem item,
+    List<ScheduleSubtask> subtasks,
+  ) {
+    final status =
+        widget.itemStatuses[item.cardId] ?? _parseStatus(item.status);
+    if (!_isTaskItem(item)) return status;
+    return ScheduleItem.deriveTodoStatus(subtasks, fallback: status);
+  }
+
+  List<_IndexedSubtask> _visibleSubtasks(
+    String cardId,
+    List<ScheduleSubtask> subtasks,
+  ) {
+    final indexed = [
+      for (final entry in subtasks.indexed)
+        _IndexedSubtask(index: entry.$1, subtask: entry.$2),
+    ];
+    if (_expandedTaskIds.contains(cardId) ||
+        indexed.length <= _collapsedSubtaskCount) {
+      return indexed;
+    }
+
+    final pending = indexed.where((entry) => !entry.subtask.completed);
+    final completed = indexed.where((entry) => entry.subtask.completed);
+    return [...pending, ...completed].take(_collapsedSubtaskCount).toList();
+  }
+
   ScheduleItemStatus _parseStatus(String value) {
     final normalized = value.toLowerCase().trim().replaceAll('-', '_');
     return switch (normalized) {
       'completed' || 'done' => ScheduleItemStatus.completed,
       'in_progress' ||
       'inprogress' ||
-      'active' =>
-        ScheduleItemStatus.inProgress,
+      'active' => ScheduleItemStatus.inProgress,
       'overdue' => ScheduleItemStatus.overdue,
       _ => ScheduleItemStatus.pending,
     };
   }
+}
+
+class _IndexedSubtask {
+  final int index;
+  final ScheduleSubtask subtask;
+
+  const _IndexedSubtask({required this.index, required this.subtask});
 }

--- a/test/domain/models/schedule_aggregation_model_test.dart
+++ b/test/domain/models/schedule_aggregation_model_test.dart
@@ -8,10 +8,7 @@ void main() {
         'id': 'schedule_agg_2026_04_23',
         'generated_at': '2026-04-23T08:00:00Z',
         'version': 1,
-        'time_range': {
-          'from': '2026-04-21',
-          'to': '2026-04-30',
-        },
+        'time_range': {'from': '2026-04-21', 'to': '2026-04-30'},
         'hero_item': {
           'card_id': '2026/04/25.md#ts_1',
           'title': 'Q3 产品发布会',
@@ -77,6 +74,7 @@ void main() {
       expect(model.timeline.first.dayLabel, 'Today');
       expect(model.timeline.first.items.length, 1);
       expect(model.timeline.first.items.first.title, '设计评审');
+      expect(model.timeline.first.items.first.subtasks, isEmpty);
       expect(model.completed.length, 1);
       expect(model.completed.first.title, '架构评审');
       expect(model.conflicts.length, 1);
@@ -87,10 +85,7 @@ void main() {
       final yaml = {
         'id': 'schedule_agg_2026_04_23',
         'generated_at': '2026-04-23T08:00:00Z',
-        'time_range': {
-          'from': '2026-04-21',
-          'to': '2026-04-30',
-        },
+        'time_range': {'from': '2026-04-21', 'to': '2026-04-30'},
       };
 
       final model = ScheduleAggregationModel.fromYaml(yaml);
@@ -112,80 +107,88 @@ void main() {
       expect(model.timeline, isEmpty);
     });
 
-    test('parses LLM-style scalar variants and ignores malformed list entries',
-        () {
-      final model = ScheduleAggregationModel.fromYaml({
-        'id': 20260426,
-        'generated_at': DateTime.utc(2026, 4, 26, 1),
-        'version': '2',
-        'time_range': {
-          'from': DateTime(2026, 4, 26),
-          'to': '2026-05-03',
-        },
-        'hero_item': {
-          'id': 42,
-          'title': 123,
-          'priority': 'urgent',
-        },
-        'quote_blocks': [
-          {
-            'title': '风险',
-            'content': 88,
-            'priority': 'high',
-            'related_card_id': 42,
-          },
-          'not a map',
-        ],
-        'timeline': [
-          {
-            'day_label': 'Today',
-            'day_date': '2026-04-26',
-            'items': [
-              {
-                'id': 101,
-                'title': '确认材料',
-                'status': 'done',
-                'type': 'task',
-                'priority': 'low',
-              },
-              false,
-            ],
-          },
-          7,
-        ],
-        'completed': [
-          {
-            'id': 102,
-            'title': '完成彩排',
-            'completed_at': 'invalid datetime',
-          },
-        ],
-        'conflicts': [
-          {
-            'description': 404,
-            'item_ids': [101, '42'],
-          },
-        ],
-      });
+    test(
+      'parses LLM-style scalar variants and ignores malformed list entries',
+      () {
+        final model = ScheduleAggregationModel.fromYaml({
+          'id': 20260426,
+          'generated_at': DateTime.utc(2026, 4, 26, 1),
+          'version': '2',
+          'time_range': {'from': DateTime(2026, 4, 26), 'to': '2026-05-03'},
+          'hero_item': {'id': 42, 'title': 123, 'priority': 'urgent'},
+          'quote_blocks': [
+            {
+              'title': '风险',
+              'content': 88,
+              'priority': 'high',
+              'related_card_id': 42,
+            },
+            'not a map',
+          ],
+          'timeline': [
+            {
+              'day_label': 'Today',
+              'day_date': '2026-04-26',
+              'items': [
+                {
+                  'id': 101,
+                  'title': '确认材料',
+                  'status': 'done',
+                  'type': 'task',
+                  'priority': 'low',
+                  'subtasks': [
+                    {'title': '打印材料', 'completed': 'yes'},
+                    {'title': ' ', 'completed': true},
+                    {'title': '带证件', 'completed': 0},
+                    'bad entry',
+                  ],
+                },
+                false,
+              ],
+            },
+            7,
+          ],
+          'completed': [
+            {'id': 102, 'title': '完成彩排', 'completed_at': 'invalid datetime'},
+          ],
+          'conflicts': [
+            {
+              'description': 404,
+              'item_ids': [101, '42'],
+            },
+          ],
+        });
 
-      expect(model.id, '20260426');
-      expect(model.generatedAt.toUtc(), DateTime.utc(2026, 4, 26, 1));
-      expect(model.version, 2);
-      expect(model.heroItem?.cardId, '42');
-      expect(model.heroItem?.title, '123');
-      expect(model.heroItem?.priority, 3);
-      expect(model.quoteBlocks, hasLength(1));
-      expect(model.quoteBlocks.single.content, '88');
-      expect(model.quoteBlocks.single.relatedCardId, '42');
-      expect(model.timeline, hasLength(1));
-      expect(model.timeline.single.items, hasLength(1));
-      expect(model.timeline.single.items.single.cardId, '101');
-      expect(model.timeline.single.items.single.priority, 1);
-      expect(model.completed.single.cardId, '102');
-      expect(model.completed.single.completedAt, isNull);
-      expect(model.conflicts.single.description, '404');
-      expect(model.conflicts.single.itemIds, ['101', '42']);
-    });
+        expect(model.id, '20260426');
+        expect(model.generatedAt.toUtc(), DateTime.utc(2026, 4, 26, 1));
+        expect(model.version, 2);
+        expect(model.heroItem?.cardId, '42');
+        expect(model.heroItem?.title, '123');
+        expect(model.heroItem?.priority, 3);
+        expect(model.quoteBlocks, hasLength(1));
+        expect(model.quoteBlocks.single.content, '88');
+        expect(model.quoteBlocks.single.relatedCardId, '42');
+        expect(model.timeline, hasLength(1));
+        expect(model.timeline.single.items, hasLength(1));
+        expect(model.timeline.single.items.single.cardId, '101');
+        expect(model.timeline.single.items.single.priority, 1);
+        expect(model.timeline.single.items.single.subtasks, hasLength(2));
+        expect(model.timeline.single.items.single.subtasks.first.title, '打印材料');
+        expect(
+          model.timeline.single.items.single.subtasks.first.completed,
+          isTrue,
+        );
+        expect(model.timeline.single.items.single.subtasks.last.title, '带证件');
+        expect(
+          model.timeline.single.items.single.subtasks.last.completed,
+          isFalse,
+        );
+        expect(model.completed.single.cardId, '102');
+        expect(model.completed.single.completedAt, isNull);
+        expect(model.conflicts.single.description, '404');
+        expect(model.conflicts.single.itemIds, ['101', '42']);
+      },
+    );
 
     test('round-trip serialization preserves data', () {
       final original = ScheduleAggregationModel(
@@ -221,16 +224,14 @@ void main() {
                 title: 'Meeting',
                 status: 'pending',
                 type: 'event',
+                subtasks: const [
+                  ScheduleSubtask(title: 'Draft', completed: true),
+                ],
               ),
             ],
           ),
         ],
-        completed: [
-          CompletedItem(
-            cardId: 'done_1',
-            title: 'Finished task',
-          ),
-        ],
+        completed: [CompletedItem(cardId: 'done_1', title: 'Finished task')],
       );
 
       final json = original.toJson();
@@ -241,6 +242,14 @@ void main() {
       expect(restored.heroItem?.title, original.heroItem?.title);
       expect(restored.quoteBlocks.length, original.quoteBlocks.length);
       expect(restored.timeline.length, original.timeline.length);
+      expect(
+        restored.timeline.single.items.single.subtasks.single.title,
+        'Draft',
+      );
+      expect(
+        restored.timeline.single.items.single.subtasks.single.completed,
+        isTrue,
+      );
       expect(restored.completed.length, original.completed.length);
     });
 
@@ -248,10 +257,7 @@ void main() {
       final model = ScheduleAggregationModel.fromYaml({
         'id': 'schedule_agg_2026_05_14',
         'generated_at': '2026-05-14T17:39:22+08:00',
-        'time_range': {
-          'from': '2026-05-14',
-          'to': '2026-05-21',
-        },
+        'time_range': {'from': '2026-05-14', 'to': '2026-05-21'},
         'hero_item': {
           'card_id': '2026/05/14.md#ts_1',
           'title': 'Clean Apartment',
@@ -273,8 +279,9 @@ void main() {
         ],
       });
 
-      final expectedLocal =
-          DateTime.parse('2026-05-15T10:00:00+08:00').toLocal();
+      final expectedLocal = DateTime.parse(
+        '2026-05-15T10:00:00+08:00',
+      ).toLocal();
       expect(model.heroItem!.startTime, expectedLocal);
       expect(model.timeline.single.items.single.startTime, expectedLocal);
     });
@@ -288,10 +295,7 @@ void main() {
     });
 
     test('handles null datetime fields', () {
-      final yaml = {
-        'card_id': 'c1',
-        'title': 'Test',
-      };
+      final yaml = {'card_id': 'c1', 'title': 'Test'};
       final hero = HeroItem.fromYaml(yaml);
       expect(hero.startTime, isNull);
       expect(hero.endTime, isNull);

--- a/test/ui/schedule/models/schedule_item_test.dart
+++ b/test/ui/schedule/models/schedule_item_test.dart
@@ -12,6 +12,7 @@ void main() {
         type: ScheduleItemType.todo,
         status: ScheduleItemStatus.pending,
         priority: 2,
+        subtasks: const [ScheduleSubtask(title: 'Draft')],
       );
 
       final updated = item.copyWith(
@@ -24,6 +25,7 @@ void main() {
       expect(updated.status, ScheduleItemStatus.completed);
       expect(updated.completedAt, isNotNull);
       expect(updated.priority, 2);
+      expect(updated.subtasks.single.title, 'Draft');
       // Original should be unchanged
       expect(item.status, ScheduleItemStatus.pending);
     });
@@ -107,6 +109,11 @@ timeline:
         start_time: "2026-04-26T10:00:00+08:00"
         type: task
         priority: normal
+        subtasks:
+          - title: "检查环境变量"
+            completed: true
+          - title: "确认灰度开关"
+            completed: false
 completed:
   - card_id: "2026/04/25.md#ts_88"
     title: "完成彩排"
@@ -116,15 +123,14 @@ conflicts:
     item_ids: [2026/04/26.md#ts_100, 42]
 ''');
 
-      final aggregation = ScheduleAggregationModel.fromYaml(
-        _yamlToMap(yaml),
-      );
+      final aggregation = ScheduleAggregationModel.fromYaml(_yamlToMap(yaml));
       final items = ScheduleItem.fromAggregation(aggregation);
 
       expect(items, hasLength(3));
 
-      final launch =
-          items.singleWhere((item) => item.id == '2026/04/26.md#ts_100');
+      final launch = items.singleWhere(
+        (item) => item.id == '2026/04/26.md#ts_100',
+      );
       expect(launch.type, ScheduleItemType.event);
       expect(launch.priority, 3);
       expect(launch.location, '总部大礼堂');
@@ -134,9 +140,12 @@ conflicts:
       expect(checklist.type, ScheduleItemType.todo);
       expect(checklist.status, ScheduleItemStatus.inProgress);
       expect(checklist.priority, 2);
+      expect(checklist.subtasks, hasLength(2));
+      expect(checklist.subtasks.first.completed, isTrue);
 
-      final rehearsal =
-          items.singleWhere((item) => item.id == '2026/04/25.md#ts_88');
+      final rehearsal = items.singleWhere(
+        (item) => item.id == '2026/04/25.md#ts_88',
+      );
       expect(rehearsal.status, ScheduleItemStatus.completed);
       expect(rehearsal.completedAt?.toUtc(), DateTime.utc(2026, 4, 25, 11, 30));
       expect(aggregation.conflicts.single.itemIds, [
@@ -147,7 +156,8 @@ conflicts:
 
     test('keeps timeline task fields when hero points to the same card', () {
       final aggregation = ScheduleAggregationModel.fromYaml(
-        _yamlToMap(loadYaml('''
+        _yamlToMap(
+          loadYaml('''
 id: schedule_agg_2026_04_26
 generated_at: "2026-04-26T08:00:00+08:00"
 time_range:
@@ -169,7 +179,8 @@ timeline:
         status: " in-progress "
         type: task
         priority: 2
-''')),
+'''),
+        ),
       );
 
       final item = ScheduleItem.fromAggregation(aggregation).single;
@@ -184,7 +195,8 @@ timeline:
 
     test('completed section wins over duplicate pending timeline items', () {
       final aggregation = ScheduleAggregationModel.fromYaml(
-        _yamlToMap(loadYaml('''
+        _yamlToMap(
+          loadYaml('''
 id: schedule_agg_2026_04_26
 generated_at: "2026-04-26T08:00:00+08:00"
 time_range:
@@ -202,7 +214,8 @@ completed:
   - card_id: "task-done"
     title: "同步发布稿"
     completed_at: "2026-04-26T11:20:00+08:00"
-''')),
+'''),
+        ),
       );
 
       final item = ScheduleItem.fromAggregation(aggregation).single;
@@ -210,6 +223,29 @@ completed:
       expect(item.type, ScheduleItemType.todo);
       expect(item.status, ScheduleItemStatus.completed);
       expect(item.completedAt?.toUtc(), DateTime.utc(2026, 4, 26, 3, 20));
+    });
+
+    test('derives task status from subtask progress conservatively', () {
+      final pending = ScheduleItem.deriveTodoStatus(const [
+        ScheduleSubtask(title: 'A'),
+        ScheduleSubtask(title: 'B'),
+      ], fallback: ScheduleItemStatus.overdue);
+      final partial = ScheduleItem.deriveTodoStatus(const [
+        ScheduleSubtask(title: 'A', completed: true),
+        ScheduleSubtask(title: 'B'),
+      ], fallback: ScheduleItemStatus.pending);
+      final completed = ScheduleItem.deriveTodoStatus(const [
+        ScheduleSubtask(title: 'A', completed: true),
+        ScheduleSubtask(title: 'B', completed: true),
+      ], fallback: ScheduleItemStatus.pending);
+      final parentCompletedWins = ScheduleItem.deriveTodoStatus(const [
+        ScheduleSubtask(title: 'A'),
+      ], fallback: ScheduleItemStatus.completed);
+
+      expect(pending, ScheduleItemStatus.overdue);
+      expect(partial, ScheduleItemStatus.inProgress);
+      expect(completed, ScheduleItemStatus.completed);
+      expect(parentCompletedWins, ScheduleItemStatus.completed);
     });
 
     test('assigns stable fallback ids and sorts undated items by title', () {

--- a/test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart
+++ b/test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart
@@ -21,11 +21,8 @@ void main() {
     test('loads aggregation and exposes derived schedule items', () async {
       final now = DateTime.now();
       final vm = ScheduleAggregatorViewModel(
-        loadAggregation: () async => _aggregation(
-          id: 'agg_today',
-          taskTitle: '写测试',
-          taskStartTime: now,
-        ),
+        loadAggregation: () async =>
+            _aggregation(id: 'agg_today', taskTitle: '写测试', taskStartTime: now),
         listenToEvents: false,
       );
 
@@ -46,10 +43,7 @@ void main() {
       final vm = ScheduleAggregatorViewModel(
         loadAggregation: () async {
           loadCount += 1;
-          return _aggregation(
-            id: 'agg_$loadCount',
-            taskTitle: '任务 $loadCount',
-          );
+          return _aggregation(id: 'agg_$loadCount', taskTitle: '任务 $loadCount');
         },
       );
 
@@ -146,32 +140,34 @@ void main() {
       vm.dispose();
     });
 
-    test('ensureFresh loads missing data but skips reload when data is fresh',
-        () async {
-      var loadCount = 0;
-      final checkedMaxAges = <Duration?>[];
-      final vm = ScheduleAggregatorViewModel(
-        loadAggregation: () async {
-          loadCount += 1;
-          return _aggregation(id: 'agg_$loadCount');
-        },
-        needsRefresh: ({maxAge}) async {
-          checkedMaxAges.add(maxAge);
-          return false;
-        },
-        listenToEvents: false,
-      );
+    test(
+      'ensureFresh loads missing data but skips reload when data is fresh',
+      () async {
+        var loadCount = 0;
+        final checkedMaxAges = <Duration?>[];
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async {
+            loadCount += 1;
+            return _aggregation(id: 'agg_$loadCount');
+          },
+          needsRefresh: ({maxAge}) async {
+            checkedMaxAges.add(maxAge);
+            return false;
+          },
+          listenToEvents: false,
+        );
 
-      const maxAge = Duration(minutes: 5);
-      await vm.ensureFresh(maxAge: maxAge);
-      await vm.ensureFresh(maxAge: maxAge);
+        const maxAge = Duration(minutes: 5);
+        await vm.ensureFresh(maxAge: maxAge);
+        await vm.ensureFresh(maxAge: maxAge);
 
-      expect(loadCount, 1);
-      expect(checkedMaxAges, [maxAge, maxAge]);
-      expect(vm.aggregation?.id, 'agg_1');
+        expect(loadCount, 1);
+        expect(checkedMaxAges, [maxAge, maxAge]);
+        expect(vm.aggregation?.id, 'agg_1');
 
-      vm.dispose();
-    });
+        vm.dispose();
+      },
+    );
 
     test('ensureFresh reloads existing data when it is stale', () async {
       var loadCount = 0;
@@ -193,57 +189,133 @@ void main() {
       vm.dispose();
     });
 
-    test('toggleCompletion writes the real task ui_config optimistically',
-        () async {
-      String? updatedCardId;
-      int? updatedConfigIndex;
-      Map<String, dynamic>? updatedData;
-      final vm = ScheduleAggregatorViewModel(
-        loadAggregation: () async => _aggregation(),
-        fetchCardDetail: (_) async => _cardDetailWithTaskConfig(),
-        updateCardUiConfig: (cardId, configIndex, data) async {
-          updatedCardId = cardId;
-          updatedConfigIndex = configIndex;
-          updatedData = data;
-          return true;
-        },
-        listenToEvents: false,
-      );
+    test(
+      'toggleCompletion writes the real task ui_config optimistically',
+      () async {
+        String? updatedCardId;
+        int? updatedConfigIndex;
+        Map<String, dynamic>? updatedData;
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async => _aggregation(),
+          fetchCardDetail: (_) async => _cardDetailWithTaskConfig(),
+          updateCardUiConfig: (cardId, configIndex, data) async {
+            updatedCardId = cardId;
+            updatedConfigIndex = configIndex;
+            updatedData = data;
+            return true;
+          },
+          listenToEvents: false,
+        );
 
-      await vm.loadAggregation();
-      final item = vm.items.single;
+        await vm.loadAggregation();
+        final item = vm.items.single;
 
-      final toggle = vm.toggleCompletion(item);
-      expect(vm.items.single.status, ScheduleItemStatus.completed);
-      await toggle;
+        final toggle = vm.toggleCompletion(item);
+        expect(vm.items.single.status, ScheduleItemStatus.completed);
+        await toggle;
 
-      expect(updatedCardId, 'task-1');
-      expect(updatedConfigIndex, 1);
-      expect(updatedData, {'is_completed': true});
-      expect(vm.error, isNull);
+        expect(updatedCardId, 'task-1');
+        expect(updatedConfigIndex, 1);
+        expect(updatedData, {'is_completed': true});
+        expect(vm.error, isNull);
 
-      vm.dispose();
-    });
+        vm.dispose();
+      },
+    );
 
-    test('toggleCompletion reverts optimistic state when write fails',
-        () async {
-      final vm = ScheduleAggregatorViewModel(
-        loadAggregation: () async => _aggregation(),
-        fetchCardDetail: (_) async => _cardDetailWithTaskConfig(),
-        updateCardUiConfig: (_, __, ___) async => false,
-        listenToEvents: false,
-      );
+    test(
+      'toggleCompletion updates every persisted subtask for grouped tasks',
+      () async {
+        Map<String, dynamic>? updatedData;
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async => _aggregationWithSubtasks(),
+          fetchCardDetail: (_) async => _cardDetailWithTaskConfig(
+            subtasks: [
+              {'title': 'Collect documents', 'completed': false},
+              {'title': 'Submit form', 'completed': false, 'note': 'keep me'},
+            ],
+          ),
+          updateCardUiConfig: (_, __, data) async {
+            updatedData = data;
+            return true;
+          },
+          listenToEvents: false,
+        );
 
-      await vm.loadAggregation();
-      final item = vm.items.single;
+        await vm.loadAggregation();
+        final toggle = vm.toggleCompletion(vm.items.single);
+        expect(vm.items.single.status, ScheduleItemStatus.completed);
+        expect(vm.items.single.subtasks.map((subtask) => subtask.completed), [
+          true,
+          true,
+        ]);
+        await toggle;
 
-      await vm.toggleCompletion(item);
+        expect(updatedData?['is_completed'], isTrue);
+        expect(updatedData?['subtasks'], [
+          {'title': 'Collect documents', 'completed': true},
+          {'title': 'Submit form', 'completed': true, 'note': 'keep me'},
+        ]);
+        expect(vm.error, isNull);
 
-      expect(vm.items.single.status, ScheduleItemStatus.pending);
-      expect(vm.error, 'Failed to update task');
+        vm.dispose();
+      },
+    );
 
-      vm.dispose();
-    });
+    test(
+      'toggleCompletion reverts grouped tasks when card subtasks are stale',
+      () async {
+        var didUpdate = false;
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async => _aggregationWithSubtasks(),
+          fetchCardDetail: (_) async => _cardDetailWithTaskConfig(
+            subtasks: [
+              {'title': 'Collect documents', 'completed': false},
+            ],
+          ),
+          updateCardUiConfig: (_, __, ___) async {
+            didUpdate = true;
+            return true;
+          },
+          listenToEvents: false,
+        );
+
+        await vm.loadAggregation();
+        await vm.toggleCompletion(vm.items.single);
+
+        expect(didUpdate, isFalse);
+        expect(vm.items.single.status, ScheduleItemStatus.pending);
+        expect(vm.items.single.subtasks.map((subtask) => subtask.completed), [
+          false,
+          false,
+        ]);
+        expect(vm.error, 'Failed to update task');
+
+        vm.dispose();
+      },
+    );
+
+    test(
+      'toggleCompletion reverts optimistic state when write fails',
+      () async {
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async => _aggregation(),
+          fetchCardDetail: (_) async => _cardDetailWithTaskConfig(),
+          updateCardUiConfig: (_, __, ___) async => false,
+          listenToEvents: false,
+        );
+
+        await vm.loadAggregation();
+        final item = vm.items.single;
+
+        await vm.toggleCompletion(item);
+
+        expect(vm.items.single.status, ScheduleItemStatus.pending);
+        expect(vm.error, 'Failed to update task');
+
+        vm.dispose();
+      },
+    );
 
     test('toggleCompletion ignores event items', () async {
       var didFetchDetail = false;
@@ -266,28 +338,160 @@ void main() {
       vm.dispose();
     });
 
-    test('toggleCompletion reverts when the card has no task ui_config',
-        () async {
-      var didUpdate = false;
-      final vm = ScheduleAggregatorViewModel(
-        loadAggregation: () async => _aggregation(),
-        fetchCardDetail: (_) async => _cardDetailWithoutTaskConfig(),
-        updateCardUiConfig: (_, __, ___) async {
-          didUpdate = true;
-          return true;
-        },
-        listenToEvents: false,
-      );
+    test(
+      'toggleSubtask writes one subtask and derives partial status',
+      () async {
+        String? updatedCardId;
+        Map<String, dynamic>? updatedData;
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async => _aggregationWithSubtasks(),
+          fetchCardDetail: (_) async => _cardDetailWithTaskConfig(
+            subtasks: [
+              {'title': 'Collect documents', 'completed': false},
+              {'title': 'Submit form', 'completed': false},
+            ],
+          ),
+          updateCardUiConfig: (cardId, _, data) async {
+            updatedCardId = cardId;
+            updatedData = data;
+            return true;
+          },
+          listenToEvents: false,
+        );
 
-      await vm.loadAggregation();
-      await vm.toggleCompletion(vm.items.single);
+        await vm.loadAggregation();
+        final item = vm.items.single;
 
-      expect(didUpdate, isFalse);
-      expect(vm.items.single.status, ScheduleItemStatus.pending);
-      expect(vm.error, 'Failed to update task');
+        final toggle = vm.toggleSubtask(item, 0);
+        expect(vm.items.single.status, ScheduleItemStatus.inProgress);
+        expect(vm.items.single.subtasks.first.completed, isTrue);
+        await toggle;
 
-      vm.dispose();
-    });
+        expect(updatedCardId, 'task-1');
+        expect(updatedData?['is_completed'], isFalse);
+        expect(updatedData?['subtasks'], [
+          {'title': 'Collect documents', 'completed': true},
+          {'title': 'Submit form', 'completed': false},
+        ]);
+        expect(vm.error, isNull);
+
+        vm.dispose();
+      },
+    );
+
+    test(
+      'toggleSubtask marks parent completed when last subtask is done',
+      () async {
+        Map<String, dynamic>? updatedData;
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async => _aggregationWithSubtasks(
+            subtasks: const [
+              ScheduleSubtask(title: 'Collect documents', completed: true),
+              ScheduleSubtask(title: 'Submit form'),
+            ],
+          ),
+          fetchCardDetail: (_) async => _cardDetailWithTaskConfig(
+            subtasks: [
+              {'title': 'Collect documents', 'completed': true},
+              {'title': 'Submit form', 'completed': false},
+            ],
+          ),
+          updateCardUiConfig: (_, __, data) async {
+            updatedData = data;
+            return true;
+          },
+          listenToEvents: false,
+        );
+
+        await vm.loadAggregation();
+        await vm.toggleSubtask(vm.items.single, 1);
+
+        expect(vm.items.single.status, ScheduleItemStatus.completed);
+        expect(updatedData?['is_completed'], isTrue);
+        expect(updatedData?['subtasks'], [
+          {'title': 'Collect documents', 'completed': true},
+          {'title': 'Submit form', 'completed': true},
+        ]);
+
+        vm.dispose();
+      },
+    );
+
+    test(
+      'toggleSubtask ignores invalid indexes without reading the card',
+      () async {
+        var didFetch = false;
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async => _aggregationWithSubtasks(),
+          fetchCardDetail: (_) async {
+            didFetch = true;
+            return _cardDetailWithTaskConfig();
+          },
+          listenToEvents: false,
+        );
+
+        await vm.loadAggregation();
+        await vm.toggleSubtask(vm.items.single, 99);
+
+        expect(didFetch, isFalse);
+        expect(vm.items.single.status, ScheduleItemStatus.pending);
+
+        vm.dispose();
+      },
+    );
+
+    test(
+      'toggleSubtask reverts optimistic state for stale card detail',
+      () async {
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async => _aggregationWithSubtasks(),
+          fetchCardDetail: (_) async => _cardDetailWithTaskConfig(
+            subtasks: [
+              {'title': 'Collect documents', 'completed': false},
+            ],
+          ),
+          updateCardUiConfig: (_, __, ___) async => true,
+          listenToEvents: false,
+        );
+
+        await vm.loadAggregation();
+        await vm.toggleSubtask(vm.items.single, 1);
+
+        expect(vm.items.single.status, ScheduleItemStatus.pending);
+        expect(vm.items.single.subtasks.map((subtask) => subtask.completed), [
+          false,
+          false,
+        ]);
+        expect(vm.error, 'Failed to update task');
+
+        vm.dispose();
+      },
+    );
+
+    test(
+      'toggleCompletion reverts when the card has no task ui_config',
+      () async {
+        var didUpdate = false;
+        final vm = ScheduleAggregatorViewModel(
+          loadAggregation: () async => _aggregation(),
+          fetchCardDetail: (_) async => _cardDetailWithoutTaskConfig(),
+          updateCardUiConfig: (_, __, ___) async {
+            didUpdate = true;
+            return true;
+          },
+          listenToEvents: false,
+        );
+
+        await vm.loadAggregation();
+        await vm.toggleCompletion(vm.items.single);
+
+        expect(didUpdate, isFalse);
+        expect(vm.items.single.status, ScheduleItemStatus.pending);
+        expect(vm.error, 'Failed to update task');
+
+        vm.dispose();
+      },
+    );
   });
 }
 
@@ -300,10 +504,7 @@ ScheduleAggregationModel _aggregation({
   return ScheduleAggregationModel(
     id: id,
     generatedAt: DateTime(2026, 4, 26, 8),
-    timeRange: TimeRange(
-      from: DateTime(2026, 4, 26),
-      to: DateTime(2026, 5, 3),
-    ),
+    timeRange: TimeRange(from: DateTime(2026, 4, 26), to: DateTime(2026, 5, 3)),
     timeline: [
       TimelineDay(
         dayLabel: 'Today',
@@ -323,14 +524,41 @@ ScheduleAggregationModel _aggregation({
   );
 }
 
+ScheduleAggregationModel _aggregationWithSubtasks({
+  List<ScheduleSubtask> subtasks = const [
+    ScheduleSubtask(title: 'Collect documents'),
+    ScheduleSubtask(title: 'Submit form'),
+  ],
+}) {
+  return ScheduleAggregationModel(
+    id: 'agg_subtasks',
+    generatedAt: DateTime(2026, 4, 26, 8),
+    timeRange: TimeRange(from: DateTime(2026, 4, 26), to: DateTime(2026, 5, 3)),
+    timeline: [
+      TimelineDay(
+        dayLabel: 'Today',
+        dayDate: DateTime(2026, 4, 26),
+        items: [
+          TimelineItem(
+            cardId: 'task-1',
+            title: 'Visa checklist',
+            status: 'pending',
+            startTime: DateTime(2026, 4, 26, 10),
+            type: 'task',
+            priority: 2,
+            subtasks: subtasks,
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
 ScheduleAggregationModel _eventAggregation() {
   return ScheduleAggregationModel(
     id: 'event_agg',
     generatedAt: DateTime(2026, 4, 26, 8),
-    timeRange: TimeRange(
-      from: DateTime(2026, 4, 26),
-      to: DateTime(2026, 5, 3),
-    ),
+    timeRange: TimeRange(from: DateTime(2026, 4, 26), to: DateTime(2026, 5, 3)),
     timeline: [
       TimelineDay(
         dayLabel: 'Today',
@@ -349,19 +577,21 @@ ScheduleAggregationModel _eventAggregation() {
   );
 }
 
-CardDetailModel _cardDetailWithTaskConfig() {
+CardDetailModel _cardDetailWithTaskConfig({
+  List<Map<String, dynamic>>? subtasks,
+}) {
   return CardDetailModel.fromJson(<String, dynamic>{
     'id': 'task-1',
     'title': '待办事项',
     'timestamp': 1777188000,
     'ui_configs': <Map<String, dynamic>>[
-      <String, dynamic>{
-        'template_id': 'event',
-        'data': <String, dynamic>{},
-      },
+      <String, dynamic>{'template_id': 'event', 'data': <String, dynamic>{}},
       <String, dynamic>{
         'template_id': 'task',
-        'data': <String, dynamic>{'is_completed': false},
+        'data': <String, dynamic>{
+          'is_completed': false,
+          if (subtasks != null) 'subtasks': subtasks,
+        },
       },
     ],
   });
@@ -373,10 +603,7 @@ CardDetailModel _cardDetailWithoutTaskConfig() {
     'title': '待办事项',
     'timestamp': 1777188000,
     'ui_configs': <Map<String, dynamic>>[
-      <String, dynamic>{
-        'template_id': 'event',
-        'data': <String, dynamic>{},
-      },
+      <String, dynamic>{'template_id': 'event', 'data': <String, dynamic>{}},
     ],
   });
 }

--- a/test/ui/schedule/widgets/schedule_widgets_test.dart
+++ b/test/ui/schedule/widgets/schedule_widgets_test.dart
@@ -125,6 +125,52 @@ void main() {
       );
     });
 
+    testWidgets(
+      'renders grouped subtasks and toggles them without navigating',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(420, 1000));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        final tappedCards = <String>[];
+        final toggledSubtasks = <String>[];
+
+        await tester.pumpWidget(
+          buildHost(
+            MagazineNarrativeTab(
+              aggregation: _subtaskAggregation(),
+              onTapCardId: tappedCards.add,
+              onToggleSubtask: (cardId, index) {
+                toggledSubtasks.add('$cardId:$index');
+              },
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Visa checklist'), findsOneWidget);
+        expect(find.text('1/5'), findsOneWidget);
+        expect(find.text('Fill application'), findsOneWidget);
+        expect(find.text('Print confirmation'), findsOneWidget);
+        expect(find.text('Book appointment'), findsOneWidget);
+        expect(find.text('Collect passport photos'), findsNothing);
+
+        await tester.tap(
+          find.byKey(const ValueKey('schedule_subtask_toggle_task-visa_1')),
+        );
+        await tester.pump();
+
+        expect(toggledSubtasks, ['task-visa:1']);
+        expect(tappedCards, isEmpty);
+
+        await tester.tap(
+          find.byKey(const ValueKey('schedule_subtasks_expand_task-visa')),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Collect passport photos'), findsOneWidget);
+        expect(find.text('Buy mailing envelope'), findsOneWidget);
+      },
+    );
+
     testWidgets('recomputes relative day labels from day dates', (
       tester,
     ) async {
@@ -269,9 +315,7 @@ void main() {
       );
     });
 
-    testWidgets('renders fresh output from a task-scoped run', (
-      tester,
-    ) async {
+    testWidgets('renders fresh output from a task-scoped run', (tester) async {
       await tester.pumpWidget(
         buildHost(
           MagazineNarrativeTab(
@@ -341,6 +385,42 @@ void main() {
       );
     });
   });
+}
+
+ScheduleAggregationModel _subtaskAggregation() {
+  return ScheduleAggregationModel(
+    id: 'agg_subtasks',
+    generatedAt: DateTime(2026, 5, 14, 18),
+    timeRange: TimeRange(
+      from: DateTime(2026, 5, 14),
+      to: DateTime(2026, 5, 21),
+    ),
+    timeline: [
+      TimelineDay(
+        dayLabel: 'Friday',
+        dayDate: DateTime(2026, 5, 15),
+        items: [
+          TimelineItem(
+            cardId: 'task-visa',
+            title: 'Visa checklist',
+            type: 'task',
+            status: 'pending',
+            startTime: DateTime(2026, 5, 15, 10),
+            subtasks: const [
+              ScheduleSubtask(
+                title: 'Collect passport photos',
+                completed: true,
+              ),
+              ScheduleSubtask(title: 'Fill application'),
+              ScheduleSubtask(title: 'Print confirmation'),
+              ScheduleSubtask(title: 'Book appointment'),
+              ScheduleSubtask(title: 'Buy mailing envelope'),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
 }
 
 ScheduleAggregationModel _complexAggregation({


### PR DESCRIPTION
## Background

Closes #148.

Schedule task cards can already contain real `subtasks`, but the schedule aggregation model and agenda UI flattened those tasks into one card. This hid checklist progress and made larger tasks feel like undifferentiated single items.

## Changes

- Preserves task `subtasks` in schedule aggregation schema and agent instructions.
- Derives schedule task status from subtask progress while keeping explicit parent completion authoritative.
- Renders grouped task agenda cards with progress, collapsed pending-first subtasks, expansion, and direct subtask toggles.
- Adds ViewModel write paths for parent completion and individual subtask toggles through `updateCardUiConfig`.
- Adds stale/malformed data guards so optimistic UI rolls back instead of writing to the wrong persisted subtask row.

## Validation

- `dart pub get --offline`
- `dart analyze lib/domain/models/schedule_aggregation_model.dart lib/ui/schedule/models/schedule_item.dart lib/ui/schedule/view_models/schedule_aggregator_view_model.dart lib/ui/schedule/widgets/schedule_aggregator_screen.dart lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart lib/agent/prompts.dart lib/agent/schedule_aggregator_agent/prompt.dart lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart test/domain/models/schedule_aggregation_model_test.dart test/ui/schedule/models/schedule_item_test.dart test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart`
- `flutter test --no-pub test/domain/models/schedule_aggregation_model_test.dart test/ui/schedule/models/schedule_item_test.dart test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart`
- `flutter test --no-pub`

## Notes

An online `flutter pub get` stalled while downloading packages in this workspace; `dart pub get --offline` succeeded using the local cache, and tests were run with `--no-pub` after package config generation.
