### PR TITLE
[codex] 优化 Location Context 定位失败引导

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1219,6 +1219,35 @@
   "locationDebugUnavailable": "unavailable",
   "locationDebugInjected": "injected",
   "locationDebugNotInjected": "not injected",
+  "locationStatusUpdatedAt": "Updated",
+  "locationStatusSuccessTitle": "Current location is ready",
+  "locationStatusSuccessBody": "Memex can attach this location summary when location context is relevant.",
+  "locationStatusApproximateTitle": "Approximate location only",
+  "locationStatusApproximateBody": "Accuracy looks city or area level. You can keep using it, or enable Precise Location in system settings for a tighter context.",
+  "locationStatusServiceDisabledTitle": "System location is off",
+  "locationStatusServiceDisabledBody": "Memex only uses device GPS and will not infer location from network or IP. On Android, open Location settings; on iOS, enable Settings > Privacy & Security > Location Services.",
+  "locationStatusPermissionDeniedTitle": "Location permission is needed",
+  "locationStatusPermissionDeniedBody": "Allow Memex to use location while testing or when location context is needed. Always access is not requested.",
+  "locationStatusPermissionForeverTitle": "Location permission is blocked",
+  "locationStatusPermissionForeverBody": "Open app settings and allow location for Memex. On iOS, While Using the App is enough.",
+  "locationStatusDisabledTitle": "Location Context is off",
+  "locationStatusDisabledBody": "Turn on the switch above and save when you want Memex to attach device location to agent context.",
+  "locationStatusGeocodeUnavailableTitle": "GPS works, address lookup failed",
+  "locationStatusGeocodeUnavailableBody": "Memex has coordinates but will not inject GPS-only context into the agent. Check the reverse geocoding provider and try again.",
+  "locationStatusUnavailableTitle": "Location unavailable",
+  "locationStatusUnavailableBody": "Check system location services and app permission, then test again.",
+  "allowLocationPermissionButton": "Allow location permission",
+  "openAppSettingsButton": "Open app settings",
+  "openLocationSettingsButton": "Open location settings",
+  "locationSettingsOpenFailed": "Could not open system settings.",
+  "locationActionFailed": "Location action failed: {error}",
+  "@locationActionFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
 
   "settingsSearchPlaceholder": "Search settings...",
   "settingsSearchEmpty": "No matching settings found",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4856,6 +4856,138 @@ abstract class AppLocalizations {
   /// **'not injected'**
   String get locationDebugNotInjected;
 
+  /// No description provided for @locationStatusUpdatedAt.
+  ///
+  /// In en, this message translates to:
+  /// **'Updated'**
+  String get locationStatusUpdatedAt;
+
+  /// No description provided for @locationStatusSuccessTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Current location is ready'**
+  String get locationStatusSuccessTitle;
+
+  /// No description provided for @locationStatusSuccessBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Memex can attach this location summary when location context is relevant.'**
+  String get locationStatusSuccessBody;
+
+  /// No description provided for @locationStatusApproximateTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Approximate location only'**
+  String get locationStatusApproximateTitle;
+
+  /// No description provided for @locationStatusApproximateBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Accuracy looks city or area level. You can keep using it, or enable Precise Location in system settings for a tighter context.'**
+  String get locationStatusApproximateBody;
+
+  /// No description provided for @locationStatusServiceDisabledTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'System location is off'**
+  String get locationStatusServiceDisabledTitle;
+
+  /// No description provided for @locationStatusServiceDisabledBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Memex only uses device GPS and will not infer location from network or IP. On Android, open Location settings; on iOS, enable Settings > Privacy & Security > Location Services.'**
+  String get locationStatusServiceDisabledBody;
+
+  /// No description provided for @locationStatusPermissionDeniedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Location permission is needed'**
+  String get locationStatusPermissionDeniedTitle;
+
+  /// No description provided for @locationStatusPermissionDeniedBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Allow Memex to use location while testing or when location context is needed. Always access is not requested.'**
+  String get locationStatusPermissionDeniedBody;
+
+  /// No description provided for @locationStatusPermissionForeverTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Location permission is blocked'**
+  String get locationStatusPermissionForeverTitle;
+
+  /// No description provided for @locationStatusPermissionForeverBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Open app settings and allow location for Memex. On iOS, While Using the App is enough.'**
+  String get locationStatusPermissionForeverBody;
+
+  /// No description provided for @locationStatusDisabledTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Location Context is off'**
+  String get locationStatusDisabledTitle;
+
+  /// No description provided for @locationStatusDisabledBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Turn on the switch above and save when you want Memex to attach device location to agent context.'**
+  String get locationStatusDisabledBody;
+
+  /// No description provided for @locationStatusGeocodeUnavailableTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'GPS works, address lookup failed'**
+  String get locationStatusGeocodeUnavailableTitle;
+
+  /// No description provided for @locationStatusGeocodeUnavailableBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Memex has coordinates but will not inject GPS-only context into the agent. Check the reverse geocoding provider and try again.'**
+  String get locationStatusGeocodeUnavailableBody;
+
+  /// No description provided for @locationStatusUnavailableTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Location unavailable'**
+  String get locationStatusUnavailableTitle;
+
+  /// No description provided for @locationStatusUnavailableBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Check system location services and app permission, then test again.'**
+  String get locationStatusUnavailableBody;
+
+  /// No description provided for @allowLocationPermissionButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Allow location permission'**
+  String get allowLocationPermissionButton;
+
+  /// No description provided for @openAppSettingsButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Open app settings'**
+  String get openAppSettingsButton;
+
+  /// No description provided for @openLocationSettingsButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Open location settings'**
+  String get openLocationSettingsButton;
+
+  /// No description provided for @locationSettingsOpenFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open system settings.'**
+  String get locationSettingsOpenFailed;
+
+  /// No description provided for @locationActionFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Location action failed: {error}'**
+  String locationActionFailed(String error);
+
   /// No description provided for @settingsSearchPlaceholder.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2671,6 +2671,85 @@ class AppLocalizationsEn extends AppLocalizations {
   String get locationDebugNotInjected => 'not injected';
 
   @override
+  String get locationStatusUpdatedAt => 'Updated';
+
+  @override
+  String get locationStatusSuccessTitle => 'Current location is ready';
+
+  @override
+  String get locationStatusSuccessBody =>
+      'Memex can attach this location summary when location context is relevant.';
+
+  @override
+  String get locationStatusApproximateTitle => 'Approximate location only';
+
+  @override
+  String get locationStatusApproximateBody =>
+      'Accuracy looks city or area level. You can keep using it, or enable Precise Location in system settings for a tighter context.';
+
+  @override
+  String get locationStatusServiceDisabledTitle => 'System location is off';
+
+  @override
+  String get locationStatusServiceDisabledBody =>
+      'Memex only uses device GPS and will not infer location from network or IP. On Android, open Location settings; on iOS, enable Settings > Privacy & Security > Location Services.';
+
+  @override
+  String get locationStatusPermissionDeniedTitle =>
+      'Location permission is needed';
+
+  @override
+  String get locationStatusPermissionDeniedBody =>
+      'Allow Memex to use location while testing or when location context is needed. Always access is not requested.';
+
+  @override
+  String get locationStatusPermissionForeverTitle =>
+      'Location permission is blocked';
+
+  @override
+  String get locationStatusPermissionForeverBody =>
+      'Open app settings and allow location for Memex. On iOS, While Using the App is enough.';
+
+  @override
+  String get locationStatusDisabledTitle => 'Location Context is off';
+
+  @override
+  String get locationStatusDisabledBody =>
+      'Turn on the switch above and save when you want Memex to attach device location to agent context.';
+
+  @override
+  String get locationStatusGeocodeUnavailableTitle =>
+      'GPS works, address lookup failed';
+
+  @override
+  String get locationStatusGeocodeUnavailableBody =>
+      'Memex has coordinates but will not inject GPS-only context into the agent. Check the reverse geocoding provider and try again.';
+
+  @override
+  String get locationStatusUnavailableTitle => 'Location unavailable';
+
+  @override
+  String get locationStatusUnavailableBody =>
+      'Check system location services and app permission, then test again.';
+
+  @override
+  String get allowLocationPermissionButton => 'Allow location permission';
+
+  @override
+  String get openAppSettingsButton => 'Open app settings';
+
+  @override
+  String get openLocationSettingsButton => 'Open location settings';
+
+  @override
+  String get locationSettingsOpenFailed => 'Could not open system settings.';
+
+  @override
+  String locationActionFailed(String error) {
+    return 'Location action failed: $error';
+  }
+
+  @override
   String get settingsSearchPlaceholder => 'Search settings...';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2580,6 +2580,80 @@ class AppLocalizationsZh extends AppLocalizations {
   String get locationDebugNotInjected => '未注入';
 
   @override
+  String get locationStatusUpdatedAt => '更新时间';
+
+  @override
+  String get locationStatusSuccessTitle => '当前位置已可用';
+
+  @override
+  String get locationStatusSuccessBody => '当位置上下文与对话相关时，Memex 可以附加这段位置摘要。';
+
+  @override
+  String get locationStatusApproximateTitle => '仅获得大致位置';
+
+  @override
+  String get locationStatusApproximateBody =>
+      '当前精度看起来只到城市或区域级别。你可以继续使用，也可以在系统设置中开启精确位置以获得更细的上下文。';
+
+  @override
+  String get locationStatusServiceDisabledTitle => '系统定位已关闭';
+
+  @override
+  String get locationStatusServiceDisabledBody =>
+      'Memex 只使用设备 GPS，不会通过网络或 IP 推测位置。Android 可打开定位设置；iOS 请前往 设置 > 隐私与安全性 > 定位服务 开启。';
+
+  @override
+  String get locationStatusPermissionDeniedTitle => '需要允许位置权限';
+
+  @override
+  String get locationStatusPermissionDeniedBody =>
+      '仅在测试或实际需要位置上下文时允许 Memex 使用位置即可；不会请求始终访问。';
+
+  @override
+  String get locationStatusPermissionForeverTitle => '位置权限已被系统阻止';
+
+  @override
+  String get locationStatusPermissionForeverBody =>
+      '请打开应用设置，重新允许 Memex 使用位置。iOS 选择“使用 App 期间”即可。';
+
+  @override
+  String get locationStatusDisabledTitle => '位置上下文未开启';
+
+  @override
+  String get locationStatusDisabledBody =>
+      '如果希望 Memex 为 Agent 上下文附加设备位置，请打开上方开关并保存。';
+
+  @override
+  String get locationStatusGeocodeUnavailableTitle => 'GPS 可用，但地址解析失败';
+
+  @override
+  String get locationStatusGeocodeUnavailableBody =>
+      'Memex 已拿到坐标，但不会把纯 GPS 坐标注入给 Agent。请检查逆地理编码服务商后再试。';
+
+  @override
+  String get locationStatusUnavailableTitle => '位置不可用';
+
+  @override
+  String get locationStatusUnavailableBody => '请检查系统定位服务和应用权限，然后再次测试。';
+
+  @override
+  String get allowLocationPermissionButton => '允许位置权限';
+
+  @override
+  String get openAppSettingsButton => '打开应用设置';
+
+  @override
+  String get openLocationSettingsButton => '开启系统定位';
+
+  @override
+  String get locationSettingsOpenFailed => '无法打开系统设置。';
+
+  @override
+  String locationActionFailed(String error) {
+    return '位置操作失败：$error';
+  }
+
+  @override
   String get settingsSearchPlaceholder => '搜索设置项...';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1182,6 +1182,35 @@
   "locationDebugUnavailable": "不可用",
   "locationDebugInjected": "已注入",
   "locationDebugNotInjected": "未注入",
+  "locationStatusUpdatedAt": "更新时间",
+  "locationStatusSuccessTitle": "当前位置已可用",
+  "locationStatusSuccessBody": "当位置上下文与对话相关时，Memex 可以附加这段位置摘要。",
+  "locationStatusApproximateTitle": "仅获得大致位置",
+  "locationStatusApproximateBody": "当前精度看起来只到城市或区域级别。你可以继续使用，也可以在系统设置中开启精确位置以获得更细的上下文。",
+  "locationStatusServiceDisabledTitle": "系统定位已关闭",
+  "locationStatusServiceDisabledBody": "Memex 只使用设备 GPS，不会通过网络或 IP 推测位置。Android 可打开定位设置；iOS 请前往 设置 > 隐私与安全性 > 定位服务 开启。",
+  "locationStatusPermissionDeniedTitle": "需要允许位置权限",
+  "locationStatusPermissionDeniedBody": "仅在测试或实际需要位置上下文时允许 Memex 使用位置即可；不会请求始终访问。",
+  "locationStatusPermissionForeverTitle": "位置权限已被系统阻止",
+  "locationStatusPermissionForeverBody": "请打开应用设置，重新允许 Memex 使用位置。iOS 选择“使用 App 期间”即可。",
+  "locationStatusDisabledTitle": "位置上下文未开启",
+  "locationStatusDisabledBody": "如果希望 Memex 为 Agent 上下文附加设备位置，请打开上方开关并保存。",
+  "locationStatusGeocodeUnavailableTitle": "GPS 可用，但地址解析失败",
+  "locationStatusGeocodeUnavailableBody": "Memex 已拿到坐标，但不会把纯 GPS 坐标注入给 Agent。请检查逆地理编码服务商后再试。",
+  "locationStatusUnavailableTitle": "位置不可用",
+  "locationStatusUnavailableBody": "请检查系统定位服务和应用权限，然后再次测试。",
+  "allowLocationPermissionButton": "允许位置权限",
+  "openAppSettingsButton": "打开应用设置",
+  "openLocationSettingsButton": "开启系统定位",
+  "locationSettingsOpenFailed": "无法打开系统设置。",
+  "locationActionFailed": "位置操作失败：{error}",
+  "@locationActionFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
 
   "settingsSearchPlaceholder": "搜索设置项...",
   "settingsSearchEmpty": "未找到匹配的设置项",

--- a/lib/ui/settings/widgets/location_context_settings_page.dart
+++ b/lib/ui/settings/widgets/location_context_settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:memex/data/services/location_context_service.dart';
 import 'package:memex/domain/models/location_context_config.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
@@ -7,11 +8,22 @@ import 'package:memex/utils/user_storage.dart';
 
 typedef CurrentLocationContextLoader =
     Future<CurrentLocationContext> Function({bool forceRefresh});
+typedef LocationPermissionRequester = Future<void> Function();
+typedef LocationSettingsOpener = Future<bool> Function();
 
 class LocationContextSettingsPage extends StatefulWidget {
-  const LocationContextSettingsPage({super.key, this.loadCurrentContext});
+  const LocationContextSettingsPage({
+    super.key,
+    this.loadCurrentContext,
+    this.requestLocationPermission,
+    this.openAppSettings,
+    this.openLocationSettings,
+  });
 
   final CurrentLocationContextLoader? loadCurrentContext;
+  final LocationPermissionRequester? requestLocationPermission;
+  final LocationSettingsOpener? openAppSettings;
+  final LocationSettingsOpener? openLocationSettings;
 
   @override
   State<LocationContextSettingsPage> createState() =>
@@ -26,7 +38,9 @@ class _LocationContextSettingsPageState
   bool _loading = true;
   bool _saving = false;
   bool _testing = false;
+  bool _runningLocationAction = false;
   String? _testResult;
+  CurrentLocationContext? _testContext;
 
   bool get _hasChanges => !_isSameConfig(_config, _savedConfig);
 
@@ -84,6 +98,7 @@ class _LocationContextSettingsPageState
     setState(() {
       _testing = true;
       _testResult = null;
+      _testContext = null;
     });
     try {
       final loader =
@@ -93,6 +108,7 @@ class _LocationContextSettingsPageState
       if (!mounted) return;
       setState(() {
         _testResult = _formatLocationDebugResult(context);
+        _testContext = context;
       });
     } catch (e) {
       if (!mounted) return;
@@ -102,6 +118,53 @@ class _LocationContextSettingsPageState
     } finally {
       if (mounted) {
         setState(() => _testing = false);
+      }
+    }
+  }
+
+  Future<void> _handleGuidanceAction(_LocationGuidanceAction action) async {
+    if (_runningLocationAction) return;
+    setState(() => _runningLocationAction = true);
+
+    try {
+      switch (action) {
+        case _LocationGuidanceAction.requestPermission:
+          final requester =
+              widget.requestLocationPermission ??
+              () async => Geolocator.requestPermission();
+          await requester();
+          if (mounted) {
+            await _testLocation();
+          }
+        case _LocationGuidanceAction.openAppSettings:
+          final opener = widget.openAppSettings ?? Geolocator.openAppSettings;
+          final opened = await opener();
+          if (mounted && !opened) {
+            ToastHelper.showError(
+              context,
+              UserStorage.l10n.locationSettingsOpenFailed,
+            );
+          }
+        case _LocationGuidanceAction.openLocationSettings:
+          final opener =
+              widget.openLocationSettings ?? Geolocator.openLocationSettings;
+          final opened = await opener();
+          if (mounted && !opened) {
+            ToastHelper.showError(
+              context,
+              UserStorage.l10n.locationSettingsOpenFailed,
+            );
+          }
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ToastHelper.showError(
+        context,
+        UserStorage.l10n.locationActionFailed(e.toString()),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _runningLocationAction = false);
       }
     }
   }
@@ -401,6 +464,10 @@ class _LocationContextSettingsPageState
                               : const Icon(Icons.location_searching),
                           label: Text(l10n.testCurrentLocation),
                         ),
+                        if (_testContext != null) ...[
+                          const SizedBox(height: 16),
+                          _locationStatusFeedback(_testContext!),
+                        ],
                         if (_testResult != null) ...[
                           const SizedBox(height: 12),
                           SelectableText(
@@ -419,6 +486,176 @@ class _LocationContextSettingsPageState
               ),
       ),
     );
+  }
+
+  Widget _locationStatusFeedback(CurrentLocationContext context) {
+    final feedback = _feedbackFor(context);
+    final details = _feedbackDetails(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(feedback.icon, color: feedback.color),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    feedback.title,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    feedback.message,
+                    style: TextStyle(color: Colors.grey[700], height: 1.35),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        if (details.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          ...details.map(
+            (detail) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Text(
+                detail,
+                style: TextStyle(fontSize: 13, color: Colors.grey[700]),
+              ),
+            ),
+          ),
+        ],
+        if (feedback.action != null) ...[
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            onPressed: _runningLocationAction
+                ? null
+                : () => _handleGuidanceAction(feedback.action!),
+            icon: _runningLocationAction
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Icon(feedback.actionIcon),
+            label: Text(feedback.actionLabel!),
+          ),
+        ],
+      ],
+    );
+  }
+
+  _LocationStatusFeedback _feedbackFor(CurrentLocationContext context) {
+    final l10n = UserStorage.l10n;
+    final reason = (context.reason ?? '').toLowerCase();
+
+    if (context.status == 'disabled') {
+      return _LocationStatusFeedback(
+        icon: Icons.location_disabled_outlined,
+        color: Colors.grey,
+        title: l10n.locationStatusDisabledTitle,
+        message: l10n.locationStatusDisabledBody,
+      );
+    }
+    if (reason.contains('service is disabled')) {
+      return _LocationStatusFeedback(
+        icon: Icons.location_off_outlined,
+        color: Colors.orange,
+        title: l10n.locationStatusServiceDisabledTitle,
+        message: l10n.locationStatusServiceDisabledBody,
+        action: _LocationGuidanceAction.openLocationSettings,
+        actionIcon: Icons.settings_outlined,
+        actionLabel: l10n.openLocationSettingsButton,
+      );
+    }
+    if (reason.contains('permanently denied')) {
+      return _LocationStatusFeedback(
+        icon: Icons.app_settings_alt_outlined,
+        color: Colors.orange,
+        title: l10n.locationStatusPermissionForeverTitle,
+        message: l10n.locationStatusPermissionForeverBody,
+        action: _LocationGuidanceAction.openAppSettings,
+        actionIcon: Icons.app_settings_alt_outlined,
+        actionLabel: l10n.openAppSettingsButton,
+      );
+    }
+    if (reason.contains('permission denied')) {
+      return _LocationStatusFeedback(
+        icon: Icons.location_on_outlined,
+        color: AppColors.primary,
+        title: l10n.locationStatusPermissionDeniedTitle,
+        message: l10n.locationStatusPermissionDeniedBody,
+        action: _LocationGuidanceAction.requestPermission,
+        actionIcon: Icons.location_on_outlined,
+        actionLabel: l10n.allowLocationPermissionButton,
+      );
+    }
+    if (context.isFresh && _looksApproximate(context)) {
+      return _LocationStatusFeedback(
+        icon: Icons.adjust_outlined,
+        color: Colors.orange,
+        title: l10n.locationStatusApproximateTitle,
+        message: l10n.locationStatusApproximateBody,
+        action: _LocationGuidanceAction.openAppSettings,
+        actionIcon: Icons.app_settings_alt_outlined,
+        actionLabel: l10n.openAppSettingsButton,
+      );
+    }
+    if (context.isFresh && context.address == null) {
+      return _LocationStatusFeedback(
+        icon: Icons.gps_fixed_outlined,
+        color: Colors.orange,
+        title: l10n.locationStatusGeocodeUnavailableTitle,
+        message: l10n.locationStatusGeocodeUnavailableBody,
+      );
+    }
+    if (context.isFresh) {
+      return _LocationStatusFeedback(
+        icon: Icons.check_circle_outline,
+        color: Colors.green,
+        title: l10n.locationStatusSuccessTitle,
+        message: l10n.locationStatusSuccessBody,
+      );
+    }
+
+    return _LocationStatusFeedback(
+      icon: Icons.info_outline,
+      color: Colors.orange,
+      title: l10n.locationStatusUnavailableTitle,
+      message: l10n.locationStatusUnavailableBody,
+    );
+  }
+
+  List<String> _feedbackDetails(CurrentLocationContext context) {
+    final l10n = UserStorage.l10n;
+    final summary = context.address?.summary(context.granularity);
+    return [
+      '${l10n.locationStatusUpdatedAt}: ${_formatTimestamp(context.updatedAt)}',
+      if (summary != null && summary.isNotEmpty)
+        '${l10n.locationDebugAddressSummary}: $summary',
+      if (context.accuracyMeters != null)
+        '${l10n.locationDebugAccuracy}: '
+            '${context.accuracyMeters!.toStringAsFixed(1)}m',
+    ];
+  }
+
+  bool _looksApproximate(CurrentLocationContext context) {
+    final accuracy = context.accuracyMeters;
+    return accuracy != null && accuracy >= 500;
+  }
+
+  String _formatTimestamp(DateTime value) {
+    String twoDigits(int number) => number.toString().padLeft(2, '0');
+    final local = value.toLocal();
+    return '${local.year}-${twoDigits(local.month)}-${twoDigits(local.day)} '
+        '${twoDigits(local.hour)}:${twoDigits(local.minute)}';
   }
 
   Widget _saveBar() {
@@ -481,4 +718,30 @@ class _LocationContextSettingsPageState
       child: child,
     );
   }
+}
+
+enum _LocationGuidanceAction {
+  requestPermission,
+  openAppSettings,
+  openLocationSettings,
+}
+
+class _LocationStatusFeedback {
+  const _LocationStatusFeedback({
+    required this.icon,
+    required this.color,
+    required this.title,
+    required this.message,
+    this.action,
+    this.actionIcon,
+    this.actionLabel,
+  });
+
+  final IconData icon;
+  final Color color;
+  final String title;
+  final String message;
+  final _LocationGuidanceAction? action;
+  final IconData? actionIcon;
+  final String? actionLabel;
 }

--- a/test/ui/settings/location_context_settings_page_test.dart
+++ b/test/ui/settings/location_context_settings_page_test.dart
@@ -13,6 +13,9 @@ void main() {
     String language = 'en',
     LocationContextConfig config = const LocationContextConfig(),
     CurrentLocationContextLoader? loadCurrentContext,
+    LocationPermissionRequester? requestLocationPermission,
+    LocationSettingsOpener? openAppSettings,
+    LocationSettingsOpener? openLocationSettings,
   }) async {
     SharedPreferences.setMockInitialValues({
       'language': language,
@@ -24,6 +27,9 @@ void main() {
       MaterialApp(
         home: LocationContextSettingsPage(
           loadCurrentContext: loadCurrentContext,
+          requestLocationPermission: requestLocationPermission,
+          openAppSettings: openAppSettings,
+          openLocationSettings: openLocationSettings,
         ),
       ),
     );
@@ -297,6 +303,24 @@ void main() {
     expect(find.text('已保存'), findsOneWidget);
   });
 
+  testWidgets('enabling location context does not request permission', (
+    WidgetTester tester,
+  ) async {
+    var requestCount = 0;
+    await pumpLocationSettingsPage(
+      tester,
+      requestLocationPermission: () async {
+        requestCount += 1;
+      },
+    );
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Save'), findsOneWidget);
+    expect(requestCount, 0);
+  });
+
   testWidgets('test button displays a fresh reverse-geocoded location', (
     WidgetTester tester,
   ) async {
@@ -336,11 +360,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(receivedForceRefresh, isTrue);
+    expect(find.text('Current location is ready'), findsOneWidget);
+    expect(find.textContaining('Updated: 2026-05-15'), findsOneWidget);
     expect(find.textContaining('GPS: fresh'), findsOneWidget);
     expect(find.textContaining('Reverse geocode: OK'), findsOneWidget);
     expect(find.textContaining('Agent context: injected'), findsOneWidget);
     expect(
-      find.textContaining('Shanghai · Huangpu · People Square'),
+      find.text('Address summary: Shanghai · Huangpu · People Square'),
       findsOneWidget,
     );
     expect(
@@ -371,11 +397,179 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('GPS: unavailable'), findsOneWidget);
+    expect(find.text('Location permission is needed'), findsOneWidget);
+    expect(find.text('Allow location permission'), findsOneWidget);
     expect(find.textContaining('Reverse geocode: unavailable'), findsOneWidget);
     expect(
       find.textContaining('Reason: location permission denied'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('permission guidance can request permission and retest', (
+    WidgetTester tester,
+  ) async {
+    var requestCount = 0;
+    var loadCount = 0;
+    await pumpLocationSettingsPage(
+      tester,
+      loadCurrentContext: ({bool forceRefresh = false}) async {
+        loadCount += 1;
+        if (loadCount == 1) {
+          return CurrentLocationContext(
+            status: 'unavailable',
+            source: 'device_gps',
+            updatedAt: DateTime.utc(2026, 5, 15, 10),
+            granularity: LocationContextGranularity.neighborhood,
+            reason: 'location permission denied',
+          );
+        }
+        return CurrentLocationContext(
+          status: 'fresh',
+          latitude: 31.230416,
+          longitude: 121.473701,
+          accuracyMeters: 8.5,
+          source: 'device_gps + reverse_geocode',
+          updatedAt: DateTime.utc(2026, 5, 15, 10),
+          granularity: LocationContextGranularity.neighborhood,
+          address: GeocodedAddress(
+            city: 'Shanghai',
+            district: 'Huangpu',
+            neighborhood: 'People Square',
+            provider: 'amap',
+            updatedAt: DateTime.utc(2026, 5, 15, 10),
+            confidence: 'high',
+          ),
+        );
+      },
+      requestLocationPermission: () async {
+        requestCount += 1;
+      },
+    );
+
+    await scrollToTestButton(tester);
+    await tester.tap(find.text('Test current location'));
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.text('Allow location permission'),
+      100,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Allow location permission'));
+    await tester.pumpAndSettle();
+
+    expect(requestCount, 1);
+    expect(loadCount, 2);
+    expect(find.text('Current location is ready'), findsOneWidget);
+  });
+
+  testWidgets('service disabled guidance opens location settings', (
+    WidgetTester tester,
+  ) async {
+    var opened = false;
+    await pumpLocationSettingsPage(
+      tester,
+      loadCurrentContext: ({bool forceRefresh = false}) async {
+        return CurrentLocationContext(
+          status: 'unavailable',
+          source: 'device_gps',
+          updatedAt: DateTime.utc(2026, 5, 15, 10),
+          granularity: LocationContextGranularity.neighborhood,
+          reason: 'location service is disabled',
+        );
+      },
+      openLocationSettings: () async {
+        opened = true;
+        return true;
+      },
+    );
+
+    await scrollToTestButton(tester);
+    await tester.tap(find.text('Test current location'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('System location is off'), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.text('Open location settings'),
+      100,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Open location settings'));
+    await tester.pumpAndSettle();
+
+    expect(opened, isTrue);
+  });
+
+  testWidgets('blocked and approximate states point to app settings', (
+    WidgetTester tester,
+  ) async {
+    var appSettingsOpenCount = 0;
+    await pumpLocationSettingsPage(
+      tester,
+      loadCurrentContext: ({bool forceRefresh = false}) async {
+        return CurrentLocationContext(
+          status: 'unavailable',
+          source: 'device_gps',
+          updatedAt: DateTime.utc(2026, 5, 15, 10),
+          granularity: LocationContextGranularity.neighborhood,
+          reason: 'location permission permanently denied',
+        );
+      },
+      openAppSettings: () async {
+        appSettingsOpenCount += 1;
+        return true;
+      },
+    );
+
+    await scrollToTestButton(tester);
+    await tester.tap(find.text('Test current location'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Location permission is blocked'), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.text('Open app settings'),
+      100,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Open app settings'));
+    await tester.pumpAndSettle();
+    expect(appSettingsOpenCount, 1);
+
+    await pumpLocationSettingsPage(
+      tester,
+      loadCurrentContext: ({bool forceRefresh = false}) async {
+        return CurrentLocationContext(
+          status: 'fresh',
+          latitude: 31.230416,
+          longitude: 121.473701,
+          accuracyMeters: 1200,
+          source: 'device_gps + reverse_geocode',
+          updatedAt: DateTime.utc(2026, 5, 15, 10),
+          granularity: LocationContextGranularity.city,
+          address: GeocodedAddress(
+            city: 'Shanghai',
+            provider: 'amap',
+            updatedAt: DateTime.utc(2026, 5, 15, 10),
+            confidence: 'low',
+          ),
+        );
+      },
+      openAppSettings: () async {
+        appSettingsOpenCount += 1;
+        return true;
+      },
+    );
+
+    await scrollToTestButton(tester);
+    await tester.tap(find.text('Test current location'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Approximate location only'), findsOneWidget);
+    expect(find.text('Open app settings'), findsOneWidget);
   });
 
   testWidgets('test button explains GPS-only reverse geocode failure', (


### PR DESCRIPTION
## 背景

Closes #133。

这个 issue 是合理的：现有页面已经能在 `Test current location` 后展示 `GPS: unavailable`、权限拒绝、系统定位关闭等原因，但失败后只给 debug 文本，真实用户缺少下一步动作；同时它要求不要在打开 Location Context 开关时直接弹权限，这也符合当前“显式测试/实际使用时才请求定位”的产品边界。

## 改动

- 将 `Test current location` 的结果升级为状态反馈：成功、权限未授权、权限永久拒绝、系统定位关闭、模糊定位、GPS 可用但逆地理编码失败、功能未开启等状态都有明确说明。
- 根据失败类型提供 CTA：允许位置权限、打开应用设置、开启系统定位。
- 保留原有 debug 详情，便于开发/排查，同时在状态反馈里补充更新时间、地址摘要、精度。
- 补齐中英文文案，并重新生成 Flutter l10n 代码。
- 增加 widget tests 覆盖：开关不触发权限请求、权限 CTA 后复测、系统定位设置 CTA、永久拒绝/模糊定位提示。

## 验证

- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter pub get --offline`
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub test/ui/settings/location_context_settings_page_test.dart`
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter analyze --no-pub lib/ui/settings/widgets/location_context_settings_page.dart test/ui/settings/location_context_settings_page_test.dart`
