### PR TITLE
[codex] 修复 Schedule Aggregator 空窗口刷新收敛

### DIFF
--- a/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart
+++ b/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart
@@ -3,8 +3,155 @@ import 'dart:convert';
 import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/schedule_refresh_state_service.dart';
+import 'package:memex/domain/models/schedule_refresh_state.dart';
 
 const int defaultScheduleAggregationCardLimit = 80;
+
+class ScheduleAggregationWindow {
+  const ScheduleAggregationWindow({
+    required this.from,
+    required this.to,
+    required this.source,
+    this.sourceCardIds = const [],
+  });
+
+  final DateTime from;
+  final DateTime to;
+  final String source;
+  final List<String> sourceCardIds;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'from': from.toIso8601String(),
+      'to': to.toIso8601String(),
+      'source': source,
+      if (sourceCardIds.isNotEmpty) 'source_card_ids': sourceCardIds,
+    };
+  }
+}
+
+class ScheduleAggregationRunPlan {
+  const ScheduleAggregationRunPlan({
+    required this.runId,
+    required this.generatedAt,
+    required this.window,
+    required this.scheduleCards,
+    required this.refreshState,
+    required this.latestAggregation,
+  });
+
+  final String runId;
+  final DateTime generatedAt;
+  final ScheduleAggregationWindow window;
+  final Map<String, dynamic> scheduleCards;
+  final ScheduleRefreshState refreshState;
+  final Map<String, dynamic>? latestAggregation;
+
+  bool get hasScheduleCards =>
+      (scheduleCards['cards'] as List?)?.isNotEmpty == true;
+}
+
+Future<ScheduleAggregationRunPlan> buildScheduleAggregationRunPlan({
+  required String userId,
+  required String runId,
+  DateTime? now,
+  int scheduleCardLimit = defaultScheduleAggregationCardLimit,
+}) async {
+  final fileSystem = FileSystemService.instance;
+  final generatedAt = now ?? DateTime.now();
+  final refreshState = await ScheduleRefreshStateService.instance.read(userId);
+  final window = resolveScheduleAggregationWindow(
+    generatedAt: generatedAt,
+    refreshState: refreshState,
+  );
+
+  final scheduleCards = await queryScheduleCardsForRange(
+    userId: userId,
+    from: window.from,
+    to: window.to,
+    limit: scheduleCardLimit,
+  );
+  final latestAggregation = await fileSystem.getLatestScheduleAggregation(
+    userId,
+  );
+
+  return ScheduleAggregationRunPlan(
+    runId: runId,
+    generatedAt: generatedAt,
+    window: window,
+    scheduleCards: scheduleCards,
+    refreshState: refreshState,
+    latestAggregation: latestAggregation,
+  );
+}
+
+ScheduleAggregationWindow resolveScheduleAggregationWindow({
+  required DateTime generatedAt,
+  required ScheduleRefreshState refreshState,
+}) {
+  final dirtyDates = <DateTime>[];
+  final sourceCardIds = <String>[];
+  for (final cardId in refreshState.cardIds) {
+    final cardDate = _parseFactIdDate(cardId);
+    if (cardDate == null) continue;
+    dirtyDates.add(cardDate);
+    sourceCardIds.add(cardId);
+  }
+
+  if (dirtyDates.isNotEmpty) {
+    dirtyDates.sort();
+    final first = _startOfDay(dirtyDates.first);
+    final last = _endOfDay(dirtyDates.last);
+    return ScheduleAggregationWindow(
+      from: first.subtract(const Duration(days: 3)),
+      to: last.add(const Duration(days: 7)),
+      source: 'dirty_card_dates',
+      sourceCardIds: sourceCardIds,
+    );
+  }
+
+  return ScheduleAggregationWindow(
+    from: generatedAt.subtract(const Duration(days: 3)),
+    to: generatedAt.add(const Duration(days: 7)),
+    source: 'generated_at_window',
+  );
+}
+
+String scheduleAggregationIdFor(DateTime generatedAt) {
+  return 'schedule_agg_${generatedAt.year.toString().padLeft(4, '0')}_'
+      '${generatedAt.month.toString().padLeft(2, '0')}_'
+      '${generatedAt.day.toString().padLeft(2, '0')}';
+}
+
+Map<String, dynamic> buildNoOpScheduleAggregation({
+  required String aggregationId,
+  required ScheduleAggregationRunPlan plan,
+  String reason = 'no_temporal_cards_in_window',
+}) {
+  return {
+    'id': aggregationId,
+    'generated_at': plan.generatedAt.toIso8601String(),
+    'version': 1,
+    'time_range': {
+      'from': _formatDate(plan.window.from),
+      'to': _formatDate(plan.window.to),
+    },
+    'editorial_intro':
+        'No temporal schedule cards found for this refresh window.',
+    'quote_blocks': const [],
+    'timeline': const [],
+    'completed': const [],
+    'conflicts': const [],
+    'no_op': true,
+    'no_op_reason': reason,
+    'diagnostics': {
+      'target_window_source': plan.window.source,
+      'target_window': plan.window.toJson(),
+      'schedule_card_count': 0,
+      'refresh_state': plan.refreshState.toJson(),
+    },
+  };
+}
 
 /// Builds a compact context packet for a fresh schedule aggregation run.
 ///
@@ -16,39 +163,33 @@ Future<String> buildScheduleAggregationRunContext({
   required String runId,
   DateTime? now,
   int scheduleCardLimit = defaultScheduleAggregationCardLimit,
+  ScheduleAggregationRunPlan? plan,
 }) async {
-  final fileSystem = FileSystemService.instance;
-  final generatedAt = now ?? DateTime.now();
-  final from = generatedAt.subtract(const Duration(days: 3));
-  final to = generatedAt.add(const Duration(days: 7));
-
-  final scheduleCards = await queryScheduleCardsForRange(
-    userId: userId,
-    from: from,
-    to: to,
-    limit: scheduleCardLimit,
-  );
-  final latestAggregation = await fileSystem.getLatestScheduleAggregation(
-    userId,
-  );
-  final refreshState = await ScheduleRefreshStateService.instance.read(userId);
+  final resolvedPlan = plan ??
+      await buildScheduleAggregationRunPlan(
+        userId: userId,
+        runId: runId,
+        now: now,
+        scheduleCardLimit: scheduleCardLimit,
+      );
 
   final payload = {
-    'run_id': runId,
-    'generated_at': generatedAt.toIso8601String(),
+    'run_id': resolvedPlan.runId,
+    'generated_at': resolvedPlan.generatedAt.toIso8601String(),
     'fresh_execution_state': true,
+    'target_window': resolvedPlan.window.toJson(),
     'durable_sources': {
-      'schedule_cards': scheduleCards,
+      'schedule_cards': resolvedPlan.scheduleCards,
       'schedule_cards_limit': scheduleCardLimit,
       'latest_schedule_aggregation': _compactScheduleAggregation(
-        latestAggregation,
+        resolvedPlan.latestAggregation,
       ),
-      'refresh_state': refreshState.toJson(),
+      'refresh_state': resolvedPlan.refreshState.toJson(),
     },
     'execution_policy': [
       'This is a fresh schedule aggregation execution. Do not rely on prior LLM conversation history.',
       'Use durable workspace data as the source of truth: Cards, Facts, ScheduleAggregations, event log, and injected user memory context.',
-      'Start from schedule_cards for the current refresh window, then inspect source cards with Read or BatchRead when details are needed.',
+      'Start from schedule_cards for target_window, then inspect source cards with Read or BatchRead when details are needed.',
       'Use save_schedule_aggregation to persist exactly one current aggregation result.',
       'Preserve completed task status only when task is_completed is true; card processing status does not mean task completion.',
       'When a task card has subtasks, preserve those subtasks on the timeline item; do not invent subtasks for independent cards.',
@@ -112,4 +253,28 @@ String? _itemId(dynamic value) {
 String _truncate(String value, int maxLength) {
   if (value.length <= maxLength) return value;
   return '${value.substring(0, maxLength)}...';
+}
+
+DateTime? _parseFactIdDate(String value) {
+  final match = RegExp(r'(\d{4})/(\d{2})/(\d{2})\.md#ts_\d+').firstMatch(value);
+  if (match == null) return null;
+  return DateTime(
+    int.parse(match.group(1)!),
+    int.parse(match.group(2)!),
+    int.parse(match.group(3)!),
+  );
+}
+
+DateTime _startOfDay(DateTime value) {
+  return DateTime(value.year, value.month, value.day);
+}
+
+DateTime _endOfDay(DateTime value) {
+  return DateTime(value.year, value.month, value.day, 23, 59, 59, 999);
+}
+
+String _formatDate(DateTime value) {
+  return '${value.year.toString().padLeft(4, '0')}-'
+      '${value.month.toString().padLeft(2, '0')}-'
+      '${value.day.toString().padLeft(2, '0')}';
 }

--- a/lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart
+++ b/lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart
@@ -15,6 +15,7 @@ import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_ski
 import 'package:memex/agent/state_util.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/schedule_refresh_state_service.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/utils/logger.dart';
@@ -144,6 +145,20 @@ class ScheduleAggregatorAgent {
       effectiveRunId,
     );
 
+    final runPlan = await buildScheduleAggregationRunPlan(
+      userId: effectiveUserId,
+      runId: effectiveRunId,
+      now: now,
+    );
+    if (!runPlan.hasScheduleCards) {
+      await _completeNoOpScheduleAggregation(
+        userId: effectiveUserId,
+        sessionId: sessionId,
+        plan: runPlan,
+      );
+      return true;
+    }
+
     final resources = await UserStorage.getAgentLLMResources(
       AgentDefinitions.scheduleAggregatorAgent,
       defaultClientKey: LLMConfig.defaultClientKey,
@@ -157,6 +172,7 @@ class ScheduleAggregatorAgent {
       sessionId: sessionId,
       now: now,
     );
+    _applyScheduleWindowMetadata(state, runPlan.window);
 
     if (!state.isRunning && state.history.messages.isNotEmpty) {
       _logger.info(
@@ -169,6 +185,7 @@ class ScheduleAggregatorAgent {
         sessionId: sessionId,
         now: now,
       );
+      _applyScheduleWindowMetadata(state, runPlan.window);
     } else if (state.isRunning &&
         !shouldResumeScheduleAggregatorRun(state, now, resumeTtl)) {
       _logger.info(
@@ -181,6 +198,7 @@ class ScheduleAggregatorAgent {
         sessionId: sessionId,
         now: now,
       );
+      _applyScheduleWindowMetadata(state, runPlan.window);
     }
 
     final agent = await _createAgent(
@@ -207,6 +225,7 @@ class ScheduleAggregatorAgent {
           userId: effectiveUserId,
           runId: effectiveRunId,
           now: now,
+          plan: runPlan,
         );
 
         final messages = [
@@ -258,5 +277,55 @@ class ScheduleAggregatorAgent {
       "ScheduleAggregatorAgent done, sessionId:${state.sessionId}, result messages length:${result.length}",
     );
     return true;
+  }
+
+  static void _applyScheduleWindowMetadata(
+    AgentState state,
+    ScheduleAggregationWindow window,
+  ) {
+    state.metadata['schedule_window_from'] = window.from.toIso8601String();
+    state.metadata['schedule_window_to'] = window.to.toIso8601String();
+    state.metadata['schedule_window_source'] = window.source;
+  }
+
+  static Future<void> _completeNoOpScheduleAggregation({
+    required String userId,
+    required String sessionId,
+    required ScheduleAggregationRunPlan plan,
+  }) async {
+    final aggregationId = scheduleAggregationIdFor(plan.generatedAt);
+    final fileSystem = FileSystemService.instance;
+    await fileSystem.writeScheduleAggregation(
+      userId,
+      aggregationId,
+      buildNoOpScheduleAggregation(aggregationId: aggregationId, plan: plan),
+    );
+    await ScheduleRefreshStateService.instance.clearDirty(
+      userId: userId,
+      aggregationId: aggregationId,
+    );
+
+    try {
+      await fileSystem.eventLogService.logFileCreated(
+        userId: userId,
+        filePath: 'ScheduleAggregations/$aggregationId.yaml',
+        description: 'Schedule aggregation completed as no-op',
+        metadata: {
+          'aggregation_id': aggregationId,
+          'reason': 'no_temporal_cards_in_window',
+          'target_window_source': plan.window.source,
+        },
+      );
+    } catch (e) {
+      // Event logging failure should not break no-op completion.
+    }
+
+    await deleteAgentState(userId, sessionId);
+    EventBusService.instance.emitEvent(
+      ScheduleAggregationUpdatedMessage(aggregationId: aggregationId),
+    );
+    _logger.info(
+      'ScheduleAggregatorAgent no-op completed, sessionId:$sessionId, aggregationId:$aggregationId',
+    );
   }
 }

--- a/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
+++ b/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
@@ -33,10 +33,7 @@ const scheduleTemporalTemplateIds = {
   'procedure',
 };
 
-dynamic scheduleStartTimeForCard(
-  String templateId,
-  Map<String, dynamic> data,
-) {
+dynamic scheduleStartTimeForCard(String templateId, Map<String, dynamic> data) {
   final startTime = _nonEmptyScheduleValue(data['start_time']);
   if (startTime != null) return startTime;
 
@@ -157,22 +154,24 @@ Tool buildGetScheduleCardsTool() {
         },
       },
     },
-    executable: (
-      String? fromDate,
-      String? toDate,
-    ) async {
+    executable: (String? fromDate, String? toDate) async {
       final logger = getLogger('ScheduleAggregationSkill');
-      final userId = AgentCallToolContext.current!.state.metadata['userId'];
+      final metadata = AgentCallToolContext.current!.state.metadata;
+      final userId = metadata['userId'] as String;
 
-      // Default date range: past 3 days ~ future 7 days
       final now = DateTime.now();
-      final from = _parseBoundaryDate(
-        fromDate,
+      final defaultFrom = _parseBoundaryDate(
+        metadata['schedule_window_from']?.toString(),
         fallback: now.subtract(const Duration(days: 3)),
       );
+      final defaultTo = _parseBoundaryDate(
+        metadata['schedule_window_to']?.toString(),
+        fallback: now.add(const Duration(days: 7)),
+      );
+      final from = _parseBoundaryDate(fromDate, fallback: defaultFrom);
       final to = _parseBoundaryDate(
         toDate,
-        fallback: now.add(const Duration(days: 7)),
+        fallback: defaultTo,
         endOfDay: true,
       );
 
@@ -217,10 +216,7 @@ Tool buildSaveScheduleAggregationTool() {
       },
       'required': ['aggregation_id', 'yaml_data'],
     },
-    executable: (
-      String aggregationId,
-      Map<String, dynamic> yamlData,
-    ) async {
+    executable: (String aggregationId, Map<String, dynamic> yamlData) async {
       final logger = getLogger('ScheduleAggregationSkill');
       final fileSystem = FileSystemService.instance;
       final userId = AgentCallToolContext.current!.state.metadata['userId'];
@@ -313,14 +309,17 @@ DateTime? _parseScheduleDateTime(dynamic value) {
   if (value is DateTime) return value;
   if (value is int) {
     final milliseconds = value > 100000000000 ? value : value * 1000;
-    return DateTime.fromMillisecondsSinceEpoch(milliseconds, isUtc: true)
-        .toLocal();
+    return DateTime.fromMillisecondsSinceEpoch(
+      milliseconds,
+      isUtc: true,
+    ).toLocal();
   }
   if (value is num) {
     final milliseconds = value > 100000000000 ? value.toInt() : value * 1000;
-    return DateTime.fromMillisecondsSinceEpoch(milliseconds.toInt(),
-            isUtc: true)
-        .toLocal();
+    return DateTime.fromMillisecondsSinceEpoch(
+      milliseconds.toInt(),
+      isUtc: true,
+    ).toLocal();
   }
   if (value is String) return DateTime.tryParse(value);
   return null;
@@ -342,10 +341,7 @@ DateTime _resultScheduleDate(Map<String, dynamic> result) {
       fallback;
 }
 
-String deriveScheduleCardStatus(
-  String templateId,
-  Map<String, dynamic> data,
-) {
+String deriveScheduleCardStatus(String templateId, Map<String, dynamic> data) {
   if (templateId == 'task') {
     return _parseScheduleBool(data['is_completed']) == true
         ? 'completed'

--- a/lib/data/services/task_handlers/schedule_aggregator_handler.dart
+++ b/lib/data/services/task_handlers/schedule_aggregator_handler.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart';
+import 'package:memex/domain/models/task_exceptions.dart';
 
 final Logger _logger = getLogger('LocalTaskHandlers');
 
@@ -21,6 +23,15 @@ Future<void> handleScheduleAggregation(
       userId: userId,
       runId: context.taskId,
     );
+  } on AgentException catch (e) {
+    if (e.code == AgentExceptionCode.loopDetection) {
+      _logger.severe('Schedule aggregation loop detected: $e');
+      throw NonRetryableAgentLoopException(
+        'Schedule aggregation reached the max-turn guard.',
+        originalError: e,
+      );
+    }
+    rethrow;
   } catch (e) {
     _logger.severe('Schedule aggregation failed: $e');
     rethrow;

--- a/lib/domain/models/task_exceptions.dart
+++ b/lib/domain/models/task_exceptions.dart
@@ -8,8 +8,9 @@ class InvalidModelConfigException implements NonRetryableTaskException {
   @override
   final String message;
 
-  InvalidModelConfigException(
-      [this.message = 'The LLM configuration is invalid.']);
+  InvalidModelConfigException([
+    this.message = 'The LLM configuration is invalid.',
+  ]);
 
   @override
   String toString() => "InvalidModelConfigException: $message";
@@ -24,16 +25,29 @@ class NonRetryableLlmException implements NonRetryableTaskException {
   final int? statusCode;
   final Object? originalError;
 
-  NonRetryableLlmException(
-    this.message, {
-    this.statusCode,
-    this.originalError,
-  });
+  NonRetryableLlmException(this.message, {this.statusCode, this.originalError});
 
   @override
   String toString() {
     final buf = StringBuffer('NonRetryableLlmException: $message');
     if (statusCode != null) buf.write(' (HTTP $statusCode)');
+    if (originalError != null) buf.write('\nOriginal error: $originalError');
+    return buf.toString();
+  }
+}
+
+/// Exception thrown when an agent reached its max-turn/loop guard.
+class NonRetryableAgentLoopException implements NonRetryableTaskException {
+  @override
+  final String message;
+
+  final Object? originalError;
+
+  NonRetryableAgentLoopException(this.message, {this.originalError});
+
+  @override
+  String toString() {
+    final buf = StringBuffer('NonRetryableAgentLoopException: $message');
     if (originalError != null) buf.write('\nOriginal error: $originalError');
     return buf.toString();
   }

--- a/test/agent/schedule_aggregation_run_context_test.dart
+++ b/test/agent/schedule_aggregation_run_context_test.dart
@@ -172,6 +172,92 @@ void main() {
         contains(contains('Do not rely on prior LLM conversation history')),
       );
     });
+
+    test(
+      'uses dirty card dates instead of wall clock for target window',
+      () async {
+        final fileSystem = FileSystemService.instance;
+        await fileSystem.safeWriteCardFile(
+          userId,
+          '2026/01/06.md#ts_1',
+          CardData(
+            factId: '2026/01/06.md#ts_1',
+            title: 'Father follow-up documents',
+            timestamp: DateTime.utc(2026, 1, 6).millisecondsSinceEpoch ~/ 1000,
+            status: 'completed',
+            tags: const ['schedule'],
+            uiConfigs: const [
+              UiConfig(
+                templateId: 'task',
+                data: {
+                  'due_date': '2026-01-08T17:00:00Z',
+                  'is_completed': false,
+                },
+              ),
+            ],
+          ),
+        );
+        await ScheduleRefreshStateService.instance.markDirty(
+          userId: userId,
+          reason: 'historical card changed',
+          cardIds: const ['2026/01/06.md#ts_1'],
+        );
+
+        final context = await buildScheduleAggregationRunContext(
+          userId: userId,
+          runId: 'task_historical_dirty',
+          now: DateTime.utc(2026, 5, 18, 12),
+          scheduleCardLimit: 10,
+        );
+
+        final payload = _decodeContextPayload(context);
+        final targetWindow = payload['target_window'] as Map<String, dynamic>;
+        final sources = payload['durable_sources'] as Map<String, dynamic>;
+        final cards = sources['schedule_cards'] as Map<String, dynamic>;
+
+        expect(targetWindow['source'], 'dirty_card_dates');
+        expect(targetWindow['from'], startsWith('2026-01-03'));
+        expect(targetWindow['to'], startsWith('2026-01-13'));
+        expect(
+          (cards['cards'] as List).map((card) => card['card_id']),
+          contains('2026/01/06.md#ts_1'),
+        );
+        expect(payload['target_window'],
+            containsPair('source', 'dirty_card_dates'));
+      },
+    );
+
+    test('builds no-op aggregation payload for empty target window', () async {
+      await ScheduleRefreshStateService.instance.markDirty(
+        userId: userId,
+        reason: 'historical card changed',
+        cardIds: const ['2026/01/06.md#ts_1'],
+      );
+
+      final plan = await buildScheduleAggregationRunPlan(
+        userId: userId,
+        runId: 'task_empty_window',
+        now: DateTime.utc(2026, 5, 18, 12),
+        scheduleCardLimit: 10,
+      );
+      final aggregationId = scheduleAggregationIdFor(plan.generatedAt);
+      final noOp = buildNoOpScheduleAggregation(
+        aggregationId: aggregationId,
+        plan: plan,
+      );
+
+      expect(plan.hasScheduleCards, isFalse);
+      expect(noOp['id'], 'schedule_agg_2026_05_18');
+      expect(noOp['no_op'], isTrue);
+      expect(noOp['no_op_reason'], 'no_temporal_cards_in_window');
+      expect(noOp['timeline'], isEmpty);
+      expect(noOp['completed'], isEmpty);
+      expect(noOp['conflicts'], isEmpty);
+      expect(
+        (noOp['diagnostics'] as Map)['target_window_source'],
+        'dirty_card_dates',
+      );
+    });
   });
 }
 

--- a/test/data/services/task_handlers/schedule_aggregator_handler_test.dart
+++ b/test/data/services/task_handlers/schedule_aggregator_handler_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/data/services/schedule_refresh_state_service.dart';
+import 'package:memex/data/services/task_handlers/schedule_aggregator_handler.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('handleScheduleAggregation', () {
+    late Directory tempRoot;
+    late AppDatabase db;
+    const userId = 'schedule_handler_user';
+
+    setUp(() async {
+      tempRoot = await Directory.systemTemp.createTemp(
+        'memex_schedule_handler_',
+      );
+      await FileSystemService.init(tempRoot.path);
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      AppDatabase.setTestInstance(db);
+      await db.searchDao.createFtsTables();
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test(
+      'completes empty schedule window as no-op and clears dirty state',
+      () async {
+        await ScheduleRefreshStateService.instance.markDirty(
+          userId: userId,
+          reason: 'historical card changed',
+          cardIds: const ['2026/01/06.md#ts_1'],
+          refreshRequested: true,
+        );
+
+        await handleScheduleAggregation(
+          userId,
+          const {},
+          TaskContext(
+            taskId: 'schedule_refresh_empty_window',
+            taskType: 'schedule_aggregator_task',
+          ),
+        );
+
+        final latest = await FileSystemService.instance
+            .getLatestScheduleAggregation(userId);
+        final refreshState = await ScheduleRefreshStateService.instance.read(
+          userId,
+        );
+
+        expect(latest, isNotNull);
+        expect(latest!['no_op'], isTrue);
+        expect(latest['no_op_reason'], 'no_temporal_cards_in_window');
+        expect(latest['timeline'], isEmpty);
+        expect(refreshState.isDirty, isFalse);
+        expect(refreshState.cardIds, isEmpty);
+        expect(refreshState.lastAggregationId, latest['id']);
+        expect(refreshState.refreshRequested, isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## 背景

Closes #147。

真实 replay 中，Schedule Aggregator 遇到「当前刷新窗口没有 temporal cards，但 dirty state 指向历史卡片」时，会继续回读历史 Cards 并尝试推理，最终触发 max-turn loop detection。根因是刷新窗口只跟随真实 wall clock，而 dirty card 的历史日期没有参与窗口选择；同时空窗口没有一个结构性的 no-op completion path，清 dirty 只能依赖 agent 成功保存 aggregation。

## 改动

- 新增 `ScheduleAggregationRunPlan`，在 agent 启动前统一解析目标窗口、刷新状态、当前 schedule cards 和最新 aggregation。
- 当 dirty state 带有可解析 card id 时，目标窗口改为基于 dirty card 日期推导，避免历史 replay 被真实 wall clock 带偏。
- 当目标窗口内没有 temporal cards 时，不再启动 LLM agent，直接保存 no-op schedule aggregation，并清理 dirty state、发送 UI update 事件。
- `get_schedule_cards` 的默认窗口改为读取本次 run metadata，确保 agent 工具默认使用同一个目标窗口。
- Schedule Aggregator 的 loop detection 在 task handler 层转为 non-retryable failure，避免 max-turn 后继续占用 active/retrying 状态。
- 增加单测覆盖历史 dirty card 窗口推导、no-op payload、task handler 空窗口完成并清 dirty。

## 验证

- `flutter pub get --offline`
- `flutter test --no-pub --concurrency=1 test/agent/schedule_aggregation_run_context_test.dart test/data/services/task_handlers/schedule_aggregator_handler_test.dart`
- `flutter test --no-pub --concurrency=1 test/agent/schedule_aggregation_run_lifecycle_test.dart test/data/repositories/get_schedule_briefing_timeline_card_test.dart test/domain/models/schedule_aggregation_model_test.dart test/ui/schedule/models/schedule_item_test.dart`
- `flutter analyze --no-pub lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart lib/data/services/task_handlers/schedule_aggregator_handler.dart lib/domain/models/task_exceptions.dart test/agent/schedule_aggregation_run_context_test.dart test/data/services/task_handlers/schedule_aggregator_handler_test.dart`
- `git diff --check`

## 发布前检查

- 已从最新 `upstream/main` 创建分支。
- PR 创建前再次 `git fetch upstream main`，确认 `upstream/main...HEAD` 为 `0 1`，当前分支只领先目标分支一个提交且没有落后。
