### PR TITLE
[codex] 修复 PKM 澄清请求后的循环重试

### DIFF
--- a/lib/agent/pkm_agent/pkm_agent.dart
+++ b/lib/agent/pkm_agent/pkm_agent.dart
@@ -413,14 +413,38 @@ $instruction
 
     while (true) {
       runCount++;
-      if (runCount == 1 && wasRunning) {
+      final shouldResume = runCount == 1 && wasRunning;
+      if (shouldResume) {
         _logger.info(
             "PkmAgent resume (attempt $runCount/${maxRetries + 1}), sessionId:${agent.state.sessionId}");
-        await agent.resume(useStream: false);
       } else {
         _logger.info(
             "PkmAgent run (attempt $runCount/${maxRetries + 1}), sessionId:${agent.state.sessionId}");
-        await agent.run(messagesToRun, useStream: false);
+      }
+
+      try {
+        if (shouldResume) {
+          await agent.resume(useStream: false);
+        } else {
+          await agent.run(messagesToRun, useStream: false);
+        }
+      } on AgentException catch (e) {
+        if (e.code == AgentExceptionCode.loopDetection) {
+          final factId = agent.state.metadata['factId'] as String?;
+          if (factId != null) {
+            final check = inspectPkmRunCompletion(
+              messages: agent.state.history.messages,
+              factId: factId,
+            );
+            if (check.isComplete) {
+              _logger.info(
+                'PKM agent hit loop detection after valid completion evidence for $factId: ${check.toJson()}',
+              );
+              break;
+            }
+          }
+        }
+        rethrow;
       }
 
       if (runCount == 1) {
@@ -468,7 +492,8 @@ $instruction
             '<system-reminder>The PKM task is incomplete. Complete one valid path before finishing:\n'
             '1. Persistent organization path: complete all missing steps below.\n'
             '$reminderText\n'
-            '2. Non-persistent skip path: if the user explicitly asked not to save, persist, write long-term memory, or modify existing knowledge, call skip_pkm_organization with the reason and evidence instead of writing P.A.R.A. files.</system-reminder>',
+            '2. Non-persistent skip path: if the user explicitly asked not to save, persist, write long-term memory, or modify existing knowledge, call skip_pkm_organization with the reason and evidence instead of writing P.A.R.A. files.\n'
+            '3. Clarification path: if missing or conflicting details block a safe PKM update, create one deduped clarification request and then stop.</system-reminder>',
           ),
         ])
       ];
@@ -530,10 +555,12 @@ $instruction
     bool wrotePara = false;
     bool updatedInsight = false;
     bool skippedPkm = false;
+    bool clarificationRequested = false;
     bool successfulPkmMutation = false;
     String? skipReason;
     String? skipTemporalScope;
     String? skipEvidence;
+    String? clarificationDedupeKey;
 
     for (final msg in messages) {
       if (msg is! FunctionExecutionResultMessage) continue;
@@ -559,6 +586,11 @@ $instruction
           skipTemporalScope = args['temporal_scope'] as String?;
           skipEvidence = args['evidence'] as String?;
         }
+        if (r.name == 'create_clarification_request') {
+          clarificationRequested = true;
+          final args = _decodeToolArguments(r.arguments);
+          clarificationDedupeKey = args['dedupe_key'] as String?;
+        }
       }
     }
 
@@ -566,10 +598,12 @@ $instruction
       wrotePara: wrotePara,
       updatedInsight: updatedInsight,
       skippedPkm: skippedPkm,
+      clarificationRequested: clarificationRequested,
       successfulPkmMutation: successfulPkmMutation,
       skipReason: skipReason,
       skipTemporalScope: skipTemporalScope,
       skipEvidence: skipEvidence,
+      clarificationDedupeKey: clarificationDedupeKey,
     );
   }
 
@@ -657,33 +691,45 @@ class PkmRunCompletionEvidence {
     required this.wrotePara,
     required this.updatedInsight,
     required this.skippedPkm,
+    required this.clarificationRequested,
     required this.successfulPkmMutation,
     this.skipReason,
     this.skipTemporalScope,
     this.skipEvidence,
+    this.clarificationDedupeKey,
   });
 
   final bool wrotePara;
   final bool updatedInsight;
   final bool skippedPkm;
+  final bool clarificationRequested;
   final bool successfulPkmMutation;
   final String? skipReason;
   final String? skipTemporalScope;
   final String? skipEvidence;
+  final String? clarificationDedupeKey;
 
   bool get isComplete =>
-      (wrotePara && updatedInsight) || (skippedPkm && !successfulPkmMutation);
+      (wrotePara && updatedInsight) ||
+      (skippedPkm && !successfulPkmMutation) ||
+      (clarificationRequested && !successfulPkmMutation);
 
   List<String> get missingRequirements {
     if (isComplete) return const [];
     if (skippedPkm && successfulPkmMutation) {
       return const ['skip_without_successful_pkm_mutation'];
     }
+    if (clarificationRequested && successfulPkmMutation) {
+      return const ['clarification_without_persistent_completion'];
+    }
 
     final missing = <String>[];
     if (!wrotePara) missing.add('wrote_para_with_fact_id');
     if (!updatedInsight) missing.add('updated_timeline_card_insight');
     if (!skippedPkm) missing.add('skip_pkm_organization');
+    if (!clarificationRequested) {
+      missing.add('create_clarification_request');
+    }
     return missing;
   }
 
@@ -692,10 +738,13 @@ class PkmRunCompletionEvidence {
         'wrote_para': wrotePara,
         'updated_insight': updatedInsight,
         'skipped_pkm': skippedPkm,
+        'clarification_requested': clarificationRequested,
         'successful_pkm_mutation': successfulPkmMutation,
         'missing_requirements': missingRequirements,
         if (skipReason != null) 'skip_reason': skipReason,
         if (skipTemporalScope != null) 'skip_temporal_scope': skipTemporalScope,
         if (skipEvidence != null) 'skip_evidence': skipEvidence,
+        if (clarificationDedupeKey != null)
+          'clarification_dedupe_key': clarificationDedupeKey,
       };
 }

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -103,7 +103,6 @@ $contentText$assetInfo
       '''# Persona
 This skill acts as an intelligent librarian specializing in the P.A.R.A. method (Projects, Areas, Resources, Archives), responsible for organizing and analyzing the user's P.A.R.A. knowledge base.
 
-Important: Do not ask users for additional information or clarification.
 Important: All P.A.R.A. files are located under the working directory `$workingDirectory`. Use this parent path when operating on P.A.R.A. files.
 
 # User Assets
@@ -140,6 +139,12 @@ Bad Examples:
 If the current raw input explicitly asks not to persist this input or not to modify existing knowledge, call `skip_pkm_organization` instead of writing P.A.R.A. files for this input.
 Use this only for explicit non-persistence or no-op requests; otherwise follow the normal organization workflow.
 
+# Information-Insufficient Inputs
+Use `ask_clarification` only when missing or conflicting details would make a PKM update unsafe.
+- Create at most one focused request with the current fact_id as evidence and a stable dedupe_key.
+- A created or deduped clarification request completes this PKM task if no P.A.R.A. file has been changed.
+- After an empty search or unchanged read, broaden once at most; then clarify or finish safely.
+
 # Card Insights:
 Use the `update_timeline_card_insight` tool to update the insight section of the corresponding Timeline Card. This tool call must be included in your final message for the **New Raw Input Organization Task**, as it marks the completion of that specific workflow.
 - insight contains:
@@ -160,9 +165,10 @@ When the user provides new raw input, follow this sequence:
 0. **Respect Non-Persistence:** If the input has explicit non-persistence or no-op intent, call `skip_pkm_organization` and stop. Do not write or edit P.A.R.A. files for this input.
 1. **Analyze:** Extract all distinct information from the user's raw input.
 2. **Categorize:** Determine the storage location in the P.A.R.A. knowledge base based on `LS` results. If those are insufficient, use `Grep`, `Read` to gather more context.
-3. **Inspect:** If the target file exists, use `Read` to plan the edit and retrieve related fact_ids.
-4. **Store:** Create or update the file content, ensuring proper association with `fact_id`.
-5. **Update Insight:** Use `update_timeline_card_insight` to update the timeline card’s insight, summary, and related facts.
+3. **Clarify if unsafe:** If a safe update is blocked, follow the Information-Insufficient Inputs path.
+4. **Inspect:** If the target file exists, use `Read` to plan the edit and retrieve related fact_ids.
+5. **Store:** Create or update the file content, ensuring proper association with `fact_id`.
+6. **Update Insight:** Use `update_timeline_card_insight` to update the timeline card’s insight, summary, and related facts.
 
 ## P.A.R.A. Maintenance Task
 When the user provides feedback regarding structure (e.g., "Move this", "Fix this") OR you identify a structural mess that needs explicit fixing, follow this sequence:

--- a/lib/agent/skills/ask_clarification/ask_clarification_skill.dart
+++ b/lib/agent/skills/ask_clarification/ask_clarification_skill.dart
@@ -171,8 +171,8 @@ ${UserStorage.l10n.userLanguageInstruction}
                         .millisecondsSinceEpoch ~/
                     1000;
 
-            final requestId =
-                await ClarificationRequestService.instance.createRequest(
+            final result = await ClarificationRequestService.instance
+                .createRequestWithResult(
               question: question,
               responseType: responseType,
               options: normalizedOptions.isEmpty ? null : normalizedOptions,
@@ -190,8 +190,14 @@ ${UserStorage.l10n.userLanguageInstruction}
               expiresAt: expiresAt,
             );
 
+            final status = result.created ? 'created' : 'existing';
             return AgentToolResult(
-              content: TextPart('Clarification request created: $requestId'),
+              content: TextPart(
+                'Clarification request $status: '
+                'request_id=${result.id}; '
+                'created=${result.created}; '
+                'dedupe_key=${result.dedupeKey ?? '-'}',
+              ),
             );
           } catch (e, st) {
             _logger.severe('Failed to create clarification request', e, st);

--- a/lib/data/services/clarification_request_service.dart
+++ b/lib/data/services/clarification_request_service.dart
@@ -29,6 +29,24 @@ class ClarificationResponseType {
   static const shortText = 'short_text';
 }
 
+class ClarificationRequestCreateResult {
+  const ClarificationRequestCreateResult({
+    required this.id,
+    required this.created,
+    this.dedupeKey,
+  });
+
+  final String id;
+  final bool created;
+  final String? dedupeKey;
+
+  Map<String, dynamic> toJson() => {
+        'request_id': id,
+        'created': created,
+        if (dedupeKey != null) 'dedupe_key': dedupeKey,
+      };
+}
+
 class ClarificationRequestService {
   static final ClarificationRequestService instance =
       ClarificationRequestService._internal();
@@ -195,6 +213,45 @@ class ClarificationRequestService {
     String? factId,
     int? expiresAt,
   }) async {
+    final result = await createRequestWithResult(
+      id: id,
+      question: question,
+      responseType: responseType,
+      options: options,
+      entityType: entityType,
+      entityLabel: entityLabel,
+      evidenceFactIds: evidenceFactIds,
+      reason: reason,
+      impact: impact,
+      confidence: confidence,
+      proposedMemory: proposedMemory,
+      resolutionTarget: resolutionTarget,
+      sourceAgent: sourceAgent,
+      dedupeKey: dedupeKey,
+      factId: factId,
+      expiresAt: expiresAt,
+    );
+    return result.id;
+  }
+
+  Future<ClarificationRequestCreateResult> createRequestWithResult({
+    String? id,
+    required String question,
+    required String responseType,
+    List<Map<String, dynamic>>? options,
+    String? entityType,
+    String? entityLabel,
+    List<String>? evidenceFactIds,
+    String? reason,
+    String? impact,
+    double? confidence,
+    String? proposedMemory,
+    String? resolutionTarget,
+    String? sourceAgent,
+    String? dedupeKey,
+    String? factId,
+    int? expiresAt,
+  }) async {
     final trimmedDedupeKey = dedupeKey?.trim();
     if (trimmedDedupeKey != null && trimmedDedupeKey.isNotEmpty) {
       final existing = await (_db.select(_db.clarificationRequests)
@@ -210,7 +267,11 @@ class ClarificationRequestService {
       if (existing != null) {
         _logger.info(
             'Reusing active clarification request ${existing.id} for $trimmedDedupeKey');
-        return existing.id;
+        return ClarificationRequestCreateResult(
+          id: existing.id,
+          created: false,
+          dedupeKey: trimmedDedupeKey,
+        );
       }
     }
 
@@ -247,7 +308,11 @@ class ClarificationRequestService {
         );
 
     _logger.info('Created clarification request $requestId');
-    return requestId;
+    return ClarificationRequestCreateResult(
+      id: requestId,
+      created: true,
+      dedupeKey: trimmedDedupeKey,
+    );
   }
 
   Stream<List<ClarificationRequest>> watchPending() {

--- a/test/agent/agent_tool_error_result_test.dart
+++ b/test/agent/agent_tool_error_result_test.dart
@@ -4,12 +4,15 @@ import 'dart:io';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/agent/built_in_tools/search_event_logs_tool.dart';
+import 'package:memex/agent/skills/ask_clarification/ask_clarification_skill.dart';
 import 'package:memex/agent/skills/comment_agent/tools/comment_tools.dart';
 import 'package:memex/agent/skills/comment_agent/tools/memory_tools.dart';
 import 'package:memex/agent/skills/manage_timeline_card/timeline_card_skill.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/db/app_database.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -17,10 +20,14 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('agent tool error results', () {
+    late AppDatabase db;
     late Directory tempRoot;
     late String userId;
 
     setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      AppDatabase.setTestInstance(db);
+
       SharedPreferences.setMockInitialValues({});
       await UserStorage.initL10n();
       userId = 'tool_error_${DateTime.now().microsecondsSinceEpoch}';
@@ -34,6 +41,7 @@ void main() {
       if (await tempRoot.exists()) {
         await tempRoot.delete(recursive: true);
       }
+      await db.close();
     });
 
     test('save_timeline_card missing fact is marked as a tool error', () async {
@@ -209,6 +217,44 @@ void main() {
 
       expect(result.isError, isTrue);
       expect(_text(result), contains('ui_configs must be an array'));
+    });
+
+    test('create_clarification_request reports dedupe reuse status', () async {
+      final tool = AskClarificationSkill(forceActivate: true)
+          .tools!
+          .singleWhere((tool) => tool.name == 'create_clarification_request');
+      const dedupeKey = 'reminder:missing_time';
+      final arguments = {
+        'question': '需要提醒你的具体时间是什么？',
+        'response_type': 'short_text',
+        'evidence_fact_ids': ['2026/05/18.md#ts_1'],
+        'dedupe_key': dedupeKey,
+      };
+
+      final first = await _runToolCall(
+        tool: tool,
+        arguments: arguments,
+        metadata: {
+          'userId': userId,
+          'factId': '2026/05/18.md#ts_1',
+          'agentName': 'pkm_agent',
+        },
+      );
+      final second = await _runToolCall(
+        tool: tool,
+        arguments: arguments,
+        metadata: {
+          'userId': userId,
+          'factId': '2026/05/18.md#ts_1',
+          'agentName': 'pkm_agent',
+        },
+      );
+
+      expect(first.isError, isFalse);
+      expect(second.isError, isFalse);
+      expect(_text(first), contains('created=true'));
+      expect(_text(second), contains('created=false'));
+      expect(_text(second), contains('dedupe_key=$dedupeKey'));
     });
 
     test('SaveComment invalid input is marked as a tool error', () async {

--- a/test/agent/pkm_agent_skip_completion_test.dart
+++ b/test/agent/pkm_agent_skip_completion_test.dart
@@ -140,6 +140,34 @@ void main() {
       expect(evidence.toJson()['skipped_pkm'], isTrue);
     });
 
+    test(
+      'clarification request is a valid completion path without PKM writes',
+      () {
+        final evidence = PkmAgent.inspectPkmRunCompletion(
+          factId: factId,
+          messages: [
+            _toolResultMessage(
+              name: 'create_clarification_request',
+              arguments: {
+                'question': '周末具体是周六还是周日？',
+                'response_type': 'single_choice',
+                'evidence_fact_ids': [factId],
+                'dedupe_key': 'weekend:reminder_time',
+              },
+            ),
+          ],
+        );
+
+        expect(evidence.wrotePara, isFalse);
+        expect(evidence.updatedInsight, isFalse);
+        expect(evidence.clarificationRequested, isTrue);
+        expect(evidence.clarificationDedupeKey, 'weekend:reminder_time');
+        expect(evidence.isComplete, isTrue);
+        expect(evidence.missingRequirements, isEmpty);
+        expect(evidence.toJson()['clarification_requested'], isTrue);
+      },
+    );
+
     test('skip is not accepted after a successful PKM mutation', () {
       final evidence = PkmAgent.inspectPkmRunCompletion(
         factId: factId,
@@ -168,6 +196,37 @@ void main() {
       expect(
         evidence.missingRequirements,
         contains('skip_without_successful_pkm_mutation'),
+      );
+    });
+
+    test('clarification alone is not accepted after a PKM mutation', () {
+      final evidence = PkmAgent.inspectPkmRunCompletion(
+        factId: factId,
+        messages: [
+          _toolResultMessage(
+            name: 'Write',
+            arguments: {
+              'file_path': '/Projects/导出灰度提醒设置.md',
+              'content': 'accidental write',
+            },
+          ),
+          _toolResultMessage(
+            name: 'create_clarification_request',
+            arguments: {
+              'question': '要提醒的具体时间是什么？',
+              'response_type': 'short_text',
+              'dedupe_key': 'reminder:time',
+            },
+          ),
+        ],
+      );
+
+      expect(evidence.clarificationRequested, isTrue);
+      expect(evidence.successfulPkmMutation, isTrue);
+      expect(evidence.isComplete, isFalse);
+      expect(
+        evidence.missingRequirements,
+        contains('clarification_without_persistent_completion'),
       );
     });
 
@@ -205,6 +264,8 @@ void main() {
       expect(prompt, contains('skip_pkm_organization'));
       expect(prompt, contains('explicitly asks not to persist'));
       expect(prompt, contains('Use this only for explicit'));
+      expect(prompt, contains('Information-Insufficient Inputs'));
+      expect(prompt, contains('ask_clarification'));
       expect(prompt, isNot(contains('不要写成长记忆')));
       expect(prompt, isNot(contains('不要影响某某项目/规则')));
     });


### PR DESCRIPTION
## 背景

Closes #146。

这个 issue 是合理的：当前 PKM workflow 的完成证据只接受“P.A.R.A. 写入 + card insight”或显式 skip；但真实 replay 里的信息不足场景已经创建了 clarification request，却仍被视为未完成，后续 retry 会反复走相同的空搜索、重复澄清或重复读取，最终触发 loopDetection / max turns。

## 改动

- 让 `create_clarification_request` 返回明确的去重状态：`request_id`、`created=true/false`、`dedupe_key`，让 agent 能识别“已存在同 key 请求”并停止重复创建。
- 将“成功创建或命中 clarification request，且没有发生 PKM 文件 mutation”纳入 PKM completion evidence。
- 在 `AgentExceptionCode.loopDetection` 发生时，如果历史里已经存在有效 completion evidence，PKM task 会按完成处理，避免 LocalTaskExecutor 继续重试同一死路。
- 调整 PKM prompt：信息不足时使用一次 `ask_clarification` 收口；同参空 `Glob` / `Grep`、重复 `Read` 不应继续打转。
- 补充单测覆盖 clarification completion path、mutation 后不能只靠 clarification 完成，以及 clarification dedupe 返回状态。

## 验证

- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 flutter pub get --offline`
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 dart analyze lib/agent/pkm_agent/pkm_agent.dart lib/agent/prompts.dart lib/agent/skills/ask_clarification/ask_clarification_skill.dart lib/data/services/clarification_request_service.dart test/agent/agent_tool_error_result_test.dart test/agent/pkm_agent_skip_completion_test.dart`
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 flutter test --no-pub test/agent/pkm_agent_skip_completion_test.dart test/agent/agent_tool_error_result_test.dart`

备注：`flutter analyze --no-pub` 可执行，但当前 `main` 基线已有 324 个 info 级 lint，因此本 PR 用触达文件的 `dart analyze` 作为静态检查 gate。
