### PR TITLE
[codex] 修复 Location Context 设置页 ListTile 断言

### DIFF
--- a/lib/ui/settings/widgets/location_context_settings_page.dart
+++ b/lib/ui/settings/widgets/location_context_settings_page.dart
@@ -702,11 +702,10 @@ class _LocationContextSettingsPageState
   }
 
   Widget _section({required Widget child}) {
-    return Container(
-      padding: const EdgeInsets.all(20),
+    final borderRadius = BorderRadius.circular(16);
+    return DecoratedBox(
       decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: borderRadius,
         boxShadow: [
           BoxShadow(
             color: AppColors.textSecondary.withValues(alpha: 0.08),
@@ -715,7 +714,12 @@ class _LocationContextSettingsPageState
           ),
         ],
       ),
-      child: child,
+      child: Material(
+        color: Colors.white,
+        borderRadius: borderRadius,
+        clipBehavior: Clip.antiAlias,
+        child: Padding(padding: const EdgeInsets.all(20), child: child),
+      ),
     );
   }
 }


### PR DESCRIPTION
## 背景

`PR Flutter Quality` 在 run 26049138264 中拦下了 #151 的后续检查：Analyzer baseline 通过，但 Flutter test baseline 发现 `test/ui/settings/location_context_settings_page_test.dart` 新增 4 个失败。

失败根因是 `LocationContextSettingsPage._section()` 用带白色背景的 `Container`/`DecoratedBox` 直接包住 `SwitchListTile`。Flutter 会把 `ListTile` 的 ink splash 和背景绘制到最近的 `Material` 上，中间存在带背景色的 `DecoratedBox` 时，测试环境会触发 `ListTile background color or ink splashes may be invisible` 断言。

## 改动

- 将 `_section()` 改成外层 `DecoratedBox` 只负责阴影。
- 新增内层 `Material` 承载白底、圆角和 clip，再用 `Padding` 保持原有内边距。
- 保持页面视觉结构不变，同时让 `SwitchListTile` 能找到正确的最近 `Material`。

## 验证

- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter pub get --offline`
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub test/ui/settings/location_context_settings_page_test.dart`
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter analyze --no-pub lib/ui/settings/widgets/location_context_settings_page.dart test/ui/settings/location_context_settings_page_test.dart`
