### PR TITLE
修复 Android 长按图标快捷记入口

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -86,13 +86,14 @@ android {
     val globalDevApplicationId = "com.memexlab.memex.dev"
     val cnDevApplicationId = "com.memexlab.memex.cn.dev"
 
+    // Static shortcut targetPackage must be a literal in each flavor overlay.
+    // Android persists @string references as resource IDs in ShortcutInfo intents.
     flavorDimensions += "market"
     productFlavors {
         create("global") {
             dimension = "market"
             applicationId = globalApplicationId
             manifestPlaceholders["appLabel"] = "Memex"
-            resValue("string", "quick_action_target_package", globalApplicationId)
             if (hasGlobalKeystore) {
                 signingConfig = signingConfigs.getByName("globalRelease")
             }
@@ -101,7 +102,6 @@ android {
             dimension = "market"
             applicationId = cnApplicationId
             manifestPlaceholders["appLabel"] = "Memex"
-            resValue("string", "quick_action_target_package", cnApplicationId)
             if (hasCnKeystore) {
                 signingConfig = signingConfigs.getByName("cnRelease")
             }
@@ -110,11 +110,6 @@ android {
             dimension = "market"
             applicationId = globalEarlyApplicationId
             manifestPlaceholders["appLabel"] = "Memex Early"
-            resValue(
-                "string",
-                "quick_action_target_package",
-                globalEarlyApplicationId,
-            )
             if (hasEarlyKeystore) {
                 signingConfig = signingConfigs.getByName("earlyRelease")
             }
@@ -123,7 +118,6 @@ android {
             dimension = "market"
             applicationId = cnEarlyApplicationId
             manifestPlaceholders["appLabel"] = "Memex Early CN"
-            resValue("string", "quick_action_target_package", cnEarlyApplicationId)
             if (hasEarlyKeystore) {
                 signingConfig = signingConfigs.getByName("earlyRelease")
             }
@@ -132,13 +126,11 @@ android {
             dimension = "market"
             applicationId = globalDevApplicationId
             manifestPlaceholders["appLabel"] = "Memex Dev"
-            resValue("string", "quick_action_target_package", globalDevApplicationId)
         }
         create("cnDev") {
             dimension = "market"
             applicationId = cnDevApplicationId
             manifestPlaceholders["appLabel"] = "Memex Dev CN"
-            resValue("string", "quick_action_target_package", cnDevApplicationId)
         }
     }
 

--- a/android/app/src/cn/res/xml/shortcuts.xml
+++ b/android/app/src/cn/res/xml/shortcuts.xml
@@ -8,7 +8,7 @@
         android:shortcutLongLabel="@string/shortcut_quick_note_long">
         <intent
             android:action="android.intent.action.RUN"
-            android:targetPackage="com.memexlab.memex"
+            android:targetPackage="com.memexlab.memex.cn"
             android:targetClass="com.memexlab.memex.MainActivity">
             <extra android:name="some unique action key" android:value="quick_note" />
         </intent>

--- a/android/app/src/cnDev/res/xml/shortcuts.xml
+++ b/android/app/src/cnDev/res/xml/shortcuts.xml
@@ -8,7 +8,7 @@
         android:shortcutLongLabel="@string/shortcut_quick_note_long">
         <intent
             android:action="android.intent.action.RUN"
-            android:targetPackage="com.memexlab.memex"
+            android:targetPackage="com.memexlab.memex.cn.dev"
             android:targetClass="com.memexlab.memex.MainActivity">
             <extra android:name="some unique action key" android:value="quick_note" />
         </intent>

--- a/android/app/src/cnEarly/res/xml/shortcuts.xml
+++ b/android/app/src/cnEarly/res/xml/shortcuts.xml
@@ -8,7 +8,7 @@
         android:shortcutLongLabel="@string/shortcut_quick_note_long">
         <intent
             android:action="android.intent.action.RUN"
-            android:targetPackage="com.memexlab.memex"
+            android:targetPackage="com.memexlab.memex.cn.early"
             android:targetClass="com.memexlab.memex.MainActivity">
             <extra android:name="some unique action key" android:value="quick_note" />
         </intent>

--- a/android/app/src/globalDev/res/xml/shortcuts.xml
+++ b/android/app/src/globalDev/res/xml/shortcuts.xml
@@ -8,7 +8,7 @@
         android:shortcutLongLabel="@string/shortcut_quick_note_long">
         <intent
             android:action="android.intent.action.RUN"
-            android:targetPackage="com.memexlab.memex"
+            android:targetPackage="com.memexlab.memex.dev"
             android:targetClass="com.memexlab.memex.MainActivity">
             <extra android:name="some unique action key" android:value="quick_note" />
         </intent>

--- a/android/app/src/globalEarly/res/xml/shortcuts.xml
+++ b/android/app/src/globalEarly/res/xml/shortcuts.xml
@@ -8,7 +8,7 @@
         android:shortcutLongLabel="@string/shortcut_quick_note_long">
         <intent
             android:action="android.intent.action.RUN"
-            android:targetPackage="com.memexlab.memex"
+            android:targetPackage="com.memexlab.memex.early"
             android:targetClass="com.memexlab.memex.MainActivity">
             <extra android:name="some unique action key" android:value="quick_note" />
         </intent>

--- a/android/app/src/main/res/drawable/ic_quick_note.xml
+++ b/android/app/src/main/res/drawable/ic_quick_note.xml
@@ -1,10 +1,33 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <group
+        android:scaleX="1.35"
+        android:scaleY="1.35"
+        android:translateX="7.8"
+        android:translateY="7.8">
+        <path
+            android:fillColor="@android:color/transparent"
+            android:strokeColor="#202124"
+            android:strokeWidth="1.9"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M4,20h16" />
+        <path
+            android:fillColor="@android:color/transparent"
+            android:strokeColor="#202124"
+            android:strokeWidth="1.9"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M13.5,5.5l5,5L8,21H3v-5L13.5,5.5z" />
+        <path
+            android:fillColor="@android:color/transparent"
+            android:strokeColor="#202124"
+            android:strokeWidth="1.9"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M16.5,2.5l5,5" />
+    </group>
 </vector>


### PR DESCRIPTION
Closes #157

## 背景

Android Early / Dev 包在 Launcher 长按应用图标时能看到「记一下 / Quick Note」入口，但点击后没有打开输入面板。排查发现 Dart 侧 quick action 处理链路可以正常消费 `quick_note`，真正的问题出在 Android 静态 shortcut 的目标组件。

原实现把 `android:targetPackage` 写成 `@string/quick_action_target_package`，AAPT 可以编译，但系统持久化 `ShortcutInfo` 后会把这个引用保存成资源 id，Launcher 点击时目标包名变成类似 `@2131624018`，因此无法命中实际应用包。

## 改动

- 移除 Gradle flavor 里用于 shortcut target package 的 `resValue`。
- 为 `global` / `cn` / `globalEarly` / `cnEarly` / `globalDev` / `cnDev` 分别提供字面量 `targetPackage` 的 `shortcuts.xml`，避免 Android 将资源引用持久化为资源 id。
- 将 `Quick Note` shortcut 图标改为深灰线性笔记图标，视觉上更接近 Pixel Launcher 中 App Info / Pause App 的系统动作图标。

## 验证

- `flutter build apk --debug --flavor globalEarly --no-pub`
- `flutter build apk --debug --flavor globalDev --no-pub`
- `flutter build apk --debug --flavor cnEarly --no-pub`
- `flutter build apk --debug --flavor cnDev --no-pub`
- `aapt dump xmltree build/app/outputs/flutter-apk/app-globalearly-debug.apk res/xml/shortcuts.xml`：确认 `targetPackage="com.memexlab.memex.early"`
- `aapt dump xmltree build/app/outputs/flutter-apk/app-globaldev-debug.apk res/xml/shortcuts.xml`：确认 `targetPackage="com.memexlab.memex.dev"`
- `aapt dump xmltree build/app/outputs/flutter-apk/app-cnearly-debug.apk res/xml/shortcuts.xml`：确认 `targetPackage="com.memexlab.memex.cn.early"`
- `aapt dump xmltree build/app/outputs/flutter-apk/app-cndev-debug.apk res/xml/shortcuts.xml`：确认 `targetPackage="com.memexlab.memex.cn.dev"`
- Android 模拟器验证 Early / Dev 静态 shortcut 注册后组件指向正确包名，显式 `quick_note` action 能打开输入面板。
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub test/data/services/quick_action_service_test.dart`

## 备注

Pixel Launcher 仍会把 app deep shortcut 放进自己的圆形 icon slot；这部分是系统菜单样式。这里调整的是 app 提供的图标本体，让它从原来的偏淡白色填充改成更接近系统动作的深灰线性风格。
