### PR TITLE
feat: batch clear notifications in Action Center

### DIFF
--- a/lib/data/services/card_attachment_service.dart
+++ b/lib/data/services/card_attachment_service.dart
@@ -37,6 +37,29 @@ class CardAttachmentService {
     EventBusService.instance.emitEvent(AttachmentsChangedMessage());
   }
 
+  /// Dismiss all pending items of a specific type, or all types if null.
+  /// Returns the total number of items dismissed.
+  Future<int> dismissAllPending({String? type}) async {
+    int total = 0;
+    final userId = await UserStorage.getUserId();
+
+    if (type == null || type == CardAttachmentType.systemAction) {
+      total += await SystemActionService.instance.rejectAllPending();
+    }
+    if (type == null || type == CardAttachmentType.clarificationRequest) {
+      total += await ClarificationRequestService.instance.dismissAllPending();
+    }
+    if ((type == null || type == CardAttachmentType.cardDetailNotification) &&
+        userId != null) {
+      total += await UserNotificationService.instance.dismissAll(
+        userId: userId,
+        notificationType: 'card_detail_update',
+      );
+    }
+
+    return total;
+  }
+
   /// Fetches all pending attachments (for the action center / notification badge).
   Future<List<CardAttachmentData>> getPendingAttachments() async {
     final userId = await UserStorage.getUserId();
@@ -154,7 +177,7 @@ class CardAttachmentService {
                 'fact_id': r.subjectKey,
                 'updated_at': r.updatedAt,
               },
-              sortKey: 30,
+              sortKey: 200,
             ))
         .toList();
   }

--- a/lib/data/services/clarification_request_service.dart
+++ b/lib/data/services/clarification_request_service.dart
@@ -329,6 +329,25 @@ class ClarificationRequestService {
     return query.get();
   }
 
+  /// Dismiss all pending clarification requests (batch operation).
+  Future<int> dismissAllPending() async {
+    try {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final count = await (_db.update(_db.clarificationRequests)
+            ..where((t) => t.status.equals(ClarificationRequestStatus.pending)))
+          .write(ClarificationRequestsCompanion(
+        status: const Value(ClarificationRequestStatus.dismissed),
+        updatedAt: Value(now),
+      ));
+      _logger
+          .info('Dismissed all pending clarification requests (count=$count)');
+      return count;
+    } catch (e) {
+      _logger.severe('Failed to dismiss all pending requests: $e');
+      return 0;
+    }
+  }
+
   Future<List<ClarificationRequest>> getVisibleForFact(String factId) async {
     // Skip if factId itself is a global Ask — those are rendered as their own
     // timeline card, not as attachments.

--- a/lib/data/services/system_action_service.dart
+++ b/lib/data/services/system_action_service.dart
@@ -91,6 +91,24 @@ class SystemActionService {
         .get();
   }
 
+  /// Reject all pending actions (batch dismiss).
+  Future<int> rejectAllPending() async {
+    try {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final count = await (_db.update(_db.systemActions)
+            ..where((t) => t.status.equals('pending')))
+          .write(SystemActionsCompanion(
+        status: const Value('rejected'),
+        updatedAt: Value(now),
+      ));
+      _logger.info('Rejected all pending system actions (count=$count)');
+      return count;
+    } catch (e) {
+      _logger.severe('Failed to reject all pending actions: $e');
+      return 0;
+    }
+  }
+
   /// Gets recent actions for agent context.
   Future<List<SystemAction>> getRecentActions({int limit = 20}) async {
     try {

--- a/lib/data/services/user_notification_service.dart
+++ b/lib/data/services/user_notification_service.dart
@@ -209,6 +209,33 @@ class UserNotificationService {
     }
   }
 
+  /// Dismiss all notifications for a user, optionally filtered by type.
+  Future<int> dismissAll({
+    required String userId,
+    String? notificationType,
+  }) async {
+    if (!AppDatabase.isInitialized) return 0;
+
+    try {
+      final stmt = _db.delete(_db.userNotifications)
+        ..where((t) {
+          var condition = t.userId.equals(userId);
+          if (notificationType != null) {
+            condition = condition & t.notificationType.equals(notificationType);
+          }
+          return condition;
+        });
+      final count = await stmt.go();
+      _logger.info(
+        'DismissAll userId=$userId, type=$notificationType (deleted=$count)',
+      );
+      return count;
+    } catch (e) {
+      _logger.severe('Failed to dismissAll for userId=$userId: $e');
+      return 0;
+    }
+  }
+
   /// Check if a [SqliteException] is a constraint violation.
   bool _isConstraintError(SqliteException e) {
     // extendedResultCode 2067 = SQLITE_CONSTRAINT_UNIQUE

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1387,5 +1387,24 @@
   },
   "earlyUpdateCheckFailed": "Update check failed: {error}",
   "earlyUpdateDialogTitle": "Early update available",
-  "earlyUpdateReleaseNotes": "Release notes"
+  "earlyUpdateReleaseNotes": "Release notes",
+
+  "dismissAllNotifications": "Clear all",
+  "dismissByType": "Clear by type",
+  "dismissTypeSystemAction": "Reminders & events",
+  "dismissTypeClarification": "Clarifications",
+  "dismissTypeCardUpdate": "Card updates",
+  "dismissAllConfirm": "Clear all notifications?",
+  "dismissTypeConfirm": "Clear all {type} notifications?",
+  "@dismissTypeConfirm": {
+    "placeholders": {
+      "type": {}
+    }
+  },
+  "dismissedCount": "{count} cleared",
+  "@dismissedCount": {
+    "placeholders": {
+      "count": {}
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5449,6 +5449,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Release notes'**
   String get earlyUpdateReleaseNotes;
+
+  /// No description provided for @dismissAllNotifications.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all'**
+  String get dismissAllNotifications;
+
+  /// No description provided for @dismissByType.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear by type'**
+  String get dismissByType;
+
+  /// No description provided for @dismissTypeSystemAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Reminders & events'**
+  String get dismissTypeSystemAction;
+
+  /// No description provided for @dismissTypeClarification.
+  ///
+  /// In en, this message translates to:
+  /// **'Clarifications'**
+  String get dismissTypeClarification;
+
+  /// No description provided for @dismissTypeCardUpdate.
+  ///
+  /// In en, this message translates to:
+  /// **'Card updates'**
+  String get dismissTypeCardUpdate;
+
+  /// No description provided for @dismissAllConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all notifications?'**
+  String get dismissAllConfirm;
+
+  /// No description provided for @dismissTypeConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all {type} notifications?'**
+  String dismissTypeConfirm(Object type);
+
+  /// No description provided for @dismissedCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} cleared'**
+  String dismissedCount(Object count);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3022,4 +3022,32 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get earlyUpdateReleaseNotes => 'Release notes';
+
+  @override
+  String get dismissAllNotifications => 'Clear all';
+
+  @override
+  String get dismissByType => 'Clear by type';
+
+  @override
+  String get dismissTypeSystemAction => 'Reminders & events';
+
+  @override
+  String get dismissTypeClarification => 'Clarifications';
+
+  @override
+  String get dismissTypeCardUpdate => 'Card updates';
+
+  @override
+  String get dismissAllConfirm => 'Clear all notifications?';
+
+  @override
+  String dismissTypeConfirm(Object type) {
+    return 'Clear all $type notifications?';
+  }
+
+  @override
+  String dismissedCount(Object count) {
+    return '$count cleared';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2910,4 +2910,32 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get earlyUpdateReleaseNotes => '更新说明';
+
+  @override
+  String get dismissAllNotifications => '清除全部';
+
+  @override
+  String get dismissByType => '按类型清除';
+
+  @override
+  String get dismissTypeSystemAction => '日程提醒';
+
+  @override
+  String get dismissTypeClarification => '澄清确认';
+
+  @override
+  String get dismissTypeCardUpdate => '卡片更新';
+
+  @override
+  String get dismissAllConfirm => '确定清除全部通知？';
+
+  @override
+  String dismissTypeConfirm(Object type) {
+    return '确定清除所有$type通知？';
+  }
+
+  @override
+  String dismissedCount(Object count) {
+    return '已清除 $count 条';
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1350,5 +1350,24 @@
   },
   "earlyUpdateCheckFailed": "检查更新失败：{error}",
   "earlyUpdateDialogTitle": "发现 Early 更新",
-  "earlyUpdateReleaseNotes": "更新说明"
+  "earlyUpdateReleaseNotes": "更新说明",
+
+  "dismissAllNotifications": "清除全部",
+  "dismissByType": "按类型清除",
+  "dismissTypeSystemAction": "日程提醒",
+  "dismissTypeClarification": "澄清确认",
+  "dismissTypeCardUpdate": "卡片更新",
+  "dismissAllConfirm": "确定清除全部通知？",
+  "dismissTypeConfirm": "确定清除所有{type}通知？",
+  "@dismissTypeConfirm": {
+    "placeholders": {
+      "type": {}
+    }
+  },
+  "dismissedCount": "已清除 {count} 条",
+  "@dismissedCount": {
+    "placeholders": {
+      "count": {}
+    }
+  }
 }

--- a/lib/ui/main_screen/widgets/action_center_sheet.dart
+++ b/lib/ui/main_screen/widgets/action_center_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/db/app_database.dart';
@@ -15,13 +16,26 @@ class ActionCenterSheet extends StatefulWidget {
   State<ActionCenterSheet> createState() => _ActionCenterSheetState();
 }
 
-class _ActionCenterSheetState extends State<ActionCenterSheet> {
+class _ActionCenterSheetState extends State<ActionCenterSheet>
+    with SingleTickerProviderStateMixin {
   List<CardAttachmentData>? _items;
   bool _isLoading = true;
+  bool _isDismissing = false;
+
+  late final AnimationController _fadeController;
+  late final Animation<double> _fadeAnimation;
 
   @override
   void initState() {
     super.initState();
+    _fadeController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _fadeAnimation = CurvedAnimation(
+      parent: _fadeController,
+      curve: Curves.easeOut,
+    );
     _load();
     EventBusService.instance.addHandler(
       EventBusMessageType.attachmentsChanged,
@@ -31,6 +45,7 @@ class _ActionCenterSheetState extends State<ActionCenterSheet> {
 
   @override
   void dispose() {
+    _fadeController.dispose();
     EventBusService.instance.removeHandler(
       EventBusMessageType.attachmentsChanged,
       _onAttachmentsChanged,
@@ -49,6 +64,75 @@ class _ActionCenterSheetState extends State<ActionCenterSheet> {
       _items = items;
       _isLoading = false;
     });
+    if (items.isNotEmpty) {
+      _fadeController.forward();
+    }
+  }
+
+  /// Count items by type.
+  Map<String, int> _countByType() {
+    final items = _items ?? [];
+    final counts = <String, int>{};
+    for (final item in items) {
+      counts[item.type] = (counts[item.type] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  /// Clear all — direct action.
+  Future<void> _clearAll() async {
+    await _performDismiss(null);
+  }
+
+  /// Show per-type options via dropdown.
+  void _showTypeMenu() {
+    final counts = _countByType();
+    if (counts.isEmpty) return;
+
+    final l10n = UserStorage.l10n;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => _DismissOptionsSheet(
+        counts: counts,
+        l10n: l10n,
+        colorScheme: colorScheme,
+        onDismiss: (String? type) {
+          Navigator.pop(ctx);
+          _performDismiss(type);
+        },
+      ),
+    );
+  }
+
+  Future<void> _performDismiss(String? type) async {
+    if (_isDismissing) return;
+    setState(() => _isDismissing = true);
+
+    HapticFeedback.mediumImpact();
+
+    final count =
+        await CardAttachmentService.instance.dismissAllPending(type: type);
+
+    if (!mounted) return;
+
+    setState(() => _isDismissing = false);
+
+    if (count > 0) {
+      final l10n = UserStorage.l10n;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.dismissedCount(count)),
+          behavior: SnackBarBehavior.floating,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    }
   }
 
   @override
@@ -60,9 +144,16 @@ class _ActionCenterSheetState extends State<ActionCenterSheet> {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Container(
-      decoration: const BoxDecoration(
-        color: Color(0xFFF7F8FA),
-        borderRadius: BorderRadius.vertical(top: Radius.circular(32)),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 24,
+            offset: const Offset(0, -4),
+          ),
+        ],
       ),
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.85,
@@ -71,58 +162,105 @@ class _ActionCenterSheetState extends State<ActionCenterSheet> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          // Header
-          Padding(
-            padding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(8),
-                      decoration: BoxDecoration(
-                        color: colorScheme.primaryContainer,
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Icon(
-                        Icons.assignment_turned_in,
-                        size: 20,
-                        color: colorScheme.onPrimaryContainer,
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Text(
-                      UserStorage.l10n.actionCenterTitle,
-                      style: const TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                        color: AppColors.textPrimary,
-                      ),
-                    ),
-                  ],
-                ),
-                IconButton(
-                  icon: const Icon(Icons.close, color: AppColors.textSecondary),
-                  onPressed: () => Navigator.pop(context),
-                  style: IconButton.styleFrom(
-                    backgroundColor: Colors.white,
-                  ),
-                ),
-              ],
+          // Drag handle
+          Center(
+            child: Container(
+              margin: const EdgeInsets.only(top: 12),
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.25),
+                borderRadius: BorderRadius.circular(2),
+              ),
             ),
           ),
 
-          const Divider(height: 1),
+          // Header
+          _buildHeader(colorScheme),
+
+          // Divider
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Divider(
+              height: 1,
+              color: colorScheme.outlineVariant.withValues(alpha: 0.3),
+            ),
+          ),
 
           // Content
-          Expanded(child: _buildContent()),
+          Expanded(child: _buildContent(colorScheme)),
         ],
       ),
     );
   }
 
-  Widget _buildContent() {
+  Widget _buildHeader(ColorScheme colorScheme) {
+    final l10n = UserStorage.l10n;
+    final hasItems = (_items ?? []).isNotEmpty;
+    final itemCount = _items?.length ?? 0;
+    final hasMultipleTypes = _countByType().length > 1;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 16, 16, 16),
+      child: Row(
+        children: [
+          // Title + count badge
+          Text(
+            l10n.actionCenterTitle,
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              color: AppColors.textPrimary,
+              letterSpacing: -0.3,
+            ),
+          ),
+          if (hasItems) ...[
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+              decoration: BoxDecoration(
+                color: AppColors.primary.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text(
+                '$itemCount',
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.primary,
+                ),
+              ),
+            ),
+          ],
+
+          const Spacer(),
+
+          // Clear button
+          if (hasItems) ...[
+            _ClearButtonGroup(
+              isDismissing: _isDismissing,
+              hasMultipleTypes: hasMultipleTypes,
+              onClearAll: _clearAll,
+              onShowTypeMenu: _showTypeMenu,
+            ),
+            const SizedBox(width: 8),
+          ],
+
+          // Close button
+          GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: Icon(
+              Icons.close_rounded,
+              color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
+              size: 22,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(ColorScheme colorScheme) {
     if (_isLoading) {
       return const Center(child: AgentLogoLoading());
     }
@@ -130,32 +268,44 @@ class _ActionCenterSheetState extends State<ActionCenterSheet> {
     final items = _items ?? const [];
 
     if (items.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(
-              Icons.inbox_rounded,
-              size: 64,
-              color: Color(0xFFCBD5E1),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              UserStorage.l10n.noPendingActions,
-              style: const TextStyle(
-                fontSize: 16,
-                color: AppColors.textTertiary,
+      return FadeTransition(
+        opacity: _fadeAnimation,
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(20),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerHighest
+                      .withValues(alpha: 0.4),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  Icons.inbox_rounded,
+                  size: 48,
+                  color: colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+                ),
               ),
-            ),
-          ],
+              const SizedBox(height: 16),
+              Text(
+                UserStorage.l10n.noPendingActions,
+                style: TextStyle(
+                  fontSize: 15,
+                  color: colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
         ),
       );
     }
 
     return ListView.separated(
-      padding: const EdgeInsets.symmetric(vertical: 16),
+      padding: const EdgeInsets.fromLTRB(0, 12, 0, 24),
       itemCount: items.length,
-      separatorBuilder: (context, index) => const SizedBox(height: 8),
+      separatorBuilder: (context, index) => const SizedBox(height: 6),
       itemBuilder: (context, index) {
         final item = items[index];
         return KeyedSubtree(
@@ -163,6 +313,297 @@ class _ActionCenterSheetState extends State<ActionCenterSheet> {
           child: CardAttachmentFactory.build(item),
         );
       },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Clear button group: [Clear All] [▼]
+// ---------------------------------------------------------------------------
+
+class _ClearButtonGroup extends StatelessWidget {
+  const _ClearButtonGroup({
+    required this.isDismissing,
+    required this.hasMultipleTypes,
+    required this.onClearAll,
+    required this.onShowTypeMenu,
+  });
+
+  final bool isDismissing;
+  final bool hasMultipleTypes;
+  final VoidCallback onClearAll;
+  final VoidCallback onShowTypeMenu;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = UserStorage.l10n;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Main clear text button
+        GestureDetector(
+          onTap: isDismissing ? null : onClearAll,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isDismissing)
+                const SizedBox(
+                  width: 13,
+                  height: 13,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 1.5,
+                    color: AppColors.textTertiary,
+                  ),
+                )
+              else
+                const Icon(
+                  Icons.clear_all_rounded,
+                  size: 16,
+                  color: AppColors.textSecondary,
+                ),
+              const SizedBox(width: 3),
+              Text(
+                l10n.dismissAllNotifications,
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        // Dropdown arrow (only if multiple types)
+        if (hasMultipleTypes) ...[
+          const SizedBox(width: 4),
+          GestureDetector(
+            onTap: isDismissing ? null : onShowTypeMenu,
+            behavior: HitTestBehavior.opaque,
+            child: const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+              child: Icon(
+                Icons.keyboard_arrow_down_rounded,
+                size: 20,
+                color: AppColors.textTertiary,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dismiss options bottom sheet (per-type selection)
+// ---------------------------------------------------------------------------
+
+class _DismissOptionsSheet extends StatelessWidget {
+  const _DismissOptionsSheet({
+    required this.counts,
+    required this.l10n,
+    required this.colorScheme,
+    required this.onDismiss,
+  });
+
+  final Map<String, int> counts;
+  final dynamic l10n;
+  final ColorScheme colorScheme;
+  final void Function(String? type) onDismiss;
+
+  String _typeLabel(String type) {
+    switch (type) {
+      case CardAttachmentType.systemAction:
+        return l10n.dismissTypeSystemAction;
+      case CardAttachmentType.clarificationRequest:
+        return l10n.dismissTypeClarification;
+      case CardAttachmentType.cardDetailNotification:
+        return l10n.dismissTypeCardUpdate;
+      default:
+        return type;
+    }
+  }
+
+  IconData _typeIcon(String type) {
+    switch (type) {
+      case CardAttachmentType.systemAction:
+        return Icons.event_note_rounded;
+      case CardAttachmentType.clarificationRequest:
+        return Icons.help_outline_rounded;
+      case CardAttachmentType.cardDetailNotification:
+        return Icons.article_outlined;
+      default:
+        return Icons.circle_outlined;
+    }
+  }
+
+  Color _typeColor(String type) {
+    switch (type) {
+      case CardAttachmentType.systemAction:
+        return const Color(0xFF10B981);
+      case CardAttachmentType.clarificationRequest:
+        return const Color(0xFFF59E0B);
+      case CardAttachmentType.cardDetailNotification:
+        return const Color(0xFF6366F1);
+      default:
+        return AppColors.primary;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.1),
+            blurRadius: 20,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Header
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 20, 24, 12),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.filter_list_rounded,
+                  size: 20,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 10),
+                Text(
+                  l10n.dismissByType,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: -0.3,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          Divider(
+            height: 1,
+            indent: 24,
+            endIndent: 24,
+            color: colorScheme.outlineVariant.withValues(alpha: 0.3),
+          ),
+
+          const SizedBox(height: 8),
+
+          // Per-type options
+          ...counts.entries.map((entry) => _DismissOptionTile(
+                icon: _typeIcon(entry.key),
+                iconColor: _typeColor(entry.key),
+                label: _typeLabel(entry.key),
+                count: entry.value,
+                onTap: () => onDismiss(entry.key),
+              )),
+
+          const SizedBox(height: 12),
+
+          // Cancel
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: SizedBox(
+              width: double.infinity,
+              child: TextButton(
+                onPressed: () => Navigator.pop(context),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  backgroundColor: colorScheme.surfaceContainerHighest
+                      .withValues(alpha: 0.5),
+                ),
+                child: Text(
+                  MaterialLocalizations.of(context).cancelButtonLabel,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DismissOptionTile extends StatelessWidget {
+  const _DismissOptionTile({
+    required this.icon,
+    required this.iconColor,
+    required this.label,
+    required this.count,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String label;
+  final int count;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: iconColor.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Icon(icon, size: 18, color: iconColor),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Text(
+                label,
+                style: const TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: iconColor.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                '$count',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: iconColor,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
- Reorder card update notifications to appear last in the list
- Add clear all / clear by type functionality to Action Center header
- Refresh Action Center header UI for a cleaner look