### PR TITLE
[codex] 在洞察页添加用户活动统计

### DIFF
--- a/lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart
+++ b/lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart
@@ -5,6 +5,8 @@ import 'package:memex/agent/prompts.dart';
 import 'package:memex/agent/skills/knowledge_insight/native_widgets.dart';
 
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/user_stats_service.dart';
+import 'package:memex/domain/models/user_stats_model.dart';
 import 'package:memex/utils/user_storage.dart';
 import '../../../utils/logger.dart';
 
@@ -24,6 +26,7 @@ class KnowledgeInsightSkill extends Skill {
             buildDeleteKnowledgeInsightCardTool(),
             buildDeleteKnowledgeInsightTagsTool(),
             buildGetAvailableTemplatesTool(),
+            buildGetUserActivityStatsTool(),
           ],
         );
 }
@@ -471,6 +474,42 @@ Tool buildGetAvailableTemplatesTool() {
       }
 
       return buffer.toString();
+    },
+  );
+}
+
+Tool buildGetUserActivityStatsTool() {
+  return Tool(
+    name: 'get_user_activity_stats',
+    description:
+        'Get deterministic user-facing activity statistics for recent recording, card, PKM, insight, and todo activity. Use this as read-only evidence when explaining trends or creating recap insight cards.',
+    parameters: {
+      'type': 'object',
+      'properties': {
+        'days': {
+          'type': 'integer',
+          'description':
+              'Number of recent calendar days to include. Defaults to 7. Maximum 90.',
+        },
+      },
+    },
+    executable: (int? days) async {
+      final logger = getLogger('KnowledgeInsightSkill');
+      final fileSystem = FileSystemService.instance;
+      final userId = AgentCallToolContext.current!.state.metadata['userId'];
+      final safeDays = (days ?? 7).clamp(1, 90).toInt();
+
+      try {
+        final snapshot = await UserStatsService(fileSystemService: fileSystem)
+            .fetchSnapshot(
+          userId: userId,
+          range: UserStatsDateRange.lastDays(safeDays),
+        );
+        return jsonEncode(snapshot.toJson());
+      } catch (e, st) {
+        logger.warning('Failed to get user activity stats', e, st);
+        rethrow;
+      }
     },
   );
 }

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -7,6 +7,7 @@ import 'package:memex/data/repositories/update_card_ui_config.dart'
     as update_config_endpoint;
 import 'package:memex/data/services/search_service.dart';
 import 'package:memex/data/services/backup_service.dart';
+import 'package:memex/data/services/user_stats_service.dart';
 import 'package:memex/domain/models/calendar_model.dart';
 import 'package:memex/data/repositories/hydrate_card.dart';
 import 'package:memex/data/services/task_handlers/knowledge_insight_handler.dart';
@@ -75,6 +76,7 @@ import 'package:memex/agent/state_util.dart';
 import 'package:memex/agent/skills/knowledge_insight/native_widgets.dart';
 import 'package:memex/utils/result.dart';
 import 'package:memex/domain/models/system_event.dart';
+import 'package:memex/domain/models/user_stats_model.dart';
 
 /// Local data service for Memex. Handles all data operations via local storage (FileSystemService, DB).
 class MemexRouter {
@@ -863,6 +865,24 @@ class MemexRouter {
       });
 
       return insights;
+    });
+  }
+
+  Future<Result<UserStatsSnapshot>> fetchUserStats({
+    required UserStatsDateRange range,
+  }) async {
+    return runResult(() async {
+      await _ensureInitialized();
+      _logger.info(
+        'LocalMode: fetchUserStats called: start=${range.start}, end=${range.end}',
+      );
+      final userId = await UserStorage.getUserId();
+      if (userId == null) {
+        return UserStatsSnapshot.empty(range);
+      }
+      return UserStatsService(
+        fileSystemService: fileSystemService,
+      ).fetchSnapshot(userId: userId, range: range);
     });
   }
 

--- a/lib/data/repositories/update_card_ui_config.dart
+++ b/lib/data/repositories/update_card_ui_config.dart
@@ -70,11 +70,56 @@ Future<bool> updateCardUiConfigEndpoint(
       previousData: previousData,
       updatedData: updatedData,
     );
+    await _logUserStatsEventIfNeeded(
+      userId: userId,
+      cardId: cardId,
+      templateId: templateId,
+      updates: updates,
+      previousData: previousData,
+      updatedData: updatedData,
+    );
     return true;
   } catch (e) {
     _logger.severe('Failed to update card ui config for $cardId: $e');
     return false;
   }
+}
+
+Future<void> _logUserStatsEventIfNeeded({
+  required String userId,
+  required String cardId,
+  required String? templateId,
+  required Map<String, dynamic> updates,
+  required Map<String, dynamic>? previousData,
+  required Map<String, dynamic>? updatedData,
+}) async {
+  if (templateId != 'task' && templateId != 'todo') return;
+  if (!updates.containsKey('is_completed')) return;
+  if (previousData == null || updatedData == null) return;
+
+  final wasCompleted = previousData['is_completed'] == true;
+  final isCompleted = updatedData['is_completed'] == true;
+  if (wasCompleted == isCompleted) return;
+
+  final title = updatedData['title']?.toString();
+  await _fileSystemService.eventLogService.logEvent(
+    userId: userId,
+    eventType: isCompleted ? 'todo_completed' : 'todo_reopened',
+    description: isCompleted ? 'User completed todo' : 'User reopened todo',
+    filePath: _cardRelativePath(cardId),
+    metadata: {
+      'card_id': cardId,
+      if (title != null && title.trim().isNotEmpty) 'title': title.trim(),
+    },
+  );
+}
+
+String? _cardRelativePath(String cardId) {
+  final match = RegExp(
+    r'^(\d{4})/(\d{2})/(\d{2})\.md#(ts_\d+)$',
+  ).firstMatch(cardId);
+  if (match == null) return null;
+  return 'Cards/${match.group(1)}/${match.group(2)}/${match.group(3)}_${match.group(4)}.yaml';
 }
 
 Future<void> _publishCardUiConfigUpdated({

--- a/lib/data/services/user_stats_service.dart
+++ b/lib/data/services/user_stats_service.dart
@@ -1,0 +1,627 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:memex/domain/models/user_stats_model.dart';
+import 'package:memex/utils/logger.dart';
+
+final _logger = getLogger('UserStatsService');
+
+class UserStatsService {
+  UserStatsService({FileSystemService? fileSystemService})
+      : _fileSystemService = fileSystemService ?? FileSystemService.instance;
+
+  final FileSystemService _fileSystemService;
+
+  Future<UserStatsSnapshot> fetchSnapshot({
+    required String userId,
+    required UserStatsDateRange range,
+  }) async {
+    final normalizedRange = UserStatsDateRange(
+      start: _dateOnly(range.start),
+      end: _dateOnly(range.end),
+    );
+    if (normalizedRange.end.isBefore(normalizedRange.start)) {
+      return UserStatsSnapshot.empty(normalizedRange);
+    }
+
+    final daily = <String, _DailyStatsAccumulator>{};
+    final details = <String, _DayDetailAccumulator>{};
+    for (var i = 0; i < normalizedRange.dayCount; i++) {
+      final date = normalizedRange.start.add(Duration(days: i));
+      final key = _dateKey(date);
+      daily[key] = _DailyStatsAccumulator(date);
+      details[key] = _DayDetailAccumulator(date);
+    }
+
+    final events = await _loadEvents(userId, normalizedRange);
+
+    final inputFactIds = _collectInputFactIds(events, daily);
+
+    await _collectFactInputStats(
+      userId,
+      normalizedRange,
+      events,
+      inputFactIds,
+      daily,
+    );
+    _collectSourceStats(events, daily);
+    await _collectCardStats(
+      userId,
+      normalizedRange,
+      events,
+      inputFactIds,
+      daily,
+      details,
+    );
+    await _collectKnowledgeStats(
+      userId,
+      normalizedRange,
+      events,
+      daily,
+      details,
+    );
+    await _collectInsightStats(userId, normalizedRange, events, daily, details);
+
+    final dailyPoints = daily.values.map((item) => item.toPoint()).toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+    final sourceBreakdown = UserStatsSourceBreakdown(
+      textInputs: daily.values.fold(0, (sum, item) => sum + item.textInputs),
+      imageInputs: daily.values.fold(0, (sum, item) => sum + item.imageInputs),
+      audioInputs: daily.values.fold(0, (sum, item) => sum + item.audioInputs),
+    );
+
+    final summary = UserStatsSummary(
+      totalInputs: dailyPoints.fold(0, (sum, item) => sum + item.inputs),
+      totalWords: dailyPoints.fold(0, (sum, item) => sum + item.words),
+      totalCards: dailyPoints.fold(0, (sum, item) => sum + item.cards),
+      totalKnowledgeUnits: dailyPoints.fold(
+        0,
+        (sum, item) => sum + item.knowledgeUnits,
+      ),
+      totalInsights: dailyPoints.fold(0, (sum, item) => sum + item.insights),
+      totalCompletedTodos: dailyPoints.fold(
+        0,
+        (sum, item) => sum + item.completedTodos,
+      ),
+      activeDays: dailyPoints.where((item) => item.isActive).length,
+      currentStreakDays: _currentStreak(dailyPoints),
+    );
+
+    final topTags = _buildTopTags(daily.values);
+    final dayDetails = {
+      for (final entry in details.entries) entry.key: entry.value.toDetail(),
+    };
+
+    return UserStatsSnapshot(
+      range: normalizedRange,
+      summary: summary,
+      daily: dailyPoints,
+      sourceBreakdown: sourceBreakdown.total == 0 && summary.totalInputs > 0
+          ? UserStatsSourceBreakdown(
+              textInputs: summary.totalInputs,
+              imageInputs: 0,
+              audioInputs: 0,
+            )
+          : sourceBreakdown,
+      topTags: topTags,
+      dayDetails: dayDetails,
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> _loadEvents(
+    String userId,
+    UserStatsDateRange range,
+  ) async {
+    try {
+      return await _fileSystemService.eventLogService.searchEvents(
+        userId: userId,
+        fromTime: range.start.toIso8601String(),
+        toTime: range.end
+            .add(const Duration(days: 1))
+            .subtract(const Duration(microseconds: 1))
+            .toIso8601String(),
+        offset: 0,
+        limit: 100000,
+      );
+    } catch (e) {
+      _logger.warning('Failed to load user stats events: $e');
+      return const [];
+    }
+  }
+
+  Future<void> _collectFactInputStats(
+    String userId,
+    UserStatsDateRange range,
+    List<Map<String, dynamic>> events,
+    Set<String> inputFactIds,
+    Map<String, _DailyStatsAccumulator> daily,
+  ) async {
+    final userInputCountsByDay = <String, int>{};
+    for (final event in events) {
+      if (event['event_type'] != 'user_input') continue;
+      final date = _eventDate(event);
+      if (date == null) continue;
+      final key = _dateKey(date);
+      if (!daily.containsKey(key)) continue;
+      userInputCountsByDay[key] = (userInputCountsByDay[key] ?? 0) + 1;
+    }
+    final hasUserInputEvents = userInputCountsByDay.isNotEmpty;
+
+    for (var i = 0; i < range.dayCount; i++) {
+      final date = range.start.add(Duration(days: i));
+      final key = _dateKey(date);
+      final file = File(_factPath(userId, date));
+      final eventInputCount = userInputCountsByDay[key] ?? 0;
+
+      try {
+        if (hasUserInputEvents) {
+          daily[key]?.inputs += eventInputCount;
+          if (!await file.exists()) continue;
+
+          final content = await file.readAsString();
+          final entries = _parseFactEntries(content, date);
+          final eventEntries = entries.where(
+            (entry) => inputFactIds.contains(entry.factId),
+          );
+          daily[key]?.words += eventEntries.fold(
+            0,
+            (sum, item) => sum + item.words,
+          );
+          continue;
+        }
+
+        if (!await file.exists()) continue;
+        final content = await file.readAsString();
+        final entries = _parseFactEntries(content, date);
+        daily[key]?.inputs += entries.length;
+        daily[key]?.words += entries.fold(0, (sum, item) => sum + item.words);
+      } catch (e) {
+        _logger.warning('Failed to read fact stats from ${file.path}: $e');
+      }
+    }
+  }
+
+  void _collectSourceStats(
+    List<Map<String, dynamic>> events,
+    Map<String, _DailyStatsAccumulator> daily,
+  ) {
+    for (final event in events) {
+      if (event['event_type'] != 'user_input') continue;
+      final date = _eventDate(event);
+      if (date == null) continue;
+      final bucket = daily[_dateKey(date)];
+      if (bucket == null) continue;
+
+      final metadata = _metadata(event);
+      if (metadata['has_text'] == true) bucket.textInputs += 1;
+      if (metadata['has_images'] == true) bucket.imageInputs += 1;
+      if (metadata['has_audio'] == true) bucket.audioInputs += 1;
+    }
+  }
+
+  Future<void> _collectCardStats(
+    String userId,
+    UserStatsDateRange range,
+    List<Map<String, dynamic>> events,
+    Set<String> inputFactIds,
+    Map<String, _DailyStatsAccumulator> daily,
+    Map<String, _DayDetailAccumulator> details,
+  ) async {
+    final completionEvents = _collectTodoCompletionEvents(
+      events,
+      daily,
+      details,
+    );
+    final hasTodoCompletionEvents = completionEvents > 0;
+
+    final cardPaths = await _fileSystemService.listAllCardFiles(userId);
+    for (final cardPath in cardPaths) {
+      final factId = _factIdFromCardPath(userId, cardPath);
+      if (factId == null) continue;
+      if (inputFactIds.isNotEmpty && !inputFactIds.contains(factId)) {
+        continue;
+      }
+
+      final card = await _fileSystemService.readCardFile(userId, factId);
+      if (card == null || card.deleted == true) continue;
+
+      final date = _cardDate(card);
+      if (!_dateInRange(date, range)) continue;
+      final key = _dateKey(date);
+      final bucket = daily[key];
+      if (bucket == null) continue;
+
+      if (_isGeneratedCard(card)) {
+        bucket.cards += 1;
+        details[key]?.cardTitles.add(_cardTitle(card));
+      }
+
+      for (final tag in card.tags) {
+        final trimmed = tag.trim();
+        if (trimmed.isNotEmpty) {
+          bucket.tagCounts[trimmed] = (bucket.tagCounts[trimmed] ?? 0) + 1;
+        }
+      }
+
+      if (!hasTodoCompletionEvents && _isCompletedTask(card)) {
+        bucket.completedTodos += 1;
+        details[key]?.completedTodoTitles.add(_cardTitle(card));
+      }
+    }
+  }
+
+  int _collectTodoCompletionEvents(
+    List<Map<String, dynamic>> events,
+    Map<String, _DailyStatsAccumulator> daily,
+    Map<String, _DayDetailAccumulator> details,
+  ) {
+    var count = 0;
+    for (final event in events) {
+      if (event['event_type'] != 'todo_completed') continue;
+      final date = _eventDate(event);
+      if (date == null) continue;
+      final key = _dateKey(date);
+      final bucket = daily[key];
+      if (bucket == null) continue;
+
+      bucket.completedTodos += 1;
+      count += 1;
+      final metadata = _metadata(event);
+      final title = metadata['title']?.toString();
+      if (title != null && title.trim().isNotEmpty) {
+        details[key]?.completedTodoTitles.add(title.trim());
+      }
+    }
+    return count;
+  }
+
+  Future<void> _collectKnowledgeStats(
+    String userId,
+    UserStatsDateRange range,
+    List<Map<String, dynamic>> events,
+    Map<String, _DailyStatsAccumulator> daily,
+    Map<String, _DayDetailAccumulator> details,
+  ) async {
+    final byDay = <String, Set<String>>{};
+    for (final event in events) {
+      final type = event['event_type'];
+      if (type != 'file_created' && type != 'file_modified') continue;
+      final filePath = event['file_path']?.toString();
+      if (filePath == null || !filePath.startsWith('PKM/')) continue;
+
+      final date = _eventDate(event);
+      if (date == null) continue;
+      final key = _dateKey(date);
+      if (!daily.containsKey(key)) continue;
+      byDay.putIfAbsent(key, () => <String>{}).add(filePath);
+    }
+
+    if (byDay.isEmpty && events.isEmpty) {
+      await _collectKnowledgeStatsFromModifiedFiles(
+        userId,
+        range,
+        daily,
+        details,
+      );
+      return;
+    }
+
+    for (final entry in byDay.entries) {
+      final bucket = daily[entry.key];
+      bucket?.knowledgeUnits += entry.value.length;
+      details[entry.key]?.knowledgePaths.addAll(entry.value.toList()..sort());
+    }
+  }
+
+  Future<void> _collectKnowledgeStatsFromModifiedFiles(
+    String userId,
+    UserStatsDateRange range,
+    Map<String, _DailyStatsAccumulator> daily,
+    Map<String, _DayDetailAccumulator> details,
+  ) async {
+    final root = Directory(_fileSystemService.getPkmPath(userId));
+    if (!await root.exists()) return;
+
+    await for (final entity in root.list(recursive: true, followLinks: false)) {
+      if (entity is! File || !entity.path.endsWith('.md')) continue;
+      final stat = await entity.stat();
+      final date = _dateOnly(stat.modified);
+      if (!_dateInRange(date, range)) continue;
+      final key = _dateKey(date);
+      final relative = path.join(
+        'PKM',
+        path.relative(entity.path, from: root.path),
+      );
+      daily[key]?.knowledgeUnits += 1;
+      details[key]?.knowledgePaths.add(relative);
+    }
+  }
+
+  Future<void> _collectInsightStats(
+    String userId,
+    UserStatsDateRange range,
+    List<Map<String, dynamic>> events,
+    Map<String, _DailyStatsAccumulator> daily,
+    Map<String, _DayDetailAccumulator> details,
+  ) async {
+    final createdByDay = <String, Set<String>>{};
+    for (final event in events) {
+      if (event['event_type'] != 'file_created') continue;
+      final filePath = event['file_path']?.toString();
+      if (filePath == null || !filePath.startsWith('KnowledgeInsights/')) {
+        continue;
+      }
+      final date = _eventDate(event);
+      if (date == null) continue;
+      final key = _dateKey(date);
+      if (!daily.containsKey(key)) continue;
+      createdByDay.putIfAbsent(key, () => <String>{}).add(filePath);
+      final title = _metadata(event)['title']?.toString();
+      if (title != null && title.trim().isNotEmpty) {
+        details[key]?.insightTitles.add(title.trim());
+      }
+    }
+
+    if (createdByDay.isNotEmpty) {
+      for (final entry in createdByDay.entries) {
+        daily[entry.key]?.insights += entry.value.length;
+      }
+      return;
+    }
+
+    if (events.isNotEmpty) return;
+
+    final cards = await _fileSystemService.listKnowledgeInsightCards(userId);
+    for (final card in cards) {
+      final updatedAt = DateTime.tryParse(card['updated_at']?.toString() ?? '');
+      if (updatedAt == null) continue;
+      final date = _dateOnly(updatedAt);
+      if (!_dateInRange(date, range)) continue;
+      final key = _dateKey(date);
+      daily[key]?.insights += 1;
+      final title = card['title']?.toString();
+      if (title != null && title.trim().isNotEmpty) {
+        details[key]?.insightTitles.add(title.trim());
+      }
+    }
+  }
+
+  List<UserStatsTopTag> _buildTopTags(Iterable<_DailyStatsAccumulator> daily) {
+    final counts = <String, int>{};
+    for (final item in daily) {
+      item.tagCounts.forEach((tag, count) {
+        counts[tag] = (counts[tag] ?? 0) + count;
+      });
+    }
+    final entries = counts.entries.toList()
+      ..sort((a, b) {
+        final countCompare = b.value.compareTo(a.value);
+        if (countCompare != 0) return countCompare;
+        return a.key.compareTo(b.key);
+      });
+    return entries
+        .take(6)
+        .map((entry) => UserStatsTopTag(label: entry.key, count: entry.value))
+        .toList();
+  }
+
+  int _currentStreak(List<UserStatsDailyPoint> daily) {
+    var streak = 0;
+    for (final point in daily.reversed) {
+      if (!point.isActive) break;
+      streak += 1;
+    }
+    return streak;
+  }
+
+  String _factPath(String userId, DateTime date) {
+    final year = date.year.toString().padLeft(4, '0');
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return path.join(
+      _fileSystemService.getFactsPath(userId),
+      year,
+      month,
+      '$day.md',
+    );
+  }
+
+  Set<String> _collectInputFactIds(
+    List<Map<String, dynamic>> events,
+    Map<String, _DailyStatsAccumulator> daily,
+  ) {
+    final factIds = <String>{};
+    for (final event in events) {
+      if (event['event_type'] != 'user_input') continue;
+      final date = _eventDate(event);
+      if (date == null || !daily.containsKey(_dateKey(date))) continue;
+      final factId = _metadata(event)['fact_id']?.toString();
+      if (factId != null && factId.trim().isNotEmpty) {
+        factIds.add(factId.trim());
+      }
+    }
+    return factIds;
+  }
+
+  List<_FactEntryStats> _parseFactEntries(String content, DateTime date) {
+    final matches = RegExp(r'^## <id:([^>]+)>.*$', multiLine: true)
+        .allMatches(content)
+        .toList();
+    final entries = <_FactEntryStats>[];
+    for (var i = 0; i < matches.length; i++) {
+      final start = matches[i].end;
+      final end =
+          i + 1 < matches.length ? matches[i + 1].start : content.length;
+      final simpleId = matches[i].group(1) ?? '';
+      entries.add(
+        _FactEntryStats(
+          factId: _factIdForDate(date, simpleId),
+          words: _countWords(content.substring(start, end)),
+        ),
+      );
+    }
+    return entries;
+  }
+
+  String _factIdForDate(DateTime date, String simpleId) {
+    final year = date.year.toString().padLeft(4, '0');
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '$year/$month/$day.md#$simpleId';
+  }
+
+  int _countWords(String value) {
+    final withoutMedia = value
+        .replaceAll(RegExp(r'!\[[^\]]*\]\([^)]+\)'), ' ')
+        .replaceAll(RegExp(r'\[[^\]]*\]\([^)]+\)'), ' ');
+    final cjkCount = RegExp(r'[\u3400-\u9fff]').allMatches(withoutMedia).length;
+    final latinSource = withoutMedia.replaceAll(
+      RegExp(r'[\u3400-\u9fff]'),
+      ' ',
+    );
+    final latinCount = RegExp(
+      r"[A-Za-z0-9]+(?:[-'][A-Za-z0-9]+)?",
+    ).allMatches(latinSource).length;
+    return cjkCount + latinCount;
+  }
+
+  String? _factIdFromCardPath(String userId, String cardPath) {
+    try {
+      final relative = path.relative(
+        cardPath,
+        from: _fileSystemService.getCardsPath(userId),
+      );
+      final parts = path.split(relative);
+      if (parts.length != 3) return null;
+      final filename = path.basenameWithoutExtension(parts[2]);
+      final match = RegExp(r'^(\d{2})_(ts_\d+)$').firstMatch(filename);
+      if (match == null) return null;
+      return '${parts[0]}/${parts[1]}/${match.group(1)}.md#${match.group(2)}';
+    } catch (_) {
+      return null;
+    }
+  }
+
+  bool _isGeneratedCard(CardData card) {
+    if (card.status == 'processing' || card.status == 'failed') return false;
+    return card.uiConfigs.isNotEmpty;
+  }
+
+  bool _isCompletedTask(CardData card) {
+    for (final config in card.uiConfigs) {
+      if ((config.templateId == 'task' || config.templateId == 'todo') &&
+          config.data['is_completed'] == true) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  DateTime _cardDate(CardData card) {
+    final seconds = card.userFixedTimestamp ?? card.timestamp;
+    return _dateOnly(DateTime.fromMillisecondsSinceEpoch(seconds * 1000));
+  }
+
+  String _cardTitle(CardData card) {
+    final direct = card.title?.trim();
+    if (direct != null && direct.isNotEmpty) return direct;
+    for (final config in card.uiConfigs) {
+      final title = config.data['title']?.toString().trim();
+      if (title != null && title.isNotEmpty) return title;
+    }
+    return card.factId;
+  }
+
+  DateTime? _eventDate(Map<String, dynamic> event) {
+    final raw = event['event_time']?.toString();
+    if (raw == null) return null;
+    final parsed = DateTime.tryParse(raw);
+    if (parsed == null) return null;
+    return _dateOnly(parsed);
+  }
+
+  Map<String, dynamic> _metadata(Map<String, dynamic> event) {
+    final metadata = event['metadata'];
+    if (metadata is Map<String, dynamic>) return metadata;
+    if (metadata is Map) return Map<String, dynamic>.from(metadata);
+    return const {};
+  }
+
+  bool _dateInRange(DateTime date, UserStatsDateRange range) {
+    return !date.isBefore(range.start) && !date.isAfter(range.end);
+  }
+
+  DateTime _dateOnly(DateTime date) =>
+      DateTime(date.year, date.month, date.day);
+
+  String _dateKey(DateTime date) {
+    final normalized = _dateOnly(date);
+    final year = normalized.year.toString().padLeft(4, '0');
+    final month = normalized.month.toString().padLeft(2, '0');
+    final day = normalized.day.toString().padLeft(2, '0');
+    return '$year-$month-$day';
+  }
+}
+
+class _DailyStatsAccumulator {
+  _DailyStatsAccumulator(this.date);
+
+  final DateTime date;
+  int inputs = 0;
+  int words = 0;
+  int cards = 0;
+  int knowledgeUnits = 0;
+  int insights = 0;
+  int completedTodos = 0;
+  int textInputs = 0;
+  int imageInputs = 0;
+  int audioInputs = 0;
+  final Map<String, int> tagCounts = {};
+
+  UserStatsDailyPoint toPoint() => UserStatsDailyPoint(
+        date: date,
+        inputs: inputs,
+        words: words,
+        cards: cards,
+        knowledgeUnits: knowledgeUnits,
+        insights: insights,
+        completedTodos: completedTodos,
+      );
+}
+
+class _DayDetailAccumulator {
+  _DayDetailAccumulator(this.date);
+
+  final DateTime date;
+  final List<String> cardTitles = [];
+  final List<String> knowledgePaths = [];
+  final List<String> insightTitles = [];
+  final List<String> completedTodoTitles = [];
+
+  UserStatsDayDetail toDetail() => UserStatsDayDetail(
+        date: date,
+        cardTitles: _dedupe(cardTitles),
+        knowledgePaths: _dedupe(knowledgePaths),
+        insightTitles: _dedupe(insightTitles),
+        completedTodoTitles: _dedupe(completedTodoTitles),
+      );
+
+  List<String> _dedupe(List<String> values) {
+    final seen = <String>{};
+    final result = <String>[];
+    for (final value in values) {
+      if (seen.add(value)) result.add(value);
+    }
+    return result;
+  }
+}
+
+class _FactEntryStats {
+  _FactEntryStats({required this.factId, required this.words});
+
+  final String factId;
+  final int words;
+}

--- a/lib/domain/models/user_stats_model.dart
+++ b/lib/domain/models/user_stats_model.dart
@@ -1,0 +1,270 @@
+enum UserStatsMetric {
+  inputs,
+  words,
+  cards,
+  knowledgeUnits,
+  insights,
+  completedTodos,
+}
+
+class UserStatsDateRange {
+  final DateTime start;
+  final DateTime end;
+
+  const UserStatsDateRange({required this.start, required this.end});
+
+  factory UserStatsDateRange.lastDays(int days, {DateTime? now}) {
+    final anchor = now ?? DateTime.now();
+    final end = DateTime(anchor.year, anchor.month, anchor.day);
+    return UserStatsDateRange(
+      start: end.subtract(Duration(days: days - 1)),
+      end: end,
+    );
+  }
+
+  int get dayCount => end.difference(start).inDays + 1;
+
+  Map<String, dynamic> toJson() => {
+        'start': _dateKey(start),
+        'end': _dateKey(end),
+        'day_count': dayCount,
+      };
+}
+
+class UserStatsSummary {
+  final int totalInputs;
+  final int totalWords;
+  final int totalCards;
+  final int totalKnowledgeUnits;
+  final int totalInsights;
+  final int totalCompletedTodos;
+  final int activeDays;
+  final int currentStreakDays;
+
+  const UserStatsSummary({
+    required this.totalInputs,
+    required this.totalWords,
+    required this.totalCards,
+    required this.totalKnowledgeUnits,
+    required this.totalInsights,
+    required this.totalCompletedTodos,
+    required this.activeDays,
+    required this.currentStreakDays,
+  });
+
+  int get totalOutputs =>
+      totalCards + totalKnowledgeUnits + totalInsights + totalCompletedTodos;
+
+  Map<String, dynamic> toJson() => {
+        'total_inputs': totalInputs,
+        'total_words': totalWords,
+        'total_cards': totalCards,
+        'total_knowledge_units': totalKnowledgeUnits,
+        'total_insights': totalInsights,
+        'total_completed_todos': totalCompletedTodos,
+        'total_outputs': totalOutputs,
+        'active_days': activeDays,
+        'current_streak_days': currentStreakDays,
+      };
+}
+
+class UserStatsDailyPoint {
+  final DateTime date;
+  final int inputs;
+  final int words;
+  final int cards;
+  final int knowledgeUnits;
+  final int insights;
+  final int completedTodos;
+
+  const UserStatsDailyPoint({
+    required this.date,
+    required this.inputs,
+    required this.words,
+    required this.cards,
+    required this.knowledgeUnits,
+    required this.insights,
+    required this.completedTodos,
+  });
+
+  bool get isActive =>
+      inputs > 0 ||
+      cards > 0 ||
+      knowledgeUnits > 0 ||
+      insights > 0 ||
+      completedTodos > 0;
+
+  int valueFor(UserStatsMetric metric) {
+    switch (metric) {
+      case UserStatsMetric.inputs:
+        return inputs;
+      case UserStatsMetric.words:
+        return words;
+      case UserStatsMetric.cards:
+        return cards;
+      case UserStatsMetric.knowledgeUnits:
+        return knowledgeUnits;
+      case UserStatsMetric.insights:
+        return insights;
+      case UserStatsMetric.completedTodos:
+        return completedTodos;
+    }
+  }
+
+  Map<String, dynamic> toJson() => {
+        'date': _dateKey(date),
+        'inputs': inputs,
+        'words': words,
+        'cards': cards,
+        'knowledge_units': knowledgeUnits,
+        'insights': insights,
+        'completed_todos': completedTodos,
+        'is_active': isActive,
+      };
+}
+
+class UserStatsSourceBreakdown {
+  final int textInputs;
+  final int imageInputs;
+  final int audioInputs;
+
+  const UserStatsSourceBreakdown({
+    required this.textInputs,
+    required this.imageInputs,
+    required this.audioInputs,
+  });
+
+  int get total => textInputs + imageInputs + audioInputs;
+
+  Map<String, dynamic> toJson() => {
+        'text_inputs': textInputs,
+        'image_inputs': imageInputs,
+        'audio_inputs': audioInputs,
+        'total': total,
+      };
+}
+
+class UserStatsTopTag {
+  final String label;
+  final int count;
+
+  const UserStatsTopTag({required this.label, required this.count});
+
+  Map<String, dynamic> toJson() => {'label': label, 'count': count};
+}
+
+class UserStatsDayDetail {
+  final DateTime date;
+  final List<String> cardTitles;
+  final List<String> knowledgePaths;
+  final List<String> insightTitles;
+  final List<String> completedTodoTitles;
+
+  const UserStatsDayDetail({
+    required this.date,
+    this.cardTitles = const [],
+    this.knowledgePaths = const [],
+    this.insightTitles = const [],
+    this.completedTodoTitles = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'date': _dateKey(date),
+        'card_titles': cardTitles,
+        'knowledge_paths': knowledgePaths,
+        'insight_titles': insightTitles,
+        'completed_todo_titles': completedTodoTitles,
+      };
+}
+
+class UserStatsSnapshot {
+  final UserStatsDateRange range;
+  final UserStatsSummary summary;
+  final List<UserStatsDailyPoint> daily;
+  final UserStatsSourceBreakdown sourceBreakdown;
+  final List<UserStatsTopTag> topTags;
+  final Map<String, UserStatsDayDetail> dayDetails;
+
+  const UserStatsSnapshot({
+    required this.range,
+    required this.summary,
+    required this.daily,
+    required this.sourceBreakdown,
+    required this.topTags,
+    required this.dayDetails,
+  });
+
+  factory UserStatsSnapshot.empty(UserStatsDateRange range) {
+    final daily = List.generate(range.dayCount, (index) {
+      return UserStatsDailyPoint(
+        date: range.start.add(Duration(days: index)),
+        inputs: 0,
+        words: 0,
+        cards: 0,
+        knowledgeUnits: 0,
+        insights: 0,
+        completedTodos: 0,
+      );
+    });
+    return UserStatsSnapshot(
+      range: range,
+      summary: const UserStatsSummary(
+        totalInputs: 0,
+        totalWords: 0,
+        totalCards: 0,
+        totalKnowledgeUnits: 0,
+        totalInsights: 0,
+        totalCompletedTodos: 0,
+        activeDays: 0,
+        currentStreakDays: 0,
+      ),
+      daily: daily,
+      sourceBreakdown: const UserStatsSourceBreakdown(
+        textInputs: 0,
+        imageInputs: 0,
+        audioInputs: 0,
+      ),
+      topTags: const [],
+      dayDetails: {
+        for (final point in daily)
+          _dateKey(point.date): UserStatsDayDetail(date: point.date),
+      },
+    );
+  }
+
+  UserStatsDailyPoint? pointFor(DateTime date) {
+    final key = _dateKey(date);
+    for (final point in daily) {
+      if (_dateKey(point.date) == key) return point;
+    }
+    return null;
+  }
+
+  int maxValueFor(UserStatsMetric metric) {
+    var max = 0;
+    for (final point in daily) {
+      final value = point.valueFor(metric);
+      if (value > max) max = value;
+    }
+    return max;
+  }
+
+  Map<String, dynamic> toJson() => {
+        'range': range.toJson(),
+        'summary': summary.toJson(),
+        'daily': daily.map((point) => point.toJson()).toList(),
+        'source_breakdown': sourceBreakdown.toJson(),
+        'top_tags': topTags.map((tag) => tag.toJson()).toList(),
+        'day_details': dayDetails.map((key, value) {
+          return MapEntry(key, value.toJson());
+        }),
+      };
+}
+
+String _dateKey(DateTime date) {
+  final normalized = DateTime(date.year, date.month, date.day);
+  final year = normalized.year.toString().padLeft(4, '0');
+  final month = normalized.month.toString().padLeft(2, '0');
+  final day = normalized.day.toString().padLeft(2, '0');
+  return '$year-$month-$day';
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -88,6 +88,36 @@
   "lineCount": "Line count: ",
   "all": "All",
   "schedule": "Schedule",
+  "statistics": "Stats",
+  "activityStats": "Activity stats",
+  "activityStatsSummary": "In this period you recorded {inputs} time(s), generated {cards} card(s), and completed {todos} todo(s).",
+  "@activityStatsSummary": {
+    "placeholders": {
+      "inputs": {},
+      "cards": {},
+      "todos": {}
+    }
+  },
+  "last7Days": "7 days",
+  "last30Days": "30 days",
+  "last90Days": "90 days",
+  "records": "Records",
+  "words": "Words",
+  "cards": "Cards",
+  "knowledgeUnits": "Knowledge units",
+  "completedTodos": "Completed todos",
+  "activeDays": "Active days",
+  "streakDays": "Streak",
+  "dailyRhythm": "Daily rhythm",
+  "recordToOutput": "Record to output",
+  "sourceBreakdown": "Source breakdown",
+  "topThemes": "Top themes",
+  "textInput": "Text",
+  "imageInput": "Images",
+  "audioInput": "Audio",
+  "noStatsYet": "No activity stats yet",
+  "tapDayForDetails": "Tap a day to view details",
+  "dayDetails": "Day details",
   "@loadStatsFailed": {
     "placeholders": {
       "error": {}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -464,6 +464,144 @@ abstract class AppLocalizations {
   /// **'Schedule'**
   String get schedule;
 
+  /// No description provided for @statistics.
+  ///
+  /// In en, this message translates to:
+  /// **'Stats'**
+  String get statistics;
+
+  /// No description provided for @activityStats.
+  ///
+  /// In en, this message translates to:
+  /// **'Activity stats'**
+  String get activityStats;
+
+  /// No description provided for @activityStatsSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'In this period you recorded {inputs} time(s), generated {cards} card(s), and completed {todos} todo(s).'**
+  String activityStatsSummary(Object inputs, Object cards, Object todos);
+
+  /// No description provided for @last7Days.
+  ///
+  /// In en, this message translates to:
+  /// **'7 days'**
+  String get last7Days;
+
+  /// No description provided for @last30Days.
+  ///
+  /// In en, this message translates to:
+  /// **'30 days'**
+  String get last30Days;
+
+  /// No description provided for @last90Days.
+  ///
+  /// In en, this message translates to:
+  /// **'90 days'**
+  String get last90Days;
+
+  /// No description provided for @records.
+  ///
+  /// In en, this message translates to:
+  /// **'Records'**
+  String get records;
+
+  /// No description provided for @words.
+  ///
+  /// In en, this message translates to:
+  /// **'Words'**
+  String get words;
+
+  /// No description provided for @cards.
+  ///
+  /// In en, this message translates to:
+  /// **'Cards'**
+  String get cards;
+
+  /// No description provided for @knowledgeUnits.
+  ///
+  /// In en, this message translates to:
+  /// **'Knowledge units'**
+  String get knowledgeUnits;
+
+  /// No description provided for @completedTodos.
+  ///
+  /// In en, this message translates to:
+  /// **'Completed todos'**
+  String get completedTodos;
+
+  /// No description provided for @activeDays.
+  ///
+  /// In en, this message translates to:
+  /// **'Active days'**
+  String get activeDays;
+
+  /// No description provided for @streakDays.
+  ///
+  /// In en, this message translates to:
+  /// **'Streak'**
+  String get streakDays;
+
+  /// No description provided for @dailyRhythm.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily rhythm'**
+  String get dailyRhythm;
+
+  /// No description provided for @recordToOutput.
+  ///
+  /// In en, this message translates to:
+  /// **'Record to output'**
+  String get recordToOutput;
+
+  /// No description provided for @sourceBreakdown.
+  ///
+  /// In en, this message translates to:
+  /// **'Source breakdown'**
+  String get sourceBreakdown;
+
+  /// No description provided for @topThemes.
+  ///
+  /// In en, this message translates to:
+  /// **'Top themes'**
+  String get topThemes;
+
+  /// No description provided for @textInput.
+  ///
+  /// In en, this message translates to:
+  /// **'Text'**
+  String get textInput;
+
+  /// No description provided for @imageInput.
+  ///
+  /// In en, this message translates to:
+  /// **'Images'**
+  String get imageInput;
+
+  /// No description provided for @audioInput.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio'**
+  String get audioInput;
+
+  /// No description provided for @noStatsYet.
+  ///
+  /// In en, this message translates to:
+  /// **'No activity stats yet'**
+  String get noStatsYet;
+
+  /// No description provided for @tapDayForDetails.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap a day to view details'**
+  String get tapDayForDetails;
+
+  /// No description provided for @dayDetails.
+  ///
+  /// In en, this message translates to:
+  /// **'Day details'**
+  String get dayDetails;
+
   /// No description provided for @loadStatsFailed.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -213,6 +213,77 @@ class AppLocalizationsEn extends AppLocalizations {
   String get schedule => 'Schedule';
 
   @override
+  String get statistics => 'Stats';
+
+  @override
+  String get activityStats => 'Activity stats';
+
+  @override
+  String activityStatsSummary(Object inputs, Object cards, Object todos) {
+    return 'In this period you recorded $inputs time(s), generated $cards card(s), and completed $todos todo(s).';
+  }
+
+  @override
+  String get last7Days => '7 days';
+
+  @override
+  String get last30Days => '30 days';
+
+  @override
+  String get last90Days => '90 days';
+
+  @override
+  String get records => 'Records';
+
+  @override
+  String get words => 'Words';
+
+  @override
+  String get cards => 'Cards';
+
+  @override
+  String get knowledgeUnits => 'Knowledge units';
+
+  @override
+  String get completedTodos => 'Completed todos';
+
+  @override
+  String get activeDays => 'Active days';
+
+  @override
+  String get streakDays => 'Streak';
+
+  @override
+  String get dailyRhythm => 'Daily rhythm';
+
+  @override
+  String get recordToOutput => 'Record to output';
+
+  @override
+  String get sourceBreakdown => 'Source breakdown';
+
+  @override
+  String get topThemes => 'Top themes';
+
+  @override
+  String get textInput => 'Text';
+
+  @override
+  String get imageInput => 'Images';
+
+  @override
+  String get audioInput => 'Audio';
+
+  @override
+  String get noStatsYet => 'No activity stats yet';
+
+  @override
+  String get tapDayForDetails => 'Tap a day to view details';
+
+  @override
+  String get dayDetails => 'Day details';
+
+  @override
   String loadStatsFailed(Object error) {
     return 'Failed to load stats: $error';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -208,6 +208,77 @@ class AppLocalizationsZh extends AppLocalizations {
   String get schedule => '日程';
 
   @override
+  String get statistics => '统计';
+
+  @override
+  String get activityStats => '活动统计';
+
+  @override
+  String activityStatsSummary(Object inputs, Object cards, Object todos) {
+    return '这段时间你记录了 $inputs 次，生成了 $cards 张卡片，完成了 $todos 个待办。';
+  }
+
+  @override
+  String get last7Days => '7 天';
+
+  @override
+  String get last30Days => '30 天';
+
+  @override
+  String get last90Days => '90 天';
+
+  @override
+  String get records => '记录';
+
+  @override
+  String get words => '字词';
+
+  @override
+  String get cards => '卡片';
+
+  @override
+  String get knowledgeUnits => '知识单元';
+
+  @override
+  String get completedTodos => '完成待办';
+
+  @override
+  String get activeDays => '活跃天数';
+
+  @override
+  String get streakDays => '连续记录';
+
+  @override
+  String get dailyRhythm => '每日节奏';
+
+  @override
+  String get recordToOutput => '记录到沉淀';
+
+  @override
+  String get sourceBreakdown => '来源分布';
+
+  @override
+  String get topThemes => '高频主题';
+
+  @override
+  String get textInput => '文本';
+
+  @override
+  String get imageInput => '图片';
+
+  @override
+  String get audioInput => '音频';
+
+  @override
+  String get noStatsYet => '暂无活动统计';
+
+  @override
+  String get tapDayForDetails => '点击某一天查看详情';
+
+  @override
+  String get dayDetails => '当天详情';
+
+  @override
   String loadStatsFailed(Object error) {
     return '加载统计数据失败: $error';
   }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -88,6 +88,36 @@
   "lineCount": "行数: ",
   "all": "全部",
   "schedule": "日程",
+  "statistics": "统计",
+  "activityStats": "活动统计",
+  "activityStatsSummary": "这段时间你记录了 {inputs} 次，生成了 {cards} 张卡片，完成了 {todos} 个待办。",
+  "@activityStatsSummary": {
+    "placeholders": {
+      "inputs": {},
+      "cards": {},
+      "todos": {}
+    }
+  },
+  "last7Days": "7 天",
+  "last30Days": "30 天",
+  "last90Days": "90 天",
+  "records": "记录",
+  "words": "字词",
+  "cards": "卡片",
+  "knowledgeUnits": "知识单元",
+  "completedTodos": "完成待办",
+  "activeDays": "活跃天数",
+  "streakDays": "连续记录",
+  "dailyRhythm": "每日节奏",
+  "recordToOutput": "记录到沉淀",
+  "sourceBreakdown": "来源分布",
+  "topThemes": "高频主题",
+  "textInput": "文本",
+  "imageInput": "图片",
+  "audioInput": "音频",
+  "noStatsYet": "暂无活动统计",
+  "tapDayForDetails": "点击某一天查看详情",
+  "dayDetails": "当天详情",
   "@loadStatsFailed": {
     "placeholders": {
       "error": {}

--- a/lib/ui/insight/view_models/insight_viewmodel.dart
+++ b/lib/ui/insight/view_models/insight_viewmodel.dart
@@ -3,22 +3,39 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import 'package:memex/domain/models/knowledge_insight_card.dart';
+import 'package:memex/domain/models/user_stats_model.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/utils/result.dart';
 import 'package:memex/utils/user_storage.dart';
 
+enum InsightSection { insights, stats }
+
+typedef UserStatsFetcher = Future<Result<UserStatsSnapshot>> Function(
+    UserStatsDateRange range);
+
 /// ViewModel for the Insight page. Holds insight list, pin/delete/reorder state.
 class InsightViewModel extends ChangeNotifier {
-  InsightViewModel({required MemexRouter router}) : _router = router {
+  InsightViewModel({
+    required MemexRouter router,
+    UserStatsFetcher? userStatsFetcher,
+  })  : _router = router,
+        _userStatsFetcher =
+            userStatsFetcher ?? ((range) => router.fetchUserStats(range: range)) {
     EventBusService.instance
         .addHandler(EventBusMessageType.newInsight, _handleNewInsightEvent);
+    EventBusService.instance
+        .addHandler(EventBusMessageType.cardAdded, _handleActivityChangedEvent);
+    EventBusService.instance.addHandler(
+        EventBusMessageType.cardUpdated, _handleActivityChangedEvent);
   }
 
   final MemexRouter _router;
+  final UserStatsFetcher _userStatsFetcher;
 
   List<KnowledgeInsightCard>? insights;
+  InsightSection selectedSection = InsightSection.insights;
   bool isLoading = true;
   String? errorMessage;
   String? activeCardId;
@@ -27,6 +44,11 @@ class InsightViewModel extends ChangeNotifier {
   bool isReordering = false;
   TaskActivitySnapshot taskActivity = const TaskActivitySnapshot.empty();
   final Set<String> pinningIds = {};
+  UserStatsDateRange statsRange = UserStatsDateRange.lastDays(7);
+  UserStatsSnapshot? statsSnapshot;
+  bool isStatsLoading = false;
+  String? statsErrorMessage;
+  UserStatsMetric selectedStatsMetric = UserStatsMetric.inputs;
 
   int get activeTaskCount => taskActivity.total;
   bool get hasActiveTaskBacklog => activeTaskCount > 0;
@@ -34,6 +56,10 @@ class InsightViewModel extends ChangeNotifier {
   void _handleNewInsightEvent(EventBusMessage message) {
     if (message is! NewInsightMessage) return;
     unawaited(_reloadAfterInsightUpdated());
+  }
+
+  void _handleActivityChangedEvent(EventBusMessage message) {
+    unawaited(refreshStatsForVisibleInsightPage());
   }
 
   Future<void> _reloadAfterInsightUpdated() async {
@@ -50,6 +76,7 @@ class InsightViewModel extends ChangeNotifier {
     notifyListeners();
     final result = await _router.fetchKnowledgeInsights();
     await refreshTaskActivity(notify: false);
+    await loadStats(notify: false);
     result.when(
       onOk: (list) {
         insights = list;
@@ -70,6 +97,53 @@ class InsightViewModel extends ChangeNotifier {
       taskActivity = const TaskActivitySnapshot.empty();
     }
     if (notify) notifyListeners();
+  }
+
+  Future<void> loadStats({bool notify = true}) async {
+    isStatsLoading = true;
+    statsErrorMessage = null;
+    if (notify) notifyListeners();
+
+    final result = await _userStatsFetcher(statsRange);
+    result.when(
+      onOk: (snapshot) {
+        statsSnapshot = snapshot;
+        statsErrorMessage = null;
+      },
+      onError: (_, __) {
+        statsErrorMessage = UserStorage.l10n.dataLoadFailedRetry;
+      },
+    );
+    isStatsLoading = false;
+    if (notify) notifyListeners();
+  }
+
+  void setSection(InsightSection section) {
+    if (selectedSection == section) return;
+    selectedSection = section;
+    notifyListeners();
+    if (section == InsightSection.stats) {
+      unawaited(loadStats());
+    }
+  }
+
+  Future<void> refreshStatsForVisibleInsightPage() {
+    return loadStats(notify: selectedSection == InsightSection.stats);
+  }
+
+  void setStatsMetric(UserStatsMetric metric) {
+    if (selectedStatsMetric == metric) return;
+    selectedStatsMetric = metric;
+    notifyListeners();
+  }
+
+  void setStatsPresetDays(int days) {
+    final nextRange = UserStatsDateRange.lastDays(days);
+    if (statsRange.start == nextRange.start && statsRange.end == nextRange.end) {
+      return;
+    }
+    statsRange = nextRange;
+    unawaited(loadStats());
   }
 
   Future<void> togglePin(KnowledgeInsightCard item) async {
@@ -171,6 +245,10 @@ class InsightViewModel extends ChangeNotifier {
   void dispose() {
     EventBusService.instance
         .removeHandler(EventBusMessageType.newInsight, _handleNewInsightEvent);
+    EventBusService.instance.removeHandler(
+        EventBusMessageType.cardAdded, _handleActivityChangedEvent);
+    EventBusService.instance.removeHandler(
+        EventBusMessageType.cardUpdated, _handleActivityChangedEvent);
     super.dispose();
   }
 }

--- a/lib/ui/insight/widgets/insight_screen.dart
+++ b/lib/ui/insight/widgets/insight_screen.dart
@@ -9,6 +9,8 @@ import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/data/services/demo_service.dart';
 import 'package:memex/ui/insight/widgets/insight_preview_data.dart';
+import 'package:memex/ui/insight/widgets/user_stats_overview_card.dart';
+import 'package:memex/ui/insight/widgets/user_stats_page.dart';
 
 /// Insight screen - global knowledge analytics. Receives [viewModel] from parent (Compass-style).
 class InsightScreen extends StatefulWidget {
@@ -74,6 +76,13 @@ class _InsightScreenState extends State<InsightScreen> {
             context, UserStorage.l10n.refreshFailed(e.toString()));
       }
     }
+  }
+
+  Future<void> _onRefreshCurrentSection(InsightViewModel vm) {
+    if (vm.selectedSection == InsightSection.stats) {
+      return vm.loadStats();
+    }
+    return vm.loadData();
   }
 
   void _onChatWithAssistant() {
@@ -382,6 +391,83 @@ class _InsightScreenState extends State<InsightScreen> {
     );
   }
 
+  Widget _buildSectionSwitcher(InsightViewModel vm) {
+    final items = [
+      (
+        InsightSection.insights,
+        UserStorage.l10n.knowledgeInsight,
+        Icons.auto_graph_rounded,
+      ),
+      (
+        InsightSection.stats,
+        UserStorage.l10n.activityStats,
+        Icons.query_stats_rounded,
+      ),
+    ];
+
+    return Container(
+      height: 44,
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: const Color(0xFFEFF1F5),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: items.map((item) {
+          final selected = vm.selectedSection == item.$1;
+          return Expanded(
+            child: InkWell(
+              onTap: () => vm.setSection(item.$1),
+              borderRadius: BorderRadius.circular(9),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 180),
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: selected ? Colors.white : Colors.transparent,
+                  borderRadius: BorderRadius.circular(9),
+                  boxShadow: selected
+                      ? [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.07),
+                            blurRadius: 8,
+                            offset: const Offset(0, 2),
+                          ),
+                        ]
+                      : null,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      item.$3,
+                      size: 17,
+                      color: selected
+                          ? const Color(0xFF111827)
+                          : const Color(0xFF6B7280),
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      item.$2,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: selected
+                            ? const Color(0xFF111827)
+                            : const Color(0xFF6B7280),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
@@ -396,7 +482,7 @@ class _InsightScreenState extends State<InsightScreen> {
             final content = Stack(
               children: [
                 RefreshIndicator(
-                  onRefresh: () => vm.loadData(),
+                  onRefresh: () => _onRefreshCurrentSection(vm),
                   child: vm.isReordering
                       ? ReorderableListView(
                           padding: const EdgeInsets.fromLTRB(20, 16, 20, 160),
@@ -444,9 +530,21 @@ class _InsightScreenState extends State<InsightScreen> {
                                   ))
                               .toList(),
                         )
-                      : ListView(
-                          padding: const EdgeInsets.fromLTRB(20, 0, 20, 160),
-                          children: [
+                      : vm.selectedSection == InsightSection.stats
+                          ? UserStatsPage(
+                              snapshot: vm.statsSnapshot,
+                              isLoading: vm.isStatsLoading,
+                              errorMessage: vm.statsErrorMessage,
+                              selectedMetric: vm.selectedStatsMetric,
+                              onMetricChanged: vm.setStatsMetric,
+                              onPresetSelected: (days) =>
+                                  vm.setStatsPresetDays(days),
+                              onReload: () => vm.loadStats(),
+                              header: _buildSectionSwitcher(vm),
+                            )
+                          : ListView(
+                              padding: const EdgeInsets.fromLTRB(20, 0, 20, 160),
+                              children: [
                             // Header
                             // Add some top padding if embedded since we removed SafeArea/Scaffold top padding
                             // Actually ListView padding controls it.
@@ -516,6 +614,10 @@ class _InsightScreenState extends State<InsightScreen> {
 
                             const SizedBox(height: 16),
 
+                            _buildSectionSwitcher(vm),
+
+                            const SizedBox(height: 16),
+
                             if (vm.hasActiveTaskBacklog)
                               _buildBacklogBanner(vm),
 
@@ -549,6 +651,13 @@ class _InsightScreenState extends State<InsightScreen> {
                                 ),
                               )
                             else ...[
+                              UserStatsOverviewCard(
+                                snapshot: vm.statsSnapshot,
+                                isLoading: vm.isStatsLoading,
+                                onTap: () =>
+                                    vm.setSection(InsightSection.stats),
+                              ),
+                              const SizedBox(height: 16),
                               if (vm.insights != null &&
                                   vm.insights!.isNotEmpty)
                                 ...(vm.insights!.map((item) => Padding(
@@ -600,7 +709,8 @@ class _InsightScreenState extends State<InsightScreen> {
                           ],
                         ),
                 ),
-                if (!vm.isReordering)
+                if (!vm.isReordering &&
+                    vm.selectedSection == InsightSection.insights)
                   Positioned(
                     left: _fabPosition?.dx,
                     top: _fabPosition?.dy,

--- a/lib/ui/insight/widgets/user_stats_overview_card.dart
+++ b/lib/ui/insight/widgets/user_stats_overview_card.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+
+import 'package:memex/domain/models/user_stats_model.dart';
+import 'package:memex/utils/user_storage.dart';
+
+class UserStatsOverviewCard extends StatelessWidget {
+  const UserStatsOverviewCard({
+    super.key,
+    required this.snapshot,
+    required this.isLoading,
+    required this.onTap,
+  });
+
+  final UserStatsSnapshot? snapshot;
+  final bool isLoading;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = snapshot?.summary;
+    final daily = snapshot?.daily ?? const <UserStatsDailyPoint>[];
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        key: const ValueKey('user_stats_overview_card'),
+        onTap: isLoading ? null : onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: const Color(0xFFE5E7EB)),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.04),
+                blurRadius: 12,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: isLoading || summary == null
+              ? const _OverviewLoading()
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Container(
+                          width: 32,
+                          height: 32,
+                          decoration: BoxDecoration(
+                            color: const Color(
+                              0xFF10B981,
+                            ).withValues(alpha: 0.1),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: const Icon(
+                            Icons.query_stats_rounded,
+                            size: 18,
+                            color: Color(0xFF059669),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Text(
+                            UserStorage.l10n.activityStats,
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                              color: Color(0xFF111827),
+                            ),
+                          ),
+                        ),
+                        const Icon(
+                          Icons.chevron_right_rounded,
+                          color: Color(0xFF9CA3AF),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      UserStorage.l10n.activityStatsSummary(
+                        summary.totalInputs,
+                        summary.totalCards,
+                        summary.totalCompletedTodos,
+                      ),
+                      style: const TextStyle(
+                        fontSize: 13,
+                        height: 1.35,
+                        color: Color(0xFF4B5563),
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+                    Row(
+                      children: [
+                        _MetricPill(
+                          label: UserStorage.l10n.records,
+                          value: summary.totalInputs,
+                          color: const Color(0xFF5B6CFF),
+                        ),
+                        const SizedBox(width: 8),
+                        _MetricPill(
+                          label: UserStorage.l10n.cards,
+                          value: summary.totalCards,
+                          color: const Color(0xFF10B981),
+                        ),
+                        const SizedBox(width: 8),
+                        _MetricPill(
+                          label: UserStorage.l10n.completedTodos,
+                          value: summary.totalCompletedTodos,
+                          color: const Color(0xFFF59E0B),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 14),
+                    SizedBox(height: 42, child: _MiniBarChart(points: daily)),
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MetricPill extends StatelessWidget {
+  const _MetricPill({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final int value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              value.toString(),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 17,
+                fontWeight: FontWeight.w800,
+                color: color,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 11, color: Color(0xFF6B7280)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MiniBarChart extends StatelessWidget {
+  const _MiniBarChart({required this.points});
+
+  final List<UserStatsDailyPoint> points;
+
+  @override
+  Widget build(BuildContext context) {
+    if (points.isEmpty) return const SizedBox.shrink();
+    final maxValue = points
+        .map((point) => point.inputs + point.cards + point.completedTodos)
+        .fold<int>(1, (max, value) => value > max ? value : max);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: points.map((point) {
+        final value = point.inputs + point.cards + point.completedTodos;
+        final height = 8 + (value / maxValue) * 30;
+        return Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: Container(
+                height: height,
+                decoration: BoxDecoration(
+                  color: value == 0
+                      ? const Color(0xFFE5E7EB)
+                      : const Color(0xFF5B6CFF).withValues(alpha: 0.75),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+              ),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _OverviewLoading extends StatelessWidget {
+  const _OverviewLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 150,
+          height: 18,
+          decoration: BoxDecoration(
+            color: const Color(0xFFE5E7EB),
+            borderRadius: BorderRadius.circular(6),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          width: double.infinity,
+          height: 12,
+          decoration: BoxDecoration(
+            color: const Color(0xFFF3F4F6),
+            borderRadius: BorderRadius.circular(6),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Container(
+          width: double.infinity,
+          height: 42,
+          decoration: BoxDecoration(
+            color: const Color(0xFFF3F4F6),
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/insight/widgets/user_stats_page.dart
+++ b/lib/ui/insight/widgets/user_stats_page.dart
@@ -1,0 +1,970 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:memex/domain/models/user_stats_model.dart';
+import 'package:memex/utils/user_storage.dart';
+
+class UserStatsPage extends StatelessWidget {
+  const UserStatsPage({
+    super.key,
+    required this.snapshot,
+    required this.isLoading,
+    required this.errorMessage,
+    required this.selectedMetric,
+    required this.onMetricChanged,
+    required this.onPresetSelected,
+    required this.onReload,
+    this.header,
+  });
+
+  final UserStatsSnapshot? snapshot;
+  final bool isLoading;
+  final String? errorMessage;
+  final UserStatsMetric selectedMetric;
+  final ValueChanged<UserStatsMetric> onMetricChanged;
+  final ValueChanged<int> onPresetSelected;
+  final VoidCallback onReload;
+  final Widget? header;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading && snapshot == null) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(32),
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (errorMessage != null && snapshot == null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                errorMessage!,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 14, color: Color(0xFF6B7280)),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: onReload,
+                child: Text(UserStorage.l10n.retry),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final data = snapshot;
+    if (data == null) {
+      return Center(child: Text(UserStorage.l10n.noStatsYet));
+    }
+
+    return ListView(
+      key: const ValueKey('user_stats_page'),
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 160),
+      children: [
+        const SizedBox(height: 16),
+        if (header != null) ...[header!, const SizedBox(height: 16)],
+        _RangeSelector(
+          selectedDays: data.range.dayCount,
+          onSelected: onPresetSelected,
+        ),
+        const SizedBox(height: 16),
+        _SummaryPanel(snapshot: data),
+        const SizedBox(height: 16),
+        _MetricGrid(snapshot: data),
+        const SizedBox(height: 16),
+        _DailyRhythmCard(
+          snapshot: data,
+          selectedMetric: selectedMetric,
+          onMetricChanged: onMetricChanged,
+        ),
+        const SizedBox(height: 16),
+        _OutputFlowCard(snapshot: data),
+        const SizedBox(height: 16),
+        _SourceBreakdownCard(snapshot: data),
+        const SizedBox(height: 16),
+        _TopThemesCard(snapshot: data),
+      ],
+    );
+  }
+}
+
+class _RangeSelector extends StatelessWidget {
+  const _RangeSelector({required this.selectedDays, required this.onSelected});
+
+  final int selectedDays;
+  final ValueChanged<int> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [
+      (7, UserStorage.l10n.last7Days),
+      (30, UserStorage.l10n.last30Days),
+      (90, UserStorage.l10n.last90Days),
+    ];
+    return Row(
+      children: items.map((item) {
+        final selected = selectedDays == item.$1;
+        return Padding(
+          padding: const EdgeInsets.only(right: 8),
+          child: ChoiceChip(
+            key: ValueKey('stats_range_${item.$1}'),
+            label: Text(item.$2),
+            selected: selected,
+            onSelected: (_) => onSelected(item.$1),
+            selectedColor: const Color(0xFF111827),
+            backgroundColor: Colors.white,
+            labelStyle: TextStyle(
+              color: selected ? Colors.white : const Color(0xFF4B5563),
+              fontWeight: FontWeight.w700,
+              fontSize: 12,
+            ),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: BorderSide(
+                color: selected
+                    ? const Color(0xFF111827)
+                    : const Color(0xFFE5E7EB),
+              ),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _SummaryPanel extends StatelessWidget {
+  const _SummaryPanel({required this.snapshot});
+
+  final UserStatsSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = snapshot.summary;
+    return _SectionSurface(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: const Color(0xFF5B6CFF).withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Icon(
+                  Icons.auto_graph_rounded,
+                  color: Color(0xFF5B6CFF),
+                  size: 20,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  UserStorage.l10n.activityStats,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFF111827),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Text(
+            UserStorage.l10n.activityStatsSummary(
+              summary.totalInputs,
+              summary.totalCards,
+              summary.totalCompletedTodos,
+            ),
+            style: const TextStyle(
+              fontSize: 14,
+              height: 1.45,
+              color: Color(0xFF4B5563),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricGrid extends StatelessWidget {
+  const _MetricGrid({required this.snapshot});
+
+  final UserStatsSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = snapshot.summary;
+    final items = [
+      _MetricItem(
+        UserStorage.l10n.records,
+        summary.totalInputs,
+        Icons.edit_note_rounded,
+        const Color(0xFF5B6CFF),
+      ),
+      _MetricItem(
+        UserStorage.l10n.words,
+        summary.totalWords,
+        Icons.notes_rounded,
+        const Color(0xFF0EA5E9),
+      ),
+      _MetricItem(
+        UserStorage.l10n.cards,
+        summary.totalCards,
+        Icons.view_agenda_rounded,
+        const Color(0xFF10B981),
+      ),
+      _MetricItem(
+        UserStorage.l10n.knowledgeUnits,
+        summary.totalKnowledgeUnits,
+        Icons.hub_rounded,
+        const Color(0xFF8B5CF6),
+      ),
+      _MetricItem(
+        UserStorage.l10n.knowledgeInsight,
+        summary.totalInsights,
+        Icons.auto_awesome_rounded,
+        const Color(0xFFF59E0B),
+      ),
+      _MetricItem(
+        UserStorage.l10n.completedTodos,
+        summary.totalCompletedTodos,
+        Icons.task_alt_rounded,
+        const Color(0xFFEF4444),
+      ),
+      _MetricItem(
+        UserStorage.l10n.activeDays,
+        summary.activeDays,
+        Icons.calendar_month_rounded,
+        const Color(0xFF14B8A6),
+      ),
+      _MetricItem(
+        UserStorage.l10n.streakDays,
+        summary.currentStreakDays,
+        Icons.local_fire_department_rounded,
+        const Color(0xFFF97316),
+      ),
+    ];
+
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: items.length,
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 10,
+        mainAxisSpacing: 10,
+        childAspectRatio: 2.25,
+      ),
+      itemBuilder: (context, index) => _MetricTile(item: items[index]),
+    );
+  }
+}
+
+class _DailyRhythmCard extends StatelessWidget {
+  const _DailyRhythmCard({
+    required this.snapshot,
+    required this.selectedMetric,
+    required this.onMetricChanged,
+  });
+
+  final UserStatsSnapshot snapshot;
+  final UserStatsMetric selectedMetric;
+  final ValueChanged<UserStatsMetric> onMetricChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return _SectionSurface(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionHeader(
+            title: UserStorage.l10n.dailyRhythm,
+            subtitle: UserStorage.l10n.tapDayForDetails,
+          ),
+          const SizedBox(height: 12),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: UserStatsMetric.values.map((metric) {
+                final selected = metric == selectedMetric;
+                return Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: ChoiceChip(
+                    key: ValueKey('stats_metric_${metric.name}'),
+                    label: Text(_metricLabel(metric)),
+                    selected: selected,
+                    onSelected: (_) => onMetricChanged(metric),
+                    selectedColor: const Color(0xFF5B6CFF),
+                    backgroundColor: const Color(0xFFF9FAFB),
+                    labelStyle: TextStyle(
+                      color: selected ? Colors.white : const Color(0xFF4B5563),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      side: BorderSide(
+                        color: selected
+                            ? const Color(0xFF5B6CFF)
+                            : const Color(0xFFE5E7EB),
+                      ),
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+          const SizedBox(height: 18),
+          _DailyBars(snapshot: snapshot, metric: selectedMetric),
+        ],
+      ),
+    );
+  }
+}
+
+class _DailyBars extends StatelessWidget {
+  const _DailyBars({required this.snapshot, required this.metric});
+
+  final UserStatsSnapshot snapshot;
+  final UserStatsMetric metric;
+
+  @override
+  Widget build(BuildContext context) {
+    final maxValue = snapshot.maxValueFor(metric).clamp(1, 1 << 30);
+    final formatter = DateFormat.Md(UserStorage.l10n.localeName);
+    final contentWidth = snapshot.daily.length <= 14
+        ? MediaQuery.sizeOf(context).width - 80
+        : snapshot.daily.length * 28.0;
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: SizedBox(
+        width: contentWidth,
+        height: 172,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: snapshot.daily.map((point) {
+            final value = point.valueFor(metric);
+            final height = value == 0 ? 8.0 : 20 + value / maxValue * 100;
+            return Expanded(
+              child: GestureDetector(
+                key: ValueKey('stats_day_${_dateKey(point.date)}'),
+                behavior: HitTestBehavior.opaque,
+                onTap: () => _showDayDetails(context, snapshot, point),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 3),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Text(
+                        value == 0 ? '' : value.toString(),
+                        style: const TextStyle(
+                          fontSize: 10,
+                          color: Color(0xFF6B7280),
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      AnimatedContainer(
+                        duration: const Duration(milliseconds: 180),
+                        width: double.infinity,
+                        height: height,
+                        decoration: BoxDecoration(
+                          color: value == 0
+                              ? const Color(0xFFE5E7EB)
+                              : const Color(0xFF5B6CFF),
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        formatter.format(point.date),
+                        maxLines: 1,
+                        overflow: TextOverflow.visible,
+                        style: const TextStyle(
+                          fontSize: 10,
+                          color: Color(0xFF9CA3AF),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+}
+
+class _OutputFlowCard extends StatelessWidget {
+  const _OutputFlowCard({required this.snapshot});
+
+  final UserStatsSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = snapshot.summary;
+    final values = [
+      (UserStorage.l10n.records, summary.totalInputs, const Color(0xFF5B6CFF)),
+      (UserStorage.l10n.cards, summary.totalCards, const Color(0xFF10B981)),
+      (
+        UserStorage.l10n.knowledgeUnits,
+        summary.totalKnowledgeUnits,
+        const Color(0xFF8B5CF6),
+      ),
+      (
+        UserStorage.l10n.knowledgeInsight,
+        summary.totalInsights,
+        const Color(0xFFF59E0B),
+      ),
+      (
+        UserStorage.l10n.completedTodos,
+        summary.totalCompletedTodos,
+        const Color(0xFFEF4444),
+      ),
+    ];
+    final maxValue = values
+        .map((item) => item.$2)
+        .fold<int>(1, (max, value) => value > max ? value : max);
+
+    return _SectionSurface(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionHeader(title: UserStorage.l10n.recordToOutput),
+          const SizedBox(height: 14),
+          ...values.map((item) {
+            final widthFactor = item.$2 / maxValue;
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          item.$1,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF4B5563),
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        item.$2.toString(),
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Color(0xFF111827),
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(5),
+                    child: LinearProgressIndicator(
+                      value: widthFactor,
+                      minHeight: 8,
+                      backgroundColor: const Color(0xFFF3F4F6),
+                      valueColor: AlwaysStoppedAnimation<Color>(item.$3),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}
+
+class _SourceBreakdownCard extends StatelessWidget {
+  const _SourceBreakdownCard({required this.snapshot});
+
+  final UserStatsSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final source = snapshot.sourceBreakdown;
+    final items = [
+      (UserStorage.l10n.textInput, source.textInputs, const Color(0xFF5B6CFF)),
+      (
+        UserStorage.l10n.imageInput,
+        source.imageInputs,
+        const Color(0xFF10B981),
+      ),
+      (
+        UserStorage.l10n.audioInput,
+        source.audioInputs,
+        const Color(0xFFF59E0B),
+      ),
+    ];
+    final total = source.total == 0 ? 1 : source.total;
+
+    return _SectionSurface(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionHeader(title: UserStorage.l10n.sourceBreakdown),
+          const SizedBox(height: 14),
+          Row(
+            children: items.map((item) {
+              final flex = item.$2 == 0 ? 1 : item.$2;
+              return Expanded(
+                flex: flex,
+                child: Container(
+                  height: 14,
+                  decoration: BoxDecoration(
+                    color: item.$2 == 0
+                        ? const Color(0xFFE5E7EB)
+                        : item.$3.withValues(alpha: 0.85),
+                    borderRadius: BorderRadius.circular(5),
+                  ),
+                ),
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 14),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: items.map((item) {
+              final percentage = (item.$2 / total * 100).round();
+              return _LegendPill(
+                label: '${item.$1} $percentage%',
+                color: item.$3,
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TopThemesCard extends StatelessWidget {
+  const _TopThemesCard({required this.snapshot});
+
+  final UserStatsSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    return _SectionSurface(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionHeader(title: UserStorage.l10n.topThemes),
+          const SizedBox(height: 12),
+          if (snapshot.topTags.isEmpty)
+            Text(
+              UserStorage.l10n.noData,
+              style: const TextStyle(color: Color(0xFF9CA3AF), fontSize: 13),
+            )
+          else
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: snapshot.topTags.map((tag) {
+                return Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 7,
+                  ),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFF3F4F6),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '${tag.label} ${tag.count}',
+                    style: const TextStyle(
+                      color: Color(0xFF374151),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricItem {
+  const _MetricItem(this.label, this.value, this.icon, this.color);
+
+  final String label;
+  final int value;
+  final IconData icon;
+  final Color color;
+}
+
+class _MetricTile extends StatelessWidget {
+  const _MetricTile({required this.item});
+
+  final _MetricItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFE5E7EB)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: item.color.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(item.icon, size: 18, color: item.color),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.value.toString(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 18,
+                    color: Color(0xFF111827),
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                Text(
+                  item.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 11,
+                    color: Color(0xFF6B7280),
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionSurface extends StatelessWidget {
+  const _SectionSurface({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFE5E7EB)),
+      ),
+      child: child,
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title, this.subtitle});
+
+  final String title;
+  final String? subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w800,
+                  color: Color(0xFF111827),
+                ),
+              ),
+              if (subtitle != null) ...[
+                const SizedBox(height: 3),
+                Text(
+                  subtitle!,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: Color(0xFF9CA3AF),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _LegendPill extends StatelessWidget {
+  const _LegendPill({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.09),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 7,
+            height: 7,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              color: Color(0xFF374151),
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _metricLabel(UserStatsMetric metric) {
+  switch (metric) {
+    case UserStatsMetric.inputs:
+      return UserStorage.l10n.records;
+    case UserStatsMetric.words:
+      return UserStorage.l10n.words;
+    case UserStatsMetric.cards:
+      return UserStorage.l10n.cards;
+    case UserStatsMetric.knowledgeUnits:
+      return UserStorage.l10n.knowledgeUnits;
+    case UserStatsMetric.insights:
+      return UserStorage.l10n.knowledgeInsight;
+    case UserStatsMetric.completedTodos:
+      return UserStorage.l10n.completedTodos;
+  }
+}
+
+void _showDayDetails(
+  BuildContext context,
+  UserStatsSnapshot snapshot,
+  UserStatsDailyPoint point,
+) {
+  final key = _dateKey(point.date);
+  final detail = snapshot.dayDetails[key];
+  final dateLabel = DateFormat.yMMMd(
+    UserStorage.l10n.localeName,
+  ).format(point.date);
+
+  showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    backgroundColor: Colors.white,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (context) {
+      return SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  UserStorage.l10n.dayDetails,
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFF111827),
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  dateLabel,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    color: Color(0xFF6B7280),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                _DetailCountRow(point: point),
+                const SizedBox(height: 18),
+                if (detail != null) ...[
+                  _DetailList(
+                    title: UserStorage.l10n.cards,
+                    items: detail.cardTitles,
+                  ),
+                  _DetailList(
+                    title: UserStorage.l10n.knowledgeUnits,
+                    items: detail.knowledgePaths,
+                  ),
+                  _DetailList(
+                    title: UserStorage.l10n.knowledgeInsight,
+                    items: detail.insightTitles,
+                  ),
+                  _DetailList(
+                    title: UserStorage.l10n.completedTodos,
+                    items: detail.completedTodoTitles,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}
+
+class _DetailCountRow extends StatelessWidget {
+  const _DetailCountRow({required this.point});
+
+  final UserStatsDailyPoint point;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [
+      (UserStorage.l10n.records, point.inputs),
+      (UserStorage.l10n.cards, point.cards),
+      (UserStorage.l10n.knowledgeInsight, point.insights),
+      (UserStorage.l10n.completedTodos, point.completedTodos),
+    ];
+    return Row(
+      children: items.map((item) {
+        return Expanded(
+          child: Container(
+            margin: const EdgeInsets.only(right: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF9FAFB),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.$2.toString(),
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFF111827),
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  item.$1,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 10,
+                    color: Color(0xFF6B7280),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _DetailList extends StatelessWidget {
+  const _DetailList({required this.title, required this.items});
+
+  final String title;
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w800,
+              color: Color(0xFF374151),
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...items.take(6).map((item) {
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Text(
+                item,
+                style: const TextStyle(
+                  fontSize: 13,
+                  height: 1.35,
+                  color: Color(0xFF4B5563),
+                ),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}
+
+String _dateKey(DateTime date) {
+  final year = date.year.toString().padLeft(4, '0');
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '$year-$month-$day';
+}

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -247,6 +247,7 @@ class TimelineScreenState extends State<TimelineScreen> {
     if (index == 1) {
       vm.setViewMode(TimelineViewMode.insight);
       vm.setActiveFilter('insight');
+      widget.insightViewModel.refreshStatsForVisibleInsightPage();
     } else {
       vm.setViewMode(TimelineViewMode.timeline);
       vm.setActiveFilter(filter);
@@ -812,6 +813,7 @@ class TimelineScreenState extends State<TimelineScreen> {
             onTap: () {
               vm.setViewMode(TimelineViewMode.insight);
               vm.setActiveFilter('insight');
+              widget.insightViewModel.refreshStatsForVisibleInsightPage();
               _animateToPage(1);
               DemoService.instance.tryAdvance(DemoStep.tapInsightTab);
             },

--- a/test/data/services/user_stats_service_test.dart
+++ b/test/data/services/user_stats_service_test.dart
@@ -1,0 +1,318 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/user_stats_service.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:memex/domain/models/user_stats_model.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+
+const userId = 'stats_user';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.saveUser(userId);
+    await UserStorage.setLocale(const Locale('en'));
+    tempDir = await Directory.systemTemp.createTemp('memex_user_stats_');
+    await FileSystemService.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test(
+    'aggregates user-facing stats from facts, cards, and event logs',
+    () async {
+      final fs = FileSystemService.instance;
+
+      await _writeFactFile(
+        fs,
+        userId,
+        DateTime(2026, 5, 18),
+        '## <id:ts_0> 08:00:00 "{}"\n\nWelcome seed card\n'
+        '## <id:ts_1> 09:00:00 "{}"\n\nHello world 中文\n'
+        '## <id:ts_2> 10:00:00 "{}"\n\nBuy milk\n',
+      );
+      await _writeFactFile(
+        fs,
+        userId,
+        DateTime(2026, 5, 19),
+        '## <id:ts_1> 09:00:00 "{}"\n\nAnother note\n',
+      );
+
+      await fs.safeWriteCardFile(
+        userId,
+        '2026/05/18.md#ts_0',
+        CardData(
+          factId: '2026/05/18.md#ts_0',
+          timestamp: DateTime(2026, 5, 18, 8).millisecondsSinceEpoch ~/ 1000,
+          status: 'completed',
+          tags: const ['seed'],
+          uiConfigs: const [
+            UiConfig(
+              templateId: 'classic_card',
+              data: {'title': 'Welcome seed'},
+            ),
+          ],
+        ),
+      );
+      await fs.safeWriteCardFile(
+        userId,
+        '2026/05/18.md#ts_1',
+        CardData(
+          factId: '2026/05/18.md#ts_1',
+          timestamp: DateTime(2026, 5, 18, 9).millisecondsSinceEpoch ~/ 1000,
+          status: 'completed',
+          tags: const ['work'],
+          uiConfigs: const [
+            UiConfig(
+              templateId: 'classic_card',
+              data: {'title': 'Morning note'},
+            ),
+          ],
+        ),
+      );
+      await fs.safeWriteCardFile(
+        userId,
+        '2026/05/18.md#ts_2',
+        CardData(
+          factId: '2026/05/18.md#ts_2',
+          timestamp: DateTime(2026, 5, 18, 10).millisecondsSinceEpoch ~/ 1000,
+          status: 'processing',
+          tags: const [],
+          uiConfigs: const [
+            UiConfig(templateId: 'classic_card', data: {'title': 'Pending'}),
+          ],
+        ),
+      );
+      await fs.safeWriteCardFile(
+        userId,
+        '2026/05/19.md#ts_1',
+        CardData(
+          factId: '2026/05/19.md#ts_1',
+          timestamp: DateTime(2026, 5, 19, 9).millisecondsSinceEpoch ~/ 1000,
+          status: 'completed',
+          tags: const ['home'],
+          uiConfigs: const [
+            UiConfig(
+              templateId: 'task',
+              data: {'title': 'Clean desk', 'is_completed': true},
+            ),
+          ],
+        ),
+      );
+
+      await _writeEvents(fs, userId, [
+        _event(
+          type: 'user_input',
+          time: DateTime(2026, 5, 18, 9),
+          metadata: {
+            'fact_id': '2026/05/18.md#ts_1',
+            'has_text': true,
+            'has_images': false,
+            'has_audio': false,
+          },
+        ),
+        _event(
+          type: 'user_input',
+          time: DateTime(2026, 5, 18, 10),
+          metadata: {
+            'fact_id': '2026/05/18.md#ts_2',
+            'has_text': false,
+            'has_images': true,
+            'has_audio': false,
+          },
+        ),
+        _event(
+          type: 'user_input',
+          time: DateTime(2026, 5, 19, 9),
+          metadata: {
+            'fact_id': '2026/05/19.md#ts_1',
+            'has_text': false,
+            'has_images': false,
+            'has_audio': true,
+          },
+        ),
+        _event(
+          type: 'file_modified',
+          time: DateTime(2026, 5, 18, 12),
+          filePath: 'PKM/Areas/work.md',
+        ),
+        _event(
+          type: 'file_modified',
+          time: DateTime(2026, 5, 18, 13),
+          filePath: 'PKM/Areas/work.md',
+        ),
+        _event(
+          type: 'file_created',
+          time: DateTime(2026, 5, 19, 12),
+          filePath: 'PKM/Projects/app.md',
+        ),
+        _event(
+          type: 'file_created',
+          time: DateTime(2026, 5, 19, 16),
+          filePath: 'KnowledgeInsights/Cards/weekly.yaml',
+          metadata: {'title': 'Weekly pattern'},
+        ),
+        _event(
+          type: 'todo_completed',
+          time: DateTime(2026, 5, 20, 8),
+          metadata: {'title': 'Clean desk'},
+        ),
+      ]);
+
+      final snapshot = await UserStatsService().fetchSnapshot(
+        userId: userId,
+        range: UserStatsDateRange(
+          start: DateTime(2026, 5, 14),
+          end: DateTime(2026, 5, 20),
+        ),
+      );
+
+      expect(snapshot.summary.totalInputs, 3);
+      expect(snapshot.summary.totalWords, 8);
+      expect(snapshot.summary.totalCards, 2);
+      expect(snapshot.summary.totalKnowledgeUnits, 2);
+      expect(snapshot.summary.totalInsights, 1);
+      expect(snapshot.summary.totalCompletedTodos, 1);
+      expect(snapshot.summary.activeDays, 3);
+      expect(snapshot.summary.currentStreakDays, 3);
+      expect(snapshot.sourceBreakdown.textInputs, 1);
+      expect(snapshot.sourceBreakdown.imageInputs, 1);
+      expect(snapshot.sourceBreakdown.audioInputs, 1);
+      expect(
+        snapshot.topTags.map((tag) => tag.label),
+        containsAll(['work', 'home']),
+      );
+
+      final may18 = snapshot.pointFor(DateTime(2026, 5, 18))!;
+      expect(may18.inputs, 2);
+      expect(may18.cards, 1);
+      expect(may18.knowledgeUnits, 1);
+
+      final may19Detail = snapshot.dayDetails['2026-05-19']!;
+      expect(may19Detail.insightTitles, contains('Weekly pattern'));
+      expect(may19Detail.knowledgePaths, contains('PKM/Projects/app.md'));
+    },
+  );
+
+  test(
+    'falls back to local files when activity events are unavailable',
+    () async {
+      final fs = FileSystemService.instance;
+      final pkmFile = File(p.join(fs.getPkmPath(userId), 'Areas', 'health.md'));
+      await pkmFile.parent.create(recursive: true);
+      await pkmFile.writeAsString('# Health\n');
+      await pkmFile.setLastModified(DateTime(2026, 5, 18, 12));
+
+      await fs.writeKnowledgeInsightCard(userId, 'health_week', {
+        'id': 'health_week',
+        'title': 'Health week',
+        'template_id': 'summary_card_v1',
+        'updated_at': DateTime(2026, 5, 18, 10).toIso8601String(),
+      });
+
+      await fs.safeWriteCardFile(
+        userId,
+        '2026/05/18.md#ts_1',
+        CardData(
+          factId: '2026/05/18.md#ts_1',
+          timestamp: DateTime(2026, 5, 18, 9).millisecondsSinceEpoch ~/ 1000,
+          status: 'completed',
+          tags: const [],
+          uiConfigs: const [
+            UiConfig(
+              templateId: 'task',
+              data: {'title': 'Drink water', 'is_completed': true},
+            ),
+          ],
+        ),
+      );
+
+      final snapshot = await UserStatsService().fetchSnapshot(
+        userId: userId,
+        range: UserStatsDateRange(
+          start: DateTime(2026, 5, 18),
+          end: DateTime(2026, 5, 18),
+        ),
+      );
+
+      expect(snapshot.summary.totalKnowledgeUnits, 1);
+      expect(snapshot.summary.totalInsights, 1);
+      expect(snapshot.summary.totalCompletedTodos, 1);
+      expect(
+        snapshot.dayDetails['2026-05-18']!.knowledgePaths,
+        contains('PKM/Areas/health.md'),
+      );
+      expect(
+        snapshot.dayDetails['2026-05-18']!.insightTitles,
+        contains('Health week'),
+      );
+    },
+  );
+}
+
+Map<String, dynamic> _event({
+  required String type,
+  required DateTime time,
+  String? filePath,
+  Map<String, dynamic>? metadata,
+}) {
+  return {
+    'event_type': type,
+    'description': type,
+    'event_time': time.toIso8601String(),
+    'event_time_unix_seconds': time.millisecondsSinceEpoch ~/ 1000,
+    'user_id': userId,
+    if (filePath != null) 'file_path': filePath,
+    if (metadata != null) 'metadata': metadata,
+  };
+}
+
+Future<void> _writeEvents(
+  FileSystemService fs,
+  String userId,
+  List<Map<String, dynamic>> events,
+) async {
+  final byDate = <String, List<Map<String, dynamic>>>{};
+  for (final event in events) {
+    final date = DateTime.parse(event['event_time'] as String);
+    final key =
+        '${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+    byDate.putIfAbsent(key, () => []).add(event);
+  }
+
+  for (final entry in byDate.entries) {
+    final date = DateTime.parse(entry.key);
+    final file = File(fs.eventLogService.getEventLogPath(userId, date));
+    await file.parent.create(recursive: true);
+    await file.writeAsString(
+      '${entry.value.map(jsonEncode).join('\n')}\n',
+      mode: FileMode.append,
+    );
+  }
+}
+
+Future<void> _writeFactFile(
+  FileSystemService fs,
+  String userId,
+  DateTime date,
+  String content,
+) async {
+  final year = date.year.toString().padLeft(4, '0');
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  final file = File(p.join(fs.getFactsPath(userId), year, month, '$day.md'));
+  await file.parent.create(recursive: true);
+  await file.writeAsString(content);
+}

--- a/test/ui/insight/user_stats_page_test.dart
+++ b/test/ui/insight/user_stats_page_test.dart
@@ -1,0 +1,304 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/domain/models/knowledge_insight_card.dart';
+import 'package:memex/domain/models/user_stats_model.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/insight/view_models/insight_viewmodel.dart';
+import 'package:memex/ui/insight/widgets/insight_screen.dart';
+import 'package:memex/ui/insight/widgets/user_stats_page.dart';
+import 'package:memex/utils/result.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.saveUser('stats_widget_user');
+    await UserStorage.setLocale(const Locale('en'));
+    tempDir = await Directory.systemTemp.createTemp('memex_stats_widget_');
+    await FileSystemService.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  testWidgets('shows stats overview card and opens stats section', (
+    tester,
+  ) async {
+    final vm = _buildViewModel();
+
+    await tester.pumpWidget(
+      _wrap(InsightScreen(viewModel: vm, isEmbedded: true)),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.byKey(const ValueKey('user_stats_overview_card')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('user_stats_overview_card')),
+        matching: find.text('Activity stats'),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('user_stats_overview_card')));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byKey(const ValueKey('user_stats_page')), findsOneWidget);
+    await tester.drag(
+      find.byKey(const ValueKey('user_stats_page')),
+      const Offset(0, -520),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(find.text('Daily rhythm'), findsOneWidget);
+
+    vm.dispose();
+  });
+
+  testWidgets('reloads fresh stats when opening stats section', (
+    tester,
+  ) async {
+    final vm = _buildViewModel(statsReloadSnapshot: _singleInputSnapshot());
+    vm.statsSnapshot = UserStatsSnapshot.empty(vm.statsRange);
+
+    await tester.pumpWidget(
+      _wrap(InsightScreen(viewModel: vm, isEmbedded: true)),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.tap(find.byKey(const ValueKey('user_stats_overview_card')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 700));
+
+    expect(find.byKey(const ValueKey('user_stats_page')), findsOneWidget);
+    expect(
+      find.text(
+        'In this period you recorded 1 time(s), generated 0 card(s), and completed 0 todo(s).',
+      ),
+      findsOneWidget,
+    );
+
+    vm.dispose();
+  });
+
+  testWidgets('switches metric and opens day detail sheet', (tester) async {
+    var selectedMetric = UserStatsMetric.inputs;
+    await tester.pumpWidget(
+      _wrap(
+        StatefulBuilder(
+          builder: (context, setState) {
+            return UserStatsPage(
+              snapshot: _snapshot(),
+              isLoading: false,
+              errorMessage: null,
+              selectedMetric: selectedMetric,
+              onMetricChanged: (metric) => setState(() {
+                selectedMetric = metric;
+              }),
+              onPresetSelected: (_) {},
+              onReload: () {},
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('stats_metric_cards')),
+      220,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.tap(find.byKey(const ValueKey('stats_metric_cards')));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(selectedMetric, UserStatsMetric.cards);
+
+    final dayKey = find.byKey(const ValueKey('stats_day_2026-05-20'));
+    await tester.scrollUntilVisible(
+      dayKey,
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.tap(dayKey);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Day details'), findsOneWidget);
+    expect(find.text('Weekly review'), findsOneWidget);
+    expect(find.text('Clean desk'), findsOneWidget);
+  });
+}
+
+InsightViewModel _buildViewModel({UserStatsSnapshot? statsReloadSnapshot}) {
+  final vm = InsightViewModel(
+    router: MemexRouter(),
+    userStatsFetcher: (_) async => Ok(statsReloadSnapshot ?? _snapshot()),
+  );
+  vm.isLoading = false;
+  vm.insights = [
+    KnowledgeInsightCard(
+      id: 'dummy',
+      title: 'Dummy',
+      html: '',
+      createdAt: 0,
+      isPinned: false,
+      sortOrder: 0,
+      tags: const [],
+      widgetType: 'native',
+      widgetTemplate: 'highlight_card_v1',
+      widgetData: const {'quote_content': 'A small insight'},
+    ),
+  ];
+  vm.statsSnapshot = _snapshot();
+  vm.isStatsLoading = false;
+  return vm;
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: child),
+  );
+}
+
+UserStatsSnapshot _snapshot() {
+  final range = UserStatsDateRange(
+    start: DateTime(2026, 5, 18),
+    end: DateTime(2026, 5, 20),
+  );
+  final daily = [
+    UserStatsDailyPoint(
+      date: DateTime(2026, 5, 18),
+      inputs: 2,
+      words: 18,
+      cards: 1,
+      knowledgeUnits: 1,
+      insights: 0,
+      completedTodos: 0,
+    ),
+    UserStatsDailyPoint(
+      date: DateTime(2026, 5, 19),
+      inputs: 1,
+      words: 8,
+      cards: 1,
+      knowledgeUnits: 0,
+      insights: 1,
+      completedTodos: 0,
+    ),
+    UserStatsDailyPoint(
+      date: DateTime(2026, 5, 20),
+      inputs: 1,
+      words: 5,
+      cards: 2,
+      knowledgeUnits: 1,
+      insights: 1,
+      completedTodos: 1,
+    ),
+  ];
+  return UserStatsSnapshot(
+    range: range,
+    summary: const UserStatsSummary(
+      totalInputs: 4,
+      totalWords: 31,
+      totalCards: 4,
+      totalKnowledgeUnits: 2,
+      totalInsights: 2,
+      totalCompletedTodos: 1,
+      activeDays: 3,
+      currentStreakDays: 3,
+    ),
+    daily: daily,
+    sourceBreakdown: const UserStatsSourceBreakdown(
+      textInputs: 3,
+      imageInputs: 1,
+      audioInputs: 1,
+    ),
+    topTags: const [
+      UserStatsTopTag(label: 'work', count: 2),
+      UserStatsTopTag(label: 'health', count: 1),
+    ],
+    dayDetails: {
+      '2026-05-18': UserStatsDayDetail(
+        date: DateTime(2026, 5, 18),
+        cardTitles: const ['Morning note'],
+        knowledgePaths: const ['PKM/Areas/work.md'],
+      ),
+      '2026-05-19': UserStatsDayDetail(
+        date: DateTime(2026, 5, 19),
+        insightTitles: const ['Pattern found'],
+      ),
+      '2026-05-20': UserStatsDayDetail(
+        date: DateTime(2026, 5, 20),
+        cardTitles: const ['Weekly review'],
+        knowledgePaths: const ['PKM/Projects/app.md'],
+        insightTitles: const ['Better cadence'],
+        completedTodoTitles: const ['Clean desk'],
+      ),
+    },
+  );
+}
+
+UserStatsSnapshot _singleInputSnapshot() {
+  final today = DateTime.now();
+  final range = UserStatsDateRange.lastDays(7, now: today);
+  final daily = List.generate(range.dayCount, (index) {
+    final date = range.start.add(Duration(days: index));
+    final isToday = date.year == today.year &&
+        date.month == today.month &&
+        date.day == today.day;
+    return UserStatsDailyPoint(
+      date: date,
+      inputs: isToday ? 1 : 0,
+      words: isToday ? 3 : 0,
+      cards: 0,
+      knowledgeUnits: 0,
+      insights: 0,
+      completedTodos: 0,
+    );
+  });
+
+  return UserStatsSnapshot(
+    range: range,
+    summary: const UserStatsSummary(
+      totalInputs: 1,
+      totalWords: 3,
+      totalCards: 0,
+      totalKnowledgeUnits: 0,
+      totalInsights: 0,
+      totalCompletedTodos: 0,
+      activeDays: 1,
+      currentStreakDays: 1,
+    ),
+    daily: daily,
+    sourceBreakdown: const UserStatsSourceBreakdown(
+      textInputs: 1,
+      imageInputs: 0,
+      audioInputs: 0,
+    ),
+    topTags: const [],
+    dayDetails: {
+      for (final point in daily)
+        _dateKey(point.date): UserStatsDayDetail(date: point.date),
+    },
+  );
+}
+
+String _dateKey(DateTime date) {
+  final year = date.year.toString().padLeft(4, '0');
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '$year-$month-$day';
+}


### PR DESCRIPTION
## 背景
关联 #165。本 PR 把用户面向的活动统计放进「洞察」大 tab，而不是新增一级页面：洞察页顶部保留「洞察 / 活动统计」二级切换，洞察列表里也会出现轻量统计入口卡片。

## 主要改动
- 新增 UserStatsService 和 UserStatsSnapshot，从本地 Facts、Cards、KnowledgeInsights、event log 聚合最近 7/30/90 天的记录次数、字数、生成卡片、知识单元、洞察、完成 todo、来源占比和高频主题。
- 在洞察页新增活动统计概览卡片和统计二级页，支持指标切换、日期范围切换、每日明细弹层。
- 给知识洞察 Agent 增加只读 get_user_activity_stats 工具，供生成 recap/洞察时引用确定性统计数据。
- todo 完成/重新打开时写入用户活动事件，时间线切进洞察时刷新统计快照。
- 补充中英文文案、服务单测和 Widget test。

## 测试
- flutter test --no-pub test/data/services/user_stats_service_test.dart test/ui/insight/user_stats_page_test.dart
- dart analyze lib/data/services/user_stats_service.dart lib/domain/models/user_stats_model.dart lib/ui/insight/widgets/user_stats_overview_card.dart lib/ui/insight/widgets/user_stats_page.dart test/data/services/user_stats_service_test.dart test/ui/insight/user_stats_page_test.dart
- dart analyze lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart lib/data/repositories/memex_router.dart lib/data/repositories/update_card_ui_config.dart lib/ui/insight/view_models/insight_viewmodel.dart lib/ui/insight/widgets/insight_screen.dart lib/ui/timeline/widgets/timeline_screen.dart（仅保留仓库既有 info 级提示，未为清 lint 修改无关代码）
- 已用私有备份在 headless Android 模拟器做脱敏烟测：数据恢复、统计展示、AI 生成洞察流程可用；提交与 PR 中不包含密钥、备份文件名或用户原始数据。