### PR TITLE
[codex] 修复待办完成状态同步

### DIFF
--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -740,8 +740,8 @@ You are a "Personal Schedule Curator" — an empathetic time coach who sees patt
 ## Completion Semantics
 - `get_schedule_cards.status` is the schedule item status, not the timeline card processing status.
 - `get_schedule_cards.start_time` is the schedule display time. For task cards, it falls back to `due_date` when the original card has no explicit `start_time`.
-- For task cards, only `is_completed: true` means the user's task is done.
-- If `is_completed` is absent or false, keep the task pending even if the AI card generation has finished.
+- For task cards, `is_completed: true` means the user's task is done. For grouped tasks, all source subtasks completed also means the parent task is done.
+- If `is_completed` is absent/false and not all subtasks are completed, keep the task pending even if the AI card generation has finished.
 
 ## Output Schema
 When calling `save_schedule_aggregation`, the `yaml_data` object MUST follow this structure:

--- a/lib/agent/schedule_refresh_router_agent/prompt.dart
+++ b/lib/agent/schedule_refresh_router_agent/prompt.dart
@@ -14,12 +14,17 @@ Available actions:
 1. skip_schedule_refresh: use when the new card is unrelated to schedule/todos.
 2. mark_schedule_dirty: use for most schedule-related changes. This only marks
    the view as potentially stale; it does not run the full aggregator.
-3. request_schedule_refresh: use sparingly, only when immediate refresh is
+3. mark_existing_task_completed: use only when the user's new input clearly says
+   an existing todo/task or one of its subtasks is now completed, and the target
+   is unambiguous in recent schedule context.
+4. request_schedule_refresh: use sparingly, only when immediate refresh is
    clearly valuable, such as an explicit edit/cancel/reschedule of a near-term
    item that would make the current schedule view misleading.
 
 Prefer mark_schedule_dirty over request_schedule_refresh. Do not call more than
 one action tool. If the new card contains event/task/routine/duration/procedure
 template data, do not skip it; mark it dirty unless an immediate refresh is
-clearly needed. Keep the reason short and user-facing.
+clearly needed. For completion updates, prefer mark_existing_task_completed when
+the match is clear; if uncertain, use mark_schedule_dirty instead. Keep the
+reason short and user-facing.
 ''';

--- a/lib/agent/schedule_refresh_router_agent/schedule_refresh_router_agent.dart
+++ b/lib/agent/schedule_refresh_router_agent/schedule_refresh_router_agent.dart
@@ -7,6 +7,7 @@ import 'package:memex/agent/agent_system_prompt_helper.dart';
 import 'package:memex/agent/schedule_refresh_router_agent/prompt.dart';
 import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart';
 import 'package:memex/agent/state_util.dart';
+import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/global_event_bus.dart';
 import 'package:memex/data/services/schedule_refresh_state_service.dart';
 import 'package:memex/domain/models/card_model.dart';
@@ -19,6 +20,7 @@ final _logger = getLogger('ScheduleRefreshRouterAgent');
 enum ScheduleRefreshRouteAction {
   skipped,
   markedDirty,
+  updatedExistingTask,
   requestedRefresh,
 }
 
@@ -66,6 +68,10 @@ class ScheduleRefreshRouterAgent {
       _buildMarkDirtyTool(
         userId: userId,
         defaultFactId: factId,
+        onDecision: (decision) => toolDecision = decision,
+      ),
+      _buildMarkExistingTaskCompletedTool(
+        userId: userId,
         onDecision: (decision) => toolDecision = decision,
       ),
       _buildRequestRefreshTool(
@@ -141,6 +147,65 @@ class ScheduleRefreshRouterAgent {
   }
 }
 
+Future<bool> markExistingScheduleTaskCompleted({
+  required String userId,
+  required String cardId,
+  String? subtaskTitle,
+}) async {
+  final fileSystem = FileSystemService.instance;
+  final trimmedSubtaskTitle = subtaskTitle?.trim();
+  var didUpdate = false;
+
+  final updatedCard = await fileSystem.updateCardFile(userId, cardId, (card) {
+    final taskIndex = card.uiConfigs.indexWhere(
+      (config) => config.templateId == 'task',
+    );
+    if (taskIndex < 0) {
+      throw StateError('No task ui_config found for $cardId');
+    }
+
+    final config = card.uiConfigs[taskIndex];
+    final data = Map<String, dynamic>.from(config.data);
+    final rawSubtasks = data['subtasks'];
+
+    if (rawSubtasks is List && rawSubtasks.isNotEmpty) {
+      final subtasks = _normalizeTaskSubtasks(rawSubtasks);
+      if (subtasks.isEmpty) {
+        throw StateError('Malformed subtasks for $cardId');
+      }
+
+      if (trimmedSubtaskTitle == null || trimmedSubtaskTitle.isEmpty) {
+        data['subtasks'] = _setSubtasksCompleted(subtasks);
+        data['is_completed'] = true;
+      } else {
+        final index = _findSubtaskIndex(subtasks, trimmedSubtaskTitle);
+        if (index < 0) {
+          throw StateError(
+            'No matching subtask "$trimmedSubtaskTitle" found for $cardId',
+          );
+        }
+        subtasks[index] = {...subtasks[index], 'completed': true};
+        data['subtasks'] = subtasks;
+        data['is_completed'] = subtasks.every(
+          (subtask) => _parseTaskCompleted(subtask['completed']),
+        );
+      }
+    } else {
+      data['is_completed'] = true;
+    }
+
+    final updatedConfigs = card.uiConfigs.toList();
+    updatedConfigs[taskIndex] = UiConfig(
+      templateId: config.templateId,
+      data: data,
+    );
+    didUpdate = true;
+    return card.copyWith(uiConfigs: updatedConfigs);
+  });
+
+  return didUpdate && updatedCard != null;
+}
+
 Future<ScheduleRefreshRouteResult> ensureScheduleRelevantDecision({
   required String userId,
   required String factId,
@@ -152,9 +217,7 @@ Future<ScheduleRefreshRouteResult> ensureScheduleRelevantDecision({
     return decision;
   }
 
-  _logger.info(
-    'Schedule refresh skip overridden for temporal card $factId',
-  );
+  _logger.info('Schedule refresh skip overridden for temporal card $factId');
   return fallbackScheduleRefreshDecision(
     userId: userId,
     factId: factId,
@@ -212,10 +275,12 @@ Map<String, dynamic> buildScheduleRefreshRouterContext({
       'status': cardData.status,
       'tags': cardData.tags,
       'ui_configs': cardData.uiConfigs
-          .map((config) => {
-                'template_id': config.templateId,
-                'data': _compactValue(config.data),
-              })
+          .map(
+            (config) => {
+              'template_id': config.templateId,
+              'data': _compactValue(config.data),
+            },
+          )
           .toList(),
     },
     'recent_schedule_context': recentScheduleContext,
@@ -283,11 +348,7 @@ Tool _buildMarkDirtyTool({
       },
       'required': ['reason'],
     },
-    executable: (
-      String reason,
-      List<dynamic>? cardIds,
-      num? confidence,
-    ) async {
+    executable: (String reason, List<dynamic>? cardIds, num? confidence) async {
       final ids = _normalizeCardIds(cardIds, defaultFactId);
       await ScheduleRefreshStateService.instance.markDirty(
         userId: userId,
@@ -303,6 +364,70 @@ Tool _buildMarkDirtyTool({
       onDecision(decision);
       return 'Schedule marked dirty: $reason';
     },
+  );
+}
+
+Tool _buildMarkExistingTaskCompletedTool({
+  required String userId,
+  required void Function(ScheduleRefreshRouteResult decision) onDecision,
+}) {
+  return Tool(
+    name: 'mark_existing_task_completed',
+    description:
+        'Mark an existing todo/task card or one exact subtask as completed. Use only when the user explicitly says it is done and the target clearly matches recent schedule context.',
+    parameters: {
+      'type': 'object',
+      'properties': {
+        'card_id': {
+          'type': 'string',
+          'description': 'Existing task card ID from recent_schedule_context.',
+        },
+        'subtask_title': {
+          'type': 'string',
+          'description':
+              'Exact subtask title from recent_schedule_context when only one subtask was completed. Omit to complete the whole task.',
+        },
+        'reason': {
+          'type': 'string',
+          'description': 'Short user-facing reason.',
+        },
+        'confidence': {
+          'type': 'number',
+          'description': 'Confidence from 0 to 1.',
+        },
+      },
+      'required': ['card_id', 'reason'],
+    },
+    executable:
+        (
+          String cardId,
+          String? subtaskTitle,
+          String reason,
+          num? confidence,
+        ) async {
+          final updated = await markExistingScheduleTaskCompleted(
+            userId: userId,
+            cardId: cardId,
+            subtaskTitle: subtaskTitle,
+          );
+          if (!updated) {
+            throw StateError('Failed to update existing task $cardId');
+          }
+
+          await ScheduleRefreshStateService.instance.markDirty(
+            userId: userId,
+            reason: reason,
+            cardIds: [cardId],
+          );
+          final decision = ScheduleRefreshRouteResult(
+            action: ScheduleRefreshRouteAction.updatedExistingTask,
+            reason: reason,
+            cardIds: [cardId],
+            confidence: confidence?.toDouble(),
+          );
+          onDecision(decision);
+          return 'Marked existing task completed: $cardId';
+        },
   );
 }
 
@@ -333,11 +458,7 @@ Tool _buildRequestRefreshTool({
       },
       'required': ['reason'],
     },
-    executable: (
-      String reason,
-      List<dynamic>? cardIds,
-      num? confidence,
-    ) async {
+    executable: (String reason, List<dynamic>? cardIds, num? confidence) async {
       final ids = _normalizeCardIds(cardIds, defaultFactId);
       await ScheduleRefreshStateService.instance.markDirty(
         userId: userId,
@@ -350,10 +471,7 @@ Tool _buildRequestRefreshTool({
         event: SystemEvent(
           type: SystemEventTypes.scheduleAggregationRequested,
           source: 'schedule_refresh_router_agent',
-          payload: {
-            'reason': reason,
-            'card_ids': ids,
-          },
+          payload: {'reason': reason, 'card_ids': ids},
         ),
       );
       final decision = ScheduleRefreshRouteResult(
@@ -374,6 +492,48 @@ List<String> _normalizeCardIds(List<dynamic>? cardIds, String defaultFactId) {
     ...?cardIds?.map((e) => e.toString()).where((id) => id.isNotEmpty),
   };
   return ids.toList();
+}
+
+List<Map<String, dynamic>> _normalizeTaskSubtasks(List<dynamic> rawSubtasks) {
+  return rawSubtasks
+      .whereType<Map>()
+      .map((subtask) => Map<String, dynamic>.from(subtask))
+      .where(
+        (subtask) => (subtask['title']?.toString().trim() ?? '').isNotEmpty,
+      )
+      .toList();
+}
+
+List<Map<String, dynamic>> _setSubtasksCompleted(
+  List<Map<String, dynamic>> subtasks,
+) {
+  return subtasks.map((subtask) => {...subtask, 'completed': true}).toList();
+}
+
+int _findSubtaskIndex(
+  List<Map<String, dynamic>> subtasks,
+  String subtaskTitle,
+) {
+  final target = _normalizeTaskTitle(subtaskTitle);
+  return subtasks.indexWhere(
+    (subtask) => _normalizeTaskTitle(subtask['title']) == target,
+  );
+}
+
+String _normalizeTaskTitle(dynamic value) {
+  return value?.toString().trim().toLowerCase() ?? '';
+}
+
+bool _parseTaskCompleted(dynamic value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    return switch (value.toLowerCase().trim()) {
+      'true' || 'yes' || 'y' || '1' || 'done' || 'completed' => true,
+      _ => false,
+    };
+  }
+  return false;
 }
 
 String _safeSessionPart(String value) {

--- a/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
+++ b/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
@@ -11,18 +11,18 @@ import '../../../utils/user_storage.dart';
 
 class ScheduleAggregationSkill extends Skill {
   ScheduleAggregationSkill({super.forceActivate})
-      : super(
-          name: "update_schedule_aggregation",
-          description:
-              "Analyzes user's temporal cards (events, tasks, routines) and generates a magazine-style schedule aggregation.",
-          systemPrompt: Prompts.scheduleAggregatorSkillPrompt(
-            UserStorage.l10n.scheduleAggregatorLanguageInstruction,
-          ),
-          tools: [
-            buildGetScheduleCardsTool(),
-            buildSaveScheduleAggregationTool(),
-          ],
-        );
+    : super(
+        name: "update_schedule_aggregation",
+        description:
+            "Analyzes user's temporal cards (events, tasks, routines) and generates a magazine-style schedule aggregation.",
+        systemPrompt: Prompts.scheduleAggregatorSkillPrompt(
+          UserStorage.l10n.scheduleAggregatorLanguageInstruction,
+        ),
+        tools: [
+          buildGetScheduleCardsTool(),
+          buildSaveScheduleAggregationTool(),
+        ],
+      );
 }
 
 const scheduleTemporalTemplateIds = {
@@ -77,6 +77,7 @@ Future<Map<String, dynamic>> queryScheduleCardsForRange({
       final templateId = uiConfig.templateId;
       final data = uiConfig.data;
       final startTime = scheduleStartTimeForCard(templateId, data);
+      final status = deriveScheduleCardStatus(templateId, data);
 
       if (!_isCardInScheduleRange(
         templateId: templateId,
@@ -93,13 +94,13 @@ Future<Map<String, dynamic>> queryScheduleCardsForRange({
         'title': cardData.title,
         'template_id': templateId,
         'timestamp': cardData.timestamp,
-        'status': deriveScheduleCardStatus(templateId, data),
+        'status': status,
         'tags': cardData.tags,
         'start_time': startTime,
         'end_time': data['end_time'],
         'location': data['location'],
         'is_completed': templateId == 'task'
-            ? _parseScheduleBool(data['is_completed']) == true
+            ? status == 'completed'
             : data['is_completed'],
         'priority': data['priority'],
         'due_date': data['due_date'],
@@ -295,9 +296,10 @@ bool _isCardInScheduleRange({
   final start = switch (templateId) {
     'event' => _parseScheduleDateTime(data['start_time']) ?? fallback,
     'task' => _parseScheduleDateTime(data['due_date']) ?? fallback,
-    _ => _parseScheduleDateTime(data['start_time']) ??
-        _parseScheduleDateTime(data['due_date']) ??
-        fallback,
+    _ =>
+      _parseScheduleDateTime(data['start_time']) ??
+          _parseScheduleDateTime(data['due_date']) ??
+          fallback,
   };
 
   final end = _parseScheduleDateTime(data['end_time']) ?? start;
@@ -343,12 +345,31 @@ DateTime _resultScheduleDate(Map<String, dynamic> result) {
 
 String deriveScheduleCardStatus(String templateId, Map<String, dynamic> data) {
   if (templateId == 'task') {
-    return _parseScheduleBool(data['is_completed']) == true
-        ? 'completed'
-        : 'pending';
+    if (_deriveTaskCompleted(data)) return 'completed';
+    if (_hasCompletedSubtask(data['subtasks'])) return 'in_progress';
+    return 'pending';
   }
 
   return 'pending';
+}
+
+bool _deriveTaskCompleted(Map<String, dynamic> data) {
+  if (_parseScheduleBool(data['is_completed']) == true) return true;
+  final subtasks = data['subtasks'];
+  return subtasks is List &&
+      subtasks.isNotEmpty &&
+      subtasks.every(
+        (subtask) =>
+            subtask is Map && _parseScheduleBool(subtask['completed']) == true,
+      );
+}
+
+bool _hasCompletedSubtask(dynamic value) {
+  return value is List &&
+      value.any(
+        (subtask) =>
+            subtask is Map && _parseScheduleBool(subtask['completed']) == true,
+      );
 }
 
 bool? _parseScheduleBool(dynamic value) {
@@ -369,10 +390,10 @@ int _countAggregationItems(Map<String, dynamic> yamlData) {
   final heroCount = yamlData['hero_item'] == null ? 0 : 1;
   final timelineCount =
       (yamlData['timeline'] as List?)?.whereType<Map>().fold<int>(
-                0,
-                (count, day) => count + ((day['items'] as List?)?.length ?? 0),
-              ) ??
-          0;
+        0,
+        (count, day) => count + ((day['items'] as List?)?.length ?? 0),
+      ) ??
+      0;
   final completedCount = (yamlData['completed'] as List?)?.length ?? 0;
   return heroCount + timelineCount + completedCount;
 }

--- a/lib/data/repositories/get_schedule_aggregation.dart
+++ b/lib/data/repositories/get_schedule_aggregation.dart
@@ -1,4 +1,5 @@
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/domain/models/schedule_aggregation_model.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -21,7 +22,12 @@ Future<ScheduleAggregationModel?> getScheduleAggregation() async {
       return null;
     }
 
-    return ScheduleAggregationModel.fromYaml(latest);
+    final hydrated = await _hydrateLiveTaskState(
+      fileSystem: fileSystem,
+      userId: userId,
+      aggregation: latest,
+    );
+    return ScheduleAggregationModel.fromYaml(hydrated);
   } catch (e) {
     _logger.severe('Failed to get schedule aggregation: $e');
     return null;
@@ -47,4 +53,173 @@ Future<bool> scheduleAggregationNeedsRefresh({Duration? maxAge}) async {
     _logger.warning('Failed to check schedule aggregation freshness: $e');
     return true;
   }
+}
+
+Future<Map<String, dynamic>> _hydrateLiveTaskState({
+  required FileSystemService fileSystem,
+  required String userId,
+  required Map<String, dynamic> aggregation,
+}) async {
+  final cardIds = _collectScheduleCardIds(aggregation);
+  if (cardIds.isEmpty) return aggregation;
+
+  final states = <String, _LiveTaskState>{};
+  for (final cardId in cardIds) {
+    final card = await fileSystem.readCardFile(userId, cardId);
+    final state = _LiveTaskState.fromCard(card);
+    if (state != null) {
+      states[cardId] = state;
+    }
+  }
+  if (states.isEmpty) return aggregation;
+
+  final hydrated = Map<String, dynamic>.from(aggregation);
+  final timeline = hydrated['timeline'];
+  if (timeline is List) {
+    hydrated['timeline'] = timeline.map((dayValue) {
+      if (dayValue is! Map) return dayValue;
+      final day = Map<String, dynamic>.from(dayValue);
+      final items = day['items'];
+      if (items is List) {
+        day['items'] = items.map((itemValue) {
+          if (itemValue is! Map) return itemValue;
+          final item = Map<String, dynamic>.from(itemValue);
+          if (!_isTaskTimelineItem(item)) return item;
+          final state = states[_readCardId(item)];
+          if (state == null) return item;
+          return _hydrateTimelineTaskItem(item, state);
+        }).toList();
+      }
+      return day;
+    }).toList();
+  }
+
+  final completed = hydrated['completed'];
+  if (completed is List) {
+    hydrated['completed'] = completed.where((itemValue) {
+      if (itemValue is! Map) return true;
+      final state = states[_readCardId(Map<String, dynamic>.from(itemValue))];
+      return state == null || state.isCompleted;
+    }).toList();
+  }
+
+  return hydrated;
+}
+
+Set<String> _collectScheduleCardIds(Map<String, dynamic> aggregation) {
+  final cardIds = <String>{};
+  final timeline = aggregation['timeline'];
+  if (timeline is List) {
+    for (final dayValue in timeline) {
+      if (dayValue is! Map) continue;
+      final items = dayValue['items'];
+      if (items is! List) continue;
+      for (final itemValue in items) {
+        if (itemValue is! Map) continue;
+        final cardId = _readCardId(Map<String, dynamic>.from(itemValue));
+        if (cardId.isNotEmpty) cardIds.add(cardId);
+      }
+    }
+  }
+
+  final completed = aggregation['completed'];
+  if (completed is List) {
+    for (final itemValue in completed) {
+      if (itemValue is! Map) continue;
+      final cardId = _readCardId(Map<String, dynamic>.from(itemValue));
+      if (cardId.isNotEmpty) cardIds.add(cardId);
+    }
+  }
+  return cardIds;
+}
+
+Map<String, dynamic> _hydrateTimelineTaskItem(
+  Map<String, dynamic> item,
+  _LiveTaskState state,
+) {
+  return {
+    ...item,
+    'type': 'task',
+    'status': state.status,
+    if (state.subtasks.isNotEmpty) 'subtasks': state.subtasks,
+    if (state.subtasks.isEmpty) 'subtasks': null,
+  }..removeWhere((key, value) => key == 'subtasks' && value == null);
+}
+
+String _readCardId(Map<String, dynamic> value) {
+  return (value['card_id'] ?? value['id'] ?? '').toString();
+}
+
+bool _isTaskTimelineItem(Map<String, dynamic> item) {
+  final type = item['type']?.toString().toLowerCase().trim();
+  return type == 'task' || type == 'todo';
+}
+
+class _LiveTaskState {
+  _LiveTaskState({required this.isCompleted, required this.subtasks});
+
+  final bool isCompleted;
+  final List<Map<String, dynamic>> subtasks;
+
+  String get status {
+    if (isCompleted) return 'completed';
+    if (subtasks.any((subtask) => _parseTaskBool(subtask['completed']))) {
+      return 'in_progress';
+    }
+    return 'pending';
+  }
+
+  static _LiveTaskState? fromCard(CardData? card) {
+    if (card == null) return null;
+    UiConfig? taskConfig;
+    for (final config in card.uiConfigs) {
+      if (config.templateId == 'task') {
+        taskConfig = config;
+        break;
+      }
+    }
+    if (taskConfig == null) return null;
+
+    final data = taskConfig.data;
+    final normalizedSubtasks = _normalizeSubtasks(data['subtasks']);
+    final explicitCompleted = _parseTaskBool(data['is_completed']);
+    final subtasksCompleted =
+        normalizedSubtasks.isNotEmpty &&
+        normalizedSubtasks.every(
+          (subtask) => _parseTaskBool(subtask['completed']),
+        );
+    final isCompleted = explicitCompleted || subtasksCompleted;
+
+    return _LiveTaskState(
+      isCompleted: isCompleted,
+      subtasks: isCompleted
+          ? normalizedSubtasks
+                .map((subtask) => {...subtask, 'completed': true})
+                .toList()
+          : normalizedSubtasks,
+    );
+  }
+}
+
+List<Map<String, dynamic>> _normalizeSubtasks(dynamic value) {
+  if (value is! List) return const [];
+  return value
+      .whereType<Map>()
+      .map((subtask) => Map<String, dynamic>.from(subtask))
+      .where(
+        (subtask) => (subtask['title']?.toString().trim() ?? '').isNotEmpty,
+      )
+      .toList();
+}
+
+bool _parseTaskBool(dynamic value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    return switch (value.toLowerCase().trim()) {
+      'true' || 'yes' || 'y' || '1' || 'done' || 'completed' => true,
+      _ => false,
+    };
+  }
+  return false;
 }

--- a/lib/ui/core/cards/templates/temporal/task_card.dart
+++ b/lib/ui/core/cards/templates/temporal/task_card.dart
@@ -10,7 +10,7 @@ class TaskCard extends StatefulWidget {
   final String? cardId;
   final int? configIndex;
   final Function(String cardId, int configIndex, Map<String, dynamic> data)?
-      onUpdate;
+  onUpdate;
 
   const TaskCard({
     super.key,
@@ -44,13 +44,25 @@ class _TaskCardState extends State<TaskCard> {
   }
 
   void _initializeState() {
-    _isCompleted = widget.data['is_completed'] ?? false;
-    _subtasks = List.from(widget.data['subtasks'] ?? []);
+    _subtasks = (widget.data['subtasks'] as List? ?? const [])
+        .whereType<Map>()
+        .map((task) => Map<String, dynamic>.from(task))
+        .toList();
+    _isCompleted =
+        _parseCompletedBool(widget.data['is_completed']) ||
+        (_subtasks.isNotEmpty &&
+            _subtasks.every((task) => _parseCompletedBool(task['completed'])));
+    if (_isCompleted && _subtasks.isNotEmpty) {
+      _subtasks = _setSubtasksCompletion(_subtasks, completed: true);
+    }
   }
 
   void _toggleCompletion() {
     setState(() {
       _isCompleted = !_isCompleted;
+      if (_subtasks.isNotEmpty) {
+        _subtasks = _setSubtasksCompletion(_subtasks, completed: _isCompleted);
+      }
     });
     _updateData();
   }
@@ -58,11 +70,11 @@ class _TaskCardState extends State<TaskCard> {
   void _toggleSubtask(int index) {
     setState(() {
       final task = Map<String, dynamic>.from(_subtasks[index]);
-      task['completed'] = !(task['completed'] ?? false);
+      task['completed'] = !_parseCompletedBool(task['completed']);
       _subtasks[index] = task;
-
-      // Optional: Auto-update parent completion if all subtasks are done
-      // For now, keeping them independent as per typical todo list behavior
+      _isCompleted =
+          _subtasks.isNotEmpty &&
+          _subtasks.every((task) => _parseCompletedBool(task['completed']));
     });
     _updateData();
   }
@@ -71,14 +83,10 @@ class _TaskCardState extends State<TaskCard> {
     if (widget.cardId != null &&
         widget.configIndex != null &&
         widget.onUpdate != null) {
-      widget.onUpdate!(
-        widget.cardId!,
-        widget.configIndex!,
-        {
-          'is_completed': _isCompleted,
-          'subtasks': _subtasks,
-        },
-      );
+      widget.onUpdate!(widget.cardId!, widget.configIndex!, {
+        'is_completed': _isCompleted,
+        'subtasks': _subtasks,
+      });
     }
   }
 
@@ -101,17 +109,23 @@ class _TaskCardState extends State<TaskCard> {
           Row(
             children: [
               GestureDetector(
+                key: widget.cardId == null
+                    ? null
+                    : ValueKey('task_card_toggle_${widget.cardId}'),
                 onTap: _toggleCompletion,
                 child: Container(
                   width: 20,
                   height: 20,
                   decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      border:
-                          Border.all(color: const Color(0xFF5B6CFF), width: 2),
-                      color: _isCompleted
-                          ? const Color(0xFF5B6CFF)
-                          : Colors.transparent),
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: const Color(0xFF5B6CFF),
+                      width: 2,
+                    ),
+                    color: _isCompleted
+                        ? const Color(0xFF5B6CFF)
+                        : Colors.transparent,
+                  ),
                   child: _isCompleted
                       ? const Icon(Icons.check, size: 12, color: Colors.white)
                       : null,
@@ -119,18 +133,25 @@ class _TaskCardState extends State<TaskCard> {
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: Text(title,
-                    style: TextStyle(
-                        fontSize: 17,
-                        fontWeight: FontWeight.bold,
-                        color: const Color(0xFF0A0A0A),
-                        decoration:
-                            _isCompleted ? TextDecoration.lineThrough : null,
-                        decorationColor: const Color(0xFF99A1AF))),
+                child: Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.bold,
+                    color: const Color(0xFF0A0A0A),
+                    decoration: _isCompleted
+                        ? TextDecoration.lineThrough
+                        : null,
+                    decorationColor: const Color(0xFF99A1AF),
+                  ),
+                ),
               ),
               if (widget.data['priority'] == 'high')
-                const Icon(Icons.priority_high,
-                    size: 16, color: Color(0xFFF43F5E))
+                const Icon(
+                  Icons.priority_high,
+                  size: 16,
+                  color: Color(0xFFF43F5E),
+                ),
             ],
           ),
           if (hasSubtasks) ...[
@@ -140,35 +161,43 @@ class _TaskCardState extends State<TaskCard> {
             ..._subtasks.asMap().entries.map((entry) {
               final int index = entry.key;
               final Map<String, dynamic> task = entry.value;
-              final bool done = task['completed'] ?? false;
+              final bool done = _parseCompletedBool(task['completed']);
               return Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4),
                 child: Row(
                   children: [
                     GestureDetector(
+                      key: widget.cardId == null
+                          ? null
+                          : ValueKey(
+                              'task_card_subtask_${widget.cardId}_$index',
+                            ),
                       onTap: () => _toggleSubtask(index),
                       behavior: HitTestBehavior.opaque,
                       child: Padding(
                         padding: const EdgeInsets.only(right: 8.0),
                         child: Icon(
-                            done
-                                ? Icons.check_box
-                                : Icons.check_box_outline_blank,
-                            size: 18,
-                            color: done
-                                ? const Color(0xFF99A1AF)
-                                : const Color(0xFF4A5565)),
+                          done
+                              ? Icons.check_box
+                              : Icons.check_box_outline_blank,
+                          size: 18,
+                          color: done
+                              ? const Color(0xFF99A1AF)
+                              : const Color(0xFF4A5565),
+                        ),
                       ),
                     ),
                     Expanded(
-                      child: Text(task['title'] ?? '',
-                          style: TextStyle(
-                              fontSize: 13,
-                              color: done
-                                  ? const Color(0xFF99A1AF)
-                                  : const Color(0xFF334155),
-                              decoration:
-                                  done ? TextDecoration.lineThrough : null)),
+                      child: Text(
+                        task['title'] ?? '',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: done
+                              ? const Color(0xFF99A1AF)
+                              : const Color(0xFF334155),
+                          decoration: done ? TextDecoration.lineThrough : null,
+                        ),
+                      ),
                     ),
                   ],
                 ),
@@ -180,13 +209,39 @@ class _TaskCardState extends State<TaskCard> {
                 padding: const EdgeInsets.only(top: 8, left: 32),
                 child: Text(
                   dueDateLabel,
-                  style:
-                      const TextStyle(fontSize: 11, color: Color(0xFF99A1AF)),
+                  style: const TextStyle(
+                    fontSize: 11,
+                    color: Color(0xFF99A1AF),
+                  ),
                 ),
-              )
-          ]
+              ),
+          ],
         ],
       ),
     );
   }
+}
+
+List<Map<String, dynamic>> _setSubtasksCompletion(
+  List<dynamic> subtasks, {
+  required bool completed,
+}) {
+  return subtasks
+      .whereType<Map>()
+      .map(
+        (task) => {...Map<String, dynamic>.from(task), 'completed': completed},
+      )
+      .toList();
+}
+
+bool _parseCompletedBool(dynamic value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    return switch (value.toLowerCase().trim()) {
+      'true' || 'yes' || 'y' || '1' || 'done' || 'completed' => true,
+      _ => false,
+    };
+  }
+  return false;
 }

--- a/test/agent/schedule_refresh_router_agent_test.dart
+++ b/test/agent/schedule_refresh_router_agent_test.dart
@@ -35,10 +35,7 @@ void main() {
         status: 'completed',
         tags: [],
         uiConfigs: [
-          UiConfig(
-            templateId: 'classic_card',
-            data: {'content': '普通记录'},
-          ),
+          UiConfig(templateId: 'classic_card', data: {'content': '普通记录'}),
         ],
       );
 
@@ -55,10 +52,7 @@ void main() {
         uiConfigs: [
           UiConfig(
             templateId: 'task',
-            data: {
-              'title': '收拾家里',
-              'due_date': '2026-04-27T10:00:00',
-            },
+            data: {'title': '收拾家里', 'due_date': '2026-04-27T10:00:00'},
           ),
         ],
       );
@@ -77,11 +71,64 @@ void main() {
       expect(context['recent_schedule_context']['count'], 0);
     });
 
-    test('overrides skipped LLM decisions for temporal routine cards',
-        () async {
-      const userId = 'router_test_user';
-      final tempDir =
-          await Directory.systemTemp.createTemp('memex_router_guard_');
+    test(
+      'overrides skipped LLM decisions for temporal routine cards',
+      () async {
+        const userId = 'router_test_user';
+        final tempDir = await Directory.systemTemp.createTemp(
+          'memex_router_guard_',
+        );
+        addTearDown(() async {
+          if (await tempDir.exists()) {
+            await tempDir.delete(recursive: true);
+          }
+        });
+
+        SharedPreferences.setMockInitialValues({});
+        await UserStorage.saveUser(userId);
+        await UserStorage.setLocale(const Locale('en'));
+        await FileSystemService.init(tempDir.path);
+
+        const card = CardData(
+          factId: '2026/05/14.md#ts_4',
+          timestamp: 1778753606,
+          status: 'completed',
+          title: 'Water plants',
+          tags: ['routine'],
+          uiConfigs: [
+            UiConfig(
+              templateId: 'routine',
+              data: {
+                'title': 'Water plants',
+                'next_due_date': '2026-05-18T20:00:00',
+              },
+            ),
+          ],
+        );
+
+        final decision = await ensureScheduleRelevantDecision(
+          userId: userId,
+          factId: card.factId,
+          cardData: card,
+          decision: const ScheduleRefreshRouteResult(
+            action: ScheduleRefreshRouteAction.skipped,
+            reason: 'LLM thought this routine had no schedule impact.',
+          ),
+        );
+
+        expect(decision.action, ScheduleRefreshRouteAction.markedDirty);
+        final state = await ScheduleRefreshStateService.instance.read(userId);
+        expect(state.isDirty, isTrue);
+        expect(state.cardIds, contains(card.factId));
+      },
+    );
+
+    test('marks an existing task card completed', () async {
+      const userId = 'router_task_update_user';
+      const cardId = '2026/05/23.md#ts_1';
+      final tempDir = await Directory.systemTemp.createTemp(
+        'memex_router_task_update_',
+      );
       addTearDown(() async {
         if (await tempDir.exists()) {
           await tempDir.delete(recursive: true);
@@ -90,40 +137,98 @@ void main() {
 
       SharedPreferences.setMockInitialValues({});
       await UserStorage.saveUser(userId);
-      await UserStorage.setLocale(const Locale('en'));
       await FileSystemService.init(tempDir.path);
-
-      const card = CardData(
-        factId: '2026/05/14.md#ts_4',
-        timestamp: 1778753606,
-        status: 'completed',
-        title: 'Water plants',
-        tags: ['routine'],
-        uiConfigs: [
-          UiConfig(
-            templateId: 'routine',
-            data: {
-              'title': 'Water plants',
-              'next_due_date': '2026-05-18T20:00:00',
-            },
-          ),
-        ],
-      );
-
-      final decision = await ensureScheduleRelevantDecision(
-        userId: userId,
-        factId: card.factId,
-        cardData: card,
-        decision: const ScheduleRefreshRouteResult(
-          action: ScheduleRefreshRouteAction.skipped,
-          reason: 'LLM thought this routine had no schedule impact.',
+      await FileSystemService.instance.safeWriteCardFile(
+        userId,
+        cardId,
+        const CardData(
+          factId: cardId,
+          timestamp: 1779494400,
+          status: 'completed',
+          tags: [],
+          uiConfigs: [
+            UiConfig(
+              templateId: 'task',
+              data: {'title': 'Prepare documents', 'is_completed': false},
+            ),
+          ],
         ),
       );
 
-      expect(decision.action, ScheduleRefreshRouteAction.markedDirty);
-      final state = await ScheduleRefreshStateService.instance.read(userId);
-      expect(state.isDirty, isTrue);
-      expect(state.cardIds, contains(card.factId));
+      final updated = await markExistingScheduleTaskCompleted(
+        userId: userId,
+        cardId: cardId,
+      );
+
+      expect(updated, isTrue);
+      final data = await _readTaskData(userId, cardId);
+      expect(data['is_completed'], isTrue);
     });
+
+    test(
+      'marks one existing subtask completed without completing the parent',
+      () async {
+        const userId = 'router_subtask_update_user';
+        const cardId = '2026/05/23.md#ts_2';
+        final tempDir = await Directory.systemTemp.createTemp(
+          'memex_router_subtask_update_',
+        );
+        addTearDown(() async {
+          if (await tempDir.exists()) {
+            await tempDir.delete(recursive: true);
+          }
+        });
+
+        SharedPreferences.setMockInitialValues({});
+        await UserStorage.saveUser(userId);
+        await FileSystemService.init(tempDir.path);
+        await FileSystemService.instance.safeWriteCardFile(
+          userId,
+          cardId,
+          const CardData(
+            factId: cardId,
+            timestamp: 1779494400,
+            status: 'completed',
+            tags: [],
+            uiConfigs: [
+              UiConfig(
+                templateId: 'task',
+                data: {
+                  'title': 'Visa checklist',
+                  'is_completed': false,
+                  'subtasks': [
+                    {'title': 'Collect documents', 'completed': false},
+                    {'title': 'Submit form', 'completed': false},
+                  ],
+                },
+              ),
+            ],
+          ),
+        );
+
+        final updated = await markExistingScheduleTaskCompleted(
+          userId: userId,
+          cardId: cardId,
+          subtaskTitle: 'Collect documents',
+        );
+
+        expect(updated, isTrue);
+        final data = await _readTaskData(userId, cardId);
+        expect(data['is_completed'], isFalse);
+        expect(
+          (data['subtasks'] as List).map(
+            (subtask) => (subtask as Map)['completed'],
+          ),
+          [true, false],
+        );
+      },
+    );
   });
+}
+
+Future<Map<String, dynamic>> _readTaskData(String userId, String cardId) async {
+  final card = await FileSystemService.instance.readCardFile(userId, cardId);
+  return card!.uiConfigs
+      .singleWhere((config) => config.templateId == 'task')
+      .data;
 }

--- a/test/agent/skills/schedule_aggregation_skill_test.dart
+++ b/test/agent/skills/schedule_aggregation_skill_test.dart
@@ -59,7 +59,7 @@ void main() {
       );
     });
 
-    test('uses only task is_completed to mark schedule tasks completed', () {
+    test('uses task completion fields to mark schedule tasks completed', () {
       expect(
         deriveScheduleCardStatus(
           'task',
@@ -87,6 +87,33 @@ void main() {
           <String, dynamic>{'is_completed': 0},
         ),
         'pending',
+      );
+    });
+
+    test('derives grouped task status from subtasks', () {
+      expect(
+        deriveScheduleCardStatus(
+          'task',
+          <String, dynamic>{
+            'subtasks': [
+              {'title': 'A', 'completed': true},
+              {'title': 'B', 'completed': true},
+            ],
+          },
+        ),
+        'completed',
+      );
+      expect(
+        deriveScheduleCardStatus(
+          'task',
+          <String, dynamic>{
+            'subtasks': [
+              {'title': 'A', 'completed': true},
+              {'title': 'B', 'completed': false},
+            ],
+          },
+        ),
+        'in_progress',
       );
     });
 

--- a/test/data/repositories/get_schedule_aggregation_test.dart
+++ b/test/data/repositories/get_schedule_aggregation_test.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/get_schedule_aggregation.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _userId = 'schedule_aggregation_test_user';
+const _cardId = '2026/05/23.md#ts_1';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.saveUser(_userId);
+    await UserStorage.setLocale(const Locale('en'));
+    tempDir = await Directory.systemTemp.createTemp(
+      'memex_get_schedule_aggregation_',
+    );
+    await FileSystemService.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('hydrates timeline task status from the live card file', () async {
+    await _writeAggregation(
+      timelineItems: [
+        {
+          'card_id': _cardId,
+          'title': 'Visa checklist',
+          'type': 'task',
+          'status': 'pending',
+          'subtasks': [
+            {'title': 'Collect documents', 'completed': false},
+            {'title': 'Submit form', 'completed': false},
+          ],
+        },
+      ],
+    );
+    await _writeTaskCard(
+      isCompleted: true,
+      subtasks: const [
+        {'title': 'Collect documents', 'completed': false},
+        {'title': 'Submit form', 'completed': false},
+      ],
+    );
+
+    final aggregation = await getScheduleAggregation();
+    final item = aggregation!.timeline.single.items.single;
+
+    expect(item.status, 'completed');
+    expect(item.subtasks.map((subtask) => subtask.completed), [true, true]);
+  });
+
+  test(
+    'removes stale completed task entries when the source card is pending',
+    () async {
+      await _writeAggregation(
+        completedItems: [
+          {'card_id': _cardId, 'title': 'Visa checklist'},
+        ],
+      );
+      await _writeTaskCard(isCompleted: false);
+
+      final aggregation = await getScheduleAggregation();
+
+      expect(aggregation!.completed, isEmpty);
+    },
+  );
+}
+
+Future<void> _writeAggregation({
+  List<Map<String, dynamic>> timelineItems = const [],
+  List<Map<String, dynamic>> completedItems = const [],
+}) {
+  return FileSystemService.instance.writeScheduleAggregation(
+    _userId,
+    'schedule_agg_test',
+    {
+      'id': 'schedule_agg_test',
+      'generated_at': '2026-05-23T09:00:00',
+      'version': 1,
+      'time_range': {'from': '2026-05-23', 'to': '2026-05-30'},
+      'timeline': [
+        if (timelineItems.isNotEmpty)
+          {
+            'day_label': 'Today',
+            'day_date': '2026-05-23',
+            'items': timelineItems,
+          },
+      ],
+      'completed': completedItems,
+      'conflicts': [],
+    },
+  );
+}
+
+Future<void> _writeTaskCard({
+  required bool isCompleted,
+  List<Map<String, dynamic>> subtasks = const [],
+}) {
+  return FileSystemService.instance.safeWriteCardFile(
+    _userId,
+    _cardId,
+    CardData(
+      factId: _cardId,
+      timestamp: DateTime(2026, 5, 23, 9).millisecondsSinceEpoch ~/ 1000,
+      status: 'completed',
+      tags: const [],
+      title: 'Visa checklist',
+      uiConfigs: [
+        UiConfig(
+          templateId: 'task',
+          data: {
+            'title': 'Visa checklist',
+            'is_completed': isCompleted,
+            if (subtasks.isNotEmpty) 'subtasks': subtasks,
+          },
+        ),
+      ],
+    ),
+  );
+}

--- a/test/ui/core/cards/templates/temporal/task_card_test.dart
+++ b/test/ui/core/cards/templates/temporal/task_card_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/core/cards/templates/temporal/task_card.dart';
+
+void main() {
+  testWidgets('parent completion updates every grouped subtask', (
+    tester,
+  ) async {
+    final updates = <Map<String, dynamic>>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TaskCard(
+            cardId: 'task-1',
+            configIndex: 0,
+            data: const {
+              'title': 'Visa checklist',
+              'is_completed': false,
+              'subtasks': [
+                {'title': 'Collect documents', 'completed': false},
+                {'title': 'Submit form', 'completed': false},
+              ],
+            },
+            onUpdate: (_, __, data) => updates.add(data),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('task_card_toggle_task-1')));
+    await tester.pump();
+
+    expect(updates.last['is_completed'], isTrue);
+    expect(
+      (updates.last['subtasks'] as List).map(
+        (subtask) => (subtask as Map)['completed'],
+      ),
+      [true, true],
+    );
+  });
+
+  testWidgets('last completed subtask completes the parent task', (
+    tester,
+  ) async {
+    final updates = <Map<String, dynamic>>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TaskCard(
+            cardId: 'task-1',
+            configIndex: 0,
+            data: const {
+              'title': 'Visa checklist',
+              'is_completed': false,
+              'subtasks': [
+                {'title': 'Collect documents', 'completed': true},
+                {'title': 'Submit form', 'completed': false},
+              ],
+            },
+            onUpdate: (_, __, data) => updates.add(data),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('task_card_subtask_task-1_1')));
+    await tester.pump();
+
+    expect(updates.last['is_completed'], isTrue);
+    expect(
+      (updates.last['subtasks'] as List).map(
+        (subtask) => (subtask as Map)['completed'],
+      ),
+      [true, true],
+    );
+  });
+}


### PR DESCRIPTION
## 概要

修复待办完成状态在新增输入、日程聚合页刷新、分组任务父子项之间不同步的问题。

关联 issue：Fixes #169

## 背景与根因

用户可能先记录一个待办，例如“我要写作业”，之后通过新增输入说“我写完作业了”。此前 Card Agent 只负责保存当前输入的新卡片，Schedule Refresh Router 也只有标记日程聚合过期或请求刷新两类动作，没有写回已有 task 卡片的执行出口。

同时，日程页刷新/重进页面时主要读取旧的 schedule aggregation 快照，未用原始 task 卡片里的最新 `is_completed` / `subtasks[].completed` 状态校正展示，所以用户在页面里勾选完成后可能被旧聚合状态覆盖。分组待办的父子完成语义也不完全一致。

## 改动

- 在现有 Schedule Refresh Router 中新增 `mark_existing_task_completed` 工具，不新增 agent；仅在新输入明确匹配已有待办或精确子项时写回原始 task 卡片，模糊时仍只标记 dirty。
- 读取最新 schedule aggregation 时，用真实 task 卡片状态 hydrate 聚合快照中的 task 项，并移除已不再完成的 stale completed 项。
- Schedule Aggregation 状态推导支持：
  - `is_completed: true` => completed
  - 分组任务所有子项完成 => completed
  - 部分子项完成 => in_progress
- 原生 `TaskCard` 统一父子完成语义：父项完成会批量完成子项，子项变化会反推父项状态。
- 补充 Router、聚合读取、状态推导与 TaskCard 组件测试。

## 验证

- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub --concurrency=1 test/agent/skills/schedule_aggregation_skill_test.dart test/agent/schedule_refresh_router_agent_test.dart test/data/repositories/get_schedule_aggregation_test.dart test/ui/core/cards/templates/temporal/task_card_test.dart test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart`
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter analyze --no-pub lib/ui/core/cards/templates/temporal/task_card.dart lib/data/repositories/get_schedule_aggregation.dart lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart lib/agent/prompts.dart lib/agent/schedule_refresh_router_agent/prompt.dart lib/agent/schedule_refresh_router_agent/schedule_refresh_router_agent.dart test/agent/skills/schedule_aggregation_skill_test.dart test/data/repositories/get_schedule_aggregation_test.dart test/ui/core/cards/templates/temporal/task_card_test.dart test/agent/schedule_refresh_router_agent_test.dart`

## 发布前检查

- 已 fetch 最新 `upstream/main`。
- 当前分支已 rebase 到最新 `upstream/main`，本地确认包含最新目标分支。
