### PR TITLE
支持 DeepSeek 官方 API 模型配置

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -43,6 +43,7 @@ class AppConfig {
     LLMConfig.typeQwen,
     LLMConfig.typeSeed,
     LLMConfig.typeZhipu,
+    LLMConfig.typeDeepSeek,
     LLMConfig.typeMimo,
     // Aggregators
     LLMConfig.typeOpenRouter,
@@ -59,6 +60,7 @@ class AppConfig {
     LLMConfig.typeQwen,
     LLMConfig.typeSeed,
     LLMConfig.typeZhipu,
+    LLMConfig.typeDeepSeek,
     LLMConfig.typeMimo,
     // Aggregators
     LLMConfig.typeOllama,

--- a/lib/domain/models/llm_config.dart
+++ b/lib/domain/models/llm_config.dart
@@ -16,6 +16,7 @@ class LLMConfig {
   static const String typeQwen = 'qwen';
   static const String typeSeed = 'seed';
   static const String typeZhipu = 'zhipu';
+  static const String typeDeepSeek = 'deepseek';
   static const String typeMinimax = 'minimax';
   static const String typeOpenRouter = 'openrouter';
   static const String typeOllama = 'ollama';
@@ -49,6 +50,8 @@ class LLMConfig {
         return 'Volcengine';
       case typeZhipu:
         return 'Zhipu';
+      case typeDeepSeek:
+        return 'DeepSeek';
       case typeMinimax:
         return 'MiniMax';
       case typeMimo:
@@ -71,6 +74,7 @@ class LLMConfig {
       case typeKimi:
       case typeQwen:
       case typeZhipu:
+      case typeDeepSeek:
       case typeOpenRouter:
       case typeOllama:
       case typeMemex:
@@ -110,6 +114,8 @@ class LLMConfig {
         return 'Volcengine';
       case typeZhipu:
         return 'Zhipu GLM';
+      case typeDeepSeek:
+        return 'DeepSeek';
       case typeMinimax:
         return 'MiniMax';
       case typeOpenRouter:
@@ -158,6 +164,8 @@ class LLMConfig {
         return const {'doubao-seed-2-0-pro-260215', 'doubao-seed-1-8-251228'};
       case typeZhipu:
         return const {'glm-5v-turbo', 'glm-4.6v'};
+      case typeDeepSeek:
+        return const {'deepseek-v4-flash', 'deepseek-v4-pro'};
       case typeMimo:
         return const {'mimo-v2-pro'};
       case typeOpenRouter:
@@ -254,6 +262,8 @@ class LLMConfig {
         return const ['doubao-seed-1-8-251228', 'doubao-1.5-pro-256k'];
       case typeZhipu:
         return const ['glm-5v-turbo', 'glm-4.6v'];
+      case typeDeepSeek:
+        return const ['deepseek-v4-flash', 'deepseek-v4-pro'];
       case typeMinimax:
         return const ['MiniMax-M2.5', 'MiniMax-M1'];
       case typeOpenRouter:
@@ -303,6 +313,7 @@ class LLMConfig {
       case typeQwen:
       case typeSeed:
       case typeZhipu:
+      case typeDeepSeek:
       case typeMinimax:
       case typeMimo:
       case typeOpenRouter:
@@ -403,6 +414,8 @@ class LLMConfig {
         return 'https://ark.cn-beijing.volces.com/api/v3';
       case typeZhipu:
         return 'https://open.bigmodel.cn/api/paas/v4';
+      case typeDeepSeek:
+        return 'https://api.deepseek.com';
       case typeMinimax:
         return 'https://api.minimaxi.com/anthropic';
       case typeOpenRouter:
@@ -485,6 +498,7 @@ class LLMConfig {
             type == typeQwen ||
             type == typeSeed ||
             type == typeZhipu ||
+            type == typeDeepSeek ||
             type == typeMinimax ||
             type == typeMimo ||
             type == typeOpenRouter ||
@@ -502,6 +516,7 @@ class LLMConfig {
       typeQwen,
       typeSeed,
       typeZhipu,
+      typeDeepSeek,
       typeMinimax,
       typeOpenRouter,
       typeOllama,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -778,6 +778,7 @@
   "providerQwen": "Aliyun",
   "providerSeed": "Volcengine",
   "providerZhipu": "Zhipu GLM",
+  "providerDeepSeek": "DeepSeek",
   "providerMinimax": "MiniMax",
   "providerOpenRouter": "OpenRouter",
   "providerOllama": "Ollama (Local)",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3074,6 +3074,12 @@ abstract class AppLocalizations {
   /// **'Zhipu GLM'**
   String get providerZhipu;
 
+  /// No description provided for @providerDeepSeek.
+  ///
+  /// In en, this message translates to:
+  /// **'DeepSeek'**
+  String get providerDeepSeek;
+
   /// No description provided for @providerMinimax.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1668,6 +1668,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get providerZhipu => 'Zhipu GLM';
 
   @override
+  String get providerDeepSeek => 'DeepSeek';
+
+  @override
   String get providerMinimax => 'MiniMax';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1620,6 +1620,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get providerZhipu => 'Zhipu GLM (智谱)';
 
   @override
+  String get providerDeepSeek => 'DeepSeek (官方 API)';
+
+  @override
   String get providerMinimax => 'MiniMax';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -778,6 +778,7 @@
   "providerQwen": "Aliyun (阿里云)",
   "providerSeed": "Volcengine (火山引擎)",
   "providerZhipu": "Zhipu GLM (智谱)",
+  "providerDeepSeek": "DeepSeek (官方 API)",
   "providerMinimax": "MiniMax",
   "providerOpenRouter": "OpenRouter",
   "providerOllama": "Ollama (本地)",

--- a/lib/ui/settings/widgets/model_config_edit_page.dart
+++ b/lib/ui/settings/widgets/model_config_edit_page.dart
@@ -550,6 +550,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
         _ProviderEntry(LLMConfig.typeQwen, l10n.providerQwen),
         _ProviderEntry(LLMConfig.typeSeed, l10n.providerSeed),
         _ProviderEntry(LLMConfig.typeZhipu, l10n.providerZhipu),
+        _ProviderEntry(LLMConfig.typeDeepSeek, l10n.providerDeepSeek),
         _ProviderEntry(LLMConfig.typeMimo, l10n.providerMimo),
         _ProviderEntry(LLMConfig.typeOpenRouter, l10n.providerOpenRouter),
         _ProviderEntry(LLMConfig.typeOllama, l10n.providerOllama),

--- a/lib/ui/settings/widgets/model_config_list_page.dart
+++ b/lib/ui/settings/widgets/model_config_list_page.dart
@@ -45,6 +45,8 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
         return l10n.providerSeed;
       case LLMConfig.typeZhipu:
         return l10n.providerZhipu;
+      case LLMConfig.typeDeepSeek:
+        return l10n.providerDeepSeek;
       case LLMConfig.typeMinimax:
         return l10n.providerMinimax;
       case LLMConfig.typeOpenRouter:

--- a/lib/ui/user_setup/widgets/setup_model_config_page.dart
+++ b/lib/ui/user_setup/widgets/setup_model_config_page.dart
@@ -1007,6 +1007,8 @@ class _SetupModelConfigPageState extends State<SetupModelConfigPage>
           return l10n.providerSeed;
         case LLMConfig.typeZhipu:
           return l10n.providerZhipu;
+        case LLMConfig.typeDeepSeek:
+          return l10n.providerDeepSeek;
         case LLMConfig.typeMimo:
           return l10n.providerMimo;
         case LLMConfig.typeOpenRouter:
@@ -1040,6 +1042,7 @@ class _SetupModelConfigPageState extends State<SetupModelConfigPage>
         LLMConfig.typeQwen,
         LLMConfig.typeSeed,
         LLMConfig.typeZhipu,
+        LLMConfig.typeDeepSeek,
         LLMConfig.typeMimo,
         LLMConfig.typeOpenRouter,
         LLMConfig.typeOllama,
@@ -1088,7 +1091,7 @@ class _SetupModelConfigPageState extends State<SetupModelConfigPage>
 
     return DropdownButtonFormField<String>(
       isExpanded: true,
-      value: _selectedType.isEmpty ? null : _selectedType,
+      initialValue: _selectedType.isEmpty ? null : _selectedType,
       hint: Text(l10n.select),
       decoration: InputDecoration(
         labelText: l10n.clientLabel,

--- a/lib/utils/user_storage.dart
+++ b/lib/utils/user_storage.dart
@@ -629,6 +629,7 @@ class UserStorage {
       case LLMConfig.typeKimi:
       case LLMConfig.typeQwen:
       case LLMConfig.typeZhipu:
+      case LLMConfig.typeDeepSeek:
       case LLMConfig.typeOpenRouter:
       case LLMConfig.typeOllama:
       case LLMConfig.typeMemex:

--- a/test/config/app_config_test.dart
+++ b/test/config/app_config_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/config/app_config.dart';
+import 'package:memex/config/app_flavor.dart';
+import 'package:memex/domain/models/llm_config.dart';
+
+void main() {
+  group('AppConfig.availableProviders', () {
+    test('includes DeepSeek in global flavor', () {
+      AppFlavor.init('global');
+
+      expect(AppConfig.availableProviders, contains(LLMConfig.typeDeepSeek));
+    });
+
+    test('includes DeepSeek in CN flavor', () {
+      AppFlavor.init('cn');
+
+      expect(AppConfig.availableProviders, contains(LLMConfig.typeDeepSeek));
+    });
+  });
+}

--- a/test/domain/models/llm_config_test.dart
+++ b/test/domain/models/llm_config_test.dart
@@ -67,4 +67,53 @@ void main() {
       expect(duplicated.key, 'config-v1.2_test_copy');
     });
   });
+
+  group('DeepSeek provider', () {
+    test('uses official OpenAI-compatible API defaults', () {
+      expect(LLMConfig.typeDeepSeek, 'deepseek');
+      expect(LLMConfig.providerDisplayName(LLMConfig.typeDeepSeek), 'DeepSeek');
+      expect(LLMConfig.displayName(LLMConfig.typeDeepSeek), 'DeepSeek');
+      expect(
+        LLMConfig.underlyingClientType(LLMConfig.typeDeepSeek),
+        LLMConfig.typeChatCompletion,
+      );
+      expect(
+        LLMConfig.defaultBaseUrl(LLMConfig.typeDeepSeek),
+        'https://api.deepseek.com',
+      );
+      expect(LLMConfig.supportsModelListing(LLMConfig.typeDeepSeek), isTrue);
+      expect(
+        LLMConfig.modelsEndpoint(
+          LLMConfig.typeDeepSeek,
+          'https://api.deepseek.com',
+        ),
+        'https://api.deepseek.com/models',
+      );
+    });
+
+    test('recommends current official model IDs', () {
+      expect(LLMConfig.recommendedModels(LLMConfig.typeDeepSeek), [
+        'deepseek-v4-flash',
+        'deepseek-v4-pro',
+      ]);
+      expect(LLMConfig.featuredModels(LLMConfig.typeDeepSeek), {
+        'deepseek-v4-flash',
+        'deepseek-v4-pro',
+      });
+    });
+
+    test('requires an API key and base URL', () {
+      const validConfig = LLMConfig(
+        key: 'deepseek',
+        type: LLMConfig.typeDeepSeek,
+        modelId: 'deepseek-v4-flash',
+        apiKey: 'sk-test',
+        baseUrl: 'https://api.deepseek.com',
+      );
+
+      expect(validConfig.isValid, isTrue);
+      expect(validConfig.copyWith(apiKey: '').isValid, isFalse);
+      expect(validConfig.copyWith(baseUrl: '').isValid, isFalse);
+    });
+  });
 }

--- a/test/ui/settings/widgets/model_config_edit_page_test.dart
+++ b/test/ui/settings/widgets/model_config_edit_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/config/app_flavor.dart';
 import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/l10n/app_localizations.dart';
 import 'package:memex/ui/settings/widgets/model_config_edit_page.dart';
@@ -8,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   setUpAll(() async {
+    AppFlavor.init('global');
     SharedPreferences.setMockInitialValues({});
     await UserStorage.initL10n();
   });
@@ -169,6 +171,31 @@ void main() {
       final configs = await UserStorage.getLLMConfigs();
       expect(configs.length, 4);
       expect(configs.any((c) => c.key == 'myconfig_copy_2'), isTrue);
+    });
+  });
+
+  group('ModelConfigEditPage provider selection', () {
+    testWidgets('renders DeepSeek configuration with official defaults',
+        (tester) async {
+      AppFlavor.init('global');
+      const deepSeekConfig = LLMConfig(
+        key: 'deepseek',
+        type: LLMConfig.typeDeepSeek,
+        modelId: 'deepseek-v4-flash',
+        apiKey: 'sk-test',
+        baseUrl: 'https://api.deepseek.com',
+      );
+
+      await tester.pumpWidget(
+        buildTestableWidget(
+          const ModelConfigEditPage(duplicateSource: deepSeekConfig),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.textContaining('DeepSeek'), findsWidgets);
+      expect(find.text('https://api.deepseek.com'), findsOneWidget);
+      expect(find.text('deepseek-v4-flash'), findsOneWidget);
     });
   });
 }

--- a/test/utils/user_storage_llm_config_test.dart
+++ b/test/utils/user_storage_llm_config_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/domain/models/agent_config.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/domain/models/llm_config.dart';
@@ -58,6 +59,21 @@ void main() {
       const config = AgentConfig(llmConfigKey: 'custom');
 
       expect(config.copyWith(llmConfigKey: null).llmConfigKey, isNull);
+    });
+
+    test('DeepSeek builds an OpenAI-compatible chat client', () async {
+      const config = LLMConfig(
+        key: 'deepseek',
+        type: LLMConfig.typeDeepSeek,
+        modelId: 'deepseek-v4-flash',
+        apiKey: 'sk-test',
+        baseUrl: 'https://api.deepseek.com',
+      );
+
+      final resources = await UserStorage.buildLLMResources(config);
+
+      expect(resources.client, isA<OpenAIClient>());
+      expect(resources.modelConfig.model, 'deepseek-v4-flash');
     });
   });
 }


### PR DESCRIPTION
Closes #171

## 变更说明

- 新增 `deepseek` provider，默认使用 DeepSeek 官方 OpenAI-compatible API：`https://api.deepseek.com`。
- 推荐模型补齐为 `deepseek-v4-flash`、`deepseek-v4-pro`，并接入现有 OpenAI Chat Completions 客户端创建逻辑。
- 在 global / CN flavor 的 provider 列表、设置编辑页、首次设置页、配置列表和中英文 l10n 中展示 DeepSeek。
- 增加模型默认值、provider 列表、客户端映射和设置页渲染测试。

## 验证

- `flutter pub get --offline`
- DeepSeek 官方 API 实测：`deepseek-v4-flash` chat completions 返回 200/ok（密钥仅作为本地环境变量使用，未提交）
- `flutter test --no-pub --concurrency=1 test/domain/models/llm_config_test.dart test/config/app_config_test.dart test/utils/user_storage_llm_config_test.dart test/ui/settings/widgets/model_config_edit_page_test.dart`
- `flutter test --no-pub --concurrency=1`（380 passed，2 skipped）
- `flutter analyze --no-pub` 针对本次触达文件检查通过
- `dart format --output=none --set-exit-if-changed` 针对本次触达 Dart 文件检查通过
- `git diff --check`
- 密钥扫描：仓库内未匹配本次测试 key / `DEEPSEEK_API_KEY`