### PR TITLE
修复洞察页活动统计切换后空白

### DIFF
--- a/lib/ui/insight/view_models/insight_viewmodel.dart
+++ b/lib/ui/insight/view_models/insight_viewmodel.dart
@@ -21,14 +21,20 @@ class InsightViewModel extends ChangeNotifier {
     required MemexRouter router,
     UserStatsFetcher? userStatsFetcher,
   })  : _router = router,
-        _userStatsFetcher =
-            userStatsFetcher ?? ((range) => router.fetchUserStats(range: range)) {
-    EventBusService.instance
-        .addHandler(EventBusMessageType.newInsight, _handleNewInsightEvent);
-    EventBusService.instance
-        .addHandler(EventBusMessageType.cardAdded, _handleActivityChangedEvent);
+        _userStatsFetcher = userStatsFetcher ??
+            ((range) => router.fetchUserStats(range: range)) {
     EventBusService.instance.addHandler(
-        EventBusMessageType.cardUpdated, _handleActivityChangedEvent);
+      EventBusMessageType.newInsight,
+      _handleNewInsightEvent,
+    );
+    EventBusService.instance.addHandler(
+      EventBusMessageType.cardAdded,
+      _handleActivityChangedEvent,
+    );
+    EventBusService.instance.addHandler(
+      EventBusMessageType.cardUpdated,
+      _handleActivityChangedEvent,
+    );
   }
 
   final MemexRouter _router;
@@ -128,7 +134,7 @@ class InsightViewModel extends ChangeNotifier {
   }
 
   Future<void> refreshStatsForVisibleInsightPage() {
-    return loadStats(notify: selectedSection == InsightSection.stats);
+    return loadStats();
   }
 
   void setStatsMetric(UserStatsMetric metric) {
@@ -139,7 +145,8 @@ class InsightViewModel extends ChangeNotifier {
 
   void setStatsPresetDays(int days) {
     final nextRange = UserStatsDateRange.lastDays(days);
-    if (statsRange.start == nextRange.start && statsRange.end == nextRange.end) {
+    if (statsRange.start == nextRange.start &&
+        statsRange.end == nextRange.end) {
       return;
     }
     statsRange = nextRange;
@@ -243,12 +250,18 @@ class InsightViewModel extends ChangeNotifier {
 
   @override
   void dispose() {
-    EventBusService.instance
-        .removeHandler(EventBusMessageType.newInsight, _handleNewInsightEvent);
     EventBusService.instance.removeHandler(
-        EventBusMessageType.cardAdded, _handleActivityChangedEvent);
+      EventBusMessageType.newInsight,
+      _handleNewInsightEvent,
+    );
     EventBusService.instance.removeHandler(
-        EventBusMessageType.cardUpdated, _handleActivityChangedEvent);
+      EventBusMessageType.cardAdded,
+      _handleActivityChangedEvent,
+    );
+    EventBusService.instance.removeHandler(
+      EventBusMessageType.cardUpdated,
+      _handleActivityChangedEvent,
+    );
     super.dispose();
   }
 }

--- a/lib/ui/insight/widgets/user_stats_overview_card.dart
+++ b/lib/ui/insight/widgets/user_stats_overview_card.dart
@@ -19,12 +19,13 @@ class UserStatsOverviewCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final summary = snapshot?.summary;
     final daily = snapshot?.daily ?? const <UserStatsDailyPoint>[];
+    final hasSnapshot = summary != null;
 
     return Material(
       color: Colors.transparent,
       child: InkWell(
         key: const ValueKey('user_stats_overview_card'),
-        onTap: isLoading ? null : onTap,
+        onTap: hasSnapshot ? onTap : null,
         borderRadius: BorderRadius.circular(12),
         child: Container(
           width: double.infinity,
@@ -41,7 +42,7 @@ class UserStatsOverviewCard extends StatelessWidget {
               ),
             ],
           ),
-          child: isLoading || summary == null
+          child: !hasSnapshot
               ? const _OverviewLoading()
               : Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -74,10 +75,22 @@ class UserStatsOverviewCard extends StatelessWidget {
                             ),
                           ),
                         ),
-                        const Icon(
-                          Icons.chevron_right_rounded,
-                          color: Color(0xFF9CA3AF),
-                        ),
+                        if (isLoading)
+                          const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                Color(0xFF9CA3AF),
+                              ),
+                            ),
+                          )
+                        else
+                          const Icon(
+                            Icons.chevron_right_rounded,
+                            color: Color(0xFF9CA3AF),
+                          ),
                       ],
                     ),
                     const SizedBox(height: 12),

--- a/test/ui/insight/user_stats_overview_card_test.dart
+++ b/test/ui/insight/user_stats_overview_card_test.dart
@@ -1,0 +1,201 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/domain/models/user_stats_model.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/insight/widgets/user_stats_overview_card.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.saveUser('stats_overview_card_test_user');
+    await UserStorage.setLocale(const Locale('en'));
+    tempDir =
+        await Directory.systemTemp.createTemp('memex_stats_overview_card_');
+    await FileSystemService.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  testWidgets('shows loading skeleton and disables tap before first snapshot', (
+    tester,
+  ) async {
+    var taps = 0;
+
+    await tester.pumpWidget(
+      _wrap(
+        UserStatsOverviewCard(
+          snapshot: null,
+          isLoading: true,
+          onTap: () => taps += 1,
+        ),
+      ),
+    );
+
+    expect(
+        find.byKey(const ValueKey('user_stats_overview_card')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('user_stats_overview_card')),
+        matching: find.text('Activity stats'),
+      ),
+      findsNothing,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('user_stats_overview_card')));
+    await tester.pump();
+
+    expect(taps, 0);
+  });
+
+  testWidgets('renders zero stats snapshot as real content', (tester) async {
+    var taps = 0;
+    final range = UserStatsDateRange(
+      start: DateTime(2026, 5, 18),
+      end: DateTime(2026, 5, 20),
+    );
+
+    await tester.pumpWidget(
+      _wrap(
+        UserStatsOverviewCard(
+          snapshot: UserStatsSnapshot.empty(range),
+          isLoading: false,
+          onTap: () => taps += 1,
+        ),
+      ),
+    );
+
+    expect(find.text('Activity stats'), findsOneWidget);
+    expect(find.text('0'), findsWidgets);
+
+    await tester.tap(find.byKey(const ValueKey('user_stats_overview_card')));
+    await tester.pump();
+
+    expect(taps, 1);
+  });
+
+  testWidgets('keeps old content tappable while a refresh is running', (
+    tester,
+  ) async {
+    var taps = 0;
+
+    await tester.pumpWidget(
+      _wrap(
+        UserStatsOverviewCard(
+          snapshot: _snapshot(),
+          isLoading: true,
+          onTap: () => taps += 1,
+        ),
+      ),
+    );
+
+    expect(find.text('Activity stats'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('user_stats_overview_card')));
+    await tester.pump();
+
+    expect(taps, 1);
+  });
+
+  testWidgets('handles snapshots without daily chart points', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        UserStatsOverviewCard(
+          snapshot: _snapshot(daily: const []),
+          isLoading: false,
+          onTap: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('Activity stats'), findsOneWidget);
+    expect(
+      find.text(
+        'In this period you recorded 5 time(s), generated 2 card(s), and completed 1 todo(s).',
+      ),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: Center(child: child),
+    ),
+  );
+}
+
+UserStatsSnapshot _snapshot({
+  List<UserStatsDailyPoint>? daily,
+}) {
+  final range = UserStatsDateRange(
+    start: DateTime(2026, 5, 18),
+    end: DateTime(2026, 5, 20),
+  );
+  return UserStatsSnapshot(
+    range: range,
+    summary: const UserStatsSummary(
+      totalInputs: 5,
+      totalWords: 42,
+      totalCards: 2,
+      totalKnowledgeUnits: 1,
+      totalInsights: 1,
+      totalCompletedTodos: 1,
+      activeDays: 2,
+      currentStreakDays: 2,
+    ),
+    daily: daily ??
+        [
+          UserStatsDailyPoint(
+            date: DateTime(2026, 5, 18),
+            inputs: 0,
+            words: 0,
+            cards: 0,
+            knowledgeUnits: 0,
+            insights: 0,
+            completedTodos: 0,
+          ),
+          UserStatsDailyPoint(
+            date: DateTime(2026, 5, 19),
+            inputs: 3,
+            words: 24,
+            cards: 1,
+            knowledgeUnits: 1,
+            insights: 0,
+            completedTodos: 0,
+          ),
+          UserStatsDailyPoint(
+            date: DateTime(2026, 5, 20),
+            inputs: 2,
+            words: 18,
+            cards: 1,
+            knowledgeUnits: 0,
+            insights: 1,
+            completedTodos: 1,
+          ),
+        ],
+    sourceBreakdown: const UserStatsSourceBreakdown(
+      textInputs: 4,
+      imageInputs: 1,
+      audioInputs: 0,
+    ),
+    topTags: const [],
+    dayDetails: const {},
+  );
+}

--- a/test/ui/insight/user_stats_page_test.dart
+++ b/test/ui/insight/user_stats_page_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -68,9 +69,7 @@ void main() {
     vm.dispose();
   });
 
-  testWidgets('reloads fresh stats when opening stats section', (
-    tester,
-  ) async {
+  testWidgets('reloads fresh stats when opening stats section', (tester) async {
     final vm = _buildViewModel(statsReloadSnapshot: _singleInputSnapshot());
     vm.statsSnapshot = UserStatsSnapshot.empty(vm.statsRange);
 
@@ -90,6 +89,71 @@ void main() {
       ),
       findsOneWidget,
     );
+
+    vm.dispose();
+  });
+
+  testWidgets('refreshes overview stats when insight tab becomes visible', (
+    tester,
+  ) async {
+    final statsCompleter = Completer<Result<UserStatsSnapshot>>();
+    final vm = _buildViewModelWithFetcher((_) => statsCompleter.future);
+    vm.statsSnapshot = null;
+
+    await tester.pumpWidget(
+      _wrap(InsightScreen(viewModel: vm, isEmbedded: true)),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.byKey(const ValueKey('user_stats_overview_card')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('user_stats_overview_card')),
+        matching: find.text('Activity stats'),
+      ),
+      findsNothing,
+    );
+
+    final refresh = vm.refreshStatsForVisibleInsightPage();
+    await tester.pump();
+
+    statsCompleter.complete(Ok(_snapshot()));
+    await refresh;
+    await tester.pump();
+
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('user_stats_overview_card')),
+        matching: find.text('Activity stats'),
+      ),
+      findsOneWidget,
+    );
+
+    vm.dispose();
+  });
+
+  testWidgets('keeps populated overview visible while stats refresh', (
+    tester,
+  ) async {
+    final vm = _buildViewModel();
+    vm.isStatsLoading = true;
+
+    await tester.pumpWidget(
+      _wrap(InsightScreen(viewModel: vm, isEmbedded: true)),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('user_stats_overview_card')),
+        matching: find.text('Activity stats'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
     vm.dispose();
   });
@@ -142,9 +206,15 @@ void main() {
 }
 
 InsightViewModel _buildViewModel({UserStatsSnapshot? statsReloadSnapshot}) {
+  return _buildViewModelWithFetcher(
+    (_) async => Ok(statsReloadSnapshot ?? _snapshot()),
+  );
+}
+
+InsightViewModel _buildViewModelWithFetcher(UserStatsFetcher userStatsFetcher) {
   final vm = InsightViewModel(
     router: MemexRouter(),
-    userStatsFetcher: (_) async => Ok(statsReloadSnapshot ?? _snapshot()),
+    userStatsFetcher: userStatsFetcher,
   );
   vm.isLoading = false;
   vm.insights = [

--- a/test/ui/insight/view_models/insight_viewmodel_test.dart
+++ b/test/ui/insight/view_models/insight_viewmodel_test.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/domain/models/user_stats_model.dart';
+import 'package:memex/ui/insight/view_models/insight_viewmodel.dart';
+import 'package:memex/utils/result.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tempDir;
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    tempDir = await Directory.systemTemp.createTemp('memex_insight_vm_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, (call) async {
+      switch (call.method) {
+        case 'getApplicationDocumentsDirectory':
+        case 'getApplicationSupportDirectory':
+        case 'getTemporaryDirectory':
+          return tempDir.path;
+        default:
+          return null;
+      }
+    });
+  });
+
+  setUp(() async {
+    EventBusService.instance.clearHandlers();
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.saveUser('insight_vm_test_user');
+    await UserStorage.setLocale(const Locale('en'));
+    await FileSystemService.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    EventBusService.instance.clearHandlers();
+  });
+
+  tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('visible stats refresh notifies listeners on insight overview',
+      () async {
+    final firstSnapshot = _snapshot(totalInputs: 3);
+    final secondSnapshot = _snapshot(totalInputs: 8);
+    var calls = 0;
+    final vm = _buildViewModel((_) async {
+      calls += 1;
+      return Ok(secondSnapshot);
+    });
+    vm.statsSnapshot = firstSnapshot;
+    vm.selectedSection = InsightSection.insights;
+
+    var notifications = 0;
+    vm.addListener(() => notifications += 1);
+
+    await vm.refreshStatsForVisibleInsightPage();
+
+    expect(calls, 1);
+    expect(vm.statsSnapshot, secondSnapshot);
+    expect(vm.isStatsLoading, isFalse);
+    expect(notifications, greaterThanOrEqualTo(2));
+
+    vm.dispose();
+  });
+
+  test('stats loading state is visible while refresh is in flight', () async {
+    final completer = Completer<Result<UserStatsSnapshot>>();
+    final vm = _buildViewModel((_) => completer.future);
+
+    final states = <bool>[];
+    vm.addListener(() => states.add(vm.isStatsLoading));
+
+    final refresh = vm.refreshStatsForVisibleInsightPage();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(vm.isStatsLoading, isTrue);
+    expect(states, contains(true));
+
+    completer.complete(Ok(_snapshot(totalInputs: 6)));
+    await refresh;
+
+    expect(vm.isStatsLoading, isFalse);
+    expect(states.last, isFalse);
+
+    vm.dispose();
+  });
+
+  test('failed stats refresh keeps previous snapshot and exposes error',
+      () async {
+    final existing = _snapshot(totalInputs: 4);
+    final vm = _buildViewModel(
+      (_) async => Error<UserStatsSnapshot>(StateError('boom')),
+    );
+    vm.statsSnapshot = existing;
+
+    await vm.refreshStatsForVisibleInsightPage();
+
+    expect(vm.statsSnapshot, existing);
+    expect(vm.statsErrorMessage, UserStorage.l10n.dataLoadFailedRetry);
+    expect(vm.isStatsLoading, isFalse);
+
+    vm.dispose();
+  });
+
+  test('failed first stats refresh leaves no snapshot and exits loading',
+      () async {
+    final vm = _buildViewModel(
+      (_) async => Error<UserStatsSnapshot>(StateError('boom')),
+    );
+    vm.statsSnapshot = null;
+
+    await vm.refreshStatsForVisibleInsightPage();
+
+    expect(vm.statsSnapshot, isNull);
+    expect(vm.statsErrorMessage, UserStorage.l10n.dataLoadFailedRetry);
+    expect(vm.isStatsLoading, isFalse);
+
+    vm.dispose();
+  });
+
+  test('selecting the current stats preset does not reload', () async {
+    var calls = 0;
+    final vm = _buildViewModel((_) async {
+      calls += 1;
+      return Ok(_snapshot(totalInputs: calls));
+    });
+    vm.statsRange = UserStatsDateRange.lastDays(30);
+
+    vm.setStatsPresetDays(30);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(calls, 0);
+
+    vm.dispose();
+  });
+
+  test('selecting a different stats preset updates range and reloads',
+      () async {
+    var calls = 0;
+    final vm = _buildViewModel((range) async {
+      calls += 1;
+      return Ok(_snapshot(totalInputs: calls, range: range));
+    });
+    vm.statsRange = UserStatsDateRange.lastDays(7);
+
+    vm.setStatsPresetDays(30);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(calls, 1);
+    expect(vm.statsRange.dayCount, 30);
+    expect(vm.statsSnapshot?.range.dayCount, 30);
+
+    vm.dispose();
+  });
+}
+
+InsightViewModel _buildViewModel(UserStatsFetcher fetcher) {
+  return InsightViewModel(router: MemexRouter(), userStatsFetcher: fetcher)
+    ..isLoading = false;
+}
+
+UserStatsSnapshot _snapshot({
+  required int totalInputs,
+  UserStatsDateRange? range,
+}) {
+  final resolvedRange = range ??
+      UserStatsDateRange(
+          start: DateTime(2026, 5, 18), end: DateTime(2026, 5, 20));
+  return UserStatsSnapshot(
+    range: resolvedRange,
+    summary: UserStatsSummary(
+      totalInputs: totalInputs,
+      totalWords: totalInputs * 5,
+      totalCards: totalInputs ~/ 2,
+      totalKnowledgeUnits: totalInputs ~/ 3,
+      totalInsights: totalInputs ~/ 4,
+      totalCompletedTodos: totalInputs ~/ 5,
+      activeDays: totalInputs == 0 ? 0 : 1,
+      currentStreakDays: totalInputs == 0 ? 0 : 1,
+    ),
+    daily: [
+      UserStatsDailyPoint(
+        date: resolvedRange.end,
+        inputs: totalInputs,
+        words: totalInputs * 5,
+        cards: totalInputs ~/ 2,
+        knowledgeUnits: totalInputs ~/ 3,
+        insights: totalInputs ~/ 4,
+        completedTodos: totalInputs ~/ 5,
+      ),
+    ],
+    sourceBreakdown: UserStatsSourceBreakdown(
+      textInputs: totalInputs,
+      imageInputs: 0,
+      audioInputs: 0,
+    ),
+    topTags: const [],
+    dayDetails: {
+      _dateKey(resolvedRange.end): UserStatsDayDetail(date: resolvedRange.end),
+    },
+  );
+}
+
+String _dateKey(DateTime date) {
+  final y = date.year.toString().padLeft(4, '0');
+  final m = date.month.toString().padLeft(2, '0');
+  final d = date.day.toString().padLeft(2, '0');
+  return '$y-$m-$d';
+}


### PR DESCRIPTION
## 变更

- 修复洞察页可见时活动统计刷新不通知 UI 的问题，避免从其他 tab 切回洞察页后活动统计卡片停留空白。
- 调整活动统计概览卡片 loading 策略：首次没有快照时显示骨架屏；已有快照刷新时继续展示旧数据，并用右侧小 loading 表示后台刷新。
- 补充更完整的 ViewModel 单元测试和 Widget 测试，覆盖可见刷新、刷新中旧数据保留、首次空快照、错误路径、日期范围切换和空 daily 图表等边界。

## 原因

原来的 `refreshStatsForVisibleInsightPage()` 只有在完整活动统计 section 可见时才 `notifyListeners()`。但活动统计概览卡片位于默认的「知识洞察」section 首屏，因此从其他 tab 切换进入时，统计快照可能已经更新，却没有触发 UI 重建，用户只能通过下拉刷新走另一条会通知的路径来恢复显示。

## 验证

- [x] `flutter test --no-pub --concurrency=1 test/ui/insight/user_stats_page_test.dart test/ui/insight/user_stats_overview_card_test.dart test/ui/insight/view_models/insight_viewmodel_test.dart`
- [x] `flutter analyze --no-pub lib/ui/insight/view_models/insight_viewmodel.dart lib/ui/insight/widgets/user_stats_overview_card.dart test/ui/insight/user_stats_page_test.dart test/ui/insight/user_stats_overview_card_test.dart test/ui/insight/view_models/insight_viewmodel_test.dart`
- [x] `flutter build apk --debug --flavor globalDev --no-pub`
- [x] Android 模拟器 `Medium_Phone_API_35`：安装 `app-globaldev-debug.apk` 后，从 All/Schedule 切回 Insights，活动统计卡片直接显示；点击进入统计详情页正常；crash buffer 无输出。

Closes #173
