### PR TITLE
移除 Android「记一下」快捷入口图标下方横线

### DIFF
--- a/android/app/src/main/res/drawable/ic_quick_note.xml
+++ b/android/app/src/main/res/drawable/ic_quick_note.xml
@@ -14,13 +14,6 @@
             android:strokeWidth="1.9"
             android:strokeLineCap="round"
             android:strokeLineJoin="round"
-            android:pathData="M4,20h16" />
-        <path
-            android:fillColor="@android:color/transparent"
-            android:strokeColor="#202124"
-            android:strokeWidth="1.9"
-            android:strokeLineCap="round"
-            android:strokeLineJoin="round"
             android:pathData="M13.5,5.5l5,5L8,21H3v-5L13.5,5.5z" />
         <path
             android:fillColor="@android:color/transparent"


### PR DESCRIPTION
## 背景

Android 桌面长按 App 图标后，「记一下」快捷入口的 shortcut 图标下方会出现一条多余横线，视觉上像下划线，影响入口的干净程度。

Closes #176

## 改动

- 移除 `android/app/src/main/res/drawable/ic_quick_note.xml` 中额外绘制的 `M4,20h16` 横线路径。
- 保留原有铅笔图标本体，不改 shortcut id、label、intent 或入口行为。

## 根因

`ic_quick_note.xml` 的 vector 里包含一条用于绘制基线的 path；在 Android launcher deep shortcut 菜单中，这条线被渲染在铅笔图标下方，看起来像图标下面多了一条横线。

## 验证

- 已基于最新 `upstream/main` 创建分支，并确认 PR 分支包含最新 base、无冲突。
- 已在 `Medium_Phone_API_35` 模拟器上安装 `globalDev` debug 包，长按桌面图标确认「记一下」shortcut 图标下方横线消失。
- 已点击 shortcut，确认仍可正常拉起 App。
- 已运行：

```bash
flutter build apk --debug --flavor globalDev --no-pub
```
