### PR TITLE
[codex] 增加失败卡片重试恢复入口

### DIFF
--- a/lib/data/repositories/card.dart
+++ b/lib/data/repositories/card.dart
@@ -65,8 +65,10 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
     }
 
     // Read raw fact content
-    final factInfo =
-        await _fileSystemService.extractFactContentFromFile(userId, factId);
+    final factInfo = await _fileSystemService.extractFactContentFromFile(
+      userId,
+      factId,
+    );
     var rawContent = factInfo?.content ?? '';
     final originalRawContent = rawContent;
 
@@ -96,8 +98,10 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
     CharacterInfo? characterInfo;
     if (characterId != null && characterId.isNotEmpty) {
       try {
-        final character =
-            await CharacterService.instance.getCharacter(userId, characterId);
+        final character = await CharacterService.instance.getCharacter(
+          userId,
+          characterId,
+        );
         if (character != null) {
           characterInfo = CharacterInfo(
             id: character.id,
@@ -121,8 +125,9 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
         }
 
         // Parse date from fact_id
-        final match = RegExp(r'(\d{4})/(\d{2})/(\d{2})\.md#ts_\d+$')
-            .firstMatch(relatedId);
+        final match = RegExp(
+          r'(\d{4})/(\d{2})/(\d{2})\.md#ts_\d+$',
+        ).firstMatch(relatedId);
         if (match == null) {
           _logger.warning('Invalid fact_id format in related_fact: $relatedId');
           continue;
@@ -134,8 +139,10 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
         final dateStr = '$year-$month-$day';
 
         // Read related card title
-        final relatedCardData =
-            await _fileSystemService.readCardFile(userId, relatedId);
+        final relatedCardData = await _fileSystemService.readCardFile(
+          userId,
+          relatedId,
+        );
 
         // Skip if related card was deleted (physical delete; readCardFile returns null)
         if (relatedCardData == null) {
@@ -154,16 +161,20 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
         final relatedRawContent = relatedFactInfo?.content ?? '';
 
         final relatedProcessed = await _parseAssetsAndCleanContent(
-            userId, relatedRawContent,
-            maxContentLength: 60);
+          userId,
+          relatedRawContent,
+          maxContentLength: 60,
+        );
 
-        relatedCards.add(RelatedCard(
-          id: relatedCardId,
-          title: relatedTitle,
-          date: dateStr,
-          rawContent: relatedProcessed['content'] as String,
-          assets: relatedProcessed['assets'] as List<AssetData>,
-        ));
+        relatedCards.add(
+          RelatedCard(
+            id: relatedCardId,
+            title: relatedTitle,
+            date: dateStr,
+            rawContent: relatedProcessed['content'] as String,
+            assets: relatedProcessed['assets'] as List<AssetData>,
+          ),
+        );
       } catch (e) {
         _logger.warning('Failed to process related fact $relatedId: $e');
         continue;
@@ -183,8 +194,10 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
         CharacterInfo? commentCharacter;
         if (commentData.isAi && commentData.characterId != null) {
           try {
-            final commentChar = await CharacterService.instance
-                .getCharacter(userId, commentData.characterId!);
+            final commentChar = await CharacterService.instance.getCharacter(
+              userId,
+              commentData.characterId!,
+            );
             if (commentChar != null) {
               commentCharacter = CharacterInfo(
                 id: commentChar.id,
@@ -195,18 +208,21 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
             }
           } catch (e) {
             _logger.warning(
-                'Failed to load comment character ${commentData.characterId}: $e');
+              'Failed to load comment character ${commentData.characterId}: $e',
+            );
           }
         }
 
-        comments.add(Comment(
-          id: commentData.id,
-          content: commentData.content,
-          isAi: commentData.isAi,
-          timestamp: commentData.timestamp,
-          character: commentCharacter,
-          replyToId: commentData.replyToId,
-        ));
+        comments.add(
+          Comment(
+            id: commentData.id,
+            content: commentData.content,
+            isAi: commentData.isAi,
+            timestamp: commentData.timestamp,
+            character: commentCharacter,
+            replyToId: commentData.replyToId,
+          ),
+        );
       } catch (e) {
         _logger.warning('Failed to process comment: $e');
         continue;
@@ -276,17 +292,19 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
           final model = call['model'] as String? ?? '';
           final sem = TokenUsageUtils.resolveFromUsageRecord(usage);
           final effPrompt = TokenUsageUtils.effectivePromptTokensOrNull(
-              promptTokens: promptTokens,
-              cachedTokens: cachedTokens,
-              cachedTokensIncludedInPrompt: sem);
+            promptTokens: promptTokens,
+            cachedTokens: cachedTokens,
+            cachedTokensIncludedInPrompt: sem,
+          );
 
           final cost = TokenUsageUtils.calculateCost(
-              model: model,
-              promptTokens: promptTokens,
-              completionTokens: completionTokens,
-              cachedTokens: cachedTokens,
-              thoughtTokens: thoughtTokens,
-              cachedTokensIncludedInPrompt: sem)['total']!;
+            model: model,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            cachedTokens: cachedTokens,
+            thoughtTokens: thoughtTokens,
+            cachedTokensIncludedInPrompt: sem,
+          )['total']!;
 
           totalCalls++;
           totalPromptTokens += promptTokens;
@@ -309,7 +327,8 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
             cachedTokens: (prev?.cachedTokens ?? 0) + cachedTokens,
             effectivePromptTokens:
                 (prev?.effectivePromptTokens ?? 0) + (effPrompt ?? 0),
-            cachedTokensForRate: (prev?.cachedTokensForRate ?? 0) +
+            cachedTokensForRate:
+                (prev?.cachedTokensForRate ?? 0) +
                 (effPrompt != null ? cachedTokens : 0),
             thoughtTokens: (prev?.thoughtTokens ?? 0) + thoughtTokens,
             totalTokens: (prev?.totalTokens ?? 0) + tokens,
@@ -349,9 +368,10 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
     return CardDetailModel(
       id: cardId,
       title: title,
-      timestamp:
-          DateTime.fromMillisecondsSinceEpoch(timestamp * 1000, isUtc: true)
-              .toLocal(),
+      timestamp: DateTime.fromMillisecondsSinceEpoch(
+        timestamp * 1000,
+        isUtc: true,
+      ).toLocal(),
       address: address,
       lat: locationInfo?['lat'] != null
           ? (locationInfo!['lat'] as num?)?.toDouble()
@@ -372,6 +392,8 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
       assets: assets,
       llmStats: llmStats,
       uiConfigs: renderResult.uiConfigs,
+      status: renderResult.status,
+      failureReason: cardData.failureReason,
     );
   } catch (e) {
     _logger.severe('Failed to get card detail $cardId: $e');
@@ -465,9 +487,14 @@ Future<bool> updateCardTimeEndpoint(String cardId, int timestamp) async {
 /// Returns:
 ///   bool: success
 Future<bool> updateCardLocationEndpoint(
-    String cardId, double lat, double lng, String name) async {
+  String cardId,
+  double lat,
+  double lng,
+  String name,
+) async {
   _logger.info(
-      'updateCardLocation called: cardId=$cardId, lat=$lat, lng=$lng, name=$name');
+    'updateCardLocation called: cardId=$cardId, lat=$lat, lng=$lng, name=$name',
+  );
 
   try {
     final userId = await UserStorage.getUserId();
@@ -538,8 +565,10 @@ String _extractToolAnalysis(String analysisContent) {
 
 /// Parse assets and clean rawContent
 Future<Map<String, dynamic>> _parseAssetsAndCleanContent(
-    String userId, String rawContent,
-    {int? maxContentLength}) async {
+  String userId,
+  String rawContent, {
+  int? maxContentLength,
+}) async {
   final assets = <AssetData>[];
   var cleanedContent = rawContent;
 
@@ -559,11 +588,10 @@ Future<Map<String, dynamic>> _parseAssetsAndCleanContent(
       if (await imgFileObj.exists()) {
         // In local mode, convert to local HTTP URL
         final url = await FileSystemService.convertFsToLocalHttp(
-            'fs://$imgFile', userId);
-        assets.add(AssetData(
-          type: 'image',
-          url: url,
-        ));
+          'fs://$imgFile',
+          userId,
+        );
+        assets.add(AssetData(type: 'image', url: url));
       }
     }
 
@@ -580,19 +608,19 @@ Future<Map<String, dynamic>> _parseAssetsAndCleanContent(
         if (await audioFileObj.exists()) {
           // In local mode, convert to local HTTP URL
           final url = await FileSystemService.convertFsToLocalHttp(
-              'fs://$audioFile', userId);
-          assets.add(AssetData(
-            type: 'audio',
-            url: url,
-          ));
+            'fs://$audioFile',
+            userId,
+          );
+          assets.add(AssetData(type: 'audio', url: url));
         }
       }
     }
   }
 
   // Remove all image/audio placeholders from rawContent
-  final assetPattern =
-      RegExp(r'((?:!\[(?:图片|image)\]|\[(?:音频|audio)\])\(fs://[^)]+\))');
+  final assetPattern = RegExp(
+    r'((?:!\[(?:图片|image)\]|\[(?:音频|audio)\])\(fs://[^)]+\))',
+  );
   cleanedContent = cleanedContent.replaceAll(assetPattern, '');
 
   // Collapse 3+ newlines to 2, trim
@@ -603,8 +631,5 @@ Future<Map<String, dynamic>> _parseAssetsAndCleanContent(
     cleanedContent = '${cleanedContent.substring(0, maxContentLength)}...';
   }
 
-  return {
-    'assets': assets,
-    'content': cleanedContent,
-  };
+  return {'assets': assets, 'content': cleanedContent};
 }

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -44,6 +44,8 @@ import 'package:memex/data/services/global_event_bus.dart';
 import 'package:memex/data/repositories/submit_input.dart'
     as submit_input_endpoint;
 import 'package:memex/data/repositories/reprocess_pending_cards.dart';
+import 'package:memex/data/repositories/retry_failed_cards.dart'
+    as retry_failed_cards_endpoint;
 import 'package:memex/data/services/task_handlers/analyze_assets_handler.dart';
 import 'package:memex/data/services/task_handlers/card_agent_handler.dart';
 import 'package:memex/data/services/task_handlers/pkm_agent_handler.dart';
@@ -68,6 +70,7 @@ import 'package:memex/data/repositories/character.dart';
 import 'package:memex/data/repositories/health.dart' as health_endpoint;
 import 'package:memex/data/repositories/pkm.dart' as pkm_endpoint;
 import 'package:memex/domain/models/knowledge_insight_card.dart';
+import 'package:memex/domain/models/card_generation_retry_result.dart';
 import 'package:memex/data/repositories/get_knowledge_insight_detail.dart';
 import 'package:memex/data/repositories/chat.dart' as chat_endpoint;
 import 'package:memex/data/services/llm_call_record_service.dart';
@@ -227,7 +230,7 @@ class MemexRouter {
   }
 
   String?
-      _targetUserIdForInit; // Track the user ID we are currently initializing for
+  _targetUserIdForInit; // Track the user ID we are currently initializing for
 
   void _registerEventSubscriptions() {
     final eventBus = GlobalEventBus.instance;
@@ -435,8 +438,10 @@ class MemexRouter {
 
   void scheduleAutoBackupCheck({required String trigger}) {
     unawaited(
-      maybeRunAutoBackup(trigger: trigger)
-          .catchError((Object e, StackTrace st) {
+      maybeRunAutoBackup(trigger: trigger).catchError((
+        Object e,
+        StackTrace st,
+      ) {
         _logger.warning('Automatic backup check failed: $e', e, st);
         return null;
       }),
@@ -646,6 +651,30 @@ class MemexRouter {
     await _ensureInitialized();
     _logger.info('LocalMode: fetchCardDetail called: cardId=$cardId');
     return getCardDetail(cardId);
+  }
+
+  Future<int> countFailedCardGenerations() async {
+    await _ensureInitialized();
+    return retry_failed_cards_endpoint.countFailedCardGenerations();
+  }
+
+  Future<bool> retryCardGeneration(String cardId) async {
+    await _ensureInitialized();
+    _logger.info('LocalMode: retryCardGeneration called: cardId=$cardId');
+    try {
+      return await retry_failed_cards_endpoint.retryFailedCardGeneration(
+        cardId,
+      );
+    } catch (e) {
+      _logger.severe('Failed to retry card generation for $cardId: $e');
+      return false;
+    }
+  }
+
+  Future<CardGenerationRetryResult> retryAllFailedCardGenerations() async {
+    await _ensureInitialized();
+    _logger.info('LocalMode: retryAllFailedCardGenerations called');
+    return retry_failed_cards_endpoint.retryAllFailedCardGenerations();
   }
 
   Future<Map<String, dynamic>> postComment(
@@ -987,8 +1016,8 @@ class MemexRouter {
             id,
           );
           if (cardData != null) {
-            final currentSortOrder =
-                (cardData['sort_order'] as num? ?? 0).toInt();
+            final currentSortOrder = (cardData['sort_order'] as num? ?? 0)
+                .toInt();
             if (currentSortOrder != i) {
               cardData['sort_order'] = i;
               await fileSystemService.writeKnowledgeInsightCard(
@@ -1485,7 +1514,8 @@ class MemexRouter {
     }
 
     final lower = avatar.toLowerCase();
-    final isRelativeImagePath = !avatar.startsWith('/') &&
+    final isRelativeImagePath =
+        !avatar.startsWith('/') &&
         (lower.endsWith('.png') ||
             lower.endsWith('.jpg') ||
             lower.endsWith('.jpeg') ||
@@ -1548,38 +1578,38 @@ class MemexRouter {
   Future<void> resetAllAgentConfigs() => UserStorage.resetAllAgentConfigs();
 
   Future<Result<void>> updateKnowledgeInsights() => runResultVoid(() async {
-        await _ensureInitialized();
-        final userId = await UserStorage.getUserId();
-        if (userId == null) {
-          throw Exception('User not logged in');
-        }
+    await _ensureInitialized();
+    final userId = await UserStorage.getUserId();
+    if (userId == null) {
+      throw Exception('User not logged in');
+    }
 
-        await GlobalEventBus.instance.publish(
-          userId: userId,
-          event: SystemEvent(
-            type: SystemEventTypes.knowledgeInsightRefreshRequested,
-            source: 'memex_router.updateKnowledgeInsights',
-            payload: const {},
-          ),
-        );
-      });
+    await GlobalEventBus.instance.publish(
+      userId: userId,
+      event: SystemEvent(
+        type: SystemEventTypes.knowledgeInsightRefreshRequested,
+        source: 'memex_router.updateKnowledgeInsights',
+        payload: const {},
+      ),
+    );
+  });
 
   Future<Result<void>> refreshScheduleAggregation() => runResultVoid(() async {
-        await _ensureInitialized();
-        final userId = await UserStorage.getUserId();
-        if (userId == null) {
-          throw Exception('User not logged in');
-        }
+    await _ensureInitialized();
+    final userId = await UserStorage.getUserId();
+    if (userId == null) {
+      throw Exception('User not logged in');
+    }
 
-        await GlobalEventBus.instance.publish(
-          userId: userId,
-          event: SystemEvent(
-            type: SystemEventTypes.scheduleAggregationRequested,
-            source: 'memex_router.refreshScheduleAggregation',
-            payload: const {},
-          ),
-        );
-      });
+    await GlobalEventBus.instance.publish(
+      userId: userId,
+      event: SystemEvent(
+        type: SystemEventTypes.scheduleAggregationRequested,
+        source: 'memex_router.refreshScheduleAggregation',
+        payload: const {},
+      ),
+    );
+  });
 
   Future<List<Task>> getTasks({int limit = 10, int offset = 0}) =>
       LocalTaskExecutor.instance.getTasks(limit: limit, offset: offset);

--- a/lib/data/repositories/retry_failed_cards.dart
+++ b/lib/data/repositories/retry_failed_cards.dart
@@ -1,0 +1,185 @@
+import 'package:memex/data/services/card_renderer.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/global_event_bus.dart';
+import 'package:memex/domain/models/card_detail_model.dart';
+import 'package:memex/domain/models/card_generation_retry_result.dart';
+import 'package:memex/domain/models/system_event.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/user_storage.dart';
+
+final _logger = getLogger('RetryFailedCardsEndpoint');
+
+Future<int> countFailedCardGenerations() async {
+  final userId = await UserStorage.getUserId();
+  if (userId == null) return 0;
+
+  final failedIds = await _listFailedCardIds(userId);
+  return failedIds.length;
+}
+
+Future<bool> retryFailedCardGeneration(String factId) async {
+  final userId = await UserStorage.getUserId();
+  if (userId == null) {
+    throw Exception('User not logged in, cannot retry card generation');
+  }
+
+  final result = await _retryCardForUser(userId, factId);
+  return result;
+}
+
+Future<CardGenerationRetryResult> retryAllFailedCardGenerations() async {
+  final userId = await UserStorage.getUserId();
+  if (userId == null) {
+    throw Exception('User not logged in, cannot retry failed cards');
+  }
+
+  final failedIds = await _listFailedCardIds(userId);
+  var retried = 0;
+  var skipped = 0;
+  final errors = <String, String>{};
+
+  for (final factId in failedIds) {
+    try {
+      final didRetry = await _retryCardForUser(userId, factId);
+      if (didRetry) {
+        retried++;
+      } else {
+        skipped++;
+      }
+    } catch (e) {
+      errors[factId] = e.toString();
+    }
+  }
+
+  return CardGenerationRetryResult(
+    requested: failedIds.length,
+    retried: retried,
+    skipped: skipped,
+    errors: errors,
+  );
+}
+
+Future<List<String>> _listFailedCardIds(String userId) async {
+  final fs = FileSystemService.instance;
+  final cardFiles = await fs.listAllCardFiles(userId);
+  final failedIds = <String>[];
+
+  for (final path in cardFiles) {
+    final factId = fs.factIdFromCardPath(path);
+    if (factId == null) continue;
+
+    try {
+      final card = await fs.readCardFile(userId, factId);
+      if (card?.status == 'failed') {
+        failedIds.add(factId);
+      }
+    } catch (e) {
+      _logger.warning('Failed to inspect card $factId for retry: $e');
+    }
+  }
+
+  return failedIds;
+}
+
+Future<bool> _retryCardForUser(String userId, String factId) async {
+  final fs = FileSystemService.instance;
+  final card = await fs.readCardFile(userId, factId);
+  if (card == null || card.status != 'failed') {
+    _logger.info('Skip retry for $factId: card is missing or not failed');
+    return false;
+  }
+
+  final factInfo = await fs.extractFactContentFromFile(userId, factId);
+  if (factInfo == null) {
+    throw Exception('Original fact content not found for $factId');
+  }
+
+  final updatedCard = await fs.updateCardFile(
+    userId,
+    factId,
+    (current) =>
+        current.copyWith(status: 'processing', clearFailureReason: true),
+  );
+
+  if (updatedCard == null) {
+    throw Exception('Card not found for retry: $factId');
+  }
+
+  await _emitCardProcessingUpdate(
+    userId: userId,
+    factId: factId,
+    combinedText: factInfo.content,
+  );
+
+  final simpleFactId = fs.extractSimpleFactId(factId);
+  final dt = factInfo.datetime;
+  final timeStr =
+      '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}:${dt.second.toString().padLeft(2, '0')}';
+  final markdownEntry =
+      '## <id:$simpleFactId> $timeStr "{}"\n\n${factInfo.content}\n';
+
+  await GlobalEventBus.instance.publish(
+    userId: userId,
+    event: SystemEvent(
+      type: SystemEventTypes.userInputSubmitted,
+      source: 'retry_failed_cards.retryFailedCardGeneration',
+      payload: UserInputSubmittedPayload(
+        factId: factId,
+        assetPaths: _assetPathsFromContent(userId, factInfo.content),
+        combinedText: factInfo.content,
+        markdownEntry: markdownEntry,
+        createdAtTs: factInfo.timestamp,
+        pkmCreatedAtTs: factInfo.timestamp.toDouble(),
+      ),
+    ),
+  );
+
+  _logger.info('Triggered card generation retry for $factId');
+  return true;
+}
+
+List<String> _assetPathsFromContent(String userId, String content) {
+  final fs = FileSystemService.instance;
+  final assetsDir = fs.getAssetsPath(userId);
+  return RegExp(r'fs://([^\s\)]+)').allMatches(content).map((m) {
+    final filename = m.group(1)!;
+    return fs.toRelativePath('$assetsDir/$filename');
+  }).toList();
+}
+
+Future<void> _emitCardProcessingUpdate({
+  required String userId,
+  required String factId,
+  required String combinedText,
+}) async {
+  final fs = FileSystemService.instance;
+  final cardData = await fs.readCardFile(userId, factId);
+  if (cardData == null) return;
+
+  final renderResult = await renderCard(
+    userId: userId,
+    cardData: cardData,
+    factContent: combinedText,
+  );
+  final assetsAndText = await extractAssetsAndRawText(userId, combinedText);
+  final assets = (assetsAndText['assets'] as List<AssetData>)
+      .map((a) => a.toJson())
+      .toList();
+  final rawText = assetsAndText['rawText'] as String?;
+
+  EventBusService.instance.emitEvent(
+    CardUpdatedMessage(
+      id: factId,
+      html: renderResult.html ?? '',
+      timestamp: cardData.timestamp,
+      tags: cardData.tags,
+      status: renderResult.status,
+      title: cardData.title,
+      uiConfigs: renderResult.uiConfigs,
+      assets: assets.isNotEmpty ? assets : null,
+      rawText: rawText,
+      address: cardData.address,
+    ),
+  );
+}

--- a/lib/domain/models/card_detail_model.dart
+++ b/lib/domain/models/card_detail_model.dart
@@ -14,6 +14,8 @@ class CardDetailModel {
   final List<AssetData> assets;
   final LLMStats? llmStats;
   final List<UiConfig> uiConfigs;
+  final String status;
+  final String? failureReason;
 
   CardDetailModel({
     required this.id,
@@ -28,6 +30,8 @@ class CardDetailModel {
     required this.assets,
     this.llmStats,
     this.uiConfigs = const [],
+    this.status = 'completed',
+    this.failureReason,
   });
 
   factory CardDetailModel.fromJson(Map<String, dynamic> json) {
@@ -66,8 +70,8 @@ class CardDetailModel {
       rawContent: json['raw_content'] as String? ?? '',
       insight:
           json['insight'] != null && json['insight'] is Map<String, dynamic>
-              ? InsightData.fromJson(json['insight'] as Map<String, dynamic>)
-              : InsightData.fromJson({}),
+          ? InsightData.fromJson(json['insight'] as Map<String, dynamic>)
+          : InsightData.fromJson({}),
       assets: (json['assets'] as List<dynamic>? ?? const [])
           .where((asset) => asset != null && asset is Map<String, dynamic>)
           .map((asset) => AssetData.fromJson(asset as Map<String, dynamic>))
@@ -76,6 +80,8 @@ class CardDetailModel {
           ? LLMStats.fromJson(json['llm_stats'] as Map<String, dynamic>)
           : null,
       uiConfigs: configs,
+      status: json['status'] as String? ?? 'completed',
+      failureReason: json['failure_reason'] as String?,
     );
   }
 
@@ -92,6 +98,9 @@ class CardDetailModel {
     List<AssetData>? assets,
     LLMStats? llmStats,
     List<UiConfig>? uiConfigs,
+    String? status,
+    String? failureReason,
+    bool clearFailureReason = false,
   }) {
     return CardDetailModel(
       id: id ?? this.id,
@@ -106,6 +115,10 @@ class CardDetailModel {
       assets: assets ?? this.assets,
       llmStats: llmStats ?? this.llmStats,
       uiConfigs: uiConfigs ?? this.uiConfigs,
+      status: status ?? this.status,
+      failureReason: clearFailureReason
+          ? null
+          : failureReason ?? this.failureReason,
     );
   }
 }
@@ -237,10 +250,7 @@ class AssetData {
   final String type; // 'image' | 'audio'
   final String url;
 
-  AssetData({
-    required this.type,
-    required this.url,
-  });
+  AssetData({required this.type, required this.url});
 
   factory AssetData.fromJson(Map<String, dynamic> json) {
     return AssetData(
@@ -250,10 +260,7 @@ class AssetData {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'type': type,
-      'url': url,
-    };
+    return {'type': type, 'url': url};
   }
 
   bool get isImage => type == 'image';
@@ -294,10 +301,10 @@ class LLMStats {
 
   factory LLMStats.fromJson(Map<String, dynamic> json) {
     final byAgentData = json['by_agent'] as Map<String, dynamic>? ?? {};
-    final byAgent = byAgentData.map((key, value) => MapEntry(
-          key,
-          AgentStats.fromJson(value as Map<String, dynamic>),
-        ));
+    final byAgent = byAgentData.map(
+      (key, value) =>
+          MapEntry(key, AgentStats.fromJson(value as Map<String, dynamic>)),
+    );
 
     return LLMStats(
       totalCalls: json['total_calls'] as int? ?? 0,

--- a/lib/domain/models/card_generation_retry_result.dart
+++ b/lib/domain/models/card_generation_retry_result.dart
@@ -1,0 +1,15 @@
+class CardGenerationRetryResult {
+  final int requested;
+  final int retried;
+  final int skipped;
+  final Map<String, String> errors;
+
+  const CardGenerationRetryResult({
+    required this.requested,
+    required this.retried,
+    required this.skipped,
+    this.errors = const {},
+  });
+
+  bool get hasErrors => errors.isNotEmpty;
+}

--- a/lib/domain/models/card_model.dart
+++ b/lib/domain/models/card_model.dart
@@ -17,10 +17,7 @@ class UiConfig {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'template_id': templateId,
-      'data': data,
-    };
+    return {'template_id': templateId, 'data': data};
   }
 }
 
@@ -125,8 +122,9 @@ class CardData {
       }
     }
     if (uiConfigsList.isEmpty && json['ui_config'] is Map) {
-      uiConfigsList.add(UiConfig.fromJson(
-          Map<String, dynamic>.from(json['ui_config'] as Map)));
+      uiConfigsList.add(
+        UiConfig.fromJson(Map<String, dynamic>.from(json['ui_config'] as Map)),
+      );
     }
 
     final commentsRaw = json['comments'];
@@ -150,7 +148,8 @@ class CardData {
     CardInsight? insightData;
     if (json['insight'] is Map) {
       insightData = CardInsight.fromJson(
-          Map<String, dynamic>.from(json['insight'] as Map));
+        Map<String, dynamic>.from(json['insight'] as Map),
+      );
     }
 
     return CardData(
@@ -209,6 +208,7 @@ class CardData {
     CardInsight? insight,
     bool? deleted,
     String? failureReason,
+    bool clearFailureReason = false,
   }) {
     return CardData(
       factId: factId ?? this.factId,
@@ -224,7 +224,9 @@ class CardData {
       comments: comments ?? this.comments,
       insight: insight ?? this.insight,
       deleted: deleted ?? this.deleted,
-      failureReason: failureReason ?? this.failureReason,
+      failureReason: clearFailureReason
+          ? null
+          : failureReason ?? this.failureReason,
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -860,6 +860,36 @@
   "failedStatus": "Failed",
   "viewDetails": "View Details",
   "failureReason": "Failure Reason",
+  "cardGenerationFailedTitle": "Card generation failed",
+  "cardGenerationFailedDescription": "Your original record is saved. You can regenerate the card without creating a duplicate record.",
+  "regenerateCard": "Regenerate Card",
+  "cardRegenerationStarted": "Card regeneration started",
+  "cardRegenerationFailed": "Failed to start card regeneration",
+  "cardRegeneratingTitle": "Regenerating card",
+  "cardRegeneratingDescription": "Memex is rebuilding this card from the saved original record.",
+  "failedCardsRetryTitle": "{count, plural, =1{1 card failed to generate} other{{count} cards failed to generate}}",
+  "@failedCardsRetryTitle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "failedCardsRetryDescription": "Original records are saved. Retry all failed card generations from the saved records.",
+  "retryAllFailedCards": "Retry All",
+  "failedCardsRetryStarted": "Started regenerating {count} failed cards",
+  "@failedCardsRetryStarted": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "failedCardsRetryPartial": "Started {retried} retries. {failed} cards need attention.",
+  "@failedCardsRetryPartial": {
+    "placeholders": {
+      "retried": {},
+      "failed": {}
+    }
+  },
   "unknownError": "Unknown error occurred",
   "enableFitness": "Enable Fitness",
   "fitnessBannerMessage": "Allow fitness access to track your health and activity data.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3476,6 +3476,78 @@ abstract class AppLocalizations {
   /// **'Failure Reason'**
   String get failureReason;
 
+  /// No description provided for @cardGenerationFailedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Card generation failed'**
+  String get cardGenerationFailedTitle;
+
+  /// No description provided for @cardGenerationFailedDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Your original record is saved. You can regenerate the card without creating a duplicate record.'**
+  String get cardGenerationFailedDescription;
+
+  /// No description provided for @regenerateCard.
+  ///
+  /// In en, this message translates to:
+  /// **'Regenerate Card'**
+  String get regenerateCard;
+
+  /// No description provided for @cardRegenerationStarted.
+  ///
+  /// In en, this message translates to:
+  /// **'Card regeneration started'**
+  String get cardRegenerationStarted;
+
+  /// No description provided for @cardRegenerationFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to start card regeneration'**
+  String get cardRegenerationFailed;
+
+  /// No description provided for @cardRegeneratingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Regenerating card'**
+  String get cardRegeneratingTitle;
+
+  /// No description provided for @cardRegeneratingDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Memex is rebuilding this card from the saved original record.'**
+  String get cardRegeneratingDescription;
+
+  /// No description provided for @failedCardsRetryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 card failed to generate} other{{count} cards failed to generate}}'**
+  String failedCardsRetryTitle(num count);
+
+  /// No description provided for @failedCardsRetryDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Original records are saved. Retry all failed card generations from the saved records.'**
+  String get failedCardsRetryDescription;
+
+  /// No description provided for @retryAllFailedCards.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry All'**
+  String get retryAllFailedCards;
+
+  /// No description provided for @failedCardsRetryStarted.
+  ///
+  /// In en, this message translates to:
+  /// **'Started regenerating {count} failed cards'**
+  String failedCardsRetryStarted(Object count);
+
+  /// No description provided for @failedCardsRetryPartial.
+  ///
+  /// In en, this message translates to:
+  /// **'Started {retried} retries. {failed} cards need attention.'**
+  String failedCardsRetryPartial(Object retried, Object failed);
+
   /// No description provided for @unknownError.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1882,6 +1882,57 @@ class AppLocalizationsEn extends AppLocalizations {
   String get failureReason => 'Failure Reason';
 
   @override
+  String get cardGenerationFailedTitle => 'Card generation failed';
+
+  @override
+  String get cardGenerationFailedDescription =>
+      'Your original record is saved. You can regenerate the card without creating a duplicate record.';
+
+  @override
+  String get regenerateCard => 'Regenerate Card';
+
+  @override
+  String get cardRegenerationStarted => 'Card regeneration started';
+
+  @override
+  String get cardRegenerationFailed => 'Failed to start card regeneration';
+
+  @override
+  String get cardRegeneratingTitle => 'Regenerating card';
+
+  @override
+  String get cardRegeneratingDescription =>
+      'Memex is rebuilding this card from the saved original record.';
+
+  @override
+  String failedCardsRetryTitle(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count cards failed to generate',
+      one: '1 card failed to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get failedCardsRetryDescription =>
+      'Original records are saved. Retry all failed card generations from the saved records.';
+
+  @override
+  String get retryAllFailedCards => 'Retry All';
+
+  @override
+  String failedCardsRetryStarted(Object count) {
+    return 'Started regenerating $count failed cards';
+  }
+
+  @override
+  String failedCardsRetryPartial(Object retried, Object failed) {
+    return 'Started $retried retries. $failed cards need attention.';
+  }
+
+  @override
   String get unknownError => 'Unknown error occurred';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1830,6 +1830,48 @@ class AppLocalizationsZh extends AppLocalizations {
   String get failureReason => '失败原因';
 
   @override
+  String get cardGenerationFailedTitle => '卡片生成失败';
+
+  @override
+  String get cardGenerationFailedDescription => '原始记录已保存，可以重新生成卡片，不会重复创建记录。';
+
+  @override
+  String get regenerateCard => '重新生成卡片';
+
+  @override
+  String get cardRegenerationStarted => '已开始重新生成卡片';
+
+  @override
+  String get cardRegenerationFailed => '未能开始重新生成卡片';
+
+  @override
+  String get cardRegeneratingTitle => '正在重新生成卡片';
+
+  @override
+  String get cardRegeneratingDescription => 'Memex 正在根据已保存的原始记录重建这张卡片。';
+
+  @override
+  String failedCardsRetryTitle(num count) {
+    return '$count 张卡片生成失败';
+  }
+
+  @override
+  String get failedCardsRetryDescription => '原始记录都已保存。可以从已保存的记录重新生成这些卡片。';
+
+  @override
+  String get retryAllFailedCards => '全部重试';
+
+  @override
+  String failedCardsRetryStarted(Object count) {
+    return '已开始重新生成 $count 张失败卡片';
+  }
+
+  @override
+  String failedCardsRetryPartial(Object retried, Object failed) {
+    return '已开始 $retried 个重试，$failed 张卡片需要处理。';
+  }
+
+  @override
   String get unknownError => '发生未知错误';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -845,6 +845,36 @@
   "failedStatus": "处理失败",
   "viewDetails": "查看详情",
   "failureReason": "失败原因",
+  "cardGenerationFailedTitle": "卡片生成失败",
+  "cardGenerationFailedDescription": "原始记录已保存，可以重新生成卡片，不会重复创建记录。",
+  "regenerateCard": "重新生成卡片",
+  "cardRegenerationStarted": "已开始重新生成卡片",
+  "cardRegenerationFailed": "未能开始重新生成卡片",
+  "cardRegeneratingTitle": "正在重新生成卡片",
+  "cardRegeneratingDescription": "Memex 正在根据已保存的原始记录重建这张卡片。",
+  "failedCardsRetryTitle": "{count} 张卡片生成失败",
+  "@failedCardsRetryTitle": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "failedCardsRetryDescription": "原始记录都已保存。可以从已保存的记录重新生成这些卡片。",
+  "retryAllFailedCards": "全部重试",
+  "failedCardsRetryStarted": "已开始重新生成 {count} 张失败卡片",
+  "@failedCardsRetryStarted": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "failedCardsRetryPartial": "已开始 {retried} 个重试，{failed} 张卡片需要处理。",
+  "@failedCardsRetryPartial": {
+    "placeholders": {
+      "retried": {},
+      "failed": {}
+    }
+  },
   "unknownError": "发生未知错误",
   "enableFitness": "开启健身权限",
   "fitnessBannerMessage": "允许访问健身数据以记录你的健康和运动信息。",

--- a/lib/ui/main_screen/widgets/action_center_sheet.dart
+++ b/lib/ui/main_screen/widgets/action_center_sheet.dart
@@ -8,9 +8,20 @@ import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/ui/card_attachments/card_attachment_data.dart';
 import 'package:memex/ui/card_attachments/card_attachment_factory.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
+import 'package:memex/domain/models/card_generation_retry_result.dart';
+import 'package:memex/data/repositories/memex_router.dart';
 
 class ActionCenterSheet extends StatefulWidget {
-  const ActionCenterSheet({super.key});
+  const ActionCenterSheet({
+    super.key,
+    this.loadPendingAttachments,
+    this.loadFailedCardCount,
+    this.retryAllFailedCards,
+  });
+
+  final Future<List<CardAttachmentData>> Function()? loadPendingAttachments;
+  final Future<int> Function()? loadFailedCardCount;
+  final Future<CardGenerationRetryResult> Function()? retryAllFailedCards;
 
   @override
   State<ActionCenterSheet> createState() => _ActionCenterSheetState();
@@ -19,8 +30,10 @@ class ActionCenterSheet extends StatefulWidget {
 class _ActionCenterSheetState extends State<ActionCenterSheet>
     with SingleTickerProviderStateMixin {
   List<CardAttachmentData>? _items;
+  int _failedCardCount = 0;
   bool _isLoading = true;
   bool _isDismissing = false;
+  bool _isRetryingFailedCards = false;
 
   late final AnimationController _fadeController;
   late final Animation<double> _fadeAnimation;
@@ -41,6 +54,10 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
       EventBusMessageType.attachmentsChanged,
       _onAttachmentsChanged,
     );
+    EventBusService.instance.addHandler(
+      EventBusMessageType.cardUpdated,
+      _onCardUpdated,
+    );
   }
 
   @override
@@ -50,6 +67,10 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
       EventBusMessageType.attachmentsChanged,
       _onAttachmentsChanged,
     );
+    EventBusService.instance.removeHandler(
+      EventBusMessageType.cardUpdated,
+      _onCardUpdated,
+    );
     super.dispose();
   }
 
@@ -57,14 +78,24 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
     _load();
   }
 
+  void _onCardUpdated(EventBusMessage message) {
+    _load();
+  }
+
   Future<void> _load() async {
-    final items = await CardAttachmentService.instance.getPendingAttachments();
+    final loadAttachments =
+        widget.loadPendingAttachments ??
+        CardAttachmentService.instance.getPendingAttachments;
+    final loadFailedCount =
+        widget.loadFailedCardCount ?? MemexRouter().countFailedCardGenerations;
+    final results = await Future.wait([loadAttachments(), loadFailedCount()]);
     if (!mounted) return;
     setState(() {
-      _items = items;
+      _items = results[0] as List<CardAttachmentData>;
+      _failedCardCount = results[1] as int;
       _isLoading = false;
     });
-    if (items.isNotEmpty) {
+    if ((_items ?? const []).isNotEmpty || _failedCardCount > 0) {
       _fadeController.forward();
     }
   }
@@ -113,8 +144,9 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
 
     HapticFeedback.mediumImpact();
 
-    final count =
-        await CardAttachmentService.instance.dismissAllPending(type: type);
+    final count = await CardAttachmentService.instance.dismissAllPending(
+      type: type,
+    );
 
     if (!mounted) return;
 
@@ -126,12 +158,49 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
         SnackBar(
           content: Text(l10n.dismissedCount(count)),
           behavior: SnackBarBehavior.floating,
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
           margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
           duration: const Duration(seconds: 2),
         ),
       );
+    }
+  }
+
+  Future<void> _retryAllFailedCards() async {
+    if (_isRetryingFailedCards) return;
+    setState(() => _isRetryingFailedCards = true);
+    HapticFeedback.mediumImpact();
+
+    try {
+      final retryAll =
+          widget.retryAllFailedCards ??
+          MemexRouter().retryAllFailedCardGenerations;
+      final result = await retryAll();
+      if (!mounted) return;
+
+      final l10n = UserStorage.l10n;
+      final failed = result.errors.length;
+      final message = failed == 0
+          ? l10n.failedCardsRetryStarted(result.retried)
+          : l10n.failedCardsRetryPartial(result.retried, failed);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(message),
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      await _load();
+    } finally {
+      if (mounted) {
+        setState(() => _isRetryingFailedCards = false);
+      }
     }
   }
 
@@ -196,9 +265,11 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
 
   Widget _buildHeader(ColorScheme colorScheme) {
     final l10n = UserStorage.l10n;
-    final hasItems = (_items ?? []).isNotEmpty;
-    final itemCount = _items?.length ?? 0;
+    final attachmentCount = _items?.length ?? 0;
+    final hasItems = attachmentCount > 0 || _failedCardCount > 0;
+    final itemCount = attachmentCount + (_failedCardCount > 0 ? 1 : 0);
     final hasMultipleTypes = _countByType().length > 1;
+    final hasDismissibleItems = attachmentCount > 0;
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 16, 16, 16),
@@ -236,7 +307,7 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
           const Spacer(),
 
           // Clear button
-          if (hasItems) ...[
+          if (hasDismissibleItems) ...[
             _ClearButtonGroup(
               isDismissing: _isDismissing,
               hasMultipleTypes: hasMultipleTypes,
@@ -267,7 +338,7 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
 
     final items = _items ?? const [];
 
-    if (items.isEmpty) {
+    if (items.isEmpty && _failedCardCount == 0) {
       return FadeTransition(
         opacity: _fadeAnimation,
         child: Center(
@@ -277,8 +348,9 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
               Container(
                 padding: const EdgeInsets.all(20),
                 decoration: BoxDecoration(
-                  color: colorScheme.surfaceContainerHighest
-                      .withValues(alpha: 0.4),
+                  color: colorScheme.surfaceContainerHighest.withValues(
+                    alpha: 0.4,
+                  ),
                   shape: BoxShape.circle,
                 ),
                 child: Icon(
@@ -304,15 +376,131 @@ class _ActionCenterSheetState extends State<ActionCenterSheet>
 
     return ListView.separated(
       padding: const EdgeInsets.fromLTRB(0, 12, 0, 24),
-      itemCount: items.length,
+      itemCount: items.length + (_failedCardCount > 0 ? 1 : 0),
       separatorBuilder: (context, index) => const SizedBox(height: 6),
       itemBuilder: (context, index) {
-        final item = items[index];
+        if (_failedCardCount > 0 && index == 0) {
+          return _FailedCardsRetryCard(
+            count: _failedCardCount,
+            isRetrying: _isRetryingFailedCards,
+            onRetryAll: _retryAllFailedCards,
+          );
+        }
+
+        final itemIndex = _failedCardCount > 0 ? index - 1 : index;
+        final item = items[itemIndex];
         return KeyedSubtree(
           key: ValueKey(item.id),
           child: CardAttachmentFactory.build(item),
         );
       },
+    );
+  }
+}
+
+class _FailedCardsRetryCard extends StatelessWidget {
+  const _FailedCardsRetryCard({
+    required this.count,
+    required this.isRetrying,
+    required this.onRetryAll,
+  });
+
+  final int count;
+  final bool isRetrying;
+  final VoidCallback onRetryAll;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = UserStorage.l10n;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: const Color(0xFFFFFBEB),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: const Color(0xFFFBBF24).withValues(alpha: 0.4),
+            width: 0.8,
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: const Color(0xFFF59E0B).withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Icon(
+                Icons.refresh_rounded,
+                color: Color(0xFFD97706),
+                size: 20,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l10n.failedCardsRetryTitle(count),
+                    style: const TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                      color: Color(0xFF92400E),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    l10n.failedCardsRetryDescription,
+                    style: TextStyle(
+                      fontSize: 13,
+                      height: 1.45,
+                      color: const Color(0xFF92400E).withValues(alpha: 0.72),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  FilledButton.icon(
+                    onPressed: isRetrying ? null : onRetryAll,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: const Color(0xFFD97706),
+                      foregroundColor: Colors.white,
+                      disabledBackgroundColor: const Color(
+                        0xFFD97706,
+                      ).withValues(alpha: 0.35),
+                      minimumSize: const Size(0, 36),
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                    icon: isRetrying
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 1.7,
+                              color: Colors.white,
+                            ),
+                          )
+                        : const Icon(Icons.refresh_rounded, size: 17),
+                    label: Text(
+                      l10n.retryAllFailedCards,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -503,13 +691,15 @@ class _DismissOptionsSheet extends StatelessWidget {
           const SizedBox(height: 8),
 
           // Per-type options
-          ...counts.entries.map((entry) => _DismissOptionTile(
-                icon: _typeIcon(entry.key),
-                iconColor: _typeColor(entry.key),
-                label: _typeLabel(entry.key),
-                count: entry.value,
-                onTap: () => onDismiss(entry.key),
-              )),
+          ...counts.entries.map(
+            (entry) => _DismissOptionTile(
+              icon: _typeIcon(entry.key),
+              iconColor: _typeColor(entry.key),
+              label: _typeLabel(entry.key),
+              count: entry.value,
+              onTap: () => onDismiss(entry.key),
+            ),
+          ),
 
           const SizedBox(height: 12),
 

--- a/lib/ui/timeline/view_models/timeline_viewmodel.dart
+++ b/lib/ui/timeline/view_models/timeline_viewmodel.dart
@@ -152,7 +152,9 @@ class TimelineViewModel extends ChangeNotifier {
     eventBus.addHandler(EventBusMessageType.cardUpdated, _handleCardUpdated);
     eventBus.addHandler(EventBusMessageType.cardAdded, _handleCardAdded);
     eventBus.addHandler(
-        EventBusMessageType.attachmentsChanged, _handleAttachmentsChanged);
+      EventBusMessageType.attachmentsChanged,
+      _handleAttachmentsChanged,
+    );
     eventBus.addHandler(
       EventBusMessageType.scheduleAggregationDirty,
       _handleScheduleBriefingChanged,
@@ -213,6 +215,7 @@ class TimelineViewModel extends ChangeNotifier {
         failureReason: message.failureReason,
       );
       updateCard(updatedCard);
+      unawaited(_refreshPendingCount());
       fetchTags();
     }
   }
@@ -232,11 +235,13 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   Future<void> _loadAttachmentsForCards(
-      List<TimelineCardModel> cardList) async {
+    List<TimelineCardModel> cardList,
+  ) async {
     if (cardList.isEmpty) return;
     final factIds = cardList.map((c) => c.id).toList();
-    final map =
-        await CardAttachmentService.instance.getAttachmentsForFacts(factIds);
+    final map = await CardAttachmentService.instance.getAttachmentsForFacts(
+      factIds,
+    );
     attachments.addAll(map);
     // Don't call notifyListeners here — caller is responsible.
   }
@@ -248,9 +253,10 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   Future<void> _refreshPendingCount() async {
-    final pending =
-        await CardAttachmentService.instance.getPendingAttachments();
-    pendingAttachmentCount = pending.length;
+    final pending = await CardAttachmentService.instance
+        .getPendingAttachments();
+    final failedCardCount = await _router.countFailedCardGenerations();
+    pendingAttachmentCount = pending.length + (failedCardCount > 0 ? 1 : 0);
     notifyListeners();
   }
 
@@ -262,8 +268,10 @@ class TimelineViewModel extends ChangeNotifier {
     final hasProcessing = cards.any((c) => c.status == 'processing');
     if (hasProcessing && _pollingTimer == null) {
       _logger.info('Starting polling for processing cards');
-      _pollingTimer =
-          Timer.periodic(pollingInterval, (_) => _pollProcessingCards());
+      _pollingTimer = Timer.periodic(
+        pollingInterval,
+        (_) => _pollProcessingCards(),
+      );
     } else if (!hasProcessing && _pollingTimer != null) {
       _stopPolling();
     }
@@ -281,8 +289,10 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   void _pollProcessingCards() {
-    final processingIds =
-        cards.where((c) => c.status == 'processing').map((c) => c.id).toList();
+    final processingIds = cards
+        .where((c) => c.status == 'processing')
+        .map((c) => c.id)
+        .toList();
     if (processingIds.isEmpty) {
       _stopPolling();
       return;
@@ -357,10 +367,10 @@ class TimelineViewModel extends ChangeNotifier {
       onOk: (newCards) async {
         _currentPage++;
         final loadedHasMore = newCards.length >= pageLimit;
-        cards = await _withScheduleBriefingCard(
-          [...cards, ...newCards],
-          hasMoreAfterList: loadedHasMore,
-        );
+        cards = await _withScheduleBriefingCard([
+          ...cards,
+          ...newCards,
+        ], hasMoreAfterList: loadedHasMore);
         hasMore = loadedHasMore;
         _startPollingIfNeeded();
         await _loadAttachmentsForCards(newCards);
@@ -398,10 +408,7 @@ class TimelineViewModel extends ChangeNotifier {
 
   Future<void> _refreshScheduleBriefingCard() async {
     if (!_shouldShowScheduleBriefing) return;
-    cards = await _withScheduleBriefingCard(
-      cards,
-      hasMoreAfterList: hasMore,
-    );
+    cards = await _withScheduleBriefingCard(cards, hasMoreAfterList: hasMore);
     notifyListeners();
   }
 
@@ -421,10 +428,10 @@ class TimelineViewModel extends ChangeNotifier {
       onOk: (newCards) async {
         _currentPage++;
         final loadedHasMore = newCards.length >= pageLimit;
-        cards = await _withScheduleBriefingCard(
-          [...cards, ...newCards],
-          hasMoreAfterList: loadedHasMore,
-        );
+        cards = await _withScheduleBriefingCard([
+          ...cards,
+          ...newCards,
+        ], hasMoreAfterList: loadedHasMore);
         hasMore = loadedHasMore;
         await _loadAttachmentsForCards(newCards);
       },
@@ -446,10 +453,14 @@ class TimelineViewModel extends ChangeNotifier {
     if (_eventBusSetup) {
       final eventBus = EventBusService.instance;
       eventBus.removeHandler(
-          EventBusMessageType.cardUpdated, _handleCardUpdated);
+        EventBusMessageType.cardUpdated,
+        _handleCardUpdated,
+      );
       eventBus.removeHandler(EventBusMessageType.cardAdded, _handleCardAdded);
       eventBus.removeHandler(
-          EventBusMessageType.attachmentsChanged, _handleAttachmentsChanged);
+        EventBusMessageType.attachmentsChanged,
+        _handleAttachmentsChanged,
+      );
       eventBus.removeHandler(
         EventBusMessageType.scheduleAggregationDirty,
         _handleScheduleBriefingChanged,

--- a/lib/ui/timeline/widgets/failed_card_recovery_banner.dart
+++ b/lib/ui/timeline/widgets/failed_card_recovery_banner.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/utils/user_storage.dart';
+
+class FailedCardRecoveryBanner extends StatelessWidget {
+  const FailedCardRecoveryBanner({
+    super.key,
+    required this.failureReason,
+    required this.isRetrying,
+    required this.onRetry,
+    required this.onShowReason,
+  });
+
+  final String? failureReason;
+  final bool isRetrying;
+  final VoidCallback? onRetry;
+  final VoidCallback? onShowReason;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = UserStorage.l10n;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFEF2F2),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: const Color(0xFFFCA5A5).withValues(alpha: 0.55),
+          width: 0.8,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 30,
+                height: 30,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFEF4444).withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(9),
+                ),
+                child: const Icon(
+                  Icons.error_outline_rounded,
+                  size: 18,
+                  color: Color(0xFFDC2626),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.cardGenerationFailedTitle,
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                        color: Color(0xFF991B1B),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      l10n.cardGenerationFailedDescription,
+                      style: TextStyle(
+                        fontSize: 13,
+                        height: 1.45,
+                        color: const Color(0xFF7F1D1D).withValues(alpha: 0.78),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              FilledButton.icon(
+                onPressed: isRetrying ? null : onRetry,
+                style: FilledButton.styleFrom(
+                  backgroundColor: const Color(0xFFDC2626),
+                  foregroundColor: Colors.white,
+                  disabledBackgroundColor: const Color(
+                    0xFFDC2626,
+                  ).withValues(alpha: 0.35),
+                  minimumSize: const Size(0, 36),
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                icon: isRetrying
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 1.7,
+                          color: Colors.white,
+                        ),
+                      )
+                    : const Icon(Icons.refresh_rounded, size: 17),
+                label: Text(
+                  l10n.regenerateCard,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              if (failureReason != null && failureReason!.isNotEmpty) ...[
+                const SizedBox(width: 10),
+                TextButton(
+                  onPressed: onShowReason,
+                  style: TextButton.styleFrom(
+                    foregroundColor: AppColors.textSecondary,
+                    minimumSize: const Size(0, 36),
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                  ),
+                  child: Text(
+                    l10n.failureReason,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CardRegeneratingBanner extends StatelessWidget {
+  const CardRegeneratingBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = UserStorage.l10n;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFEEF2FF),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: const Color(0xFF818CF8).withValues(alpha: 0.35),
+          width: 0.8,
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(
+            width: 24,
+            height: 24,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: Color(0xFF6366F1),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.cardRegeneratingTitle,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    color: Color(0xFF3730A3),
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  l10n.cardRegeneratingDescription,
+                  style: TextStyle(
+                    fontSize: 13,
+                    height: 1.45,
+                    color: const Color(0xFF3730A3).withValues(alpha: 0.72),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -12,7 +12,6 @@ import 'package:memex/ui/calendar/view_models/calendar_viewmodel.dart';
 import 'package:provider/provider.dart';
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/services.dart';
 import 'package:memex/domain/models/card_detail_model.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/utils/toast_helper.dart';
@@ -33,15 +32,13 @@ import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/character/widgets/persona_chat_screen.dart';
 import 'package:memex/utils/share_service.dart';
 import 'package:memex/ui/core/cards/native_card_factory.dart';
+import 'package:memex/ui/timeline/widgets/failed_card_recovery_banner.dart';
 
 /// Timeline card detail screen - plays full card detail
 class TimelineCardDetailScreen extends StatefulWidget {
   final String cardId;
 
-  const TimelineCardDetailScreen({
-    super.key,
-    required this.cardId,
-  });
+  const TimelineCardDetailScreen({super.key, required this.cardId});
 
   @override
   State<TimelineCardDetailScreen> createState() =>
@@ -59,6 +56,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   bool _showInsightText = true;
   String? _replyToCommentId;
   String? _replyToCommentName;
+  bool _isRetryingCard = false;
 
   @override
   void initState() {
@@ -75,11 +73,23 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       EventBusMessageType.cardDetailUpdated,
       _handleCardDetailUpdated,
     );
+    EventBusService.instance.addHandler(
+      EventBusMessageType.cardUpdated,
+      _handleCardUpdated,
+    );
   }
 
   void _handleCardDetailUpdated(EventBusMessage message) {
     if (message is CardDetailUpdatedMessage &&
         message.cardId == widget.cardId &&
+        mounted) {
+      _fetchDetail();
+    }
+  }
+
+  void _handleCardUpdated(EventBusMessage message) {
+    if (message is CardUpdatedMessage &&
+        message.id == widget.cardId &&
         mounted) {
       _fetchDetail();
     }
@@ -118,6 +128,10 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       EventBusMessageType.cardDetailUpdated,
       _handleCardDetailUpdated,
     );
+    EventBusService.instance.removeHandler(
+      EventBusMessageType.cardUpdated,
+      _handleCardUpdated,
+    );
     super.dispose();
   }
 
@@ -146,10 +160,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       });
       ToastHelper.showError(context, e);
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isLoading = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 
@@ -159,7 +174,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     final contextString = StringBuffer();
     contextString.writeln('Card Fact ID: ${_detail!.id}');
     contextString.writeln(
-        'Card Local Time: ${formatLocalDateTimeWithZone(_detail!.timestamp)}');
+      'Card Local Time: ${formatLocalDateTimeWithZone(_detail!.timestamp)}',
+    );
     contextString.writeln('Card Title: ${_detail!.title}');
     contextString.writeln('Card Content: ${_detail!.rawContent}');
     if (_detail!.insight.text.isNotEmpty) {
@@ -177,7 +193,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
           DateTime.fromMillisecondsSinceEpoch(comment.timestamp * 1000),
         );
         contextString.writeln(
-            '- [$time] $authorName (ID: $authorId): ${comment.content}');
+          '- [$time] $authorName (ID: $authorId): ${comment.content}',
+        );
       }
     }
 
@@ -199,10 +216,49 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
               'title': _detail!.title,
               'content': contextString.toString(),
               'type': 'timeline_card',
-            }
+            },
           ],
         );
       },
+    );
+  }
+
+  Future<void> _retryCardGeneration() async {
+    if (_isRetryingCard) return;
+
+    setState(() => _isRetryingCard = true);
+    final success = await _memexRouter.retryCardGeneration(widget.cardId);
+    if (!mounted) return;
+
+    setState(() => _isRetryingCard = false);
+    if (success) {
+      ToastHelper.showSuccess(
+        context,
+        UserStorage.l10n.cardRegenerationStarted,
+      );
+      await _fetchDetail();
+    } else {
+      ToastHelper.showError(context, UserStorage.l10n.cardRegenerationFailed);
+    }
+  }
+
+  void _showFailureReason() {
+    final reason = _detail?.failureReason;
+    if (reason == null || reason.isEmpty) return;
+
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: Colors.white,
+        title: Text(UserStorage.l10n.failureReason),
+        content: SingleChildScrollView(child: SelectableText(reason)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(MaterialLocalizations.of(context).closeButtonLabel),
+          ),
+        ],
+      ),
     );
   }
 
@@ -237,7 +293,12 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     // Default to initial time or now if same day
     final initialTime = TimeOfDay.fromDateTime(initialDate);
     var selectedDateTime = DateTime(
-        date.year, date.month, date.day, initialTime.hour, initialTime.minute);
+      date.year,
+      date.month,
+      date.day,
+      initialTime.hour,
+      initialTime.minute,
+    );
 
     final timeResult = await showModalBottomSheet<DateTime>(
       context: context,
@@ -309,7 +370,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
         _detail = oldDetail;
       });
       ToastHelper.showError(
-          context, UserStorage.l10n.updateFailed(e.toString()));
+        context,
+        UserStorage.l10n.updateFailed(e.toString()),
+      );
     }
   }
 
@@ -354,7 +417,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
           _detail = oldDetail;
         });
         ToastHelper.showError(
-            context, UserStorage.l10n.updateFailed(e.toString()));
+          context,
+          UserStorage.l10n.updateFailed(e.toString()),
+        );
       }
     }
   }
@@ -376,9 +441,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
           ),
           TextButton(
             onPressed: () => Navigator.of(context).pop(true),
-            style: TextButton.styleFrom(
-              foregroundColor: Colors.red,
-            ),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
             child: Text(UserStorage.l10n.delete),
           ),
         ],
@@ -399,7 +462,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     } catch (e) {
       if (mounted) {
         ToastHelper.showError(
-            context, UserStorage.l10n.deleteFailed(e.toString()));
+          context,
+          UserStorage.l10n.deleteFailed(e.toString()),
+        );
       }
     }
   }
@@ -441,7 +506,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
             'audioUrl': audioAssets.isNotEmpty ? audioAssets.first.url : null,
             'tags': _detail!.tags,
           },
-        )
+        ),
       ];
     }
 
@@ -623,10 +688,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
             children: [
               Text(
                 DateFormat('MM-dd').format(detail.timestamp),
-                style: const TextStyle(
-                  fontSize: 13,
-                  color: Color(0xFF94A3B8),
-                ),
+                style: const TextStyle(fontSize: 13, color: Color(0xFF94A3B8)),
               ),
               if (detail.address.isNotEmpty && detail.address != 'Unknown') ...[
                 const SizedBox(width: 6),
@@ -786,8 +848,10 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
 
     return Column(
       children: commentWidgets
-          .map((w) =>
-              Padding(padding: const EdgeInsets.only(bottom: 24), child: w))
+          .map(
+            (w) =>
+                Padding(padding: const EdgeInsets.only(bottom: 24), child: w),
+          )
           .toList(),
     );
   }
@@ -856,8 +920,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                   if (replyToName != null) ...[
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 6),
-                      child: Icon(Icons.subdirectory_arrow_right_rounded,
-                          size: 14, color: AppColors.textTertiary),
+                      child: Icon(
+                        Icons.subdirectory_arrow_right_rounded,
+                        size: 14,
+                        color: AppColors.textTertiary,
+                      ),
                     ),
                     Text(
                       replyToName,
@@ -871,10 +938,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
               ),
               const SizedBox(height: 4),
               // Use plain Text for share (MarkdownBody may not render well offscreen)
-              Text(
-                content,
-                style: AppTextStyles.commentContent,
-              ),
+              Text(content, style: AppTextStyles.commentContent),
               const SizedBox(height: 6),
               Text(time, style: AppTextStyles.commentDate),
             ],
@@ -924,9 +988,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   @override
   Widget build(BuildContext context) {
     if (_isLoading) {
-      return Scaffold(
-        body: Center(child: AgentLogoLoading()),
-      );
+      return Scaffold(body: Center(child: AgentLogoLoading()));
     }
 
     if (_errorMessage != null) {
@@ -966,8 +1028,10 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
             child: SafeArea(
               bottom: false,
               child: Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
@@ -987,8 +1051,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                           ],
                         ),
                         child: const Center(
-                          child: Icon(Icons.chevron_left,
-                              size: 22, color: Color(0xFF99A1AF)),
+                          child: Icon(
+                            Icons.chevron_left,
+                            size: 22,
+                            color: Color(0xFF99A1AF),
+                          ),
                         ),
                       ),
                     ),
@@ -1050,17 +1117,31 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                           // 2. Content Area
                           SliverToBoxAdapter(
                             child: Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 16.0),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 16.0,
+                              ),
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
                                   const SizedBox(height: 16),
+                                  if (detail.status == 'failed') ...[
+                                    FailedCardRecoveryBanner(
+                                      failureReason: detail.failureReason,
+                                      isRetrying: _isRetryingCard,
+                                      onRetry: _retryCardGeneration,
+                                      onShowReason: _showFailureReason,
+                                    ),
+                                    const SizedBox(height: 16),
+                                  ] else if (detail.status == 'processing') ...[
+                                    const CardRegeneratingBanner(),
+                                    const SizedBox(height: 16),
+                                  ],
                                   // Title
                                   if (detail.title.isNotEmpty)
                                     Padding(
-                                      padding:
-                                          const EdgeInsets.only(bottom: 12),
+                                      padding: const EdgeInsets.only(
+                                        bottom: 12,
+                                      ),
                                       child: Text(
                                         detail.title,
                                         style: const TextStyle(
@@ -1103,16 +1184,21 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                                               ),
                                               recognizer: TapGestureRecognizer()
                                                 ..onTap = () {
-                                                  Navigator.pop(context, {
-                                                    'action': 'filter_tag',
-                                                    'tag': tag
-                                                  });
+                                                  Navigator.pop(
+                                                    context,
+                                                    {
+                                                      'action': 'filter_tag',
+                                                      'tag': tag,
+                                                    },
+                                                  );
                                                 },
                                             );
-                                          }).expand((span) => [
-                                                span,
-                                                const TextSpan(text: ' '),
-                                              ]),
+                                          }).expand(
+                                            (span) => [
+                                              span,
+                                              const TextSpan(text: ' '),
+                                            ],
+                                          ),
                                         ],
                                       ),
                                     )
@@ -1125,7 +1211,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                                           onTap: () {
                                             Navigator.pop(context, {
                                               'action': 'filter_tag',
-                                              'tag': tag
+                                              'tag': tag,
                                             });
                                           },
                                           child: Text(
@@ -1152,8 +1238,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                                         onTap: _openCalendar,
                                         onLongPress: _editTime,
                                         child: Text(
-                                          DateFormat('MM-dd')
-                                              .format(detail.timestamp),
+                                          DateFormat(
+                                            'MM-dd',
+                                          ).format(detail.timestamp),
                                           style: const TextStyle(
                                             fontSize: 13,
                                             color: Color(0xFF94A3B8),
@@ -1180,7 +1267,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
 
                                   const SizedBox(height: 24),
                                   const Divider(
-                                      height: 1, color: Color(0xFFE2E8F0)),
+                                    height: 1,
+                                    color: Color(0xFFE2E8F0),
+                                  ),
                                   const SizedBox(height: 16),
 
                                   // Related Records
@@ -1192,7 +1281,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                                   if (detail
                                       .insight.relatedCards.isNotEmpty) ...[
                                     _buildRelatedMemoriesSection(
-                                        context, detail.insight.relatedCards),
+                                      context,
+                                      detail.insight.relatedCards,
+                                    ),
                                     const SizedBox(height: 24),
                                   ],
                                   const SizedBox(height: 16),
@@ -1201,8 +1292,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                                   _buildCommentsList(detail),
 
                                   const SizedBox(
-                                      height:
-                                          100), // Bottom padding for fixed bar
+                                    height: 100,
+                                  ), // Bottom padding for fixed bar
                                 ],
                               ),
                             ),
@@ -1366,8 +1457,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                 name: commentName,
                 content: comment.content,
                 time: DateFormat('MM-dd').format(
-                    DateTime.fromMillisecondsSinceEpoch(
-                        comment.timestamp * 1000)),
+                  DateTime.fromMillisecondsSinceEpoch(comment.timestamp * 1000),
+                ),
                 isAi: comment.isAi,
                 replyToName: comment.replyToName,
               ),
@@ -1379,8 +1470,10 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
 
     return Column(
       children: commentWidgets
-          .map((w) =>
-              Padding(padding: const EdgeInsets.only(bottom: 24), child: w))
+          .map(
+            (w) =>
+                Padding(padding: const EdgeInsets.only(bottom: 24), child: w),
+          )
           .toList(),
     );
   }
@@ -1471,8 +1564,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                   if (replyToName != null) ...[
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 6),
-                      child: Icon(Icons.subdirectory_arrow_right_rounded,
-                          size: 14, color: AppColors.textTertiary),
+                      child: Icon(
+                        Icons.subdirectory_arrow_right_rounded,
+                        size: 14,
+                        color: AppColors.textTertiary,
+                      ),
                     ),
                     Text(
                       replyToName,
@@ -1541,12 +1637,18 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       bottom: 0,
       child: Container(
         padding: const EdgeInsets.fromLTRB(
-            16, 8, 16, 32), // Safe area handled by bottom padding
+          16,
+          8,
+          16,
+          32,
+        ), // Safe area handled by bottom padding
         decoration: BoxDecoration(
           color: AppColors.cardBackground,
           border: Border(
-              top: BorderSide(
-                  color: AppColors.textTertiary.withValues(alpha: 0.2))),
+            top: BorderSide(
+              color: AppColors.textTertiary.withValues(alpha: 0.2),
+            ),
+          ),
         ),
         child: Row(
           children: [
@@ -1562,13 +1664,18 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                   ),
                   child: Row(
                     children: [
-                      Icon(Icons.edit_outlined,
-                          size: 16, color: AppColors.textTertiary),
+                      Icon(
+                        Icons.edit_outlined,
+                        size: 16,
+                        color: AppColors.textTertiary,
+                      ),
                       const SizedBox(width: 8),
                       Text(
                         UserStorage.l10n.saySomething,
                         style: TextStyle(
-                            fontSize: 14, color: AppColors.textTertiary),
+                          fontSize: 14,
+                          color: AppColors.textTertiary,
+                        ),
                       ),
                     ],
                   ),
@@ -1582,7 +1689,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   }
 
   Widget _buildRelatedMemoriesSection(
-      BuildContext context, List<RelatedCard> cards) {
+    BuildContext context,
+    List<RelatedCard> cards,
+  ) {
     if (cards.isEmpty) return const SizedBox.shrink();
 
     // Calculate how many cards fit on screen
@@ -1643,7 +1752,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                         ),
                       ],
                     ),
-                  )
+                  ),
               ],
             ),
           ),
@@ -1945,8 +2054,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                               ],
                             ),
                           ),
-                          const Icon(Icons.arrow_forward_ios,
-                              size: 14, color: Color(0xFFCBD5E1)),
+                          const Icon(
+                            Icons.arrow_forward_ios,
+                            size: 14,
+                            color: Color(0xFFCBD5E1),
+                          ),
                         ],
                       ),
                     ),
@@ -1965,10 +2077,7 @@ class _FullScreenGallery extends StatefulWidget {
   final List<AssetData> assets;
   final int initialIndex;
 
-  const _FullScreenGallery({
-    required this.assets,
-    required this.initialIndex,
-  });
+  const _FullScreenGallery({required this.assets, required this.initialIndex});
 
   @override
   State<_FullScreenGallery> createState() => _FullScreenGalleryState();
@@ -2011,9 +2120,7 @@ class _FullScreenGalleryState extends State<_FullScreenGallery> {
                 return PhotoViewGalleryPageOptions.customChild(
                   child: Container(
                     color: Colors.black,
-                    child: Center(
-                      child: AudioPlayerWidget(url: asset.url),
-                    ),
+                    child: Center(child: AudioPlayerWidget(url: asset.url)),
                   ),
                   initialScale: PhotoViewComputedScale.contained,
                   heroAttributes: PhotoViewHeroAttributes(tag: asset.url),
@@ -2144,8 +2251,9 @@ class _CommentInputWidgetState extends State<_CommentInputWidget> {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             decoration: BoxDecoration(
               color: AppColors.primary.withValues(alpha: 0.06),
-              borderRadius:
-                  const BorderRadius.vertical(top: Radius.circular(12)),
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(12),
+              ),
             ),
             child: Row(
               children: [
@@ -2169,8 +2277,9 @@ class _CommentInputWidgetState extends State<_CommentInputWidget> {
         Container(
           decoration: BoxDecoration(
             color: AppColors.background,
-            borderRadius:
-                BorderRadius.circular(widget.replyToName != null ? 0 : 20),
+            borderRadius: BorderRadius.circular(
+              widget.replyToName != null ? 0 : 20,
+            ),
             border: widget.replyToName != null
                 ? null
                 : Border.all(
@@ -2190,16 +2299,15 @@ class _CommentInputWidgetState extends State<_CommentInputWidget> {
                         : UserStorage.l10n.saySomething,
                     border: InputBorder.none,
                     contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 16, vertical: 12),
+                      horizontal: 16,
+                      vertical: 12,
+                    ),
                     hintStyle: TextStyle(
                       color: AppColors.textTertiary,
                       fontSize: 14,
                     ),
                   ),
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: AppColors.textPrimary,
-                  ),
+                  style: TextStyle(fontSize: 14, color: AppColors.textPrimary),
                   maxLines: null,
                   textInputAction: TextInputAction.send,
                   onSubmitted: (_) => _postComment(),
@@ -2212,8 +2320,9 @@ class _CommentInputWidgetState extends State<_CommentInputWidget> {
                         height: 20,
                         child: CircularProgressIndicator(
                           strokeWidth: 2,
-                          valueColor:
-                              AlwaysStoppedAnimation<Color>(AppColors.primary),
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            AppColors.primary,
+                          ),
                         ),
                       )
                     : Icon(

--- a/test/data/repositories/retry_failed_cards_test.dart
+++ b/test/data/repositories/retry_failed_cards_test.dart
@@ -1,0 +1,196 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/retry_failed_cards.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/global_event_bus.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:memex/domain/models/system_event.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const userId = 'retry_failed_cards_user';
+  const userInputObserver = 'retry_failed_cards_user_input_observer';
+  late Directory tempDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.saveUser(userId);
+    tempDir = await Directory.systemTemp.createTemp('memex_retry_cards_');
+    await FileSystemService.init(tempDir.path);
+    EventBusService.instance.clearHandlers();
+    await EventBusService.instance.disconnect();
+    _unsubscribeDefaultUserInputTasks();
+    GlobalEventBus.instance.unsubscribeSync(
+      eventType: SystemEventTypes.userInputSubmitted,
+      subscriptionId: userInputObserver,
+    );
+  });
+
+  tearDown(() async {
+    _unsubscribeDefaultUserInputTasks();
+    GlobalEventBus.instance.unsubscribeSync(
+      eventType: SystemEventTypes.userInputSubmitted,
+      subscriptionId: userInputObserver,
+    );
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test(
+    'retryFailedCardGeneration restores status and republishes pipeline',
+    () async {
+      const factId = '2026/05/25.md#ts_1';
+      SystemEvent<UserInputSubmittedPayload>? observedEvent;
+
+      await _writeFactAndCard(
+        factId: factId,
+        time: DateTime(2026, 5, 25, 9, 30),
+        content: '今天想把失败的卡片恢复一下\n\n![image](fs://photo.jpg)',
+        status: 'failed',
+        failureReason: 'LLM timeout',
+      );
+
+      GlobalEventBus.instance.subscribeSync<UserInputSubmittedPayload>(
+        eventType: SystemEventTypes.userInputSubmitted,
+        subscription: EventSyncSubscription<UserInputSubmittedPayload>(
+          subscriptionId: userInputObserver,
+          handler: (_, event) async {
+            observedEvent = event;
+          },
+        ),
+      );
+
+      final didRetry = await retryFailedCardGeneration(factId);
+
+      expect(didRetry, isTrue);
+
+      final card = await FileSystemService.instance.readCardFile(
+        userId,
+        factId,
+      );
+      expect(card, isNotNull);
+      expect(card!.status, 'processing');
+      expect(card.failureReason, isNull);
+
+      expect(observedEvent, isNotNull);
+      final payload = observedEvent!.payload;
+      expect(payload.factId, factId);
+      expect(payload.combinedText, contains('失败的卡片'));
+      expect(payload.markdownEntry, contains('## <id:ts_1> 09:30:00 "{}"'));
+      expect(
+        payload.assetPaths.single,
+        endsWith('Facts/assets/photo.jpg'),
+      );
+      expect(
+        payload.createdAtTs,
+        DateTime(2026, 5, 25, 9, 30).millisecondsSinceEpoch ~/ 1000,
+      );
+    },
+  );
+
+  test('retryAllFailedCardGenerations retries only failed cards', () async {
+    const failedOne = '2026/05/25.md#ts_1';
+    const completed = '2026/05/25.md#ts_2';
+    const failedTwo = '2026/05/25.md#ts_3';
+    final observedFactIds = <String>[];
+
+    await _writeFactAndCard(
+      factId: failedOne,
+      time: DateTime(2026, 5, 25, 10),
+      content: '第一张失败卡片',
+      status: 'failed',
+      failureReason: 'Server error',
+    );
+    await _writeFactAndCard(
+      factId: completed,
+      time: DateTime(2026, 5, 25, 11),
+      content: '已完成卡片',
+      status: 'completed',
+    );
+    await _writeFactAndCard(
+      factId: failedTwo,
+      time: DateTime(2026, 5, 25, 12),
+      content: '第二张失败卡片',
+      status: 'failed',
+      failureReason: 'Network error',
+    );
+
+    expect(await countFailedCardGenerations(), 2);
+
+    GlobalEventBus.instance.subscribeSync<UserInputSubmittedPayload>(
+      eventType: SystemEventTypes.userInputSubmitted,
+      subscription: EventSyncSubscription<UserInputSubmittedPayload>(
+        subscriptionId: userInputObserver,
+        handler: (_, event) async {
+          observedFactIds.add(event.payload.factId);
+        },
+      ),
+    );
+
+    final result = await retryAllFailedCardGenerations();
+
+    expect(result.requested, 2);
+    expect(result.retried, 2);
+    expect(result.skipped, 0);
+    expect(result.errors, isEmpty);
+    expect(observedFactIds, unorderedEquals([failedOne, failedTwo]));
+    expect(await countFailedCardGenerations(), 0);
+
+    final completedCard = await FileSystemService.instance.readCardFile(
+      userId,
+      completed,
+    );
+    expect(completedCard!.status, 'completed');
+  });
+}
+
+Future<void> _writeFactAndCard({
+  required String factId,
+  required DateTime time,
+  required String content,
+  required String status,
+  String? failureReason,
+}) async {
+  final fs = FileSystemService.instance;
+  final simpleFactId = fs.extractSimpleFactId(factId);
+  final timeStr =
+      '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}:${time.second.toString().padLeft(2, '0')}';
+  await fs.appendToDailyFactFile(
+    'retry_failed_cards_user',
+    time,
+    '## <id:$simpleFactId> $timeStr "{}"\n\n$content\n',
+  );
+  await fs.safeWriteCardFile(
+    'retry_failed_cards_user',
+    factId,
+    CardData(
+      factId: factId,
+      timestamp: time.millisecondsSinceEpoch ~/ 1000,
+      status: status,
+      tags: const [],
+      uiConfigs: [
+        UiConfig(templateId: 'classic_card', data: {'content': content}),
+      ],
+      failureReason: failureReason,
+    ),
+  );
+}
+
+void _unsubscribeDefaultUserInputTasks() {
+  for (final id in const [
+    'analyze_assets',
+    'card_agent',
+    'pkm_agent',
+    'comment_agent',
+    'schedule_refresh_router',
+  ]) {
+    GlobalEventBus.instance.unsubscribe(
+      eventType: SystemEventTypes.userInputSubmitted,
+      subscriptionId: id,
+    );
+  }
+}

--- a/test/ui/main_screen/widgets/action_center_failed_cards_test.dart
+++ b/test/ui/main_screen/widgets/action_center_failed_cards_test.dart
@@ -1,0 +1,70 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/card_generation_retry_result.dart';
+import 'package:memex/ui/main_screen/widgets/action_center_sheet.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    AppDatabase.setTestInstance(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  testWidgets('action center renders failed card aggregate and retries all', (
+    tester,
+  ) async {
+    var failedCount = 3;
+    var retryCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ActionCenterSheet(
+            loadPendingAttachments: () async => const [],
+            loadFailedCardCount: () async => failedCount,
+            retryAllFailedCards: () async {
+              retryCalls++;
+              failedCount = 0;
+              return const CardGenerationRetryResult(
+                requested: 3,
+                retried: 3,
+                skipped: 0,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(UserStorage.l10n.failedCardsRetryTitle(3)),
+      findsOneWidget,
+    );
+    expect(find.text(UserStorage.l10n.retryAllFailedCards), findsOneWidget);
+
+    await tester.tap(find.text(UserStorage.l10n.retryAllFailedCards));
+    await tester.pumpAndSettle();
+
+    expect(retryCalls, 1);
+    expect(
+      find.text(UserStorage.l10n.failedCardsRetryStarted(3)),
+      findsOneWidget,
+    );
+    expect(find.text(UserStorage.l10n.noPendingActions), findsOneWidget);
+  });
+}

--- a/test/ui/timeline/widgets/failed_card_recovery_banner_test.dart
+++ b/test/ui/timeline/widgets/failed_card_recovery_banner_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/timeline/widgets/failed_card_recovery_banner.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  testWidgets('failed banner exposes retry and failure reason actions', (
+    tester,
+  ) async {
+    var retryCount = 0;
+    var reasonCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FailedCardRecoveryBanner(
+            failureReason: '模型服务超时',
+            isRetrying: false,
+            onRetry: () => retryCount++,
+            onShowReason: () => reasonCount++,
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.text(UserStorage.l10n.cardGenerationFailedTitle),
+      findsOneWidget,
+    );
+    expect(find.text(UserStorage.l10n.regenerateCard), findsOneWidget);
+    expect(find.text(UserStorage.l10n.failureReason), findsOneWidget);
+
+    await tester.tap(find.text(UserStorage.l10n.regenerateCard));
+    await tester.tap(find.text(UserStorage.l10n.failureReason));
+
+    expect(retryCount, 1);
+    expect(reasonCount, 1);
+  });
+
+  testWidgets('failed banner disables retry while request is running', (
+    tester,
+  ) async {
+    var retryCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FailedCardRecoveryBanner(
+            failureReason: '模型服务超时',
+            isRetrying: true,
+            onRetry: () => retryCount++,
+            onShowReason: () {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text(UserStorage.l10n.regenerateCard));
+
+    expect(retryCount, 0);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #179

## 变更

- 新增失败卡片重试仓库能力，支持统计失败卡片、单卡重试、批量重试，并复用原始 factId 与事实内容重新发布 `userInputSubmitted` 流水线。
- 卡片详情页在失败状态展示恢复模块，支持查看失败原因、触发重新生成；重试后切换到重新生成中状态并监听卡片更新事件刷新详情。
- 通知中心新增失败卡片聚合项，支持一键重试全部失败卡片；首页待处理角标同步计入这个聚合项。
- 补齐失败/重试状态的领域模型字段、双语文案和 l10n 生成文件。
- 添加单元测试和 Widget test 覆盖单卡重试、批量重试、详情页失败卡片恢复入口、通知中心聚合重试入口。

## 验证

- `flutter gen-l10n`
- `flutter analyze --no-pub --no-fatal-infos`：通过，保留仓库既有 info 级 lint 输出。
- `flutter analyze --no-pub --no-fatal-infos lib/data/repositories/retry_failed_cards.dart test/data/repositories/retry_failed_cards_test.dart test/ui/timeline/widgets/failed_card_recovery_banner_test.dart test/ui/main_screen/widgets/action_center_failed_cards_test.dart`：通过，无问题。
- `env -u http_proxy -u https_proxy -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub --concurrency=1 test/data/repositories/retry_failed_cards_test.dart test/ui/timeline/widgets/failed_card_recovery_banner_test.dart test/ui/main_screen/widgets/action_center_failed_cards_test.dart`：通过，5 个测试全部通过。

## 备注

本地环境存在 `ws_proxy/wss_proxy`，直接运行 Flutter test 容易触发 `flutter_tester` WebSocket 握手失败；验证时已按项目既有方式清理代理变量后重跑。
