### PR TITLE
[codex] 修复 Early 更新下载竞态

### DIFF
--- a/lib/data/services/app_update_service.dart
+++ b/lib/data/services/app_update_service.dart
@@ -142,6 +142,21 @@ class AppUpdateDownloadResult {
   });
 }
 
+class AppUpdateDownloadProgress {
+  final int receivedBytes;
+  final int totalBytes;
+
+  const AppUpdateDownloadProgress({
+    required this.receivedBytes,
+    required this.totalBytes,
+  });
+
+  int get percent {
+    if (totalBytes <= 0) return 0;
+    return ((receivedBytes / totalBytes) * 100).clamp(0, 100).round();
+  }
+}
+
 class AppUpdateCacheInfo {
   final int fileCount;
   final int totalBytes;
@@ -166,6 +181,22 @@ class AppUpdateWifiRequiredException implements Exception {
 
   @override
   String toString() => 'Wi-Fi is required to download this update.';
+}
+
+class AppUpdateDownloadInProgressException implements Exception {
+  const AppUpdateDownloadInProgressException();
+
+  @override
+  String toString() => 'An update package is already downloading.';
+}
+
+class AppUpdateInvalidPackageException implements Exception {
+  final String message;
+
+  const AppUpdateInvalidPackageException(this.message);
+
+  @override
+  String toString() => message;
 }
 
 class AppUpdateEnvironment {
@@ -292,6 +323,8 @@ class AppUpdateService {
   final UpdateDirectoryProvider _updateDirectoryProvider;
   final Clock _clock;
   final _logger = getLogger('AppUpdateService');
+  final Map<String, _ActiveAppUpdateDownload> _activeDownloads = {};
+  final Map<String, Future<AppUpdateInstallResult>> _activeInstalls = {};
 
   bool get isSupported => _environment.isAndroid && _environment.isEarlyChannel;
 
@@ -345,13 +378,54 @@ class AppUpdateService {
     AppUpdateInfo update, {
     void Function(int receivedBytes, int totalBytes)? onProgress,
   }) async {
+    final downloadKey = _downloadKeyFor(update);
+    final activeDownload = _activeDownloads[downloadKey];
+    if (activeDownload != null) {
+      _logger.info('Joining active APK download for ${update.displayVersion}');
+      return activeDownload.join(onProgress);
+    }
+
+    final session = _ActiveAppUpdateDownload(
+      initialProgress: AppUpdateDownloadProgress(
+        receivedBytes: 0,
+        totalBytes: update.sizeBytes,
+      ),
+    );
+    _activeDownloads[downloadKey] = session;
+    session.future =
+        _downloadUpdateToFile(
+          update,
+          onProgress: session.reportProgress,
+        ).whenComplete(() {
+          if (identical(_activeDownloads[downloadKey], session)) {
+            _activeDownloads.remove(downloadKey);
+          }
+        });
+
+    return session.join(onProgress);
+  }
+
+  bool get hasActiveDownload => _activeDownloads.isNotEmpty;
+
+  bool isDownloadingUpdate(AppUpdateInfo update) {
+    return _activeDownloads.containsKey(_downloadKeyFor(update));
+  }
+
+  AppUpdateDownloadProgress? getActiveDownloadProgress(AppUpdateInfo update) {
+    return _activeDownloads[_downloadKeyFor(update)]?.progress;
+  }
+
+  Future<AppUpdateDownloadResult> _downloadUpdateToFile(
+    AppUpdateInfo update, {
+    required void Function(int receivedBytes, int totalBytes) onProgress,
+  }) async {
     final dir = await _updateDirectoryProvider();
     final fileName = _safeFileName(update.assetName);
     final targetFile = File(path.join(dir.path, fileName));
     if (await _isReusableDownloadedApk(targetFile, update)) {
       final cachedBytes = await targetFile.length();
       final totalBytes = update.sizeBytes > 0 ? update.sizeBytes : cachedBytes;
-      onProgress?.call(totalBytes, totalBytes);
+      onProgress(totalBytes, totalBytes);
       _logger.info(
         'Reusing downloaded APK for ${update.displayVersion}: '
         '${targetFile.path}',
@@ -392,17 +466,29 @@ class AppUpdateService {
     }
 
     final totalBytes = response.contentLength ?? update.sizeBytes;
+    final expectedBytes = update.sizeBytes > 0 ? update.sizeBytes : totalBytes;
     var receivedBytes = 0;
     final sink = tempFile.openWrite();
+    var completed = false;
     try {
       await for (final chunk in response.stream) {
         sink.add(chunk);
         receivedBytes += chunk.length;
-        onProgress?.call(receivedBytes, totalBytes);
+        onProgress(receivedBytes, totalBytes);
       }
+      completed = true;
     } finally {
       await sink.close();
+      if (!completed && await tempFile.exists()) {
+        await tempFile.delete();
+      }
     }
+
+    await _validateDownloadedApkFile(
+      tempFile,
+      expectedBytes: expectedBytes,
+      update: update,
+    );
 
     if (await targetFile.exists()) {
       await targetFile.delete();
@@ -438,6 +524,10 @@ class AppUpdateService {
   }
 
   Future<int> clearDownloadedUpdates() async {
+    if (hasActiveDownload) {
+      throw const AppUpdateDownloadInProgressException();
+    }
+
     final dir = await _updateDirectoryProvider();
     if (!await dir.exists()) {
       return 0;
@@ -452,10 +542,27 @@ class AppUpdateService {
     return deletedCount;
   }
 
-  Future<AppUpdateInstallResult> installUpdate(String apkPath) async {
+  Future<AppUpdateInstallResult> installUpdate(String apkPath) {
+    final normalizedPath = path.normalize(apkPath);
+    final activeInstall = _activeInstalls[normalizedPath];
+    if (activeInstall != null) return activeInstall;
+
+    late final Future<AppUpdateInstallResult> install;
+    install = _installUpdate(normalizedPath).whenComplete(() {
+      if (identical(_activeInstalls[normalizedPath], install)) {
+        _activeInstalls.remove(normalizedPath);
+      }
+    });
+    _activeInstalls[normalizedPath] = install;
+    return install;
+  }
+
+  Future<AppUpdateInstallResult> _installUpdate(String apkPath) async {
     if (!isSupported) {
       return const AppUpdateInstallResult(AppUpdateInstallStatus.unsupported);
     }
+
+    await _validateInstallableApkPath(apkPath);
 
     final canInstall = await _platform.canInstallApk();
     if (!canInstall) {
@@ -594,6 +701,56 @@ class AppUpdateService {
     }
   }
 
+  Future<void> _validateDownloadedApkFile(
+    File file, {
+    required int expectedBytes,
+    required AppUpdateInfo update,
+  }) async {
+    final stat = await file.stat();
+    if (stat.type != FileSystemEntityType.file || stat.size <= 0) {
+      await _deleteIfExists(file);
+      throw AppUpdateInvalidPackageException(
+        'Downloaded APK is empty for ${update.displayVersion}.',
+      );
+    }
+
+    if (expectedBytes > 0 && stat.size != expectedBytes) {
+      await _deleteIfExists(file);
+      throw AppUpdateInvalidPackageException(
+        'Downloaded APK size mismatch for ${update.displayVersion}: '
+        'expected $expectedBytes bytes, found ${stat.size}.',
+      );
+    }
+  }
+
+  Future<void> _validateInstallableApkPath(String apkPath) async {
+    if (!apkPath.toLowerCase().endsWith('.apk')) {
+      throw AppUpdateInvalidPackageException('File is not an APK: $apkPath');
+    }
+
+    final file = File(apkPath);
+    final stat = await file.stat();
+    if (stat.type != FileSystemEntityType.file || stat.size <= 0) {
+      throw AppUpdateInvalidPackageException(
+        'APK file does not exist or is empty: $apkPath',
+      );
+    }
+  }
+
+  Future<void> _deleteIfExists(File file) async {
+    try {
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } catch (e, st) {
+      _logger.warning(
+        'Failed to delete invalid update file: ${file.path}',
+        e,
+        st,
+      );
+    }
+  }
+
   static bool _isUpdateCacheFile(File file) {
     final lowerPath = file.path.toLowerCase();
     return lowerPath.endsWith('.apk') || lowerPath.endsWith('.apk.part');
@@ -670,5 +827,58 @@ class AppUpdateService {
   static String _safeFileName(String value) {
     final fallback = value.trim().isEmpty ? 'memex_early_update.apk' : value;
     return fallback.replaceAll(RegExp(r'[^a-zA-Z0-9._-]'), '_');
+  }
+
+  static String _downloadKeyFor(AppUpdateInfo update) {
+    return [
+      _safeFileName(update.assetName),
+      update.downloadUrl,
+      update.sizeBytes,
+    ].join('|');
+  }
+}
+
+class _ActiveAppUpdateDownload {
+  _ActiveAppUpdateDownload({required AppUpdateDownloadProgress initialProgress})
+    : _progress = initialProgress;
+
+  final Set<void Function(int receivedBytes, int totalBytes)> _listeners = {};
+  late final Future<AppUpdateDownloadResult> future;
+  AppUpdateDownloadProgress _progress;
+
+  AppUpdateDownloadProgress get progress => _progress;
+
+  Future<AppUpdateDownloadResult> join(
+    void Function(int receivedBytes, int totalBytes)? onProgress,
+  ) {
+    if (onProgress == null) return future;
+
+    _listeners.add(onProgress);
+    final currentProgress = _progress;
+    scheduleMicrotask(() {
+      if (_listeners.contains(onProgress)) {
+        try {
+          onProgress(currentProgress.receivedBytes, currentProgress.totalBytes);
+        } catch (_) {
+          // Progress listeners are UI conveniences and must not affect downloads.
+        }
+      }
+    });
+    return future.whenComplete(() => _listeners.remove(onProgress));
+  }
+
+  void reportProgress(int receivedBytes, int totalBytes) {
+    _progress = AppUpdateDownloadProgress(
+      receivedBytes: receivedBytes,
+      totalBytes: totalBytes,
+    );
+
+    for (final listener in List.of(_listeners)) {
+      try {
+        listener(receivedBytes, totalBytes);
+      } catch (_) {
+        // Progress listeners are UI conveniences and must not affect downloads.
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1400,12 +1400,14 @@
   },
   "earlyUpdateFound": "Early build {version}+{build} is available.",
   "earlyUpdateDownloadAndInstall": "Download and install",
+  "earlyUpdateDownloadInProgress": "Downloading update...",
   "@earlyUpdateDownloadingPercent": {
     "placeholders": {
       "percent": {}
     }
   },
   "earlyUpdateDownloadingPercent": "Downloading update: {percent}%",
+  "earlyUpdateDownloadReadyToInstall": "Update package downloaded. Ready to install.",
   "earlyUpdateInstallDownloadedPackage": "Install downloaded package",
   "earlyUpdateClearDownloadedPackage": "Clear downloaded package",
   "earlyUpdateClearDownloadedPackageSuccess": "Downloaded update package cleared.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5570,11 +5570,23 @@ abstract class AppLocalizations {
   /// **'Download and install'**
   String get earlyUpdateDownloadAndInstall;
 
+  /// No description provided for @earlyUpdateDownloadInProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading update...'**
+  String get earlyUpdateDownloadInProgress;
+
   /// No description provided for @earlyUpdateDownloadingPercent.
   ///
   /// In en, this message translates to:
   /// **'Downloading update: {percent}%'**
   String earlyUpdateDownloadingPercent(Object percent);
+
+  /// No description provided for @earlyUpdateDownloadReadyToInstall.
+  ///
+  /// In en, this message translates to:
+  /// **'Update package downloaded. Ready to install.'**
+  String get earlyUpdateDownloadReadyToInstall;
 
   /// No description provided for @earlyUpdateInstallDownloadedPackage.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3077,9 +3077,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get earlyUpdateDownloadAndInstall => 'Download and install';
 
   @override
+  String get earlyUpdateDownloadInProgress => 'Downloading update...';
+
+  @override
   String earlyUpdateDownloadingPercent(Object percent) {
     return 'Downloading update: $percent%';
   }
+
+  @override
+  String get earlyUpdateDownloadReadyToInstall =>
+      'Update package downloaded. Ready to install.';
 
   @override
   String get earlyUpdateInstallDownloadedPackage =>

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2967,9 +2967,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get earlyUpdateDownloadAndInstall => '下载并安装';
 
   @override
+  String get earlyUpdateDownloadInProgress => '正在下载更新...';
+
+  @override
   String earlyUpdateDownloadingPercent(Object percent) {
     return '正在下载更新：$percent%';
   }
+
+  @override
+  String get earlyUpdateDownloadReadyToInstall => '更新包已下载，可直接安装。';
 
   @override
   String get earlyUpdateInstallDownloadedPackage => '安装已下载包';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1363,12 +1363,14 @@
   },
   "earlyUpdateFound": "发现 Early 版本 {version}+{build}。",
   "earlyUpdateDownloadAndInstall": "下载并安装",
+  "earlyUpdateDownloadInProgress": "正在下载更新...",
   "@earlyUpdateDownloadingPercent": {
     "placeholders": {
       "percent": {}
     }
   },
   "earlyUpdateDownloadingPercent": "正在下载更新：{percent}%",
+  "earlyUpdateDownloadReadyToInstall": "更新包已下载，可直接安装。",
   "earlyUpdateInstallDownloadedPackage": "安装已下载包",
   "earlyUpdateClearDownloadedPackage": "清除下载包",
   "earlyUpdateClearDownloadedPackageSuccess": "已清除下载包。",

--- a/lib/ui/settings/widgets/early_update_settings_card.dart
+++ b/lib/ui/settings/widgets/early_update_settings_card.dart
@@ -501,11 +501,10 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
   }
 
   Widget _buildShell({required Widget child}) {
-    return Container(
-      padding: const EdgeInsets.all(20),
+    final borderRadius = BorderRadius.circular(16);
+    return DecoratedBox(
       decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: borderRadius,
         boxShadow: [
           BoxShadow(
             color: AppColors.textSecondary.withValues(alpha: 0.08),
@@ -514,7 +513,15 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
           ),
         ],
       ),
-      child: child,
+      child: Material(
+        color: Colors.white,
+        borderRadius: borderRadius,
+        clipBehavior: Clip.antiAlias,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: child,
+        ),
+      ),
     );
   }
 

--- a/lib/ui/settings/widgets/early_update_settings_card.dart
+++ b/lib/ui/settings/widgets/early_update_settings_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:memex/data/services/app_update_service.dart';
@@ -25,16 +27,24 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
   AppUpdateInfo? _availableUpdate;
   AppUpdateCacheInfo _cacheInfo = AppUpdateCacheInfo.empty;
   bool _availableUpdateDownloaded = false;
+  bool _availableUpdateDownloading = false;
   bool _checking = false;
   bool _downloading = false;
   bool _clearingCache = false;
   int _downloadPercent = 0;
   String? _statusText;
+  Timer? _downloadPollTimer;
 
   @override
   void initState() {
     super.initState();
     _loadSettings();
+  }
+
+  @override
+  void dispose() {
+    _downloadPollTimer?.cancel();
+    super.dispose();
   }
 
   Future<void> _loadSettings() async {
@@ -68,9 +78,14 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
       final latestCacheInfo =
           await widget.service.getDownloadedUpdateCacheInfo();
       var availableUpdateDownloaded = false;
+      AppUpdateDownloadProgress? activeDownloadProgress;
       if (result.status == AppUpdateCheckStatus.updateAvailable) {
+        final update = result.update!;
+        activeDownloadProgress = widget.service.getActiveDownloadProgress(
+          update,
+        );
         availableUpdateDownloaded = await widget.service.hasDownloadedUpdate(
-          result.update!,
+          update,
         );
       }
       if (!mounted) return;
@@ -83,40 +98,56 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
           case AppUpdateCheckStatus.unsupported:
             _availableUpdate = null;
             _availableUpdateDownloaded = false;
+            _availableUpdateDownloading = false;
             _statusText = UserStorage.l10n.earlyUpdateUnsupported;
           case AppUpdateCheckStatus.skippedNotWifi:
             _availableUpdate = null;
             _availableUpdateDownloaded = false;
+            _availableUpdateDownloading = false;
             _statusText = UserStorage.l10n.earlyUpdateSkippedMobile;
           case AppUpdateCheckStatus.noUpdate:
             _availableUpdate = null;
             _availableUpdateDownloaded = false;
+            _availableUpdateDownloading = false;
             _statusText = UserStorage.l10n.earlyUpdateNoUpdate;
           case AppUpdateCheckStatus.updateAvailable:
             _availableUpdate = result.update;
             final update = result.update!;
-            _statusText = UserStorage.l10n.earlyUpdateFound(
-              update.versionName,
-              update.buildNumber,
-            );
+            _availableUpdateDownloading = activeDownloadProgress != null;
+            _downloadPercent = activeDownloadProgress?.percent ?? 0;
+            _statusText = _availableUpdateDownloading
+                ? _downloadStatusText(activeDownloadProgress)
+                : UserStorage.l10n.earlyUpdateFound(
+                    update.versionName,
+                    update.buildNumber,
+                  );
         }
       });
+      _syncDownloadPolling();
     } catch (e) {
       if (!mounted) return;
       setState(() {
         _checking = false;
         _availableUpdateDownloaded = false;
+        _availableUpdateDownloading = false;
         _statusText = UserStorage.l10n.earlyUpdateCheckFailed(e);
       });
+      _syncDownloadPolling();
     }
   }
 
   Future<void> _downloadAndInstall() async {
     final update = _availableUpdate;
-    if (update == null || _downloading || _clearingCache) return;
+    if (update == null ||
+        _downloading ||
+        _clearingCache ||
+        _availableUpdateDownloading) {
+      return;
+    }
 
     setState(() {
       _downloading = true;
+      _availableUpdateDownloading = false;
       _downloadPercent = 0;
       _statusText = UserStorage.l10n.earlyUpdateDownloadingPercent(0);
     });
@@ -143,6 +174,7 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
       if (!mounted) return;
       setState(() {
         _downloading = false;
+        _availableUpdateDownloading = false;
         _downloadPercent = 100;
         _cacheInfo = latestCacheInfo;
         _availableUpdateDownloaded = true;
@@ -157,11 +189,16 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
       });
     } catch (e) {
       if (!mounted) return;
-      final statusText = e is AppUpdateWifiRequiredException
-          ? UserStorage.l10n.earlyUpdateSkippedMobile
-          : UserStorage.l10n.earlyUpdateCheckFailed(e);
+      final statusText = switch (e) {
+        AppUpdateWifiRequiredException() =>
+          UserStorage.l10n.earlyUpdateSkippedMobile,
+        AppUpdateDownloadInProgressException() =>
+          UserStorage.l10n.earlyUpdateDownloadInProgress,
+        _ => UserStorage.l10n.earlyUpdateCheckFailed(e),
+      };
       setState(() {
         _downloading = false;
+        _availableUpdateDownloading = e is AppUpdateDownloadInProgressException;
         _statusText = statusText;
       });
       if (e is AppUpdateWifiRequiredException) {
@@ -169,14 +206,28 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
           context,
           UserStorage.l10n.earlyUpdateSkippedMobile,
         );
+      } else if (e is AppUpdateDownloadInProgressException) {
+        ToastHelper.showInfo(
+          context,
+          UserStorage.l10n.earlyUpdateDownloadInProgress,
+        );
       } else {
         ToastHelper.showError(context, e);
       }
+      _syncDownloadPolling();
     }
   }
 
   Future<void> _clearDownloadedPackage() async {
     if (_checking || _downloading || _clearingCache) return;
+    if (widget.service.hasActiveDownload) {
+      setState(() {
+        _availableUpdateDownloading = _availableUpdate != null;
+        _statusText = UserStorage.l10n.earlyUpdateDownloadInProgress;
+      });
+      _syncDownloadPolling();
+      return;
+    }
 
     setState(() => _clearingCache = true);
     try {
@@ -188,6 +239,7 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
         _clearingCache = false;
         _cacheInfo = latestCacheInfo;
         _availableUpdateDownloaded = false;
+        _availableUpdateDownloading = false;
         _statusText = UserStorage.l10n.earlyUpdateClearDownloadedPackageSuccess;
       });
       ToastHelper.showSuccess(
@@ -196,12 +248,85 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
       );
     } catch (e) {
       if (!mounted) return;
+      final statusText = e is AppUpdateDownloadInProgressException
+          ? UserStorage.l10n.earlyUpdateDownloadInProgress
+          : UserStorage.l10n.earlyUpdateCheckFailed(e);
       setState(() {
         _clearingCache = false;
-        _statusText = UserStorage.l10n.earlyUpdateCheckFailed(e);
+        _availableUpdateDownloading = e is AppUpdateDownloadInProgressException;
+        _statusText = statusText;
       });
-      ToastHelper.showError(context, e);
+      if (e is AppUpdateDownloadInProgressException) {
+        ToastHelper.showInfo(
+          context,
+          UserStorage.l10n.earlyUpdateDownloadInProgress,
+        );
+      } else {
+        ToastHelper.showError(context, e);
+      }
+      _syncDownloadPolling();
     }
+  }
+
+  void _syncDownloadPolling() {
+    final update = _availableUpdate;
+    final shouldPoll = update != null &&
+        (_availableUpdateDownloading ||
+            widget.service.isDownloadingUpdate(update));
+    if (!shouldPoll) {
+      _downloadPollTimer?.cancel();
+      _downloadPollTimer = null;
+      return;
+    }
+
+    _downloadPollTimer ??= Timer.periodic(const Duration(milliseconds: 500), (
+      _,
+    ) {
+      unawaited(_refreshActiveDownloadState());
+    });
+  }
+
+  Future<void> _refreshActiveDownloadState() async {
+    final update = _availableUpdate;
+    if (update == null || !mounted) return;
+
+    final progress = widget.service.getActiveDownloadProgress(update);
+    if (progress != null) {
+      setState(() {
+        _availableUpdateDownloading = true;
+        _downloadPercent = progress.percent;
+        _statusText = _downloadStatusText(progress);
+      });
+      return;
+    }
+
+    final latestCacheInfo = await widget.service.getDownloadedUpdateCacheInfo();
+    final downloaded = await widget.service.hasDownloadedUpdate(update);
+    if (!mounted) return;
+    setState(() {
+      _availableUpdateDownloading = false;
+      _availableUpdateDownloaded = downloaded;
+      _cacheInfo = latestCacheInfo;
+      if (downloaded) {
+        _downloadPercent = 100;
+        _statusText = UserStorage.l10n.earlyUpdateDownloadReadyToInstall;
+      } else {
+        _downloadPercent = 0;
+        _statusText = UserStorage.l10n.earlyUpdateFound(
+          update.versionName,
+          update.buildNumber,
+        );
+      }
+    });
+    _syncDownloadPolling();
+  }
+
+  String _downloadStatusText(AppUpdateDownloadProgress? progress) {
+    final percent = progress?.percent ?? 0;
+    if (percent > 0) {
+      return UserStorage.l10n.earlyUpdateDownloadingPercent(percent);
+    }
+    return UserStorage.l10n.earlyUpdateDownloadInProgress;
   }
 
   String? _lastCheckedText(AppUpdateSettings settings) {
@@ -230,6 +355,11 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
         ),
       );
     }
+
+    final operationBusy = _checking ||
+        _downloading ||
+        _clearingCache ||
+        _availableUpdateDownloading;
 
     return _buildShell(
       child: Column(
@@ -303,7 +433,7 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
               ),
             ),
           ],
-          if (_downloading) ...[
+          if (_downloading || _availableUpdateDownloading) ...[
             const SizedBox(height: 10),
             LinearProgressIndicator(
               value: _downloadPercent <= 0 ? null : _downloadPercent / 100,
@@ -317,9 +447,7 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
             runSpacing: 10,
             children: [
               OutlinedButton.icon(
-                onPressed: _checking || _downloading || _clearingCache
-                    ? null
-                    : _checkNow,
+                onPressed: operationBusy ? null : _checkNow,
                 icon: _checking
                     ? const SizedBox(
                         width: 16,
@@ -331,24 +459,27 @@ class _EarlyUpdateSettingsCardState extends State<EarlyUpdateSettingsCard> {
               ),
               if (_availableUpdate != null)
                 FilledButton.icon(
-                  onPressed: _checking || _downloading || _clearingCache
-                      ? null
-                      : _downloadAndInstall,
+                  onPressed: operationBusy ? null : _downloadAndInstall,
                   icon: Icon(
-                    _availableUpdateDownloaded
-                        ? Icons.install_mobile
-                        : Icons.download,
+                    _availableUpdateDownloading
+                        ? Icons.downloading
+                        : _availableUpdateDownloaded
+                            ? Icons.install_mobile
+                            : Icons.download,
                     size: 18,
                   ),
                   label: Text(
-                    _availableUpdateDownloaded
-                        ? UserStorage.l10n.earlyUpdateInstallDownloadedPackage
-                        : UserStorage.l10n.earlyUpdateDownloadAndInstall,
+                    _availableUpdateDownloading
+                        ? UserStorage.l10n.earlyUpdateDownloadInProgress
+                        : _availableUpdateDownloaded
+                            ? UserStorage
+                                .l10n.earlyUpdateInstallDownloadedPackage
+                            : UserStorage.l10n.earlyUpdateDownloadAndInstall,
                   ),
                 ),
               if (_cacheInfo.hasFiles)
                 OutlinedButton.icon(
-                  onPressed: _checking || _downloading || _clearingCache
+                  onPressed: operationBusy || widget.service.hasActiveDownload
                       ? null
                       : _clearDownloadedPackage,
                   icon: _clearingCache

--- a/test/data/services/app_update_service_test.dart
+++ b/test/data/services/app_update_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -276,9 +277,111 @@ void main() {
 
       expect(download.reusedExistingFile, isTrue);
       expect(download.apkPath, apk.path);
-      expect(progress, [4]);
+      expect(progress, contains(4));
       expect(await File(download.apkPath).readAsBytes(), [1, 2, 3, 4]);
     });
+
+    test('coalesces concurrent downloads of the same APK', () async {
+      final responseCompleter = Completer<http.StreamedResponse>();
+      final client = ControlledDownloadClient((request) {
+        expect(request.url.toString(), _testUpdate.downloadUrl);
+        return responseCompleter.future;
+      });
+      final service = buildService(client: client);
+      final firstProgress = <int>[];
+      final secondProgress = <int>[];
+
+      final first = service.downloadUpdate(
+        _testUpdate,
+        onProgress: (received, _) => firstProgress.add(received),
+      );
+      final second = service.downloadUpdate(
+        _testUpdate,
+        onProgress: (received, _) => secondProgress.add(received),
+      );
+
+      await waitFor(() => client.requestCount == 1);
+      expect(client.requestCount, 1);
+      expect(service.isDownloadingUpdate(_testUpdate), isTrue);
+
+      responseCompleter.complete(
+        http.StreamedResponse(
+          Stream.fromIterable([
+            [1, 2],
+            [3, 4],
+          ]),
+          200,
+          contentLength: 4,
+        ),
+      );
+
+      final downloads = await Future.wait([first, second]);
+
+      expect(downloads[0].apkPath, downloads[1].apkPath);
+      expect(client.requestCount, 1);
+      expect(service.hasActiveDownload, isFalse);
+      expect(firstProgress, contains(4));
+      expect(secondProgress, contains(4));
+      expect(await File(downloads[0].apkPath).readAsBytes(), [1, 2, 3, 4]);
+    });
+
+    test('does not clear update cache while a download is active', () async {
+      final responseCompleter = Completer<http.StreamedResponse>();
+      final service = buildService(
+        client: ControlledDownloadClient((_) => responseCompleter.future),
+      );
+
+      final download = service.downloadUpdate(_testUpdate);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service.hasActiveDownload, isTrue);
+      await expectLater(
+        service.clearDownloadedUpdates(),
+        throwsA(isA<AppUpdateDownloadInProgressException>()),
+      );
+
+      responseCompleter.complete(
+        http.StreamedResponse(
+          Stream.value([1, 2, 3, 4]),
+          200,
+          contentLength: 4,
+        ),
+      );
+      await download;
+
+      expect(await service.clearDownloadedUpdates(), 1);
+    });
+
+    test(
+      'deletes corrupt partial APK when downloaded size mismatches',
+      () async {
+        final service = buildService(
+          client: ControlledDownloadClient((_) async {
+            return http.StreamedResponse(
+              Stream.value([1, 2]),
+              200,
+              contentLength: 2,
+            );
+          }),
+        );
+
+        await expectLater(
+          service.downloadUpdate(_testUpdate),
+          throwsA(isA<AppUpdateInvalidPackageException>()),
+        );
+
+        expect(
+          await File(p.join(tempDir.path, _testUpdate.assetName)).exists(),
+          isFalse,
+        );
+        expect(
+          await File(
+            '${p.join(tempDir.path, _testUpdate.assetName)}.part',
+          ).exists(),
+          isFalse,
+        );
+      },
+    );
 
     test(
       'redownloads when cached APK size does not match asset size',
@@ -330,13 +433,49 @@ void main() {
     test(
       'opens unknown-app settings when install permission is missing',
       () async {
+        final apk = File(p.join(tempDir.path, _testUpdate.assetName));
+        await apk.writeAsBytes([1, 2, 3, 4]);
         platform.canInstall = false;
         final service = buildService();
 
-        final result = await service.installUpdate('/tmp/memex.apk');
+        final result = await service.installUpdate(apk.path);
 
         expect(result.status, AppUpdateInstallStatus.permissionRequired);
         expect(platform.openedInstallSettings, isTrue);
+        expect(platform.installedApkPath, isNull);
+      },
+    );
+
+    test('coalesces concurrent install requests for the same APK', () async {
+      final apk = File(p.join(tempDir.path, _testUpdate.assetName));
+      await apk.writeAsBytes([1, 2, 3, 4]);
+      platform.installCompleter = Completer<void>();
+      final service = buildService();
+
+      final first = service.installUpdate(apk.path);
+      final second = service.installUpdate(apk.path);
+      await waitFor(() => platform.installCallCount == 1);
+
+      expect(platform.installCallCount, 1);
+      platform.installCompleter!.complete();
+
+      expect((await first).status, AppUpdateInstallStatus.started);
+      expect((await second).status, AppUpdateInstallStatus.started);
+      expect(platform.installedApkPath, apk.path);
+    });
+
+    test(
+      'fails install before platform call when APK file is missing',
+      () async {
+        final service = buildService();
+
+        await expectLater(
+          service.installUpdate(p.join(tempDir.path, 'missing.apk')),
+          throwsA(isA<AppUpdateInvalidPackageException>()),
+        );
+
+        expect(platform.canInstallCheckCount, 0);
+        expect(platform.installCallCount, 0);
         expect(platform.installedApkPath, isNull);
       },
     );
@@ -373,17 +512,31 @@ Map<String, dynamic> release({
   };
 }
 
+Future<void> waitFor(bool Function() condition) async {
+  for (var i = 0; i < 20; i += 1) {
+    if (condition()) return;
+    await Future<void>.delayed(Duration.zero);
+  }
+  fail('Condition was not met before timeout.');
+}
+
 class FakeUpdatePlatform implements AppUpdatePlatform {
   bool wifiConnected = true;
   bool canInstall = true;
   bool openedInstallSettings = false;
   String? installedApkPath;
+  int canInstallCheckCount = 0;
+  int installCallCount = 0;
+  Completer<void>? installCompleter;
 
   @override
   Future<bool> isWifiConnected() async => wifiConnected;
 
   @override
-  Future<bool> canInstallApk() async => canInstall;
+  Future<bool> canInstallApk() async {
+    canInstallCheckCount += 1;
+    return canInstall;
+  }
 
   @override
   Future<void> openInstallPermissionSettings() async {
@@ -392,6 +545,25 @@ class FakeUpdatePlatform implements AppUpdatePlatform {
 
   @override
   Future<void> installApk(String apkPath) async {
+    installCallCount += 1;
     installedApkPath = apkPath;
+    final completer = installCompleter;
+    if (completer != null) {
+      await completer.future;
+    }
+  }
+}
+
+class ControlledDownloadClient extends http.BaseClient {
+  ControlledDownloadClient(this.handler);
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest request)
+      handler;
+  int requestCount = 0;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    requestCount += 1;
+    return handler(request);
   }
 }

--- a/test/ui/settings/widgets/early_update_settings_card_test.dart
+++ b/test/ui/settings/widgets/early_update_settings_card_test.dart
@@ -80,6 +80,96 @@ void main() {
     );
   });
 
+  testWidgets('shows active background download and disables manual actions', (
+    tester,
+  ) async {
+    final service = FakeWidgetUpdateService(
+      update: testUpdate,
+      cacheInfo: const AppUpdateCacheInfo(fileCount: 1, totalBytes: 2),
+      activeDownload: true,
+      activeProgress: const AppUpdateDownloadProgress(
+        receivedBytes: 2,
+        totalBytes: 4,
+      ),
+    );
+    await pumpCard(tester, service);
+
+    await tester.tap(find.text(UserStorage.l10n.earlyUpdateCheckNow));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateDownloadingPercent(50)),
+      findsOneWidget,
+    );
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateDownloadInProgress),
+      findsOneWidget,
+    );
+
+    final downloadButton = tester.widget<FilledButton>(
+      find.widgetWithText(
+        FilledButton,
+        UserStorage.l10n.earlyUpdateDownloadInProgress,
+      ),
+    );
+    expect(downloadButton.onPressed, isNull);
+
+    final clearButton = tester.widget<OutlinedButton>(
+      find.widgetWithText(
+        OutlinedButton,
+        UserStorage.l10n.earlyUpdateClearDownloadedPackage,
+      ),
+    );
+    expect(clearButton.onPressed, isNull);
+    expect(service.downloadCallCount, 0);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('background download becomes installable after polling', (
+    tester,
+  ) async {
+    final service = FakeWidgetUpdateService(
+      update: testUpdate,
+      activeDownload: true,
+      activeProgress: const AppUpdateDownloadProgress(
+        receivedBytes: 1,
+        totalBytes: 4,
+      ),
+    );
+    await pumpCard(tester, service);
+
+    await tester.tap(find.text(UserStorage.l10n.earlyUpdateCheckNow));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateDownloadingPercent(25)),
+      findsOneWidget,
+    );
+
+    service
+      ..activeDownload = false
+      ..activeProgress = null
+      ..downloadedUpdateAvailable = true
+      ..cacheInfo = const AppUpdateCacheInfo(fileCount: 1, totalBytes: 4);
+
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pump();
+
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateDownloadReadyToInstall),
+      findsOneWidget,
+    );
+    expect(
+      find.text(UserStorage.l10n.earlyUpdateInstallDownloadedPackage),
+      findsOneWidget,
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
   testWidgets('can install cached update package and clear cache', (
     tester,
   ) async {
@@ -135,6 +225,8 @@ class FakeWidgetUpdateService extends AppUpdateService {
     this.update,
     AppUpdateCacheInfo? cacheInfo,
     this.downloadedUpdateAvailable = false,
+    this.activeDownload = false,
+    this.activeProgress,
   }) : cacheInfo = cacheInfo ?? AppUpdateCacheInfo.empty,
        super(
          environment: const AppUpdateEnvironment(
@@ -147,9 +239,12 @@ class FakeWidgetUpdateService extends AppUpdateService {
   final AppUpdateInfo? update;
   AppUpdateCacheInfo cacheInfo;
   bool downloadedUpdateAvailable;
+  bool activeDownload;
+  AppUpdateDownloadProgress? activeProgress;
   AppUpdateSettings settings = const AppUpdateSettings();
   bool installStarted = false;
   bool cacheCleared = false;
+  int downloadCallCount = 0;
 
   @override
   bool get isSupported => true;
@@ -179,6 +274,7 @@ class FakeWidgetUpdateService extends AppUpdateService {
     AppUpdateInfo update, {
     void Function(int receivedBytes, int totalBytes)? onProgress,
   }) async {
+    downloadCallCount += 1;
     onProgress?.call(4, 4);
     cacheInfo = const AppUpdateCacheInfo(fileCount: 1, totalBytes: 4);
     downloadedUpdateAvailable = true;
@@ -197,12 +293,28 @@ class FakeWidgetUpdateService extends AppUpdateService {
   }
 
   @override
+  bool get hasActiveDownload => activeDownload;
+
+  @override
+  bool isDownloadingUpdate(AppUpdateInfo update) {
+    return activeDownload;
+  }
+
+  @override
+  AppUpdateDownloadProgress? getActiveDownloadProgress(AppUpdateInfo update) {
+    return activeProgress;
+  }
+
+  @override
   Future<AppUpdateCacheInfo> getDownloadedUpdateCacheInfo() async {
     return cacheInfo;
   }
 
   @override
   Future<int> clearDownloadedUpdates() async {
+    if (activeDownload) {
+      throw const AppUpdateDownloadInProgressException();
+    }
     cacheCleared = true;
     final deletedCount = cacheInfo.fileCount;
     cacheInfo = AppUpdateCacheInfo.empty;


### PR DESCRIPTION
Closes #182

## 背景

Android Early 更新包目前有后台自动下载/安装和设置页手动下载/安装两个入口。后台已经开始下载时，设置页仍允许用户再次下载或清理缓存，多个入口会同时操作同一个 `.apk` / `.apk.part` 文件，导致文件找不到、半成品 APK 被安装、系统安装器解析失败等问题。

## 改动

- 在 `AppUpdateService` 增加进程内下载会话合并：同一个更新包只发起一次真实下载，后台和手动入口共享同一个 Future 与进度。
- 增加安装会话合并：同一个 APK 路径的并发安装请求只触发一次平台安装调用。
- 下载中禁止清理更新缓存，避免 `.part` 或目标 APK 被清掉。
- 下载完成后校验 APK 文件大小与非空状态，损坏或不完整时删除临时文件并抛出明确错误。
- 安装前在 Dart 层校验 APK 路径、文件存在性和非空，避免把无效路径直接交给 Android 平台通道。
- 设置页识别后台活跃下载，展示“正在下载”状态，禁用手动下载/清缓存；后台下载完成后自动切换到“安装已下载包”。
- 补充中英文文案。

## 测试

- `flutter analyze --no-pub lib/data/services/app_update_service.dart lib/ui/settings/widgets/early_update_settings_card.dart test/data/services/app_update_service_test.dart test/ui/settings/widgets/early_update_settings_card_test.dart`
- `env -u http_proxy -u https_proxy -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub --concurrency=1 test/data/services/app_update_service_test.dart test/ui/settings/widgets/early_update_settings_card_test.dart`
