### PR TITLE
[codex] 修复日程长期项保留和系统动作展示语义

### DIFF
--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -709,7 +709,7 @@ You are a "Personal Schedule Curator" — an empathetic time coach who sees patt
 - ✅ REQUIRED: "Your afternoon is back-to-back — consider moving the design review to tomorrow morning when you're fresher"
 
 ## Core Protocol: "Editorial Flow"
-1. **Discovery**: Use `get_schedule_cards` tool to read all temporal cards in the time window (past 3 days ~ future 7 days)
+1. **Discovery**: Use `get_schedule_cards` tool to read all temporal cards in the time window (past 3 days ~ future 30 days)
 2. **Prioritization**: Identify the hero item (most important upcoming event), deadlines, conflicts
 3. **Narrative**: Write an editorial intro that captures the week's story
 4. **Presentation**: Structure output as YAML and call `save_schedule_aggregation` tool
@@ -719,6 +719,7 @@ You are a "Personal Schedule Curator" — an empathetic time coach who sees patt
 - `get_schedule_cards.start_time` is the schedule display time. For task cards, it falls back to `due_date` when the original card has no explicit `start_time`.
 - For task cards, `is_completed: true` means the user's task is done. For grouped tasks, all source subtasks completed also means the parent task is done.
 - If `is_completed` is absent/false and not all subtasks are completed, keep the task pending even if the AI card generation has finished.
+- Non-task cards with no concrete day or start time are long-term reference items. The system will add a stable `display_until` deadline and expire them; do not renew or reinterpret them as tasks just to keep them visible.
 
 ## Output Schema
 When calling `save_schedule_aggregation`, the `yaml_data` object MUST follow this structure:
@@ -755,6 +756,7 @@ timeline:
         type: "event" | "task" | "routine" | "duration" | "procedure"
         priority: 1-3 (optional)
         description: "Brief description" (optional)
+        display_until: "YYYY-MM-DD" (system-managed, optional for undated non-task reference items)
         subtasks: (task cards only, optional; preserve source subtasks, do not invent)
           - title: "Subtask title"
             completed: true | false

--- a/lib/agent/schedule_aggregator_agent/prompt.dart
+++ b/lib/agent/schedule_aggregator_agent/prompt.dart
@@ -4,7 +4,7 @@ const String scheduleAggregatorSystemPrompt = r'''
 You are the Schedule Aggregator, a specialized agent with the `update_schedule_aggregation` skill. Your mission is to analyze the user's temporal cards (events, tasks, routines, durations, procedures) and generate a magazine-style schedule aggregation.
 
 ## Core Task
-1. Read recent temporal cards from the user's timeline (past 3 days ~ future 7 days)
+1. Read recent temporal cards from the user's timeline (past 3 days ~ future 30 days)
 2. Analyze priorities, deadlines, time conflicts, and completion status
 3. Generate a schedule aggregation in magazine editorial style
 4. Output as a structured YAML file via the `save_schedule_aggregation` tool
@@ -29,6 +29,10 @@ You are the Schedule Aggregator, a specialized agent with the `update_schedule_a
   pending even if the AI card generation has finished.
 - If a task card includes `subtasks`, preserve them in the timeline output as
   the task's `subtasks` list. Do not invent subtasks for unrelated cards.
+- Non-task cards with no concrete day or start time are long-term reference
+  items. They may be surfaced briefly, but the system will add a stable
+  `display_until` deadline and expire them instead of letting them renew on
+  every refresh.
 
 ## Language Consistency Rule (CRITICAL)
 - Respect User Language: If user's input is Chinese, output MUST be Chinese

--- a/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart
+++ b/lib/agent/schedule_aggregator_agent/schedule_aggregation_run_context.dart
@@ -6,6 +6,7 @@ import 'package:memex/data/services/schedule_refresh_state_service.dart';
 import 'package:memex/domain/models/schedule_refresh_state.dart';
 
 const int defaultScheduleAggregationCardLimit = 80;
+const Duration _dirtyFactWindowLookahead = Duration(days: 7);
 
 class ScheduleAggregationWindow {
   const ScheduleAggregationWindow({
@@ -60,9 +61,14 @@ Future<ScheduleAggregationRunPlan> buildScheduleAggregationRunPlan({
   final fileSystem = FileSystemService.instance;
   final generatedAt = now ?? DateTime.now();
   final refreshState = await ScheduleRefreshStateService.instance.read(userId);
+  final dirtyScheduleDates = await _collectOutOfBandDirtyScheduleDates(
+    userId: userId,
+    cardIds: refreshState.cardIds,
+  );
   final window = resolveScheduleAggregationWindow(
     generatedAt: generatedAt,
     refreshState: refreshState,
+    dirtyScheduleDates: dirtyScheduleDates,
   );
 
   final scheduleCards = await queryScheduleCardsForRange(
@@ -88,6 +94,7 @@ Future<ScheduleAggregationRunPlan> buildScheduleAggregationRunPlan({
 ScheduleAggregationWindow resolveScheduleAggregationWindow({
   required DateTime generatedAt,
   required ScheduleRefreshState refreshState,
+  List<DateTime> dirtyScheduleDates = const [],
 }) {
   final dirtyDates = <DateTime>[];
   final sourceCardIds = <String>[];
@@ -97,22 +104,34 @@ ScheduleAggregationWindow resolveScheduleAggregationWindow({
     dirtyDates.add(cardDate);
     sourceCardIds.add(cardId);
   }
+  dirtyDates.addAll(dirtyScheduleDates);
 
   if (dirtyDates.isNotEmpty) {
     dirtyDates.sort();
     final first = _startOfDay(dirtyDates.first);
     final last = _endOfDay(dirtyDates.last);
+    var to = last.add(_dirtyFactWindowLookahead);
+    final recentBoundary =
+        generatedAt.subtract(defaultScheduleAggregationLookback);
+    if (!last.isBefore(recentBoundary)) {
+      final defaultTo = generatedAt.add(defaultScheduleAggregationLookahead);
+      if (to.isBefore(defaultTo)) {
+        to = defaultTo;
+      }
+    }
     return ScheduleAggregationWindow(
-      from: first.subtract(const Duration(days: 3)),
-      to: last.add(const Duration(days: 7)),
-      source: 'dirty_card_dates',
+      from: first.subtract(defaultScheduleAggregationLookback),
+      to: to,
+      source: dirtyScheduleDates.isNotEmpty
+          ? 'dirty_schedule_dates'
+          : 'dirty_card_dates',
       sourceCardIds: sourceCardIds,
     );
   }
 
   return ScheduleAggregationWindow(
-    from: generatedAt.subtract(const Duration(days: 3)),
-    to: generatedAt.add(const Duration(days: 7)),
+    from: generatedAt.subtract(defaultScheduleAggregationLookback),
+    to: generatedAt.add(defaultScheduleAggregationLookahead),
     source: 'generated_at_window',
   );
 }
@@ -193,6 +212,7 @@ Future<String> buildScheduleAggregationRunContext({
       'Use save_schedule_aggregation to persist exactly one current aggregation result.',
       'Preserve completed task status only when task is_completed is true; card processing status does not mean task completion.',
       'When a task card has subtasks, preserve those subtasks on the timeline item; do not invent subtasks for independent cards.',
+      'Long-term non-task reference items without a concrete day/start time are display-limited; keep existing display_until values and do not renew them.',
     ],
   };
 
@@ -248,6 +268,51 @@ Map<String, dynamic> _compactDay(dynamic value) {
 String? _itemId(dynamic value) {
   if (value is! Map) return null;
   return value['card_id']?.toString();
+}
+
+Future<List<DateTime>> _collectOutOfBandDirtyScheduleDates({
+  required String userId,
+  required List<String> cardIds,
+}) async {
+  if (cardIds.isEmpty) return const [];
+
+  final fileSystem = FileSystemService.instance;
+  final dates = <DateTime>[];
+  for (final cardId in cardIds) {
+    final factDate = _parseFactIdDate(cardId);
+    final card = await fileSystem.readCardFile(userId, cardId);
+    if (card == null) continue;
+
+    for (final config in card.uiConfigs) {
+      if (!scheduleTemporalTemplateIds.contains(config.templateId)) {
+        continue;
+      }
+      final scheduleDate = scheduleExplicitDateForCard(
+        config.templateId,
+        config.data,
+      );
+      if (scheduleDate == null) continue;
+      if (_isOutOfBandScheduleDate(
+        scheduleDate: scheduleDate,
+        factDate: factDate,
+      )) {
+        dates.add(scheduleDate);
+      }
+    }
+  }
+  return dates;
+}
+
+bool _isOutOfBandScheduleDate({
+  required DateTime scheduleDate,
+  required DateTime? factDate,
+}) {
+  if (factDate == null) return true;
+
+  final from =
+      _startOfDay(factDate).subtract(defaultScheduleAggregationLookback);
+  final to = _endOfDay(factDate).add(_dirtyFactWindowLookahead);
+  return scheduleDate.isBefore(from) || scheduleDate.isAfter(to);
 }
 
 String _truncate(String value, int maxLength) {

--- a/lib/agent/skills/manage_system_action/system_action_skill.dart
+++ b/lib/agent/skills/manage_system_action/system_action_skill.dart
@@ -27,6 +27,7 @@ Your capability includes extracting user intents for scheduling calendar events 
 
 ## Execution Rules
 1. **Explicit Consent**: ONLY perform actions when explicitly requested by the user. Do NOT hallucinate or guess intents that are not clearly expressed.
+   Diagnostic or memo inputs about Memex/app behavior are not consent. If the user is reporting a bug, asking why something disappeared, or saying they will investigate later, do not create/cancel/modify calendar or reminder actions unless this turn explicitly asks for that action.
 2. **Calendar Events Construction**: Extract a `title`, `start_time` (essential), and optional `end_time`, `location`, or `notes`.
 3. **Reminders Construction**: Extract a `title` and an optional `due_date` or `notes`.
 4. **Time Calculation**: Relative times (like "tomorrow 3 PM", "next Monday") MUST be calculated accurately based on the provided Current User Time context.
@@ -77,11 +78,11 @@ The current time is provided dynamically in your agent's state/reminders. Always
         },
         executable: (
           String title,
-          String start_time,
-          String? end_time,
+          String startTime,
+          String? endTime,
           String? notes,
           String? location,
-          bool? all_day,
+          bool? allDay,
         ) async {
           try {
             final context = AgentCallToolContext.current!;
@@ -90,11 +91,11 @@ The current time is provided dynamically in your agent's state/reminders. Always
 
             final actionData = {
               "title": title,
-              "start_time": start_time,
-              "end_time": end_time,
+              "start_time": startTime,
+              "end_time": endTime,
               "notes": notes,
               "location": location,
-              "all_day": all_day ?? false,
+              "all_day": allDay ?? false,
             };
 
             await SystemActionService.instance.createAction(
@@ -138,7 +139,7 @@ The current time is provided dynamically in your agent's state/reminders. Always
         },
         executable: (
           String title,
-          String? due_date,
+          String? dueDate,
           String? notes,
         ) async {
           try {
@@ -148,7 +149,7 @@ The current time is provided dynamically in your agent's state/reminders. Always
 
             final actionData = {
               "title": title,
-              "due_date": due_date,
+              "due_date": dueDate,
               "notes": notes,
             };
 
@@ -172,7 +173,7 @@ The current time is provided dynamically in your agent's state/reminders. Always
       Tool(
         name: 'get_recent_actions',
         description:
-            "Retrieves a list of the 20 most recent calendar events and reminders, regardless of their status (pending, completed, rejected). Use this to find the action_id before cancelling an action.",
+            "Retrieves a list of the 20 most recent calendar events and reminders, regardless of their status (pending, completed, dismissed, rejected). Use this to find the action_id before cancelling an action.",
         parameters: {"type": "object", "properties": {}},
         executable: () async {
           try {
@@ -210,18 +211,18 @@ The current time is provided dynamically in your agent's state/reminders. Always
           },
           "required": ["action_id"]
         },
-        executable: (String action_id) async {
+        executable: (String actionId) async {
           try {
             final success =
-                await SystemActionService.instance.cancelAction(action_id);
+                await SystemActionService.instance.cancelAction(actionId);
 
             if (success) {
               return AgentToolResult(
                 content: TextPart(
-                    "Successfully cancelled action with ID: $action_id"),
+                    "Successfully cancelled action with ID: $actionId"),
               );
             }
-            throw StateError("Action with ID $action_id not found.");
+            throw StateError("Action with ID $actionId not found.");
           } catch (e, st) {
             _logger.severe("Failed to cancel_action", e, st);
             rethrow;

--- a/lib/agent/skills/schedule_aggregation/schedule_aggregation_retention.dart
+++ b/lib/agent/skills/schedule_aggregation/schedule_aggregation_retention.dart
@@ -1,0 +1,221 @@
+const Duration scheduleFloatingItemRetention = Duration(days: 7);
+
+const String scheduleDisplayUntilKey = 'display_until';
+const String scheduleDisplayFirstSeenKey = 'display_first_seen_at';
+
+Map<String, dynamic> applyScheduleDisplayRetention({
+  required Map<String, dynamic> yamlData,
+  Iterable<Map<String, dynamic>> previousAggregations = const [],
+  DateTime? now,
+  Duration retention = scheduleFloatingItemRetention,
+}) {
+  final generatedAt =
+      _parseDateTime(yamlData['generated_at']) ?? now ?? DateTime.now();
+  final expiryReferenceDate = now ?? generatedAt;
+  final history = _buildRetentionHistory(
+    previousAggregations,
+    retention: retention,
+  );
+  final normalized = _copyMap(yamlData);
+  final timeline = normalized['timeline'];
+  if (timeline is! List) return normalized;
+
+  final normalizedDays = <Map<String, dynamic>>[];
+  for (final rawDay in timeline) {
+    if (rawDay is! Map) continue;
+    final day = Map<String, dynamic>.from(rawDay);
+    final items = day['items'];
+    if (items is! List) {
+      normalizedDays.add(day);
+      continue;
+    }
+
+    final retainedItems = <Map<String, dynamic>>[];
+    for (final rawItem in items) {
+      if (rawItem is! Map) continue;
+      final item = Map<String, dynamic>.from(rawItem);
+      if (!_isFloatingLongTermItem(day, item)) {
+        retainedItems.add(item);
+        continue;
+      }
+
+      final key = _retentionKey(item);
+      final record = key == null ? null : history[key];
+      final firstSeenAt = record?.firstSeenAt ??
+          _parseDateTime(item[scheduleDisplayFirstSeenKey]) ??
+          generatedAt;
+      final displayUntil = record?.displayUntil ??
+          _parseDateTime(item[scheduleDisplayUntilKey]) ??
+          _retentionEndDate(firstSeenAt, retention);
+
+      if (_isExpired(displayUntil, expiryReferenceDate)) {
+        continue;
+      }
+
+      item[scheduleDisplayFirstSeenKey] = _formatDate(firstSeenAt);
+      item[scheduleDisplayUntilKey] = _formatDate(displayUntil);
+      retainedItems.add(item);
+    }
+
+    if (retainedItems.isNotEmpty) {
+      day['items'] = retainedItems;
+      normalizedDays.add(day);
+    }
+  }
+
+  normalized['timeline'] = normalizedDays;
+  return normalized;
+}
+
+Map<String, _RetentionRecord> _buildRetentionHistory(
+  Iterable<Map<String, dynamic>> previousAggregations, {
+  required Duration retention,
+}) {
+  final sorted = previousAggregations.toList()
+    ..sort((a, b) {
+      final aTime = _parseDateTime(a['generated_at']) ?? DateTime(0);
+      final bTime = _parseDateTime(b['generated_at']) ?? DateTime(0);
+      return aTime.compareTo(bTime);
+    });
+
+  final records = <String, _RetentionRecord>{};
+  for (final aggregation in sorted) {
+    final generatedAt = _parseDateTime(aggregation['generated_at']);
+    if (generatedAt == null) continue;
+    final timeline = aggregation['timeline'];
+    if (timeline is! List) continue;
+
+    for (final rawDay in timeline) {
+      if (rawDay is! Map) continue;
+      final day = Map<String, dynamic>.from(rawDay);
+      final items = day['items'];
+      if (items is! List) continue;
+
+      for (final rawItem in items) {
+        if (rawItem is! Map) continue;
+        final item = Map<String, dynamic>.from(rawItem);
+        if (!_isFloatingLongTermItem(day, item)) continue;
+
+        final key = _retentionKey(item);
+        if (key == null || records.containsKey(key)) continue;
+
+        final firstSeenAt =
+            _parseDateTime(item[scheduleDisplayFirstSeenKey]) ?? generatedAt;
+        final displayUntil = _parseDateTime(item[scheduleDisplayUntilKey]) ??
+            _retentionEndDate(firstSeenAt, retention);
+        records[key] = _RetentionRecord(
+          firstSeenAt: firstSeenAt,
+          displayUntil: displayUntil,
+        );
+      }
+    }
+  }
+
+  return records;
+}
+
+bool _isFloatingLongTermItem(
+  Map<String, dynamic> day,
+  Map<String, dynamic> item,
+) {
+  final type = item['type']?.toString().toLowerCase().trim();
+  if (type == 'task' || type == 'todo') return false;
+  return !_hasConcreteDate(day, item);
+}
+
+bool _hasConcreteDate(Map<String, dynamic> day, Map<String, dynamic> item) {
+  final itemStartTime = _nonEmptyString(item['start_time']);
+  if (itemStartTime != null && _parseDateTime(itemStartTime) != null) {
+    return true;
+  }
+  final dayDate = _nonEmptyString(day['day_date']);
+  return dayDate != null && _parseDateTime(dayDate) != null;
+}
+
+String? _retentionKey(Map<String, dynamic> item) {
+  final cardId = _nonEmptyString(item['card_id']);
+  if (cardId != null) return 'card:$cardId';
+
+  final title = _nonEmptyString(item['title']);
+  if (title == null) return null;
+  final type = item['type']?.toString().trim().toLowerCase() ?? 'event';
+  return 'fallback:$type:$title';
+}
+
+DateTime _retentionEndDate(DateTime firstSeenAt, Duration retention) {
+  final end = firstSeenAt.add(retention);
+  return DateTime(end.year, end.month, end.day);
+}
+
+bool _isExpired(DateTime displayUntil, DateTime generatedAt) {
+  final generatedDay = DateTime(
+    generatedAt.year,
+    generatedAt.month,
+    generatedAt.day,
+  );
+  final untilDay = DateTime(
+    displayUntil.year,
+    displayUntil.month,
+    displayUntil.day,
+  );
+  return generatedDay.isAfter(untilDay);
+}
+
+DateTime? _parseDateTime(dynamic value) {
+  if (value == null) return null;
+  if (value is DateTime) return value;
+  if (value is int) {
+    final milliseconds = value > 100000000000 ? value : value * 1000;
+    return DateTime.fromMillisecondsSinceEpoch(milliseconds).toLocal();
+  }
+  if (value is num) {
+    final milliseconds = value > 100000000000 ? value.toInt() : value * 1000;
+    return DateTime.fromMillisecondsSinceEpoch(milliseconds.toInt()).toLocal();
+  }
+  if (value is String) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+    return DateTime.tryParse(trimmed);
+  }
+  return null;
+}
+
+String? _nonEmptyString(dynamic value) {
+  if (value == null) return null;
+  final string = value.toString().trim();
+  return string.isEmpty ? null : string;
+}
+
+Map<String, dynamic> _copyMap(Map<String, dynamic> value) {
+  return {
+    for (final entry in value.entries) entry.key: _copyValue(entry.value),
+  };
+}
+
+dynamic _copyValue(dynamic value) {
+  if (value is Map) {
+    return Map<String, dynamic>.from(
+      value.map((key, inner) => MapEntry(key.toString(), _copyValue(inner))),
+    );
+  }
+  if (value is List) {
+    return value.map(_copyValue).toList();
+  }
+  return value;
+}
+
+String _formatDate(DateTime value) {
+  return '${value.year.toString().padLeft(4, '0')}-'
+      '${value.month.toString().padLeft(2, '0')}-'
+      '${value.day.toString().padLeft(2, '0')}';
+}
+
+class _RetentionRecord {
+  const _RetentionRecord({
+    required this.firstSeenAt,
+    required this.displayUntil,
+  });
+
+  final DateTime firstSeenAt;
+  final DateTime displayUntil;
+}

--- a/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
+++ b/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
@@ -2,8 +2,10 @@ import 'dart:convert';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/agent/prompts.dart';
+import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_retention.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/schedule_refresh_state_service.dart';
+import 'package:memex/data/services/system_action_service.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/utils/logger.dart';
 
@@ -11,18 +13,18 @@ import '../../../utils/user_storage.dart';
 
 class ScheduleAggregationSkill extends Skill {
   ScheduleAggregationSkill({super.forceActivate})
-    : super(
-        name: "update_schedule_aggregation",
-        description:
-            "Analyzes user's temporal cards (events, tasks, routines) and generates a magazine-style schedule aggregation.",
-        systemPrompt: Prompts.scheduleAggregatorSkillPrompt(
-          UserStorage.l10n.scheduleAggregatorLanguageInstruction,
-        ),
-        tools: [
-          buildGetScheduleCardsTool(),
-          buildSaveScheduleAggregationTool(),
-        ],
-      );
+      : super(
+          name: "update_schedule_aggregation",
+          description:
+              "Analyzes user's temporal cards (events, tasks, routines) and generates a magazine-style schedule aggregation.",
+          systemPrompt: Prompts.scheduleAggregatorSkillPrompt(
+            UserStorage.l10n.scheduleAggregatorLanguageInstruction,
+          ),
+          tools: [
+            buildGetScheduleCardsTool(),
+            buildSaveScheduleAggregationTool(),
+          ],
+        );
 }
 
 const scheduleTemporalTemplateIds = {
@@ -32,6 +34,9 @@ const scheduleTemporalTemplateIds = {
   'duration',
   'procedure',
 };
+
+const defaultScheduleAggregationLookback = Duration(days: 3);
+const defaultScheduleAggregationLookahead = Duration(days: 30);
 
 dynamic scheduleStartTimeForCard(String templateId, Map<String, dynamic> data) {
   final startTime = _nonEmptyScheduleValue(data['start_time']);
@@ -52,8 +57,9 @@ Future<Map<String, dynamic>> queryScheduleCardsForRange({
   final logger = getLogger('ScheduleAggregationSkill');
   final fileSystem = FileSystemService.instance;
   final now = DateTime.now();
-  final effectiveFrom = from ?? now.subtract(const Duration(days: 3));
-  final effectiveTo = to ?? now.add(const Duration(days: 7));
+  final effectiveFrom =
+      from ?? now.subtract(defaultScheduleAggregationLookback);
+  final effectiveTo = to ?? now.add(defaultScheduleAggregationLookahead);
 
   final db = AppDatabase.instance;
   if (await db.cardDao.isCacheEmpty()) {
@@ -78,6 +84,7 @@ Future<Map<String, dynamic>> queryScheduleCardsForRange({
       final data = uiConfig.data;
       final startTime = scheduleStartTimeForCard(templateId, data);
       final status = deriveScheduleCardStatus(templateId, data);
+      final dateSource = scheduleDateSourceForCard(templateId, data);
 
       if (!_isCardInScheduleRange(
         templateId: templateId,
@@ -97,11 +104,12 @@ Future<Map<String, dynamic>> queryScheduleCardsForRange({
         'status': status,
         'tags': cardData.tags,
         'start_time': startTime,
+        'date_source': dateSource,
+        'is_unscheduled': dateSource == 'created_at_fallback',
         'end_time': data['end_time'],
         'location': data['location'],
-        'is_completed': templateId == 'task'
-            ? status == 'completed'
-            : data['is_completed'],
+        'is_completed':
+            templateId == 'task' ? status == 'completed' : data['is_completed'],
         'priority': data['priority'],
         'due_date': data['due_date'],
         'subtasks': data['subtasks'],
@@ -114,6 +122,23 @@ Future<Map<String, dynamic>> queryScheduleCardsForRange({
       results.add(result);
     } catch (e) {
       logger.warning('Error processing card ${cached.factId}: $e');
+    }
+  }
+
+  final actions = await SystemActionService.instance.getVisibleForSchedule();
+  for (final action in actions) {
+    try {
+      final actionResult = scheduleResultForSystemAction(action);
+      if (actionResult == null) continue;
+      if (!_isResultInScheduleRange(actionResult, effectiveFrom, effectiveTo)) {
+        continue;
+      }
+      if (_duplicatesExistingScheduleResult(results, actionResult)) {
+        continue;
+      }
+      results.add(actionResult);
+    } catch (e) {
+      logger.warning('Error processing system action ${action.id}: $e');
     }
   }
 
@@ -151,7 +176,7 @@ Tool buildGetScheduleCardsTool() {
         'to_date': {
           'type': 'string',
           'description':
-              'End date in ISO format (e.g., 2026-04-30). Defaults to 7 days from now.',
+              'End date in ISO format (e.g., 2026-04-30). Defaults to 30 days from now.',
         },
       },
     },
@@ -163,11 +188,11 @@ Tool buildGetScheduleCardsTool() {
       final now = DateTime.now();
       final defaultFrom = _parseBoundaryDate(
         metadata['schedule_window_from']?.toString(),
-        fallback: now.subtract(const Duration(days: 3)),
+        fallback: now.subtract(defaultScheduleAggregationLookback),
       );
       final defaultTo = _parseBoundaryDate(
         metadata['schedule_window_to']?.toString(),
-        fallback: now.add(const Duration(days: 7)),
+        fallback: now.add(defaultScheduleAggregationLookahead),
       );
       final from = _parseBoundaryDate(fromDate, fallback: defaultFrom);
       final to = _parseBoundaryDate(
@@ -234,10 +259,22 @@ Tool buildSaveScheduleAggregationTool() {
           yamlData['version'] = 1;
         }
 
+        final normalizedYamlData = await normalizeScheduleAggregationForCards(
+          userId: userId,
+          yamlData: yamlData,
+        );
+        final previousAggregations = await fileSystem.listScheduleAggregations(
+          userId,
+        );
+        final retainedYamlData = applyScheduleDisplayRetention(
+          yamlData: normalizedYamlData,
+          previousAggregations: previousAggregations,
+        );
+
         await fileSystem.writeScheduleAggregation(
           userId,
           aggregationId,
-          yamlData,
+          retainedYamlData,
         );
         await ScheduleRefreshStateService.instance.clearDirty(
           userId: userId,
@@ -252,7 +289,7 @@ Tool buildSaveScheduleAggregationTool() {
             description: 'Agent created schedule aggregation',
             metadata: {
               'aggregation_id': aggregationId,
-              'card_count': _countAggregationItems(yamlData),
+              'card_count': _countAggregationItems(retainedYamlData),
             },
           );
         } catch (e) {
@@ -296,14 +333,257 @@ bool _isCardInScheduleRange({
   final start = switch (templateId) {
     'event' => _parseScheduleDateTime(data['start_time']) ?? fallback,
     'task' => _parseScheduleDateTime(data['due_date']) ?? fallback,
-    _ =>
-      _parseScheduleDateTime(data['start_time']) ??
-          _parseScheduleDateTime(data['due_date']) ??
-          fallback,
+    _ => _parseScheduleDateTime(data['start_time']) ??
+        _parseScheduleDateTime(data['due_date']) ??
+        fallback,
   };
 
   final end = _parseScheduleDateTime(data['end_time']) ?? start;
   return !end.isBefore(from) && !start.isAfter(to);
+}
+
+String scheduleDateSourceForCard(String templateId, Map<String, dynamic> data) {
+  final startTime = _parseScheduleDateTime(data['start_time']);
+  if (startTime != null) return 'start_time';
+  if (templateId == 'task') {
+    final dueDate = _parseScheduleDateTime(data['due_date']);
+    if (dueDate != null) return 'due_date';
+  }
+  return 'created_at_fallback';
+}
+
+DateTime? scheduleExplicitDateForCard(
+  String templateId,
+  Map<String, dynamic> data,
+) {
+  final startTime = _parseScheduleDateTime(data['start_time']);
+  if (startTime != null) return startTime;
+  if (templateId == 'task') {
+    return _parseScheduleDateTime(data['due_date']);
+  }
+  return _parseScheduleDateTime(data['due_date']);
+}
+
+Map<String, dynamic>? scheduleResultForSystemAction(SystemAction action) {
+  if (action.status == 'rejected') return null;
+  if (action.actionType != 'calendar' && action.actionType != 'reminder') {
+    return null;
+  }
+
+  final data = _decodeActionData(action.actionData);
+  if (data == null) return null;
+  final title = _nonEmptyScheduleValue(data['title'])?.toString();
+  if (title == null) return null;
+
+  final isCalendar = action.actionType == 'calendar';
+  final startTime = isCalendar
+      ? _nonEmptyScheduleValue(data['start_time'])
+      : _nonEmptyScheduleValue(data['due_date']);
+  if (_parseScheduleDateTime(startTime) == null) return null;
+
+  return <String, dynamic>{
+    'card_id': 'system_action:${action.id}',
+    'source_fact_id': action.factId,
+    'system_action_id': action.id,
+    'source': 'system_action',
+    'title': title,
+    'template_id': isCalendar ? 'event' : 'reminder',
+    'timestamp': action.createdAt ?? action.updatedAt ?? 0,
+    'status': 'pending',
+    'action_status': action.status,
+    'tags': const [],
+    'start_time': startTime,
+    'end_time': data['end_time'],
+    'location': data['location'],
+    'due_date': data['due_date'],
+    'notes': data['notes'],
+    'date_source':
+        isCalendar ? 'system_action_start_time' : 'system_action_due_date',
+    'is_unscheduled': false,
+  };
+}
+
+Future<Map<String, dynamic>> normalizeScheduleAggregationForCards({
+  required String userId,
+  required Map<String, dynamic> yamlData,
+}) async {
+  final fileSystem = FileSystemService.instance;
+  final normalized = _deepCopyMap(yamlData);
+  final timeline = normalized['timeline'];
+  if (timeline is! List) return normalized;
+
+  final normalizedTimeline = <Map<String, dynamic>>[];
+  final unscheduledItems = <Map<String, dynamic>>[];
+
+  for (final rawDay in timeline) {
+    if (rawDay is! Map) continue;
+    final day = Map<String, dynamic>.from(rawDay);
+    final items = day['items'];
+    if (items is! List) {
+      normalizedTimeline.add(day);
+      continue;
+    }
+
+    final retainedItems = <Map<String, dynamic>>[];
+    for (final rawItem in items) {
+      if (rawItem is! Map) continue;
+      final item = Map<String, dynamic>.from(rawItem);
+      if (await _shouldMoveToUnscheduled(
+        fileSystem: fileSystem,
+        userId: userId,
+        day: day,
+        item: item,
+      )) {
+        unscheduledItems.add(item);
+      } else {
+        retainedItems.add(item);
+      }
+    }
+
+    if (retainedItems.isNotEmpty || !_isUnscheduledDay(day)) {
+      day['items'] = retainedItems;
+      if (retainedItems.isNotEmpty) {
+        normalizedTimeline.add(day);
+      }
+    } else {
+      unscheduledItems.insertAll(0, retainedItems);
+    }
+  }
+
+  if (unscheduledItems.isNotEmpty) {
+    final existingIndex = normalizedTimeline.indexWhere(_isUnscheduledDay);
+    if (existingIndex >= 0) {
+      final existing = normalizedTimeline[existingIndex];
+      final existingItems = existing['items'];
+      existing['items'] = [
+        if (existingItems is List) ...existingItems,
+        ...unscheduledItems,
+      ];
+    } else {
+      normalizedTimeline.add({
+        'day_label': '待安排',
+        'day_date': '',
+        'items': unscheduledItems,
+      });
+    }
+  }
+
+  normalized['timeline'] = normalizedTimeline;
+  return normalized;
+}
+
+Future<bool> _shouldMoveToUnscheduled({
+  required FileSystemService fileSystem,
+  required String userId,
+  required Map<String, dynamic> day,
+  required Map<String, dynamic> item,
+}) async {
+  if (_isUnscheduledDay(day)) return false;
+  if (_parseScheduleDateTime(item['start_time']) != null ||
+      _parseScheduleDateTime(item['due_date']) != null) {
+    return false;
+  }
+
+  final type = item['type']?.toString().toLowerCase().trim();
+  if (type != 'task' && type != 'todo') return false;
+
+  final cardId = item['card_id']?.toString();
+  if (cardId == null || !_isFactId(cardId)) return false;
+
+  final cardData = await fileSystem.readCardFile(userId, cardId);
+  if (cardData == null) return false;
+  for (final config in cardData.uiConfigs) {
+    if (config.templateId != 'task') continue;
+    return scheduleExplicitDateForCard(config.templateId, config.data) == null;
+  }
+  return false;
+}
+
+bool _isUnscheduledDay(Map<dynamic, dynamic> day) {
+  final label = day['day_label']?.toString().trim();
+  final dayDate = day['day_date']?.toString().trim();
+  return dayDate == null ||
+      dayDate.isEmpty ||
+      label == '待安排' ||
+      label == '周末待定';
+}
+
+bool _isFactId(String value) {
+  return RegExp(r'^\d{4}/\d{2}/\d{2}\.md#ts_\d+$').hasMatch(value);
+}
+
+bool _isResultInScheduleRange(
+  Map<String, dynamic> result,
+  DateTime from,
+  DateTime to,
+) {
+  final start = _parseScheduleDateTime(result['start_time']) ??
+      _parseScheduleDateTime(result['due_date']);
+  if (start == null) return false;
+  final end = _parseScheduleDateTime(result['end_time']) ?? start;
+  return !end.isBefore(from) && !start.isAfter(to);
+}
+
+bool _duplicatesExistingScheduleResult(
+  List<Map<String, dynamic>> existing,
+  Map<String, dynamic> candidate,
+) {
+  final candidateTitle = _normalizeTitle(candidate['title']);
+  final candidateDate = _parseScheduleDateTime(candidate['start_time']) ??
+      _parseScheduleDateTime(candidate['due_date']);
+  if (candidateTitle.isEmpty || candidateDate == null) return false;
+
+  for (final item in existing) {
+    final itemTitle = _normalizeTitle(item['title']);
+    final itemDate = _parseScheduleDateTime(item['start_time']) ??
+        _parseScheduleDateTime(item['due_date']);
+    if (itemTitle == candidateTitle && _sameMinute(itemDate, candidateDate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+String _normalizeTitle(dynamic value) {
+  return value
+          ?.toString()
+          .trim()
+          .toLowerCase()
+          .replaceAll(RegExp(r'\s+'), '') ??
+      '';
+}
+
+bool _sameMinute(DateTime? a, DateTime b) {
+  if (a == null) return false;
+  return a.year == b.year &&
+      a.month == b.month &&
+      a.day == b.day &&
+      a.hour == b.hour &&
+      a.minute == b.minute;
+}
+
+Map<String, dynamic>? _decodeActionData(String? value) {
+  if (value == null || value.trim().isEmpty) return null;
+  final decoded = jsonDecode(value);
+  if (decoded is Map) return Map<String, dynamic>.from(decoded);
+  return null;
+}
+
+Map<String, dynamic> _deepCopyMap(Map<String, dynamic> value) {
+  return Map<String, dynamic>.from(_deepCopy(value) as Map);
+}
+
+dynamic _deepCopy(dynamic value) {
+  if (value is Map) {
+    return {
+      for (final entry in value.entries)
+        entry.key.toString(): _deepCopy(entry.value),
+    };
+  }
+  if (value is List) {
+    return value.map(_deepCopy).toList();
+  }
+  return value;
 }
 
 DateTime? _parseScheduleDateTime(dynamic value) {
@@ -390,10 +670,10 @@ int _countAggregationItems(Map<String, dynamic> yamlData) {
   final heroCount = yamlData['hero_item'] == null ? 0 : 1;
   final timelineCount =
       (yamlData['timeline'] as List?)?.whereType<Map>().fold<int>(
-        0,
-        (count, day) => count + ((day['items'] as List?)?.length ?? 0),
-      ) ??
-      0;
+                0,
+                (count, day) => count + ((day['items'] as List?)?.length ?? 0),
+              ) ??
+          0;
   final completedCount = (yamlData['completed'] as List?)?.length ?? 0;
   return heroCount + timelineCount + completedCount;
 }

--- a/lib/agent/system_action_agent/prompt.dart
+++ b/lib/agent/system_action_agent/prompt.dart
@@ -9,6 +9,7 @@ scheduling or reminder intent, do nothing and stop.
 # Rules
 1. Explicit Consent: act only on intents that are unambiguously stated by
    the user. Do not invent events or reminders.
+   Diagnostic or memo inputs about Memex/app behavior are not consent.
 2. Multiple intents: if the input contains several distinct events or
    reminders, create one tool call per item. Make these calls in parallel.
 3. Time Calculation: relative times (such as "tomorrow 3 PM" or

--- a/lib/data/repositories/get_schedule_aggregation.dart
+++ b/lib/data/repositories/get_schedule_aggregation.dart
@@ -1,3 +1,4 @@
+import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_retention.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/domain/models/schedule_aggregation_model.dart';
@@ -16,16 +17,22 @@ Future<ScheduleAggregationModel?> getScheduleAggregation() async {
     }
 
     final fileSystem = FileSystemService.instance;
-    final latest = await fileSystem.getLatestScheduleAggregation(userId);
-    if (latest == null) {
+    final aggregations = await fileSystem.listScheduleAggregations(userId);
+    if (aggregations.isEmpty) {
       _logger.info('No schedule aggregation found for user $userId');
       return null;
     }
 
+    final latest = aggregations.first;
+    final retained = applyScheduleDisplayRetention(
+      yamlData: latest,
+      previousAggregations: aggregations.skip(1),
+      now: DateTime.now(),
+    );
     final hydrated = await _hydrateLiveTaskState(
       fileSystem: fileSystem,
       userId: userId,
-      aggregation: latest,
+      aggregation: retained,
     );
     return ScheduleAggregationModel.fromYaml(hydrated);
   } catch (e) {
@@ -117,7 +124,7 @@ Set<String> _collectScheduleCardIds(Map<String, dynamic> aggregation) {
       for (final itemValue in items) {
         if (itemValue is! Map) continue;
         final cardId = _readCardId(Map<String, dynamic>.from(itemValue));
-        if (cardId.isNotEmpty) cardIds.add(cardId);
+        if (_isFactCardId(cardId)) cardIds.add(cardId);
       }
     }
   }
@@ -127,7 +134,7 @@ Set<String> _collectScheduleCardIds(Map<String, dynamic> aggregation) {
     for (final itemValue in completed) {
       if (itemValue is! Map) continue;
       final cardId = _readCardId(Map<String, dynamic>.from(itemValue));
-      if (cardId.isNotEmpty) cardIds.add(cardId);
+      if (_isFactCardId(cardId)) cardIds.add(cardId);
     }
   }
   return cardIds;
@@ -148,6 +155,10 @@ Map<String, dynamic> _hydrateTimelineTaskItem(
 
 String _readCardId(Map<String, dynamic> value) {
   return (value['card_id'] ?? value['id'] ?? '').toString();
+}
+
+bool _isFactCardId(String value) {
+  return RegExp(r'^\d{4}/\d{2}/\d{2}\.md#ts_\d+$').hasMatch(value);
 }
 
 bool _isTaskTimelineItem(Map<String, dynamic> item) {
@@ -183,8 +194,7 @@ class _LiveTaskState {
     final data = taskConfig.data;
     final normalizedSubtasks = _normalizeSubtasks(data['subtasks']);
     final explicitCompleted = _parseTaskBool(data['is_completed']);
-    final subtasksCompleted =
-        normalizedSubtasks.isNotEmpty &&
+    final subtasksCompleted = normalizedSubtasks.isNotEmpty &&
         normalizedSubtasks.every(
           (subtask) => _parseTaskBool(subtask['completed']),
         );
@@ -194,8 +204,8 @@ class _LiveTaskState {
       isCompleted: isCompleted,
       subtasks: isCompleted
           ? normalizedSubtasks
-                .map((subtask) => {...subtask, 'completed': true})
-                .toList()
+              .map((subtask) => {...subtask, 'completed': true})
+              .toList()
           : normalizedSubtasks,
     );
   }

--- a/lib/data/services/card_attachment_service.dart
+++ b/lib/data/services/card_attachment_service.dart
@@ -44,7 +44,8 @@ class CardAttachmentService {
     final userId = await UserStorage.getUserId();
 
     if (type == null || type == CardAttachmentType.systemAction) {
-      total += await SystemActionService.instance.rejectAllPending();
+      total +=
+          await SystemActionService.instance.dismissPendingFromActionCenter();
     }
     if (type == null || type == CardAttachmentType.clarificationRequest) {
       total += await ClarificationRequestService.instance.dismissAllPending();

--- a/lib/data/services/system_action_service.dart
+++ b/lib/data/services/system_action_service.dart
@@ -83,6 +83,19 @@ class SystemActionService {
         .get();
   }
 
+  /// Gets schedule-relevant actions that should still be visible.
+  ///
+  /// `dismissed` only means hidden from the action center; it is intentionally
+  /// still visible in source-card attachments and schedule aggregation.
+  Future<List<SystemAction>> getVisibleForSchedule() async {
+    return (_db.select(_db.systemActions)
+          ..where((t) =>
+              t.status.isNotIn(['rejected']) &
+              t.actionType.isIn(['calendar', 'reminder']))
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+        .get();
+  }
+
   /// Gets all pending actions.
   Future<List<SystemAction>> getPending() async {
     return (_db.select(_db.systemActions)
@@ -105,6 +118,24 @@ class SystemActionService {
       return count;
     } catch (e) {
       _logger.severe('Failed to reject all pending actions: $e');
+      return 0;
+    }
+  }
+
+  /// Hide all pending actions from the action center without rejecting them.
+  Future<int> dismissPendingFromActionCenter() async {
+    try {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final count = await (_db.update(_db.systemActions)
+            ..where((t) => t.status.equals('pending')))
+          .write(SystemActionsCompanion(
+        status: const Value('dismissed'),
+        updatedAt: Value(now),
+      ));
+      _logger.info('Dismissed all pending system actions (count=$count)');
+      return count;
+    } catch (e) {
+      _logger.severe('Failed to dismiss pending actions: $e');
       return 0;
     }
   }

--- a/lib/db/tables.dart
+++ b/lib/db/tables.dart
@@ -78,7 +78,7 @@ class SystemActions extends Table {
   TextColumn get actionData =>
       text().nullable()(); // JSON payload (title, start_time, etc.)
   TextColumn get status =>
-      text()(); // 'pending', 'completed', 'failed', 'rejected'
+      text()(); // 'pending', 'completed', 'failed', 'dismissed', 'rejected'
   TextColumn get factId => text().nullable()(); // Associated fact_id
   IntColumn get createdAt => integer().nullable()(); // Seconds since epoch
   IntColumn get updatedAt => integer().nullable()(); // Seconds since epoch

--- a/lib/domain/models/schedule_aggregation_model.dart
+++ b/lib/domain/models/schedule_aggregation_model.dart
@@ -47,17 +47,17 @@ class ScheduleAggregationModel {
   }
 
   Map<String, dynamic> toJson() => {
-    'id': id,
-    'generated_at': generatedAt.toIso8601String(),
-    'version': version,
-    'time_range': timeRange.toJson(),
-    if (heroItem != null) 'hero_item': heroItem!.toJson(),
-    'editorial_intro': editorialIntro,
-    'quote_blocks': quoteBlocks.map((e) => e.toJson()).toList(),
-    'timeline': timeline.map((e) => e.toJson()).toList(),
-    'completed': completed.map((e) => e.toJson()).toList(),
-    'conflicts': conflicts.map((e) => e.toJson()).toList(),
-  };
+        'id': id,
+        'generated_at': generatedAt.toIso8601String(),
+        'version': version,
+        'time_range': timeRange.toJson(),
+        if (heroItem != null) 'hero_item': heroItem!.toJson(),
+        'editorial_intro': editorialIntro,
+        'quote_blocks': quoteBlocks.map((e) => e.toJson()).toList(),
+        'timeline': timeline.map((e) => e.toJson()).toList(),
+        'completed': completed.map((e) => e.toJson()).toList(),
+        'conflicts': conflicts.map((e) => e.toJson()).toList(),
+      };
 
   static DateTime _parseDateTime(dynamic value) {
     return _parseDateTimeNullable(value) ?? DateTime.now();
@@ -90,9 +90,9 @@ class TimeRange {
   }
 
   Map<String, dynamic> toJson() => {
-    'from': _formatDate(from),
-    'to': _formatDate(to),
-  };
+        'from': _formatDate(from),
+        'to': _formatDate(to),
+      };
 
   static DateTime _parseDate(dynamic value) {
     if (value == null) return DateTime.now();
@@ -138,14 +138,14 @@ class HeroItem {
   }
 
   Map<String, dynamic> toJson() => {
-    'card_id': cardId,
-    'title': title,
-    if (description != null) 'description': description,
-    if (startTime != null) 'start_time': startTime!.toIso8601String(),
-    if (endTime != null) 'end_time': endTime!.toIso8601String(),
-    if (location != null) 'location': location,
-    if (priority != null) 'priority': priority,
-  };
+        'card_id': cardId,
+        'title': title,
+        if (description != null) 'description': description,
+        if (startTime != null) 'start_time': startTime!.toIso8601String(),
+        if (endTime != null) 'end_time': endTime!.toIso8601String(),
+        if (location != null) 'location': location,
+        if (priority != null) 'priority': priority,
+      };
 }
 
 class QuoteBlock {
@@ -171,11 +171,11 @@ class QuoteBlock {
   }
 
   Map<String, dynamic> toJson() => {
-    'title': title,
-    'content': content,
-    'priority': priority,
-    if (relatedCardId != null) 'related_card_id': relatedCardId,
-  };
+        'title': title,
+        'content': content,
+        'priority': priority,
+        if (relatedCardId != null) 'related_card_id': relatedCardId,
+      };
 }
 
 class TimelineDay {
@@ -194,10 +194,10 @@ class TimelineDay {
   }
 
   Map<String, dynamic> toJson() => {
-    'day_label': dayLabel,
-    if (dayDate != null) 'day_date': _formatDate(dayDate!),
-    'items': items.map((e) => e.toJson()).toList(),
-  };
+        'day_label': dayLabel,
+        if (dayDate != null) 'day_date': _formatDate(dayDate!),
+        'items': items.map((e) => e.toJson()).toList(),
+      };
 
   static String _formatDate(DateTime date) {
     return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
@@ -213,6 +213,8 @@ class TimelineItem {
   final int? priority;
   final String? description;
   final List<ScheduleSubtask> subtasks;
+  final DateTime? displayFirstSeenAt;
+  final DateTime? displayUntil;
 
   TimelineItem({
     required this.cardId,
@@ -223,6 +225,8 @@ class TimelineItem {
     this.priority,
     this.description,
     this.subtasks = const [],
+    this.displayFirstSeenAt,
+    this.displayUntil,
   });
 
   factory TimelineItem.fromYaml(Map<String, dynamic> yaml) {
@@ -238,20 +242,26 @@ class TimelineItem {
         yaml['subtasks'],
         ScheduleSubtask.fromYaml,
       ).where((subtask) => subtask.title.trim().isNotEmpty).toList(),
+      displayFirstSeenAt: _parseDateTimeNullable(yaml['display_first_seen_at']),
+      displayUntil: _parseDateTimeNullable(yaml['display_until']),
     );
   }
 
   Map<String, dynamic> toJson() => {
-    'card_id': cardId,
-    'title': title,
-    'status': status,
-    if (startTime != null) 'start_time': startTime!.toIso8601String(),
-    'type': type,
-    if (priority != null) 'priority': priority,
-    if (description != null) 'description': description,
-    if (subtasks.isNotEmpty)
-      'subtasks': subtasks.map((e) => e.toJson()).toList(),
-  };
+        'card_id': cardId,
+        'title': title,
+        'status': status,
+        if (startTime != null) 'start_time': startTime!.toIso8601String(),
+        'type': type,
+        if (priority != null) 'priority': priority,
+        if (description != null) 'description': description,
+        if (subtasks.isNotEmpty)
+          'subtasks': subtasks.map((e) => e.toJson()).toList(),
+        if (displayFirstSeenAt != null)
+          'display_first_seen_at': TimelineDay._formatDate(displayFirstSeenAt!),
+        if (displayUntil != null)
+          'display_until': TimelineDay._formatDate(displayUntil!),
+      };
 }
 
 class ScheduleSubtask {
@@ -293,10 +303,10 @@ class CompletedItem {
   }
 
   Map<String, dynamic> toJson() => {
-    'card_id': cardId,
-    'title': title,
-    if (completedAt != null) 'completed_at': completedAt!.toIso8601String(),
-  };
+        'card_id': cardId,
+        'title': title,
+        if (completedAt != null) 'completed_at': completedAt!.toIso8601String(),
+      };
 }
 
 class Conflict {
@@ -308,8 +318,7 @@ class Conflict {
   factory Conflict.fromYaml(Map<String, dynamic> yaml) {
     return Conflict(
       description: _parseString(yaml['description']),
-      itemIds:
-          (yaml['item_ids'] as List?)
+      itemIds: (yaml['item_ids'] as List?)
               ?.map((item) => item.toString())
               .toList() ??
           [],
@@ -317,9 +326,9 @@ class Conflict {
   }
 
   Map<String, dynamic> toJson() => {
-    'description': description,
-    'item_ids': itemIds,
-  };
+        'description': description,
+        'item_ids': itemIds,
+      };
 }
 
 DateTime? _parseDateTimeNullable(dynamic value) {

--- a/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
+++ b/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
@@ -33,8 +33,7 @@ class _ScheduleAggregatorScreenBody extends StatefulWidget {
 }
 
 class _ScheduleAggregatorScreenState
-    extends State<_ScheduleAggregatorScreenBody>
-    with WidgetsBindingObserver {
+    extends State<_ScheduleAggregatorScreenBody> with WidgetsBindingObserver {
   DateTime _relativeDate = DateTime.now();
   Timer? _dayRefreshTimer;
 
@@ -87,7 +86,7 @@ class _ScheduleAggregatorScreenState
   }
 
   void _navigateToCard(String cardId) {
-    if (cardId.isEmpty) {
+    if (cardId.isEmpty || !_isFactCardId(cardId)) {
       return;
     }
     Navigator.push(
@@ -96,6 +95,10 @@ class _ScheduleAggregatorScreenState
         builder: (_) => TimelineCardDetailScreen(cardId: cardId),
       ),
     );
+  }
+
+  bool _isFactCardId(String cardId) {
+    return RegExp(r'^\d{4}/\d{2}/\d{2}\.md#ts_\d+$').hasMatch(cardId);
   }
 
   Future<void> _onReload() async {

--- a/test/agent/schedule_aggregation_run_context_test.dart
+++ b/test/agent/schedule_aggregation_run_context_test.dart
@@ -227,6 +227,59 @@ void main() {
       },
     );
 
+    test(
+      'extends dirty window to explicit future schedule dates',
+      () async {
+        final fileSystem = FileSystemService.instance;
+        await fileSystem.safeWriteCardFile(
+          userId,
+          '2026/05/20.md#ts_5',
+          CardData(
+            factId: '2026/05/20.md#ts_5',
+            title: '天津小白院领证Party调研',
+            timestamp: DateTime.utc(2026, 5, 20).millisecondsSinceEpoch ~/ 1000,
+            status: 'completed',
+            tags: const ['schedule'],
+            uiConfigs: const [
+              UiConfig(
+                templateId: 'event',
+                data: {
+                  'start_time': '2026-06-06T09:00:00+08:00',
+                  'location': '天津',
+                },
+              ),
+            ],
+          ),
+        );
+        await ScheduleRefreshStateService.instance.markDirty(
+          userId: userId,
+          reason: 'future event card changed',
+          cardIds: const ['2026/05/20.md#ts_5'],
+        );
+
+        final context = await buildScheduleAggregationRunContext(
+          userId: userId,
+          runId: 'task_future_dirty_date',
+          now: DateTime.utc(2026, 5, 25, 12),
+          scheduleCardLimit: 10,
+        );
+
+        final payload = _decodeContextPayload(context);
+        final targetWindow = payload['target_window'] as Map<String, dynamic>;
+        final sources = payload['durable_sources'] as Map<String, dynamic>;
+        final cards = sources['schedule_cards'] as Map<String, dynamic>;
+
+        expect(targetWindow['source'], 'dirty_schedule_dates');
+        expect(targetWindow['from'], startsWith('2026-05-17'));
+        expect(targetWindow['to'], startsWith('2026-06-24'));
+        expect(targetWindow['source_card_ids'], ['2026/05/20.md#ts_5']);
+        expect(
+          (cards['cards'] as List).map((card) => card['card_id']),
+          contains('2026/05/20.md#ts_5'),
+        );
+      },
+    );
+
     test('builds no-op aggregation payload for empty target window', () async {
       await ScheduleRefreshStateService.instance.markDirty(
         userId: userId,

--- a/test/agent/skills/schedule_aggregation_retention_test.dart
+++ b/test/agent/skills/schedule_aggregation_retention_test.dart
@@ -1,0 +1,284 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_retention.dart';
+
+void main() {
+  group('applyScheduleDisplayRetention', () {
+    test('adds a seven-day display deadline to undated non-task items', () {
+      final result = applyScheduleDisplayRetention(
+        yamlData: _aggregation(
+          generatedAt: '2026-05-25T11:00:00+08:00',
+          items: [
+            _item(
+              cardId: '2026/05/21.md#ts_3',
+              title: '沙球转体转髋训练要点',
+              type: 'procedure',
+            ),
+          ],
+        ),
+      );
+
+      final item = _firstItem(result);
+      expect(item[scheduleDisplayFirstSeenKey], '2026-05-25');
+      expect(item[scheduleDisplayUntilKey], '2026-06-01');
+    });
+
+    test('preserves the previous deadline instead of renewing on refresh', () {
+      final previous = _aggregation(
+        generatedAt: '2026-05-22T09:00:00+08:00',
+        items: [
+          _item(
+            cardId: 'procedure-1',
+            title: '训练要点',
+            type: 'procedure',
+            firstSeenAt: '2026-05-22',
+            displayUntil: '2026-05-29',
+          ),
+        ],
+      );
+
+      final result = applyScheduleDisplayRetention(
+        yamlData: _aggregation(
+          generatedAt: '2026-05-25T11:00:00+08:00',
+          items: [
+            _item(cardId: 'procedure-1', title: '训练要点', type: 'procedure'),
+          ],
+        ),
+        previousAggregations: [previous],
+      );
+
+      final item = _firstItem(result);
+      expect(item[scheduleDisplayFirstSeenKey], '2026-05-22');
+      expect(item[scheduleDisplayUntilKey], '2026-05-29');
+    });
+
+    test('derives legacy deadlines from first historical appearance', () {
+      final oldest = _aggregation(
+        generatedAt: '2026-05-21T18:00:00+08:00',
+        items: [_item(cardId: 'procedure-1', title: '训练要点', type: 'procedure')],
+      );
+      final latest = _aggregation(
+        generatedAt: '2026-05-25T11:00:00+08:00',
+        items: [_item(cardId: 'procedure-1', title: '训练要点', type: 'procedure')],
+      );
+
+      final result = applyScheduleDisplayRetention(
+        yamlData: latest,
+        previousAggregations: [latest, oldest],
+      );
+
+      final item = _firstItem(result);
+      expect(item[scheduleDisplayFirstSeenKey], '2026-05-21');
+      expect(item[scheduleDisplayUntilKey], '2026-05-28');
+    });
+
+    test('drops expired floating items and removes empty sections', () {
+      final previous = _aggregation(
+        generatedAt: '2026-05-21T18:00:00+08:00',
+        items: [_item(cardId: 'procedure-1', title: '训练要点', type: 'procedure')],
+      );
+      final result = applyScheduleDisplayRetention(
+        yamlData: _aggregation(
+          generatedAt: '2026-05-29T09:00:00+08:00',
+          items: [
+            _item(cardId: 'procedure-1', title: '训练要点', type: 'procedure'),
+          ],
+        ),
+        previousAggregations: [previous],
+      );
+
+      expect(result['timeline'], isEmpty);
+    });
+
+    test('uses current date to expire an old aggregation on read', () {
+      final result = applyScheduleDisplayRetention(
+        yamlData: _aggregation(
+          generatedAt: '2026-05-25T09:00:00+08:00',
+          items: [
+            _item(
+              cardId: 'procedure-1',
+              title: '训练要点',
+              type: 'procedure',
+              firstSeenAt: '2026-05-21',
+              displayUntil: '2026-05-28',
+            ),
+          ],
+        ),
+        now: DateTime(2026, 5, 29, 8),
+      );
+
+      expect(result['timeline'], isEmpty);
+    });
+
+    test('keeps tasks without dates because they are manually completable', () {
+      final previous = _aggregation(
+        generatedAt: '2026-05-21T18:00:00+08:00',
+        items: [_item(cardId: 'task-1', title: '写作业', type: 'task')],
+      );
+      final result = applyScheduleDisplayRetention(
+        yamlData: _aggregation(
+          generatedAt: '2026-06-05T09:00:00+08:00',
+          items: [_item(cardId: 'task-1', title: '写作业', type: 'task')],
+        ),
+        previousAggregations: [previous],
+      );
+
+      final item = _firstItem(result);
+      expect(item['title'], '写作业');
+      expect(item.containsKey(scheduleDisplayUntilKey), isFalse);
+    });
+
+    test(
+      'keeps non-task items with concrete dates outside retention rules',
+      () {
+        final previous = _aggregation(
+          generatedAt: '2026-05-21T18:00:00+08:00',
+          items: [
+            _item(cardId: 'procedure-1', title: '训练要点', type: 'procedure'),
+          ],
+        );
+        final result = applyScheduleDisplayRetention(
+          yamlData: _aggregation(
+            generatedAt: '2026-06-05T09:00:00+08:00',
+            dayDate: '2026-06-06',
+            items: [
+              _item(cardId: 'procedure-1', title: '训练要点复习', type: 'procedure'),
+            ],
+          ),
+          previousAggregations: [previous],
+        );
+
+        final item = _firstItem(result);
+        expect(item['title'], '训练要点复习');
+        expect(item.containsKey(scheduleDisplayUntilKey), isFalse);
+      },
+    );
+
+    test(
+      'does not let an expired floating history suppress a later dated item',
+      () {
+        final previous = _aggregation(
+          generatedAt: '2026-05-21T18:00:00+08:00',
+          items: [
+            _item(cardId: 'procedure-1', title: '训练要点', type: 'procedure'),
+          ],
+        );
+        final result = applyScheduleDisplayRetention(
+          yamlData: _aggregation(
+            generatedAt: '2026-06-05T09:00:00+08:00',
+            dayDate: '',
+            items: [
+              _item(
+                cardId: 'procedure-1',
+                title: '训练要点复习',
+                type: 'procedure',
+                startTime: '2026-06-06T10:00:00+08:00',
+              ),
+            ],
+          ),
+          previousAggregations: [previous],
+        );
+
+        expect(_firstItem(result)['title'], '训练要点复习');
+      },
+    );
+
+    test(
+      'retains mixed sections while dropping only expired floating items',
+      () {
+        final previous = _aggregation(
+          generatedAt: '2026-05-21T18:00:00+08:00',
+          items: [
+            _item(cardId: 'procedure-1', title: '训练要点', type: 'procedure'),
+          ],
+        );
+        final result = applyScheduleDisplayRetention(
+          yamlData: _aggregation(
+            generatedAt: '2026-05-29T09:00:00+08:00',
+            items: [
+              _item(cardId: 'procedure-1', title: '训练要点', type: 'procedure'),
+              _item(cardId: 'task-1', title: '补税确认', type: 'task'),
+            ],
+          ),
+          previousAggregations: [previous],
+        );
+
+        final items = _items(result);
+        expect(items, hasLength(1));
+        expect(items.single['title'], '补税确认');
+      },
+    );
+
+    test('uses a stable title fallback when card id is missing', () {
+      final previous = _aggregation(
+        generatedAt: '2026-05-21T18:00:00+08:00',
+        items: [_item(cardId: '', title: '训练要点', type: 'procedure')],
+      );
+      final result = applyScheduleDisplayRetention(
+        yamlData: _aggregation(
+          generatedAt: '2026-05-25T09:00:00+08:00',
+          items: [_item(cardId: '', title: '训练要点', type: 'procedure')],
+        ),
+        previousAggregations: [previous],
+      );
+
+      expect(_firstItem(result)[scheduleDisplayUntilKey], '2026-05-28');
+    });
+
+    test('does not mutate the input aggregation map', () {
+      final source = _aggregation(
+        generatedAt: '2026-05-25T11:00:00+08:00',
+        items: [_item(cardId: 'procedure-1', title: '训练要点', type: 'procedure')],
+      );
+
+      applyScheduleDisplayRetention(yamlData: source);
+
+      expect(_firstItem(source).containsKey(scheduleDisplayUntilKey), isFalse);
+    });
+  });
+}
+
+Map<String, dynamic> _aggregation({
+  required String generatedAt,
+  String dayDate = '',
+  required List<Map<String, dynamic>> items,
+}) {
+  return {
+    'id': 'schedule_agg_test',
+    'generated_at': generatedAt,
+    'time_range': {'from': '2026-05-21', 'to': '2026-06-01'},
+    'timeline': [
+      {'day_label': '待安排', 'day_date': dayDate, 'items': items},
+    ],
+    'completed': [],
+    'conflicts': [],
+  };
+}
+
+Map<String, dynamic> _item({
+  required String cardId,
+  required String title,
+  required String type,
+  String? firstSeenAt,
+  String? displayUntil,
+  String? startTime,
+}) {
+  return {
+    'card_id': cardId,
+    'title': title,
+    'status': 'pending',
+    'type': type,
+    if (firstSeenAt != null) scheduleDisplayFirstSeenKey: firstSeenAt,
+    if (displayUntil != null) scheduleDisplayUntilKey: displayUntil,
+    if (startTime != null) 'start_time': startTime,
+  };
+}
+
+List<Map<String, dynamic>> _items(Map<String, dynamic> aggregation) {
+  final timeline = aggregation['timeline'] as List;
+  final day = timeline.single as Map<String, dynamic>;
+  return (day['items'] as List).cast<Map<String, dynamic>>();
+}
+
+Map<String, dynamic> _firstItem(Map<String, dynamic> aggregation) {
+  return _items(aggregation).single;
+}

--- a/test/agent/skills/schedule_aggregation_skill_test.dart
+++ b/test/agent/skills/schedule_aggregation_skill_test.dart
@@ -1,5 +1,12 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/system_action_service.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/card_model.dart';
 
 void main() {
   group('scheduleStartTimeForCard', () {
@@ -134,4 +141,269 @@ void main() {
       );
     });
   });
+
+  group('queryScheduleCardsForRange', () {
+    late Directory tempRoot;
+    late AppDatabase db;
+    const userId = 'schedule_skill_user';
+
+    setUp(() async {
+      tempRoot = await Directory.systemTemp.createTemp(
+        'memex_schedule_skill_',
+      );
+      await FileSystemService.init(tempRoot.path);
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      AppDatabase.setTestInstance(db);
+      await db.searchDao.createFtsTables();
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('includes visible system actions and excludes rejected actions',
+        () async {
+      await _writeTemporalCard(
+        userId: userId,
+        factId: '2026/05/25.md#ts_7',
+        title: '排查小白院日程问题',
+        templateId: 'task',
+        data: const {'is_completed': false},
+      );
+
+      await SystemActionService.instance.createAction(
+        id: 'action-party',
+        type: 'calendar',
+        factId: '2026/05/25.md#ts_7',
+        data: const {
+          'title': '天津小白院领证Party调研',
+          'start_time': '2026-06-06 09:00:00',
+          'location': '天津',
+        },
+      );
+      await SystemActionService.instance.createAction(
+        id: 'action-reminder',
+        type: 'reminder',
+        factId: '2026/05/25.md#ts_7',
+        data: const {
+          'title': '确认小白院预约',
+          'due_date': '2026-06-07 12:00:00',
+        },
+      );
+      await SystemActionService.instance.updateActionStatus(
+        'action-reminder',
+        'dismissed',
+      );
+      await SystemActionService.instance.createAction(
+        id: 'action-rejected',
+        type: 'calendar',
+        factId: '2026/05/25.md#ts_7',
+        data: const {
+          'title': '旧的小白院日程',
+          'start_time': '2026-06-08 09:00:00',
+        },
+      );
+      await SystemActionService.instance.updateActionStatus(
+        'action-rejected',
+        'rejected',
+      );
+
+      final result = await queryScheduleCardsForRange(
+        userId: userId,
+        from: DateTime(2026, 5, 22),
+        to: DateTime(2026, 6, 24, 23, 59),
+      );
+      final cards = (result['cards'] as List).cast<Map<String, dynamic>>();
+      final ids = cards.map((card) => card['card_id']).toList();
+
+      expect(ids, contains('system_action:action-party'));
+      expect(ids, contains('system_action:action-reminder'));
+      expect(ids, isNot(contains('system_action:action-rejected')));
+
+      final party = cards.firstWhere(
+        (card) => card['card_id'] == 'system_action:action-party',
+      );
+      expect(party['source'], 'system_action');
+      expect(party['source_fact_id'], '2026/05/25.md#ts_7');
+      expect(party['action_status'], 'pending');
+      expect(party['date_source'], 'system_action_start_time');
+
+      final undatedTask = cards.firstWhere(
+        (card) => card['card_id'] == '2026/05/25.md#ts_7',
+      );
+      expect(undatedTask['date_source'], 'created_at_fallback');
+      expect(undatedTask['is_unscheduled'], isTrue);
+    });
+
+    test('deduplicates a system action matching an existing schedule card',
+        () async {
+      await _writeTemporalCard(
+        userId: userId,
+        factId: '2026/05/20.md#ts_5',
+        title: '天津小白院领证Party调研',
+        templateId: 'event',
+        data: const {
+          'start_time': '2026-06-06 09:00:00',
+          'location': '天津',
+        },
+      );
+      await SystemActionService.instance.createAction(
+        id: 'action-duplicate',
+        type: 'calendar',
+        factId: '2026/05/20.md#ts_5',
+        data: const {
+          'title': '天津小白院领证Party调研',
+          'start_time': '2026-06-06 09:00:00',
+          'location': '天津',
+        },
+      );
+
+      final result = await queryScheduleCardsForRange(
+        userId: userId,
+        from: DateTime(2026, 5, 22),
+        to: DateTime(2026, 6, 24, 23, 59),
+      );
+      final cards = (result['cards'] as List).cast<Map<String, dynamic>>();
+      final matchingTitle =
+          cards.where((card) => card['title'] == '天津小白院领证Party调研').toList();
+
+      expect(matchingTitle, hasLength(1));
+      expect(
+        cards.map((card) => card['card_id']),
+        isNot(contains('system_action:action-duplicate')),
+      );
+    });
+  });
+
+  group('normalizeScheduleAggregationForCards', () {
+    late Directory tempRoot;
+    late AppDatabase db;
+    const userId = 'schedule_normalize_user';
+
+    setUp(() async {
+      tempRoot = await Directory.systemTemp.createTemp(
+        'memex_schedule_normalize_',
+      );
+      await FileSystemService.init(tempRoot.path);
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      AppDatabase.setTestInstance(db);
+      await db.searchDao.createFtsTables();
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('moves undated task items to 待安排 and keeps dated tasks in place',
+        () async {
+      await _writeTemporalCard(
+        userId: userId,
+        factId: '2026/05/25.md#ts_7',
+        title: '排查小白院日程问题',
+        templateId: 'task',
+        data: const {'is_completed': false},
+      );
+      await _writeTemporalCard(
+        userId: userId,
+        factId: '2026/05/25.md#ts_8',
+        title: '6月6日前确认小白院',
+        templateId: 'task',
+        data: const {
+          'due_date': '2026-06-06 18:00:00',
+          'is_completed': false,
+        },
+      );
+
+      final normalized = await normalizeScheduleAggregationForCards(
+        userId: userId,
+        yamlData: {
+          'id': 'schedule_agg_2026_05_25',
+          'generated_at': DateTime(2026, 5, 25, 9),
+          'timeline': [
+            {
+              'day_label': '今天',
+              'day_date': '2026-05-25',
+              'items': [
+                {
+                  'card_id': '2026/05/25.md#ts_7',
+                  'title': '排查小白院日程问题',
+                  'type': 'task',
+                  'status': 'pending',
+                },
+                {
+                  'card_id': '2026/05/25.md#ts_8',
+                  'title': '6月6日前确认小白院',
+                  'type': 'task',
+                  'status': 'pending',
+                },
+              ],
+            },
+          ],
+        },
+      );
+
+      final timeline =
+          (normalized['timeline'] as List).cast<Map<String, dynamic>>();
+      final datedDay = timeline.firstWhere(
+        (day) => day['day_date'] == '2026-05-25',
+      );
+      expect(
+        (datedDay['items'] as List).map((item) => item['card_id']),
+        ['2026/05/25.md#ts_8'],
+      );
+
+      final unscheduled = timeline.firstWhere(
+        (day) => day['day_label'] == '待安排',
+      );
+      expect(unscheduled['day_date'], '');
+      expect(
+        (unscheduled['items'] as List).map((item) => item['card_id']),
+        ['2026/05/25.md#ts_7'],
+      );
+      expect(normalized['generated_at'], DateTime(2026, 5, 25, 9));
+    });
+  });
+}
+
+Future<void> _writeTemporalCard({
+  required String userId,
+  required String factId,
+  required String title,
+  required String templateId,
+  required Map<String, dynamic> data,
+}) async {
+  final timestamp = _timestampFromFactId(factId);
+  final success = await FileSystemService.instance.safeWriteCardFile(
+    userId,
+    factId,
+    CardData(
+      factId: factId,
+      title: title,
+      timestamp: timestamp,
+      status: 'completed',
+      tags: const ['schedule'],
+      uiConfigs: [
+        UiConfig(templateId: templateId, data: data),
+      ],
+    ),
+  );
+  expect(success, isTrue);
+}
+
+int _timestampFromFactId(String factId) {
+  final match =
+      RegExp(r'^(\d{4})/(\d{2})/(\d{2})\.md#ts_\d+$').firstMatch(factId);
+  if (match == null) return 0;
+  return DateTime.utc(
+        int.parse(match.group(1)!),
+        int.parse(match.group(2)!),
+        int.parse(match.group(3)!),
+      ).millisecondsSinceEpoch ~/
+      1000;
 }

--- a/test/data/repositories/get_schedule_aggregation_test.dart
+++ b/test/data/repositories/get_schedule_aggregation_test.dart
@@ -75,25 +75,77 @@ void main() {
       expect(aggregation!.completed, isEmpty);
     },
   );
+
+  test(
+      'filters expired floating non-task items when reading latest aggregation',
+      () async {
+    await _writeAggregation(
+      aggregationId: 'schedule_agg_2020_01_01',
+      generatedAt: '2020-01-01T09:00:00',
+      dayLabel: '待安排',
+      dayDate: '',
+      timelineItems: [
+        {
+          'card_id': 'procedure-1',
+          'title': '沙球转体转髋训练要点',
+          'type': 'procedure',
+          'status': 'pending',
+        },
+      ],
+    );
+    await _writeAggregation(
+      aggregationId: 'schedule_agg_2020_01_10',
+      generatedAt: '2020-01-10T09:00:00',
+      dayLabel: '待安排',
+      dayDate: '',
+      timelineItems: [
+        {
+          'card_id': 'procedure-1',
+          'title': '沙球转体转髋训练要点',
+          'type': 'procedure',
+          'status': 'pending',
+        },
+        {
+          'card_id': 'task-1',
+          'title': '无日期待办仍保留',
+          'type': 'task',
+          'status': 'pending',
+        },
+      ],
+    );
+
+    final aggregation = await getScheduleAggregation();
+
+    expect(
+      aggregation!.timeline
+          .expand((day) => day.items)
+          .map((item) => item.title),
+      ['无日期待办仍保留'],
+    );
+  });
 }
 
 Future<void> _writeAggregation({
+  String aggregationId = 'schedule_agg_test',
+  String generatedAt = '2026-05-23T09:00:00',
+  String dayLabel = 'Today',
+  String dayDate = '2026-05-23',
   List<Map<String, dynamic>> timelineItems = const [],
   List<Map<String, dynamic>> completedItems = const [],
 }) {
   return FileSystemService.instance.writeScheduleAggregation(
     _userId,
-    'schedule_agg_test',
+    aggregationId,
     {
-      'id': 'schedule_agg_test',
-      'generated_at': '2026-05-23T09:00:00',
+      'id': aggregationId,
+      'generated_at': generatedAt,
       'version': 1,
       'time_range': {'from': '2026-05-23', 'to': '2026-05-30'},
       'timeline': [
         if (timelineItems.isNotEmpty)
           {
-            'day_label': 'Today',
-            'day_date': '2026-05-23',
+            'day_label': dayLabel,
+            'day_date': dayDate,
             'items': timelineItems,
           },
       ],

--- a/test/data/services/system_action_service_test.dart
+++ b/test/data/services/system_action_service_test.dart
@@ -1,0 +1,122 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/card_attachment_service.dart';
+import 'package:memex/data/services/system_action_service.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'user_id': 'system-action-user'});
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    AppDatabase.setTestInstance(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('SystemActionService', () {
+    test(
+      'action center dismiss hides pending actions without rejecting source visibility',
+      () async {
+        await SystemActionService.instance.createAction(
+          id: 'pending-calendar',
+          type: 'calendar',
+          factId: '2026/05/25.md#ts_7',
+          data: const {
+            'title': '天津小白院领证Party调研',
+            'start_time': '2026-06-06 09:00:00',
+          },
+        );
+
+        final dismissedCount = await CardAttachmentService.instance
+            .dismissAllPending(type: CardAttachmentType.systemAction);
+
+        expect(dismissedCount, 1);
+        expect(await SystemActionService.instance.getPending(), isEmpty);
+
+        final visibleForFact = await SystemActionService.instance
+            .getVisibleForFact('2026/05/25.md#ts_7');
+        expect(visibleForFact, hasLength(1));
+        expect(visibleForFact.single.status, 'dismissed');
+
+        final visibleForSchedule =
+            await SystemActionService.instance.getVisibleForSchedule();
+        expect(visibleForSchedule.map((action) => action.id), [
+          'pending-calendar',
+        ]);
+      },
+    );
+
+    test('hard rejection removes actions from fact and schedule visibility',
+        () async {
+      await SystemActionService.instance.createAction(
+        id: 'rejected-calendar',
+        type: 'calendar',
+        factId: '2026/05/25.md#ts_7',
+        data: const {
+          'title': '旧的小白院日程',
+          'start_time': '2026-06-06 09:00:00',
+        },
+      );
+      await SystemActionService.instance.updateActionStatus(
+        'rejected-calendar',
+        'rejected',
+      );
+
+      expect(
+        await SystemActionService.instance.getVisibleForFact(
+          '2026/05/25.md#ts_7',
+        ),
+        isEmpty,
+      );
+      expect(
+          await SystemActionService.instance.getVisibleForSchedule(), isEmpty);
+    });
+
+    test(
+        'schedule visibility includes completed and dismissed calendar/reminder only',
+        () async {
+      await SystemActionService.instance.createAction(
+        id: 'completed-calendar',
+        type: 'calendar',
+        data: const {
+          'title': '已添加日程',
+          'start_time': '2026-06-06 09:00:00',
+        },
+      );
+      await SystemActionService.instance.updateActionStatus(
+        'completed-calendar',
+        'completed',
+      );
+      await SystemActionService.instance.createAction(
+        id: 'dismissed-reminder',
+        type: 'reminder',
+        data: const {
+          'title': '已清掉提醒',
+          'due_date': '2026-06-07 12:00:00',
+        },
+      );
+      await SystemActionService.instance.updateActionStatus(
+        'dismissed-reminder',
+        'dismissed',
+      );
+      await SystemActionService.instance.createAction(
+        id: 'unsupported-action',
+        type: 'note',
+        data: const {'title': '不是日程动作'},
+      );
+
+      final visible =
+          await SystemActionService.instance.getVisibleForSchedule();
+
+      expect(
+        visible.map((action) => action.id),
+        ['completed-calendar', 'dismissed-reminder'],
+      );
+    });
+  });
+}

--- a/test/domain/models/schedule_aggregation_model_test.dart
+++ b/test/domain/models/schedule_aggregation_model_test.dart
@@ -39,6 +39,8 @@ void main() {
                 'start_time': '2026-04-23T14:00:00Z',
                 'type': 'event',
                 'priority': 2,
+                'display_first_seen_at': '2026-04-23',
+                'display_until': '2026-04-30',
               },
             ],
           },
@@ -75,6 +77,14 @@ void main() {
       expect(model.timeline.first.items.length, 1);
       expect(model.timeline.first.items.first.title, '设计评审');
       expect(model.timeline.first.items.first.subtasks, isEmpty);
+      expect(
+        model.timeline.first.items.first.displayFirstSeenAt,
+        DateTime(2026, 4, 23),
+      );
+      expect(
+        model.timeline.first.items.first.displayUntil,
+        DateTime(2026, 4, 30),
+      );
       expect(model.completed.length, 1);
       expect(model.completed.first.title, '架构评审');
       expect(model.conflicts.length, 1);
@@ -224,6 +234,8 @@ void main() {
                 title: 'Meeting',
                 status: 'pending',
                 type: 'event',
+                displayFirstSeenAt: DateTime(2026, 4, 23),
+                displayUntil: DateTime(2026, 4, 30),
                 subtasks: const [
                   ScheduleSubtask(title: 'Draft', completed: true),
                 ],
@@ -249,6 +261,14 @@ void main() {
       expect(
         restored.timeline.single.items.single.subtasks.single.completed,
         isTrue,
+      );
+      expect(
+        restored.timeline.single.items.single.displayFirstSeenAt,
+        DateTime(2026, 4, 23),
+      );
+      expect(
+        restored.timeline.single.items.single.displayUntil,
+        DateTime(2026, 4, 30),
       );
       expect(restored.completed.length, original.completed.length);
     });

--- a/test/ui/card_attachments/widgets/system_action_card_test.dart
+++ b/test/ui/card_attachments/widgets/system_action_card_test.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/system_action_service.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/card_attachments/widgets/system_action_card.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({'language': 'en'});
+    await UserStorage.initL10n();
+  });
+
+  Widget buildHost(Widget child) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('SystemActionCard', () {
+    testWidgets('renders dismissed actions as still actionable on source cards',
+        (tester) async {
+      await tester.pumpWidget(
+        buildHost(
+          SystemActionCard(
+            action: _action(status: 'dismissed'),
+            service: SystemActionService.instance,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('天津小白院领证Party调研'), findsOneWidget);
+      expect(find.text(UserStorage.l10n.addToCalendar), findsOneWidget);
+      expect(find.text(UserStorage.l10n.ignore), findsOneWidget);
+    });
+
+    testWidgets('keeps rejected actions hidden', (tester) async {
+      await tester.pumpWidget(
+        buildHost(
+          SystemActionCard(
+            action: _action(status: 'rejected'),
+            service: SystemActionService.instance,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('天津小白院领证Party调研'), findsNothing);
+      expect(find.text(UserStorage.l10n.addToCalendar), findsNothing);
+    });
+  });
+}
+
+SystemAction _action({required String status}) {
+  return SystemAction(
+    id: 'action-$status',
+    actionType: 'calendar',
+    actionData: jsonEncode({
+      'title': '天津小白院领证Party调研',
+      'start_time': '2026-06-06 09:00:00',
+      'location': '天津',
+    }),
+    status: status,
+    factId: '2026/05/25.md#ts_7',
+    createdAt: 0,
+    updatedAt: 0,
+  );
+}

--- a/test/ui/schedule/widgets/schedule_widgets_test.dart
+++ b/test/ui/schedule/widgets/schedule_widgets_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
+import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_retention.dart';
 import 'package:memex/domain/models/schedule_aggregation_model.dart';
 import 'package:memex/l10n/app_localizations.dart';
 import 'package:memex/ui/core/cards/templates/system/schedule_briefing_card.dart';
@@ -334,6 +335,89 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets(
+      'renders retained floating procedure without todo affordances',
+      (tester) async {
+        final tappedCards = <String>[];
+        final toggledTasks = <String>[];
+
+        await tester.pumpWidget(
+          buildHost(
+            MagazineNarrativeTab(
+              aggregation: _retainedFloatingProcedureAggregation(),
+              onTapCardId: tappedCards.add,
+              onToggleTask: toggledTasks.add,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('沙球转体转髋训练要点'), findsOneWidget);
+        expect(
+          find.byKey(const ValueKey('schedule_task_toggle_procedure-1')),
+          findsNothing,
+        );
+        expect(find.text('2026-05-28'), findsNothing);
+
+        await tester.tap(find.text('沙球转体转髋训练要点'));
+        await tester.pump();
+
+        expect(tappedCards, ['procedure-1']);
+        expect(toggledTasks, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'does not render expired floating items after retention filtering',
+      (tester) async {
+        final filtered = applyScheduleDisplayRetention(
+          yamlData: _retentionAggregationMap(
+            generatedAt: '2026-05-29T09:00:00+08:00',
+            items: [
+              _retentionItem(
+                cardId: 'procedure-1',
+                title: '沙球转体转髋训练要点',
+                type: 'procedure',
+              ),
+              _retentionItem(
+                cardId: 'task-tax',
+                title: '补税/退税确认',
+                type: 'task',
+              ),
+            ],
+          ),
+          previousAggregations: [
+            _retentionAggregationMap(
+              generatedAt: '2026-05-21T09:00:00+08:00',
+              items: [
+                _retentionItem(
+                  cardId: 'procedure-1',
+                  title: '沙球转体转髋训练要点',
+                  type: 'procedure',
+                ),
+              ],
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          buildHost(
+            MagazineNarrativeTab(
+              aggregation: ScheduleAggregationModel.fromYaml(filtered),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('沙球转体转髋训练要点'), findsNothing);
+        expect(find.text('补税/退税确认'), findsOneWidget);
+        expect(
+          find.byKey(const ValueKey('schedule_task_toggle_task-tax')),
+          findsOneWidget,
+        );
+      },
+    );
   });
 
   group('ScheduleBriefingCard', () {
@@ -423,6 +507,29 @@ ScheduleAggregationModel _subtaskAggregation() {
   );
 }
 
+ScheduleAggregationModel _retainedFloatingProcedureAggregation() {
+  return ScheduleAggregationModel(
+    id: 'agg_retained_procedure',
+    generatedAt: DateTime(2026, 5, 25, 11),
+    timeRange: TimeRange(from: DateTime(2026, 5, 21), to: DateTime(2026, 6, 1)),
+    timeline: [
+      TimelineDay(
+        dayLabel: '待安排',
+        items: [
+          TimelineItem(
+            cardId: 'procedure-1',
+            title: '沙球转体转髋训练要点',
+            type: 'procedure',
+            status: 'pending',
+            displayFirstSeenAt: DateTime(2026, 5, 21),
+            displayUntil: DateTime(2026, 5, 28),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
 ScheduleAggregationModel _complexAggregation({
   bool longText = false,
   String heroTitle = 'Visa renewal',
@@ -498,4 +605,28 @@ ScheduleAggregationModel _complexAggregation({
       ),
     ],
   );
+}
+
+Map<String, dynamic> _retentionAggregationMap({
+  required String generatedAt,
+  required List<Map<String, dynamic>> items,
+}) {
+  return {
+    'id': 'schedule_agg_retention_widget',
+    'generated_at': generatedAt,
+    'time_range': {'from': '2026-05-21', 'to': '2026-06-01'},
+    'timeline': [
+      {'day_label': '待安排', 'day_date': '', 'items': items},
+    ],
+    'completed': [],
+    'conflicts': [],
+  };
+}
+
+Map<String, dynamic> _retentionItem({
+  required String cardId,
+  required String title,
+  required String type,
+}) {
+  return {'card_id': cardId, 'title': title, 'status': 'pending', 'type': type};
 }


### PR DESCRIPTION
## 背景

这组改动修复从备份排查中发现的日程聚合体验问题：无日期长期关注项无法清除、未来真实日期事件被窗口漏掉、Action Center 清空误等同拒绝系统动作，以及诊断输入误触发系统动作创建。

最新 `main` 已经把系统动作拆到独立 `SystemActionAgent`，所以本 PR 保持 PKM agent prompt 不变，只在系统动作 agent/skill 上加窄范围保护。

Fixes #190

## 主要改动

- 为无日期非 task 日程项增加 7 天展示期限：
  - 写入 `display_first_seen_at` / `display_until`
  - 继承历史期限，刷新不续期
  - 过期后在保存/读取路径过滤
  - task/todo 和有具体日期的非 task 不受影响

- 修正日程聚合窗口：
  - 默认 lookahead 从 7 天扩到 30 天
  - dirty refresh 同时参考 fact 日期和卡片真实 `start_time` / `due_date`
  - 防止 5 月记录、6 月发生的事件被漏掉

- 修正系统动作语义：
  - Action Center 批量清空改为 `dismissed`，不再写成 `rejected`
  - 来源卡片和日程仍可展示 dismissed 动作
  - hard reject 仍继续隐藏
  - 日程查询纳入非 rejected 的 calendar/reminder，并按标题+时间去重

- 兼容最新 agent 重构：
  - 不改 PKM agent prompt
  - 在 `SystemActionAgent` / `SystemActionSkill` 中明确诊断/排查输入不是创建日程同意
  - `getScheduleAggregation` 先做长期项过滤，再做 live task hydration
  - hydration 只读取真实 factId，跳过 `system_action:*` 等合成 id

## 验证

- `flutter test --no-pub --concurrency=1 test/agent/skills/schedule_aggregation_skill_test.dart test/agent/skills/schedule_aggregation_retention_test.dart test/agent/schedule_aggregation_run_context_test.dart test/data/services/system_action_service_test.dart test/data/repositories/get_schedule_aggregation_test.dart test/domain/models/schedule_aggregation_model_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart test/ui/card_attachments/widgets/system_action_card_test.dart test/agent/task_completion_agent_test.dart`
- `flutter analyze --no-pub`（touched files）
- `git diff --check`
