### PR TITLE
[codex] 增强后台 Agent 保活与进度展示

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,9 @@
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <!-- Notification permission for Android 13+ -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- Health Connect permissions removed to comply with Google Play policy.
@@ -154,6 +156,10 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/update_file_paths" />
         </provider>
+        <service
+            android:name="com.memexlab.memex.AgentBackgroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data android:name="flutterEmbedding" android:value="2" />

--- a/android/app/src/main/kotlin/com/memexlab/memex/AgentBackgroundService.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/AgentBackgroundService.kt
@@ -1,0 +1,160 @@
+package com.memexlab.memex
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import androidx.core.app.NotificationCompat
+import com.memexlab.memex.channels.AgentBackgroundChannelHandler
+
+class AgentBackgroundService : Service() {
+    companion object {
+        const val ACTION_UPDATE = "com.memexlab.memex.agent_background.UPDATE"
+        const val ACTION_STOP = "com.memexlab.memex.agent_background.STOP"
+
+        private const val CHANNEL_ID = "agent_background"
+        private const val CHANNEL_NAME = "Agent processing"
+        private const val NOTIFICATION_ID = 188
+    }
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val stopRunnable = Runnable {
+        stopForegroundCompat(removeNotification = true)
+        stopSelf()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        createNotificationChannel()
+
+        if (intent == null) {
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+
+        if (intent.action == ACTION_STOP) {
+            stopForegroundCompat(removeNotification = true)
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+
+        val state = intent.getStringExtra("state") ?: "active"
+        val notification = buildNotification(intent, state)
+        startForegroundCompat(notification)
+
+        handler.removeCallbacks(stopRunnable)
+        if (state == "completed" || state == "failed" || state == "idle") {
+            handler.postDelayed(stopRunnable, 5000)
+        }
+
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacks(stopRunnable)
+        super.onDestroy()
+    }
+
+    private fun buildNotification(intent: Intent?, state: String): Notification {
+        val title = intent?.getStringExtra("title") ?: "Memex is processing"
+        val stage = intent?.getStringExtra("stage") ?: "Processing"
+        val detail = intent?.getStringExtra("detail") ?: ""
+        val remainingTasks = intent?.getIntExtra("remainingTasks", 0) ?: 0
+        val pending = intent?.getIntExtra("pending", 0) ?: 0
+        val processing = intent?.getIntExtra("processing", 0) ?: 0
+        val retrying = intent?.getIntExtra("retrying", 0) ?: 0
+
+        val openIntent = Intent(this, MainActivity::class.java).apply {
+            action = AgentBackgroundChannelHandler.ACTION_OPEN_AGENT_ACTIVITY
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("memex_action", "agent_activity")
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            openIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val subText = when (state) {
+            "completed" -> "All tasks finished"
+            "failed" -> "Tap to review"
+            else -> "$remainingTasks remaining"
+        }
+        val body = listOf(
+            stage,
+            detail,
+            "running $processing - waiting $pending - retrying $retrying",
+        ).filter { it.isNotBlank() }.joinToString("\n")
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_quick_note)
+            .setContentTitle(title)
+            .setContentText(subText)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setContentIntent(pendingIntent)
+            .setOngoing(state == "active")
+            .setAutoCancel(state != "active")
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+
+        if (state == "active" && remainingTasks > 0) {
+            builder.setProgress(0, 0, true)
+        }
+
+        return builder.build()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val manager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Shows Memex agent background processing status"
+            setShowBadge(false)
+        }
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun startForegroundCompat(notification: Notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun stopForegroundCompat(removeNotification: Boolean) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            stopForeground(
+                if (removeNotification) {
+                    STOP_FOREGROUND_REMOVE
+                } else {
+                    STOP_FOREGROUND_DETACH
+                },
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            stopForeground(removeNotification)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/AgentBackgroundChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/AgentBackgroundChannelHandler.kt
@@ -1,0 +1,87 @@
+package com.memexlab.memex.channels
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import com.memexlab.memex.AgentBackgroundService
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+object AgentBackgroundChannelHandler {
+    private const val CHANNEL = "com.memexlab.memex/agent_background"
+    const val ACTION_OPEN_AGENT_ACTIVITY = "com.memexlab.memex.OPEN_AGENT_ACTIVITY"
+
+    private var channel: MethodChannel? = null
+    private var dartReady = false
+    private var pendingOpenAgentActivity = false
+
+    fun register(flutterEngine: FlutterEngine, activity: Activity) {
+        dartReady = false
+        channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+        channel?.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "updateAgentStatus" -> {
+                    startOrUpdateService(activity, call)
+                    result.success(null)
+                }
+                "finishAgentStatus" -> {
+                    startOrUpdateService(activity, call)
+                    result.success(null)
+                }
+                "stopAgentStatus" -> {
+                    stopService(activity)
+                    result.success(null)
+                }
+                "consumeInitialAgentAction" -> {
+                    dartReady = true
+                    if (pendingOpenAgentActivity) {
+                        pendingOpenAgentActivity = false
+                        result.success("agent_activity")
+                    } else {
+                        result.success(null)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    fun handleIntent(intent: Intent?) {
+        if (intent?.action != ACTION_OPEN_AGENT_ACTIVITY &&
+            intent?.getStringExtra("memex_action") != "agent_activity"
+        ) {
+            return
+        }
+
+        pendingOpenAgentActivity = true
+        if (dartReady) {
+            pendingOpenAgentActivity = false
+            channel?.invokeMethod("openAgentActivity", null)
+        }
+    }
+
+    private fun startOrUpdateService(context: Context, call: MethodCall) {
+        val args = call.arguments as? Map<*, *> ?: emptyMap<String, Any?>()
+        val intent = Intent(context, AgentBackgroundService::class.java).apply {
+            action = AgentBackgroundService.ACTION_UPDATE
+            putExtra("state", args["state"] as? String ?: "active")
+            putExtra("title", args["title"] as? String ?: "Memex is processing")
+            putExtra("stage", args["stage"] as? String ?: "Processing")
+            putExtra("detail", args["detail"] as? String ?: "")
+            putExtra("remainingTasks", (args["remainingTasks"] as? Number)?.toInt() ?: 0)
+            putExtra("pending", (args["pending"] as? Number)?.toInt() ?: 0)
+            putExtra("processing", (args["processing"] as? Number)?.toInt() ?: 0)
+            putExtra("retrying", (args["retrying"] as? Number)?.toInt() ?: 0)
+        }
+        ContextCompat.startForegroundService(context, intent)
+    }
+
+    private fun stopService(context: Context) {
+        val intent = Intent(context, AgentBackgroundService::class.java).apply {
+            action = AgentBackgroundService.ACTION_STOP
+        }
+        context.stopService(intent)
+    }
+}

--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/ChannelRegistrar.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/ChannelRegistrar.kt
@@ -21,5 +21,6 @@ object ChannelRegistrar {
         AppUpdateChannelHandler.register(flutterEngine, activity)
         BackupStorageChannelHandler.register(flutterEngine, activity)
         BackupImportChannelHandler.register(flutterEngine, activity)
+        AgentBackgroundChannelHandler.register(flutterEngine, activity)
     }
 }

--- a/android/app/src/main/kotlin/com/weshop/memex/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/weshop/memex/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.memexlab.memex
 
 import android.content.Intent
+import com.memexlab.memex.channels.AgentBackgroundChannelHandler
 import com.memexlab.memex.channels.BackupImportChannelHandler
 import com.memexlab.memex.channels.BackupStorageChannelHandler
 import com.memexlab.memex.channels.ChannelRegistrar
@@ -18,12 +19,14 @@ class MainActivity : FlutterFragmentActivity() {
         }
         super.onCreate(savedInstanceState)
         BackupImportChannelHandler.handleIntent(this, intent)
+        AgentBackgroundChannelHandler.handleIntent(intent)
     }
 
     override fun onNewIntent(intent: android.content.Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         BackupImportChannelHandler.handleIntent(this, intent)
+        AgentBackgroundChannelHandler.handleIntent(intent)
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -18,6 +18,7 @@ import 'package:memex/data/services/table_change_notifier.dart';
 import 'package:memex/data/services/card_attachment_service.dart';
 import 'package:memex/data/services/card_detail_notifier.dart';
 import 'package:memex/data/services/clarification_request_service.dart';
+import 'package:memex/data/services/agent_background_coordinator.dart';
 import 'package:memex/data/services/agent_background_task_service.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/app_update_service.dart';
@@ -132,95 +133,7 @@ class MemexRouter {
       // Register clarification request table watcher (creates timeline cards for global Ask)
       ClarificationRequestService.instance.init();
 
-      // Register Task Handlers - idempotent registration or check if registered?
-      // LocalTaskExecutor handles this map, re-registering overwrites which is fine.
-      LocalTaskExecutor.instance.registerHandler(
-        'handle_analyze_assets',
-        handleAnalyzeAssetsImpl,
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'card_agent_task',
-        handleCardAgentImpl,
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'pkm_agent_task',
-        handlePkmAgentImpl,
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'fts_index_update',
-        handleFtsIndexUpdateImpl,
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'reprocess_cards_task',
-        handleReprocessCardsImpl,
-        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'comment_agent_task',
-        handleCommentAgentImpl,
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'reprocess_comments_task',
-        handleReprocessCommentsImpl,
-        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'reprocess_knowledge_base_task',
-        handleReprocessKnowledgeBaseImpl,
-        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'process_ai_reply',
-        handleProcessAiReplyImpl,
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'knowledge_insight_task',
-        handleKnowledgeInsight,
-        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'schedule_aggregator_task',
-        handleScheduleAggregation,
-        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'post_card_router_task',
-        handlePostCardRouter,
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'ask_clarification_task',
-        handleAskClarificationTask,
-      );
-      LocalTaskExecutor.instance.registerHandler(
-        'clarification_resolution_task',
-        handleClarificationResolution,
-      );
-
-      // Register Failure Handlers
-      LocalTaskExecutor.instance.registerFailureHandler(
-        'card_agent_task',
-        handleCardAgentFailureImpl,
-      );
-      // Generic failure handler for all other agent tasks — emits ErrorNotificationMessage
-      for (final taskType in [
-        'pkm_agent_task',
-        'comment_agent_task',
-        'knowledge_insight_task',
-        'schedule_aggregator_task',
-        'post_card_router_task',
-        'ask_clarification_task',
-        'clarification_resolution_task',
-        'reprocess_cards_task',
-        'reprocess_comments_task',
-        'reprocess_knowledge_base_task',
-        'process_ai_reply',
-        'handle_analyze_assets',
-      ]) {
-        LocalTaskExecutor.instance.registerFailureHandler(
-          taskType,
-          handleGenericAgentFailure,
-        );
-      }
+      _registerTaskHandlers(LocalTaskExecutor.instance);
 
       // Register event subscriptions after task handlers are ready.
       _registerEventSubscriptions();
@@ -230,6 +143,10 @@ class MemexRouter {
       registerBuiltInEventSerializers();
       await CustomAgentConfigService.instance.registerAll(userId);
       await AgentBackgroundTaskService.instance.startMonitoring();
+      AgentBackgroundCoordinator.instance.start(
+        executor: LocalTaskExecutor.instance,
+        activityService: LocalAgentActivityService.instance,
+      );
 
       // Register file change callback and FTS event subscriptions.
       // Also triggers a one-time full rebuild when FTS tables were just created
@@ -247,7 +164,7 @@ class MemexRouter {
   }
 
   String?
-  _targetUserIdForInit; // Track the user ID we are currently initializing for
+      _targetUserIdForInit; // Track the user ID we are currently initializing for
 
   void _registerEventSubscriptions() {
     final eventBus = GlobalEventBus.instance;
@@ -440,6 +357,120 @@ class MemexRouter {
     return _initFuture!;
   }
 
+  Future<void> ensureInitialized() => _ensureInitialized();
+
+  /// Initializes only the task queue pieces needed from a WorkManager callback
+  /// isolate.
+  ///
+  /// Keep this as a background-only entry point. It deliberately avoids
+  /// front-end observers, UI notifiers, event subscriptions, search startup, and
+  /// platform background surfaces that are already owned by the foreground
+  /// isolate.
+  static Future<void> ensureTaskQueueInitializedForBackgroundTask(
+    String userId, {
+    LocalTaskExecutor? executor,
+  }) async {
+    final dataRoot = await UserStorage.resolveDataRoot(userId);
+    await FileSystemService.init(dataRoot);
+    await AppDatabase.init(userId);
+
+    final taskExecutor = executor ?? LocalTaskExecutor.instance;
+    AgentActivityService.setInstance(LocalAgentActivityService.instance);
+    _registerTaskHandlers(taskExecutor);
+    initCustomAgentHandler();
+    registerBuiltInEventSerializers();
+    await CustomAgentConfigService.instance.registerAll(userId);
+  }
+
+  static void _registerTaskHandlers(LocalTaskExecutor executor) {
+    // LocalTaskExecutor handles this map; re-registering overwrites which is fine.
+    executor.registerHandler(
+      'handle_analyze_assets',
+      handleAnalyzeAssetsImpl,
+    );
+    executor.registerHandler(
+      'card_agent_task',
+      handleCardAgentImpl,
+    );
+    executor.registerHandler(
+      'pkm_agent_task',
+      handlePkmAgentImpl,
+    );
+    executor.registerHandler(
+      'fts_index_update',
+      handleFtsIndexUpdateImpl,
+    );
+    executor.registerHandler(
+      'reprocess_cards_task',
+      handleReprocessCardsImpl,
+      concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+    );
+    executor.registerHandler(
+      'comment_agent_task',
+      handleCommentAgentImpl,
+    );
+    executor.registerHandler(
+      'reprocess_comments_task',
+      handleReprocessCommentsImpl,
+      concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+    );
+    executor.registerHandler(
+      'reprocess_knowledge_base_task',
+      handleReprocessKnowledgeBaseImpl,
+      concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+    );
+    executor.registerHandler(
+      'process_ai_reply',
+      handleProcessAiReplyImpl,
+    );
+    executor.registerHandler(
+      'knowledge_insight_task',
+      handleKnowledgeInsight,
+      concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+    );
+    executor.registerHandler(
+      'schedule_aggregator_task',
+      handleScheduleAggregation,
+      concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+    );
+    executor.registerHandler(
+      'post_card_router_task',
+      handlePostCardRouter,
+    );
+    executor.registerHandler(
+      'ask_clarification_task',
+      handleAskClarificationTask,
+    );
+    executor.registerHandler(
+      'clarification_resolution_task',
+      handleClarificationResolution,
+    );
+
+    executor.registerFailureHandler(
+      'card_agent_task',
+      handleCardAgentFailureImpl,
+    );
+    for (final taskType in [
+      'pkm_agent_task',
+      'comment_agent_task',
+      'knowledge_insight_task',
+      'schedule_aggregator_task',
+      'post_card_router_task',
+      'ask_clarification_task',
+      'clarification_resolution_task',
+      'reprocess_cards_task',
+      'reprocess_comments_task',
+      'reprocess_knowledge_base_task',
+      'process_ai_reply',
+      'handle_analyze_assets',
+    ]) {
+      executor.registerFailureHandler(
+        taskType,
+        handleGenericAgentFailure,
+      );
+    }
+  }
+
   /// External hook to force switch user (e.g. on login)
   Future<void> switchUser(String userId) async {
     _logger.info('Switching user to $userId');
@@ -488,6 +519,7 @@ class MemexRouter {
     _logger.info('Resetting MemexRouter for logout');
     _targetUserIdForInit = null;
     _initFuture = null;
+    unawaited(AgentBackgroundCoordinator.instance.stop());
     unawaited(AgentBackgroundTaskService.instance.stopMonitoring(
       reason: 'logout',
     ));
@@ -496,6 +528,7 @@ class MemexRouter {
   }
 
   void dispose() {
+    unawaited(AgentBackgroundCoordinator.instance.stop());
     unawaited(AgentBackgroundTaskService.instance.stopMonitoring(
       reason: 'router_dispose',
     ));
@@ -1057,8 +1090,8 @@ class MemexRouter {
             id,
           );
           if (cardData != null) {
-            final currentSortOrder = (cardData['sort_order'] as num? ?? 0)
-                .toInt();
+            final currentSortOrder =
+                (cardData['sort_order'] as num? ?? 0).toInt();
             if (currentSortOrder != i) {
               cardData['sort_order'] = i;
               await fileSystemService.writeKnowledgeInsightCard(
@@ -1160,23 +1193,24 @@ class MemexRouter {
     required String itemId,
     required String subtaskTitle,
     required bool completed,
-  }) => runResultVoid(() async {
-    await _ensureInitialized();
-    final userId = await UserStorage.getUserId();
-    if (userId == null) {
-      throw Exception('User not logged in');
-    }
+  }) =>
+      runResultVoid(() async {
+        await _ensureInitialized();
+        final userId = await UserStorage.getUserId();
+        if (userId == null) {
+          throw Exception('User not logged in');
+        }
 
-    await ScheduleStateService.instance.setSubtaskCompletion(
-      userId: userId,
-      pendingId: itemId,
-      subtaskTitle: subtaskTitle,
-      completed: completed,
-    );
-    EventBusService.instance.emitEvent(
-      ScheduleAggregationUpdatedMessage(aggregationId: 'schedule_state'),
-    );
-  });
+        await ScheduleStateService.instance.setSubtaskCompletion(
+          userId: userId,
+          pendingId: itemId,
+          subtaskTitle: subtaskTitle,
+          completed: completed,
+        );
+        EventBusService.instance.emitEvent(
+          ScheduleAggregationUpdatedMessage(aggregationId: 'schedule_state'),
+        );
+      });
 
   Future<bool> updateCardTime(String cardId, int timestamp) async {
     await _ensureInitialized();
@@ -1671,38 +1705,38 @@ class MemexRouter {
   Future<void> resetAllAgentConfigs() => UserStorage.resetAllAgentConfigs();
 
   Future<Result<void>> updateKnowledgeInsights() => runResultVoid(() async {
-    await _ensureInitialized();
-    final userId = await UserStorage.getUserId();
-    if (userId == null) {
-      throw Exception('User not logged in');
-    }
+        await _ensureInitialized();
+        final userId = await UserStorage.getUserId();
+        if (userId == null) {
+          throw Exception('User not logged in');
+        }
 
-    await GlobalEventBus.instance.publish(
-      userId: userId,
-      event: SystemEvent(
-        type: SystemEventTypes.knowledgeInsightRefreshRequested,
-        source: 'memex_router.updateKnowledgeInsights',
-        payload: const {},
-      ),
-    );
-  });
+        await GlobalEventBus.instance.publish(
+          userId: userId,
+          event: SystemEvent(
+            type: SystemEventTypes.knowledgeInsightRefreshRequested,
+            source: 'memex_router.updateKnowledgeInsights',
+            payload: const {},
+          ),
+        );
+      });
 
   Future<Result<void>> refreshScheduleAggregation() => runResultVoid(() async {
-    await _ensureInitialized();
-    final userId = await UserStorage.getUserId();
-    if (userId == null) {
-      throw Exception('User not logged in');
-    }
+        await _ensureInitialized();
+        final userId = await UserStorage.getUserId();
+        if (userId == null) {
+          throw Exception('User not logged in');
+        }
 
-    await GlobalEventBus.instance.publish(
-      userId: userId,
-      event: SystemEvent(
-        type: SystemEventTypes.scheduleAggregationRequested,
-        source: 'memex_router.refreshScheduleAggregation',
-        payload: const {},
-      ),
-    );
-  });
+        await GlobalEventBus.instance.publish(
+          userId: userId,
+          event: SystemEvent(
+            type: SystemEventTypes.scheduleAggregationRequested,
+            source: 'memex_router.refreshScheduleAggregation',
+            payload: const {},
+          ),
+        );
+      });
 
   Future<List<Task>> getTasks({int limit = 10, int offset = 0}) =>
       LocalTaskExecutor.instance.getTasks(limit: limit, offset: offset);

--- a/lib/data/services/agent_background_coordinator.dart
+++ b/lib/data/services/agent_background_coordinator.dart
@@ -1,0 +1,250 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/agent_background_platform.dart';
+import 'package:memex/data/services/agent_background_status.dart';
+import 'package:memex/data/services/agent_queue_drain_scheduler.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/utils/logger.dart';
+
+class AgentBackgroundCoordinator with WidgetsBindingObserver {
+  AgentBackgroundCoordinator({
+    AgentBackgroundPlatform? platform,
+    AgentQueueDrainScheduler? scheduler,
+    AppLifecycleState? initialLifecycleState,
+  })  : _platform = platform ?? MethodChannelAgentBackgroundPlatform(),
+        _scheduler = scheduler ?? WorkmanagerAgentQueueDrainScheduler(),
+        _initialLifecycleState = initialLifecycleState;
+
+  static AgentBackgroundCoordinator? _instance;
+  static AgentBackgroundCoordinator get instance {
+    _instance ??= AgentBackgroundCoordinator();
+    return _instance!;
+  }
+
+  final AgentBackgroundPlatform _platform;
+  final AgentQueueDrainScheduler _scheduler;
+  final _logger = getLogger('AgentBackgroundCoordinator');
+
+  StreamSubscription<TaskActivitySnapshot>? _taskSubscription;
+  StreamSubscription<AgentActivityMessageModel>? _messageSubscription;
+  StreamSubscription<String>? _actionSubscription;
+  late final StreamController<void> _openActivityController =
+      StreamController<void>.broadcast(
+    onListen: _flushPendingOpenActivityRequest,
+  );
+
+  TaskActivitySnapshot _taskSnapshot = const TaskActivitySnapshot.empty();
+  AgentActivityMessageModel? _latestMessage;
+  AgentBackgroundStatus? _lastPublishedStatus;
+  Future<void> _publishChain = Future<void>.value();
+  Timer? _terminalStopTimer;
+  bool _started = false;
+  bool _drainWorkScheduledForCurrentRun = false;
+  bool _hasPendingOpenActivityRequest = false;
+  final AppLifecycleState? _initialLifecycleState;
+  AppLifecycleState _lifecycleState = AppLifecycleState.resumed;
+  int _publishGeneration = 0;
+
+  Stream<void> get openActivityRequests => _openActivityController.stream;
+
+  void start({
+    required LocalTaskExecutor executor,
+    required AgentActivityService activityService,
+  }) {
+    if (_started || !_platform.isSupported) return;
+    _started = true;
+    _lifecycleState = _initialLifecycleState ??
+        WidgetsBinding.instance.lifecycleState ??
+        AppLifecycleState.resumed;
+    WidgetsBinding.instance.addObserver(this);
+
+    _taskSubscription = executor.taskActivitySnapshotStream.listen(
+      _handleTaskSnapshot,
+    );
+    _messageSubscription = activityService.messageStream.listen(
+      _handleActivityMessage,
+    );
+    _actionSubscription = _platform.actionStream.listen(_handleAction);
+
+    unawaited(_consumeInitialAction());
+    _queuePublishStatus();
+  }
+
+  Future<void> stop() async {
+    _started = false;
+    WidgetsBinding.instance.removeObserver(this);
+    _terminalStopTimer?.cancel();
+    _terminalStopTimer = null;
+    await _taskSubscription?.cancel();
+    await _messageSubscription?.cancel();
+    await _actionSubscription?.cancel();
+    _taskSubscription = null;
+    _messageSubscription = null;
+    _actionSubscription = null;
+    _taskSnapshot = const TaskActivitySnapshot.empty();
+    _latestMessage = null;
+    _lastPublishedStatus = null;
+    _drainWorkScheduledForCurrentRun = false;
+    _publishGeneration++;
+    await _safeStopPlatform();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    _lifecycleState = state;
+    if (_started &&
+        state != AppLifecycleState.resumed &&
+        _taskSnapshot.hasActiveTasks) {
+      unawaited(_scheduleDrainIfNeeded());
+    }
+  }
+
+  void _handleTaskSnapshot(TaskActivitySnapshot snapshot) {
+    _taskSnapshot = snapshot;
+    if (!snapshot.hasActiveTasks) {
+      _drainWorkScheduledForCurrentRun = false;
+    }
+    _queuePublishStatus();
+  }
+
+  void _handleActivityMessage(AgentActivityMessageModel message) {
+    _latestMessage = message;
+    _queuePublishStatus();
+  }
+
+  void _handleAction(String action) {
+    if (action == 'agent_activity') {
+      if (_openActivityController.hasListener) {
+        _openActivityController.add(null);
+      } else {
+        _hasPendingOpenActivityRequest = true;
+      }
+    }
+  }
+
+  void _flushPendingOpenActivityRequest() {
+    if (!_hasPendingOpenActivityRequest) return;
+    _hasPendingOpenActivityRequest = false;
+    scheduleMicrotask(() {
+      if (!_openActivityController.isClosed) {
+        _openActivityController.add(null);
+      }
+    });
+  }
+
+  Future<void> _consumeInitialAction() async {
+    try {
+      final action = await _platform.consumeInitialAction();
+      if (action != null) _handleAction(action);
+    } catch (e, stackTrace) {
+      _logger.warning(
+        'Failed to consume initial background action',
+        e,
+        stackTrace,
+      );
+    }
+  }
+
+  void _queuePublishStatus() {
+    if (!_started) return;
+    final generation = ++_publishGeneration;
+    _publishChain = _publishChain.then((_) => _publishStatus(generation));
+    unawaited(_publishChain);
+  }
+
+  Future<void> _publishStatus(int generation) async {
+    if (!_started || generation != _publishGeneration) return;
+
+    final status = AgentBackgroundStatus.fromActivity(
+      taskSnapshot: _taskSnapshot,
+      latestMessage: _latestMessage,
+    );
+
+    if (!_started || generation != _publishGeneration) return;
+    if (status == _lastPublishedStatus) return;
+    final previousPublishedStatus = _lastPublishedStatus;
+    _lastPublishedStatus = status;
+
+    _terminalStopTimer?.cancel();
+    _terminalStopTimer = null;
+
+    try {
+      if (status.state == AgentBackgroundRunState.idle) {
+        await _safeStopPlatform();
+        await _scheduler.cancel();
+        return;
+      }
+
+      if (status.state == AgentBackgroundRunState.active) {
+        await _platform.updateStatus(status);
+        if (!_started || generation != _publishGeneration) return;
+        await _scheduleDrainIfNeeded();
+        return;
+      }
+
+      await _platform.finishStatus(status);
+      if (!_started || generation != _publishGeneration) return;
+      await _scheduler.cancel();
+      _terminalStopTimer = Timer(const Duration(seconds: 5), () {
+        unawaited(_safeStopPlatform());
+      });
+    } catch (e, stackTrace) {
+      _lastPublishedStatus = previousPublishedStatus;
+      if (status.state == AgentBackgroundRunState.active) {
+        _drainWorkScheduledForCurrentRun = false;
+      }
+      _logger.warning(
+        'Failed to publish agent background status',
+        e,
+        stackTrace,
+      );
+    }
+  }
+
+  Future<void> _safeStopPlatform() async {
+    try {
+      await _platform.stopStatus();
+    } catch (e, stackTrace) {
+      _logger.fine('Failed to stop agent background surface', e, stackTrace);
+    }
+  }
+
+  Future<void> _scheduleDrainIfNeeded() async {
+    if (!_started ||
+        _drainWorkScheduledForCurrentRun ||
+        _lifecycleState == AppLifecycleState.resumed) {
+      return;
+    }
+
+    _drainWorkScheduledForCurrentRun = true;
+    try {
+      await _scheduler.schedule(expedited: true);
+    } catch (e, stackTrace) {
+      _drainWorkScheduledForCurrentRun = false;
+      _logger.warning(
+        'Failed to schedule agent queue drain',
+        e,
+        stackTrace,
+      );
+    }
+  }
+}
+
+@visibleForTesting
+void resetAgentBackgroundCoordinatorForTesting() {
+  AgentBackgroundCoordinator._instance = null;
+}
+
+@visibleForTesting
+void setAgentBackgroundCoordinatorForTesting(
+  AgentBackgroundCoordinator coordinator,
+) {
+  AgentBackgroundCoordinator._instance = coordinator;
+}
+
+@visibleForTesting
+void emitAgentBackgroundOpenActivityForTesting() {
+  AgentBackgroundCoordinator.instance._handleAction('agent_activity');
+}

--- a/lib/data/services/agent_background_platform.dart
+++ b/lib/data/services/agent_background_platform.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:memex/data/services/agent_background_status.dart';
+
+abstract class AgentBackgroundPlatform {
+  bool get isSupported;
+
+  Stream<String> get actionStream;
+
+  Future<void> updateStatus(AgentBackgroundStatus status);
+
+  Future<void> finishStatus(AgentBackgroundStatus status);
+
+  Future<void> stopStatus();
+
+  Future<String?> consumeInitialAction();
+}
+
+class MethodChannelAgentBackgroundPlatform implements AgentBackgroundPlatform {
+  MethodChannelAgentBackgroundPlatform({MethodChannel? channel})
+    : _channel = channel ?? const MethodChannel(_channelName) {
+    _channel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  static const String _channelName = 'com.memexlab.memex/agent_background';
+
+  final MethodChannel _channel;
+  final _actionController = StreamController<String>.broadcast();
+
+  @override
+  bool get isSupported => defaultTargetPlatform == TargetPlatform.android;
+
+  @override
+  Stream<String> get actionStream => _actionController.stream;
+
+  @override
+  Future<void> updateStatus(AgentBackgroundStatus status) {
+    if (!isSupported) return Future<void>.value();
+    return _channel.invokeMethod<void>(
+      'updateAgentStatus',
+      status.toPlatformMap(),
+    );
+  }
+
+  @override
+  Future<void> finishStatus(AgentBackgroundStatus status) {
+    if (!isSupported) return Future<void>.value();
+    return _channel.invokeMethod<void>(
+      'finishAgentStatus',
+      status.toPlatformMap(),
+    );
+  }
+
+  @override
+  Future<void> stopStatus() {
+    if (!isSupported) return Future<void>.value();
+    return _channel.invokeMethod<void>('stopAgentStatus');
+  }
+
+  @override
+  Future<String?> consumeInitialAction() {
+    if (!isSupported) return Future<String?>.value();
+    return _channel.invokeMethod<String>('consumeInitialAgentAction');
+  }
+
+  Future<void> _handleMethodCall(MethodCall call) async {
+    if (call.method == 'openAgentActivity') {
+      _actionController.add('agent_activity');
+    }
+  }
+}

--- a/lib/data/services/agent_background_status.dart
+++ b/lib/data/services/agent_background_status.dart
@@ -1,0 +1,187 @@
+import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+
+enum AgentBackgroundRunState { idle, active, completed, failed }
+
+class AgentBackgroundStatus {
+  const AgentBackgroundStatus({
+    required this.state,
+    required this.pending,
+    required this.processing,
+    required this.retrying,
+    required this.title,
+    required this.stage,
+    required this.detail,
+    required this.agentName,
+    required this.updatedAt,
+    this.scene,
+    this.sceneId,
+  });
+
+  factory AgentBackgroundStatus.fromActivity({
+    required TaskActivitySnapshot taskSnapshot,
+    AgentActivityMessageModel? latestMessage,
+    DateTime? now,
+  }) {
+    final messageType = latestMessage?.type;
+    final hasTasks = taskSnapshot.hasActiveTasks;
+    final state = switch (messageType) {
+      AgentActivityType.error when !hasTasks => AgentBackgroundRunState.failed,
+      AgentActivityType.agent_stop when !hasTasks =>
+        AgentBackgroundRunState.completed,
+      _ when hasTasks => AgentBackgroundRunState.active,
+      _ => AgentBackgroundRunState.idle,
+    };
+
+    final fallbackStage = switch (state) {
+      AgentBackgroundRunState.failed => 'Needs attention',
+      AgentBackgroundRunState.completed => 'Completed',
+      AgentBackgroundRunState.active => 'Processing',
+      AgentBackgroundRunState.idle => 'Idle',
+    };
+
+    final title = switch (state) {
+      AgentBackgroundRunState.failed => 'Memex task needs attention',
+      AgentBackgroundRunState.completed => 'Memex task complete',
+      AgentBackgroundRunState.active => 'Memex is processing',
+      AgentBackgroundRunState.idle => 'Memex is idle',
+    };
+
+    final stage =
+        _firstNonBlank([latestMessage?.title, latestMessage?.agentName]) ??
+        fallbackStage;
+
+    final detail = _detailFor(
+      taskSnapshot: taskSnapshot,
+      latestMessage: latestMessage,
+      state: state,
+    );
+
+    return AgentBackgroundStatus(
+      state: state,
+      pending: taskSnapshot.pending,
+      processing: taskSnapshot.processing,
+      retrying: taskSnapshot.retrying,
+      title: title,
+      stage: stage,
+      detail: detail,
+      agentName: latestMessage?.agentName ?? '',
+      scene: latestMessage?.scene,
+      sceneId: latestMessage?.sceneId,
+      updatedAt: now ?? DateTime.now(),
+    );
+  }
+
+  final AgentBackgroundRunState state;
+  final int pending;
+  final int processing;
+  final int retrying;
+  final String title;
+  final String stage;
+  final String detail;
+  final String agentName;
+  final String? scene;
+  final String? sceneId;
+  final DateTime updatedAt;
+
+  int get remainingTasks => pending + processing + retrying;
+
+  bool get hasActiveTasks => remainingTasks > 0;
+
+  bool get shouldShowSystemSurface =>
+      state == AgentBackgroundRunState.active ||
+      state == AgentBackgroundRunState.completed ||
+      state == AgentBackgroundRunState.failed;
+
+  Map<String, dynamic> toPlatformMap() {
+    return {
+      'state': state.name,
+      'pending': pending,
+      'processing': processing,
+      'retrying': retrying,
+      'remainingTasks': remainingTasks,
+      'title': title,
+      'stage': stage,
+      'detail': detail,
+      'agentName': agentName,
+      'scene': scene,
+      'sceneId': sceneId,
+      'updatedAtMs': updatedAt.millisecondsSinceEpoch,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AgentBackgroundStatus &&
+        other.state == state &&
+        other.pending == pending &&
+        other.processing == processing &&
+        other.retrying == retrying &&
+        other.title == title &&
+        other.stage == stage &&
+        other.detail == detail &&
+        other.agentName == agentName &&
+        other.scene == scene &&
+        other.sceneId == sceneId;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    state,
+    pending,
+    processing,
+    retrying,
+    title,
+    stage,
+    detail,
+    agentName,
+    scene,
+    sceneId,
+  );
+}
+
+String _detailFor({
+  required TaskActivitySnapshot taskSnapshot,
+  required AgentActivityMessageModel? latestMessage,
+  required AgentBackgroundRunState state,
+}) {
+  final messageContent = _trimToSingleLine(latestMessage?.content);
+  if (messageContent != null) return messageContent;
+
+  if (taskSnapshot.hasActiveTasks) {
+    final parts = <String>[];
+    if (taskSnapshot.processing > 0) {
+      parts.add('${taskSnapshot.processing} running');
+    }
+    if (taskSnapshot.pending > 0) {
+      parts.add('${taskSnapshot.pending} waiting');
+    }
+    if (taskSnapshot.retrying > 0) {
+      parts.add('${taskSnapshot.retrying} retrying');
+    }
+    return '${taskSnapshot.total} remaining: ${parts.join(', ')}';
+  }
+
+  return switch (state) {
+    AgentBackgroundRunState.failed => 'Processing stopped with an error.',
+    AgentBackgroundRunState.completed => 'All background tasks finished.',
+    AgentBackgroundRunState.active => 'Processing is starting.',
+    AgentBackgroundRunState.idle => 'No background tasks.',
+  };
+}
+
+String? _firstNonBlank(Iterable<String?> values) {
+  for (final value in values) {
+    final trimmed = value?.trim();
+    if (trimmed != null && trimmed.isNotEmpty) return trimmed;
+  }
+  return null;
+}
+
+String? _trimToSingleLine(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  final compact = trimmed.replaceAll(RegExp(r'\s+'), ' ');
+  if (compact.length <= 140) return compact;
+  return '${compact.substring(0, 137)}...';
+}

--- a/lib/data/services/agent_queue_background_worker.dart
+++ b/lib/data/services/agent_queue_background_worker.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/widgets.dart';
+import 'package:logging/logging.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/agent_queue_drain_scheduler.dart';
+import 'package:memex/data/services/file_logger_service.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/user_storage.dart';
+
+class AgentQueueBackgroundWorker {
+  static const Duration _maxRunDuration = Duration(seconds: 25);
+  static const Duration _defaultRetryDelay = Duration(minutes: 15);
+  static const int _databaseMaxAttempts = 3;
+
+  static bool isAgentQueueDrainTask(String taskName) {
+    return taskName == WorkmanagerAgentQueueDrainScheduler.taskName ||
+        taskName == WorkmanagerAgentQueueDrainScheduler.uniqueName;
+  }
+
+  static Future<bool> run({
+    Future<void> Function(String userId)? initializeTaskQueue,
+    LocalTaskExecutor? executor,
+    AgentQueueDrainScheduler? scheduler,
+    Duration maxRunDuration = _maxRunDuration,
+    Duration databaseRetryDelay = const Duration(milliseconds: 300),
+  }) async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await setupLogger();
+    final logger = getLogger('AgentQueueBackgroundWorker');
+
+    try {
+      await UserStorage.initL10n();
+      final userId = await UserStorage.getUserId();
+      if (userId == null || userId.isEmpty) {
+        logger.info('Skipping agent queue drain: no active user.');
+        return true;
+      }
+
+      final taskExecutor = executor ?? LocalTaskExecutor.instance;
+      final queueScheduler = scheduler ?? WorkmanagerAgentQueueDrainScheduler();
+      final result = await _withDatabaseLockRetry(
+        logger,
+        maxAttempts: _databaseMaxAttempts,
+        retryDelay: databaseRetryDelay,
+        operation: () async {
+          if (initializeTaskQueue != null) {
+            await initializeTaskQueue(userId);
+          } else {
+            await MemexRouter.ensureTaskQueueInitializedForBackgroundTask(
+              userId,
+              executor: taskExecutor,
+            );
+          }
+          return taskExecutor.drainAvailableTasks(
+            userId: userId,
+            maxDuration: maxRunDuration,
+            stopWhenDone: true,
+          );
+        },
+      );
+
+      if (result.snapshot.hasActiveTasks) {
+        await queueScheduler.schedule(
+          initialDelay: result.nextRunnableDelay ?? _defaultRetryDelay,
+          expedited: false,
+        );
+      }
+
+      logger.info(
+        'Agent queue drain finished. '
+        'active=${result.snapshot.total}, timedOut=${result.timedOut}',
+      );
+      return true;
+    } catch (e, stackTrace) {
+      logger.severe('Agent queue drain failed', e, stackTrace);
+      return false;
+    } finally {
+      await FileLoggerService.instance.dispose();
+    }
+  }
+
+  static Duration clampNextDelay(int? scheduledAtSeconds) {
+    if (scheduledAtSeconds == null) return _defaultRetryDelay;
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final seconds = max(30, scheduledAtSeconds - now);
+    return Duration(seconds: seconds);
+  }
+
+  static Future<T> _withDatabaseLockRetry<T>(
+    Logger logger, {
+    required int maxAttempts,
+    required Duration retryDelay,
+    required Future<T> Function() operation,
+  }) async {
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await operation();
+      } catch (e, stackTrace) {
+        if (!_isDatabaseLocked(e) || attempt == maxAttempts) {
+          Error.throwWithStackTrace(e, stackTrace);
+        }
+        logger.warning(
+          'Agent queue drain hit a locked database '
+          '(attempt $attempt/$maxAttempts); retrying.',
+        );
+        await Future<void>.delayed(retryDelay * attempt);
+      }
+    }
+    throw StateError('unreachable database retry path');
+  }
+
+  static bool isDatabaseLockedForTesting(Object error) =>
+      _isDatabaseLocked(error);
+
+  static bool _isDatabaseLocked(Object error) {
+    final message = error.toString().toLowerCase();
+    return message.contains('database is locked') ||
+        message.contains('sqliteexception(5)') ||
+        message.contains('code 5');
+  }
+}

--- a/lib/data/services/agent_queue_drain_scheduler.dart
+++ b/lib/data/services/agent_queue_drain_scheduler.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/foundation.dart';
+import 'package:workmanager/workmanager.dart';
+
+abstract class AgentQueueDrainScheduler {
+  Future<void> schedule({Duration? initialDelay, bool expedited});
+
+  Future<void> cancel();
+}
+
+class WorkmanagerAgentQueueDrainScheduler implements AgentQueueDrainScheduler {
+  static const String uniqueName = 'agent_queue_drain';
+  static const String taskName = 'agentQueueDrainTask';
+  static const String tag = 'agent_queue';
+
+  @override
+  Future<void> schedule({
+    Duration? initialDelay,
+    bool expedited = false,
+  }) async {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return;
+    }
+
+    await Workmanager().registerOneOffTask(
+      uniqueName,
+      taskName,
+      inputData: const {'source': 'agent_background_coordinator'},
+      initialDelay: initialDelay,
+      constraints: Constraints(
+        networkType: NetworkType.notRequired,
+        requiresBatteryNotLow: false,
+        requiresCharging: false,
+        requiresDeviceIdle: false,
+        requiresStorageNotLow: false,
+      ),
+      existingWorkPolicy: ExistingWorkPolicy.replace,
+      tag: tag,
+      outOfQuotaPolicy: expedited
+          ? OutOfQuotaPolicy.runAsNonExpeditedWorkRequest
+          : null,
+    );
+    debugPrint(
+      'Agent queue drain scheduled '
+      '(delay: ${initialDelay?.inSeconds ?? 0}s, expedited: $expedited)',
+    );
+  }
+
+  @override
+  Future<void> cancel() {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return Future<void>.value();
+    }
+    return Workmanager().cancelByUniqueName(uniqueName);
+  }
+}

--- a/lib/data/services/health_service.dart
+++ b/lib/data/services/health_service.dart
@@ -6,6 +6,7 @@ import 'package:logging/logging.dart';
 import 'package:workmanager/workmanager.dart'; // Added for Workmanager
 import 'dart:isolate'; // Added for Isolate
 import 'package:flutter/foundation.dart'; // Added for debugPrint
+import 'package:memex/data/services/agent_queue_background_worker.dart';
 import 'package:memex/data/services/file_logger_service.dart'; // Added
 import 'health_strategies.dart';
 import 'package:memex/utils/logger.dart';
@@ -305,6 +306,10 @@ void callbackDispatcher() {
       logger.severe('BackgroundCallback: Logger setup complete');
     } catch (e) {
       debugPrint('BackgroundCallback: Logger setup failed: $e');
+    }
+
+    if (AgentQueueBackgroundWorker.isAgentQueueDrainTask(task)) {
+      return AgentQueueBackgroundWorker.run();
     }
 
     try {

--- a/lib/data/services/local_task_executor.dart
+++ b/lib/data/services/local_task_executor.dart
@@ -64,6 +64,18 @@ class TaskActivitySnapshot {
       );
 }
 
+class TaskQueueDrainResult {
+  const TaskQueueDrainResult({
+    required this.snapshot,
+    required this.timedOut,
+    this.nextRunnableDelay,
+  });
+
+  final TaskActivitySnapshot snapshot;
+  final bool timedOut;
+  final Duration? nextRunnableDelay;
+}
+
 /// Handler function type
 typedef TaskHandler = Future<void> Function(
     String userId, Map<String, dynamic> payload, TaskContext context);
@@ -77,13 +89,18 @@ typedef TaskConcurrencyKeyBuilder = String Function(
 /// Per-task-type concurrency policy. The executor prefixes the returned key
 /// with the task type, so [byUser] means "one task of this type per user".
 class TaskConcurrencyPolicy {
-  TaskConcurrencyPolicy._(this._keyBuilder);
+  TaskConcurrencyPolicy._(
+    this._keyBuilder, {
+    required this.guardsProcessingTasksOfSameType,
+  });
 
   final TaskConcurrencyKeyBuilder _keyBuilder;
+  final bool guardsProcessingTasksOfSameType;
 
   factory TaskConcurrencyPolicy.byUser() {
     return TaskConcurrencyPolicy._(
       (userId, payload, context) => userId,
+      guardsProcessingTasksOfSameType: true,
     );
   }
 
@@ -127,6 +144,7 @@ class LocalTaskExecutor {
   final Map<String, TaskHandler> _handlers = {};
   final Map<String, TaskConcurrencyPolicy> _concurrencyPolicies = {};
   final Set<String> _activeConcurrencyKeys = <String>{};
+  final Map<String, Timer> _taskHeartbeatTimers = {};
 
   // Failure handlers registry
   final Map<String, TaskFailureHandler> _failureHandlers = {};
@@ -135,6 +153,7 @@ class LocalTaskExecutor {
   bool _isRunning = false;
   Timer? _pollTimer;
   bool _isProcessing = false;
+  bool _autoPollEnabled = true;
 
   // Polling interval
   static const Duration _pollInterval = Duration(seconds: 1);
@@ -143,6 +162,8 @@ class LocalTaskExecutor {
   static const String _gracefulExitMarkerKey = 'graceful_exit_marker';
   static const int crashLoopFailureThreshold = 2;
   static const Duration crashLikeExitWindow = Duration(minutes: 10);
+  static const Duration _taskHeartbeatInterval = Duration(seconds: 10);
+  static const Duration _backgroundStaleTaskAge = Duration(seconds: 30);
 
   /// Stream that emits true if there are any active (pending, processing, retrying) tasks in the DB.
   /// Useful for global UI loading indicators.
@@ -164,6 +185,59 @@ class LocalTaskExecutor {
     final query = _db.select(_db.tasks)
       ..where((t) => t.status.isIn(['pending', 'processing', 'retrying']));
     return _snapshotFromTasks(await query.get());
+  }
+
+  Future<TaskQueueDrainResult> drainAvailableTasks({
+    required String userId,
+    Duration maxDuration = const Duration(seconds: 25),
+    Duration pollInterval = const Duration(milliseconds: 200),
+    bool stopWhenDone = false,
+    Duration minimumStaleTaskAge = _backgroundStaleTaskAge,
+  }) async {
+    final wasRunning = _isRunning;
+    if (!wasRunning) {
+      await start(
+        userId: userId,
+        recoverStaleTasks: true,
+        autoPoll: false,
+        minimumStaleTaskAge: minimumStaleTaskAge,
+      );
+    } else {
+      _currentUserId ??= userId;
+    }
+
+    final deadline = DateTime.now().add(maxDuration);
+    var timedOut = false;
+    try {
+      while (true) {
+        await _workerLoop(
+          scheduleNextPoll: false,
+          rethrowErrors: true,
+          awaitClaimedTasks: true,
+        );
+        final hasProcessing = await _hasProcessingTasks();
+        final hasRunnable = await _hasRunnableTasks();
+        if (!hasProcessing && !hasRunnable) {
+          break;
+        }
+        if (DateTime.now().isAfter(deadline)) {
+          timedOut = true;
+          break;
+        }
+        _scheduleNextPoll(immediate: true);
+        await Future<void>.delayed(pollInterval);
+      }
+
+      return TaskQueueDrainResult(
+        snapshot: await getTaskActivitySnapshot(),
+        timedOut: timedOut,
+        nextRunnableDelay: await _nextRunnableDelay(),
+      );
+    } finally {
+      if (stopWhenDone || !wasRunning) {
+        stop();
+      }
+    }
   }
 
   TaskActivitySnapshot _snapshotFromTasks(List<Task> tasks) {
@@ -211,31 +285,62 @@ class LocalTaskExecutor {
   }
 
   /// Start the worker loop
-  Future<void> start({String? userId}) async {
+  Future<void> start({
+    String? userId,
+    bool recoverStaleTasks = true,
+    bool autoPoll = true,
+    Duration? minimumStaleTaskAge,
+  }) async {
     if (_isRunning) return;
     _currentUserId = userId; // Store for use in worker loop
+    _autoPollEnabled = autoPoll;
 
-    // Detect whether the previous process exited while a task was running.
-    // This must happen before resetting stale tasks, otherwise we lose the only
-    // durable signal that a crash-like exit happened during task execution.
-    await _handlePreviousExecutionMarkers();
+    if (recoverStaleTasks) {
+      // Detect whether the previous process exited while a task was running.
+      // This must happen before resetting stale tasks, otherwise we lose the only
+      // durable signal that a crash-like exit happened during task execution.
+      await _handlePreviousExecutionMarkers(
+        minimumStaleTaskAge: minimumStaleTaskAge,
+      );
 
-    // Reset any stale 'processing' tasks that might have been left over from a crash
-    await _resetStaleTasks();
+      // Reset any stale 'processing' tasks that might have been left over from a crash
+      await _resetStaleTasks(minimumStaleTaskAge: minimumStaleTaskAge);
+    }
 
     _isRunning = true;
     _logger.info('LocalTaskExecutor started for user $_currentUserId');
-    _scheduleNextPoll();
+    if (_autoPollEnabled) {
+      _scheduleNextPoll();
+    }
   }
 
   /// Reset tasks that are stuck in 'processing' state to 'pending'
-  Future<void> _resetStaleTasks() async {
+  Future<void> _resetStaleTasks({Duration? minimumStaleTaskAge}) async {
     try {
-      final count = await (_db.update(_db.tasks)
-            ..where((t) => t.status.equals('processing')))
-          .write(TasksCompanion(
+      final now = DateTime.now();
+      final update = _db.update(_db.tasks)
+        ..where((t) => t.status.equals('processing'));
+
+      if (minimumStaleTaskAge != null) {
+        final cutoff =
+            now.subtract(minimumStaleTaskAge).millisecondsSinceEpoch ~/ 1000;
+        final freshMarkerTaskIds = (await _loadTaskExecutionMarkers())
+            .where((marker) => !marker.isStale(now, minimumStaleTaskAge))
+            .map((marker) => marker.taskId)
+            .toList();
+
+        update.where(
+          (t) =>
+              t.updatedAt.isNull() | t.updatedAt.isSmallerOrEqualValue(cutoff),
+        );
+        if (freshMarkerTaskIds.isNotEmpty) {
+          update.where((t) => t.id.isNotIn(freshMarkerTaskIds));
+        }
+      }
+
+      final count = await update.write(TasksCompanion(
         status: const Value('pending'),
-        updatedAt: Value(DateTime.now().millisecondsSinceEpoch ~/ 1000),
+        updatedAt: Value(now.millisecondsSinceEpoch ~/ 1000),
       ));
 
       if (count > 0) {
@@ -249,7 +354,12 @@ class LocalTaskExecutor {
   /// Stop the worker loop
   void stop() {
     _isRunning = false;
+    _autoPollEnabled = true;
     _pollTimer?.cancel();
+    for (final timer in _taskHeartbeatTimers.values) {
+      timer.cancel();
+    }
+    _taskHeartbeatTimers.clear();
     _logger.info('LocalTaskExecutor stopped');
   }
 
@@ -330,7 +440,7 @@ class LocalTaskExecutor {
 
   void _scheduleNextPoll({bool immediate = false}) {
     _pollTimer?.cancel();
-    if (!_isRunning) return;
+    if (!_isRunning || !_autoPollEnabled) return;
 
     if (immediate) {
       _pollTimer = Timer(Duration.zero, _workerLoop);
@@ -339,7 +449,11 @@ class LocalTaskExecutor {
     }
   }
 
-  Future<void> _workerLoop() async {
+  Future<void> _workerLoop({
+    bool scheduleNextPoll = true,
+    bool rethrowErrors = false,
+    bool awaitClaimedTasks = false,
+  }) async {
     if (_isProcessing) return;
     _isProcessing = true;
 
@@ -353,7 +467,9 @@ class LocalTaskExecutor {
 
       if (activeTasks.length >= _maxConcurrency) {
         _isProcessing = false;
-        _scheduleNextPoll(); // Wait for next slot
+        if (scheduleNextPoll) {
+          _scheduleNextPoll(); // Wait for next slot
+        }
         return;
       }
 
@@ -369,7 +485,9 @@ class LocalTaskExecutor {
       if (tasksToRun.isEmpty) {
         // No runnable tasks found in top candidates
         _isProcessing = false;
-        _scheduleNextPoll();
+        if (scheduleNextPoll) {
+          _scheduleNextPoll();
+        }
         return;
       }
 
@@ -390,7 +508,11 @@ class LocalTaskExecutor {
         }
 
         try {
-          if (await _claimTaskForExecution(task, now)) {
+          if (await _claimTaskForExecution(
+            task,
+            now,
+            concurrencyKey: concurrencyKey,
+          )) {
             claimedTasks.add(task);
             claimedConcurrencyKeys[task.id] = concurrencyKey;
           } else if (acquiredConcurrencyKey) {
@@ -404,13 +526,21 @@ class LocalTaskExecutor {
         }
       }
 
+      final executionFutures = <Future<void>>[];
       for (final task in claimedTasks) {
-        unawaited(
-          _executeTask(
-            task,
-            concurrencyKey: claimedConcurrencyKeys[task.id],
-          ),
+        final executionFuture = _executeTask(
+          task,
+          concurrencyKey: claimedConcurrencyKeys[task.id],
         );
+        if (awaitClaimedTasks) {
+          executionFutures.add(executionFuture);
+        } else {
+          unawaited(executionFuture);
+        }
+      }
+
+      if (executionFutures.isNotEmpty) {
+        await Future.wait(executionFutures);
       }
 
       // Loop immediately to check for more tasks or completion
@@ -418,11 +548,18 @@ class LocalTaskExecutor {
 
       // If we filled all slots, wait. If we didn't, maybe check again soon.
       // Easiest is to just schedule next poll.
-      _scheduleNextPoll(immediate: true);
-    } catch (e) {
-      _logger.severe('Error in worker loop, $e', e);
+      if (scheduleNextPoll) {
+        _scheduleNextPoll(immediate: true);
+      }
+    } catch (e, stackTrace) {
       _isProcessing = false;
-      _scheduleNextPoll();
+      if (rethrowErrors) {
+        Error.throwWithStackTrace(e, stackTrace);
+      }
+      _logger.severe('Error in worker loop, $e', e, stackTrace);
+      if (scheduleNextPoll) {
+        _scheduleNextPoll();
+      }
     }
   }
 
@@ -463,7 +600,11 @@ class LocalTaskExecutor {
           final concurrencyKey = _concurrencyKeyForTask(task);
           if (concurrencyKey != null) {
             if (_activeConcurrencyKeys.contains(concurrencyKey) ||
-                reservedConcurrencyKeys.contains(concurrencyKey)) {
+                reservedConcurrencyKeys.contains(concurrencyKey) ||
+                await _hasProcessingConcurrencyConflict(
+                  task,
+                  concurrencyKey,
+                )) {
               continue;
             }
             reservedConcurrencyKeys.add(concurrencyKey);
@@ -479,6 +620,34 @@ class LocalTaskExecutor {
     }
 
     return tasksToRun;
+  }
+
+  Future<bool> _hasProcessingTasks() async {
+    final query = _db.selectOnly(_db.tasks)
+      ..addColumns([_db.tasks.id.count()])
+      ..where(_db.tasks.status.equals('processing'));
+    final row = await query.getSingle();
+    return (row.read(_db.tasks.id.count()) ?? 0) > 0;
+  }
+
+  Future<bool> _hasRunnableTasks() async {
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    return (await _findRunnableTasks(slotsAvailable: 1, now: now)).isNotEmpty;
+  }
+
+  Future<Duration?> _nextRunnableDelay() async {
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final query = _db.select(_db.tasks)
+      ..where((t) => t.status.isIn(['pending', 'retrying']))
+      ..where((t) => t.scheduledAt.isBiggerThanValue(now))
+      ..orderBy([
+        (t) => OrderingTerm(expression: t.scheduledAt, mode: OrderingMode.asc),
+      ])
+      ..limit(1);
+    final task = await query.getSingleOrNull();
+    if (task?.scheduledAt == null) return null;
+    final seconds = task!.scheduledAt! - now;
+    return Duration(seconds: seconds < 30 ? 30 : seconds);
   }
 
   String? _concurrencyKeyForTask(Task task) {
@@ -503,6 +672,31 @@ class LocalTaskExecutor {
       );
       return null;
     }
+  }
+
+  Future<bool> _hasProcessingConcurrencyConflict(
+    Task task,
+    String concurrencyKey,
+  ) async {
+    if (!_usesSameTypeDatabaseConcurrencyGuard(task, concurrencyKey)) {
+      return false;
+    }
+
+    final query = _db.selectOnly(_db.tasks)
+      ..addColumns([_db.tasks.id.count()])
+      ..where(_db.tasks.status.equals('processing'))
+      ..where(_db.tasks.type.equals(task.type));
+    final row = await query.getSingle();
+    return (row.read(_db.tasks.id.count()) ?? 0) > 0;
+  }
+
+  bool _usesSameTypeDatabaseConcurrencyGuard(
+    Task task,
+    String? concurrencyKey,
+  ) {
+    return concurrencyKey != null &&
+        (_concurrencyPolicies[task.type]?.guardsProcessingTasksOfSameType ??
+            false);
   }
 
   Map<String, dynamic> _decodePayload(Task task) {
@@ -632,6 +826,7 @@ class LocalTaskExecutor {
         _logger.severe('Task ${task.id} permanently failed');
       }
     } finally {
+      _stopTaskHeartbeat(task.id);
       await _clearTaskExecutionMarker(task.id);
       if (concurrencyKey != null) {
         _activeConcurrencyKeys.remove(concurrencyKey);
@@ -644,30 +839,68 @@ class LocalTaskExecutor {
     }
   }
 
-  Future<bool> _claimTaskForExecution(Task task, int now) async {
-    final updated = await (_db.update(_db.tasks)
-          ..where((t) => t.id.equals(task.id))
-          ..where((t) => t.status.isIn(['pending', 'retrying'])))
-        .write(
-      TasksCompanion(
-        status: const Value('processing'),
-        updatedAt: Value(now),
-      ),
+  Future<bool> _claimTaskForExecution(
+    Task task,
+    int now, {
+    String? concurrencyKey,
+  }) async {
+    final guardSameType =
+        _usesSameTypeDatabaseConcurrencyGuard(task, concurrencyKey);
+    final sql = StringBuffer(
+      'UPDATE tasks '
+      'SET status = ?, updated_at = ? '
+      'WHERE id = ? '
+      'AND status IN (?, ?) '
+      'AND (SELECT COUNT(*) FROM tasks WHERE status = ?) < ?',
+    );
+    final variables = <Variable>[
+      const Variable<String>('processing'),
+      Variable<int>(now),
+      Variable<String>(task.id),
+      const Variable<String>('pending'),
+      const Variable<String>('retrying'),
+      const Variable<String>('processing'),
+      const Variable<int>(_maxConcurrency),
+    ];
+
+    if (guardSameType) {
+      sql.write(
+        ' AND NOT EXISTS ('
+        'SELECT 1 FROM tasks '
+        'WHERE status = ? AND type = ?'
+        ')',
+      );
+      variables.addAll([
+        const Variable<String>('processing'),
+        Variable<String>(task.type),
+      ]);
+    }
+
+    final updated = await _db.customUpdate(
+      sql.toString(),
+      variables: variables,
+      updates: {_db.tasks},
     );
     if (updated == 0) return false;
 
-    await _markTaskExecutionStarted(task);
+    await _markTaskExecutionStarted(task, startHeartbeat: true);
     return true;
   }
 
-  Future<void> _handlePreviousExecutionMarkers() async {
+  Future<void> _handlePreviousExecutionMarkers({
+    Duration? minimumStaleTaskAge,
+  }) async {
     try {
       final markers = await _loadTaskExecutionMarkers();
       if (markers.isEmpty) return;
       final gracefulExitMarker = await _loadGracefulExitMarker();
 
       for (final marker in markers) {
-        await _handlePreviousExecutionMarker(marker, gracefulExitMarker);
+        await _handlePreviousExecutionMarker(
+          marker,
+          gracefulExitMarker,
+          minimumStaleTaskAge: minimumStaleTaskAge,
+        );
       }
       await _deleteGracefulExitMarker();
     } catch (e, stack) {
@@ -680,9 +913,8 @@ class LocalTaskExecutor {
   }
 
   Future<void> _handlePreviousExecutionMarker(
-    _TaskExecutionMarker marker,
-    _GracefulExitMarker? gracefulExitMarker,
-  ) async {
+      _TaskExecutionMarker marker, _GracefulExitMarker? gracefulExitMarker,
+      {Duration? minimumStaleTaskAge}) async {
     final task = await (_db.select(
       _db.tasks,
     )..where((t) => t.id.equals(marker.taskId)))
@@ -710,6 +942,11 @@ class LocalTaskExecutor {
     }
 
     final now = DateTime.now();
+    if (minimumStaleTaskAge != null &&
+        !marker.isStale(now, minimumStaleTaskAge)) {
+      return;
+    }
+
     if (now.difference(marker.startedAt) > crashLikeExitWindow) {
       _logger.info(
         'Ignoring old crash guard marker for task ${marker.taskId}; previous process likely stopped outside crash window',
@@ -738,7 +975,10 @@ class LocalTaskExecutor {
     );
   }
 
-  Future<void> _markTaskExecutionStarted(Task task) async {
+  Future<void> _markTaskExecutionStarted(
+    Task task, {
+    bool startHeartbeat = false,
+  }) async {
     await clearGracefulShutdownMarker();
     final existing = await _loadTaskExecutionMarker(task.id);
     final marker = _TaskExecutionMarker.fromTask(
@@ -748,6 +988,29 @@ class LocalTaskExecutor {
           : 0,
     );
     await _saveTaskExecutionMarker(marker);
+    if (startHeartbeat) {
+      _startTaskHeartbeat(task.id);
+    }
+  }
+
+  void _startTaskHeartbeat(String taskId) {
+    _taskHeartbeatTimers[taskId]?.cancel();
+    _taskHeartbeatTimers[taskId] = Timer.periodic(
+      _taskHeartbeatInterval,
+      (_) => unawaited(_touchTaskExecutionMarker(taskId)),
+    );
+  }
+
+  void _stopTaskHeartbeat(String taskId) {
+    _taskHeartbeatTimers.remove(taskId)?.cancel();
+  }
+
+  Future<void> _touchTaskExecutionMarker(String taskId) async {
+    final marker = await _loadTaskExecutionMarker(taskId);
+    if (marker == null) return;
+    await _saveTaskExecutionMarker(
+      marker.copyWith(heartbeatAt: DateTime.now()),
+    );
   }
 
   Future<_TaskExecutionMarker?> _loadTaskExecutionMarker(String taskId) async {
@@ -1019,6 +1282,7 @@ class _TaskExecutionMarker {
     required this.taskType,
     required this.payloadHash,
     required this.startedAt,
+    required this.heartbeatAt,
     required this.crashCount,
     this.bizId,
   });
@@ -1028,27 +1292,34 @@ class _TaskExecutionMarker {
   final String? bizId;
   final String payloadHash;
   final DateTime startedAt;
+  final DateTime heartbeatAt;
   final int crashCount;
 
   factory _TaskExecutionMarker.fromTask(Task task, {required int crashCount}) {
+    final now = DateTime.now();
     return _TaskExecutionMarker(
       taskId: task.id,
       taskType: task.type,
       bizId: task.bizId,
       payloadHash: _payloadHashFor(task.payload),
-      startedAt: DateTime.now(),
+      startedAt: now,
+      heartbeatAt: now,
       crashCount: crashCount,
     );
   }
 
   factory _TaskExecutionMarker.fromJson(Map<String, dynamic> json) {
+    final startedAt = DateTime.fromMillisecondsSinceEpoch(
+      json['started_at_ms'] as int,
+    );
     return _TaskExecutionMarker(
       taskId: json['task_id'] as String,
       taskType: json['task_type'] as String,
       bizId: json['biz_id'] as String?,
       payloadHash: json['payload_hash'] as String,
-      startedAt: DateTime.fromMillisecondsSinceEpoch(
-        json['started_at_ms'] as int,
+      startedAt: startedAt,
+      heartbeatAt: DateTime.fromMillisecondsSinceEpoch(
+        json['heartbeat_at_ms'] as int? ?? startedAt.millisecondsSinceEpoch,
       ),
       crashCount: json['crash_count'] as int,
     );
@@ -1061,19 +1332,29 @@ class _TaskExecutionMarker {
       'biz_id': bizId,
       'payload_hash': payloadHash,
       'started_at_ms': startedAt.millisecondsSinceEpoch,
+      'heartbeat_at_ms': heartbeatAt.millisecondsSinceEpoch,
       'crash_count': crashCount,
     };
   }
 
-  _TaskExecutionMarker copyWith({int? crashCount}) {
+  _TaskExecutionMarker copyWith({
+    int? crashCount,
+    DateTime? heartbeatAt,
+  }) {
     return _TaskExecutionMarker(
       taskId: taskId,
       taskType: taskType,
       bizId: bizId,
       payloadHash: payloadHash,
       startedAt: startedAt,
+      heartbeatAt: heartbeatAt ?? this.heartbeatAt,
       crashCount: crashCount ?? this.crashCount,
     );
+  }
+
+  bool isStale(DateTime now, Duration minimumStaleTaskAge) {
+    return !now.difference(heartbeatAt).isNegative &&
+        now.difference(heartbeatAt) >= minimumStaleTaskAge;
   }
 
   bool matchesTask(Task task) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -94,10 +94,11 @@ void main() async {
     isInDebugMode: false,
   );
 
-  // Cancel any previously registered pedometer background tasks on iOS
-  // (iOS now uses HealthKit only, not CMPedometer)
+  // Cancel legacy pedometer background tasks on iOS without wiping newer
+  // background registrations such as agent queue processing.
   if (Platform.isIOS) {
-    await Workmanager().cancelAll();
+    await Workmanager().cancelByUniqueName('workmanager.background.task');
+    await Workmanager().cancelByUniqueName('dailyStepSnapshotTask');
   }
   await AgentBackgroundTaskService.instance.initializeNativeBridge();
 

--- a/lib/ui/agent_activity/widgets/agent_activity_widget.dart
+++ b/lib/ui/agent_activity/widgets/agent_activity_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:intl/intl.dart';
 import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/agent_background_coordinator.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/utils/user_storage.dart';
 
@@ -31,6 +32,7 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
   LocalTaskExecutor? _executor;
   StreamSubscription<AgentActivityMessageModel>? _subscription;
   StreamSubscription<TaskActivitySnapshot>? _taskSubscription;
+  StreamSubscription<void>? _openActivitySubscription;
   Timer? _historyLoadTimer;
   TaskActivitySnapshot _taskSnapshot = const TaskActivitySnapshot.empty();
 
@@ -60,6 +62,9 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
     try {
       _service = AgentActivityService.instance;
       _executor = LocalTaskExecutor.instance;
+      _openActivitySubscription = AgentBackgroundCoordinator
+          .instance.openActivityRequests
+          .listen((_) => _showDetail());
       _subscribeToService();
     } catch (_) {
       _historyLoadTimer = Timer(const Duration(seconds: 3), () {
@@ -73,6 +78,9 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
     try {
       _service = AgentActivityService.instance;
       _executor = LocalTaskExecutor.instance;
+      _openActivitySubscription ??= AgentBackgroundCoordinator
+          .instance.openActivityRequests
+          .listen((_) => _showDetail());
       _subscribeToService();
     } catch (_) {}
   }
@@ -110,6 +118,7 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
   void dispose() {
     _subscription?.cancel();
     _taskSubscription?.cancel();
+    _openActivitySubscription?.cancel();
     _historyLoadTimer?.cancel();
     _bounceController.dispose();
     super.dispose();
@@ -117,7 +126,7 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
 
   bool _isDetailShowing = false;
 
-  Future<void> _showDetail(BuildContext context) async {
+  Future<void> _showDetail() async {
     if (_isDetailShowing) return;
     _isDetailShowing = true;
     final targetContext = widget.navigatorKey?.currentContext ?? context;
@@ -142,7 +151,7 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
     if (!_isActive) return const SizedBox.shrink();
 
     return GestureDetector(
-      onTap: () => _showDetail(context),
+      onTap: _showDetail,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
         decoration: BoxDecoration(

--- a/test/data/services/agent_background_coordinator_test.dart
+++ b/test/data/services/agent_background_coordinator_test.dart
@@ -1,0 +1,401 @@
+import 'dart:async';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/agent_background_coordinator.dart';
+import 'package:memex/data/services/agent_background_platform.dart';
+import 'package:memex/data/services/agent_background_status.dart';
+import 'package:memex/data/services/agent_queue_drain_scheduler.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/db/app_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late LocalTaskExecutor executor;
+  late _FakeActivityService activityService;
+  late _FakePlatform platform;
+  late _FakeScheduler scheduler;
+  late AgentBackgroundCoordinator coordinator;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    AppDatabase.setTestInstance(db);
+    executor = LocalTaskExecutor.forTesting();
+    activityService = _FakeActivityService();
+    platform = _FakePlatform();
+    scheduler = _FakeScheduler();
+    coordinator = AgentBackgroundCoordinator(
+      platform: platform,
+      scheduler: scheduler,
+      initialLifecycleState: AppLifecycleState.paused,
+    );
+  });
+
+  tearDown(() async {
+    await coordinator.stop();
+    await activityService.dispose();
+    executor.stop();
+    await db.close();
+  });
+
+  test('publishes active status and schedules one drain for a run', () async {
+    coordinator.start(executor: executor, activityService: activityService);
+
+    await _insertTask(db, id: 'pending-a', status: 'pending');
+    await _waitUntil(() => platform.updates.isNotEmpty);
+
+    expect(platform.updates.single.state, AgentBackgroundRunState.active);
+    expect(platform.updates.single.remainingTasks, 1);
+    expect(scheduler.scheduleCount, 1);
+
+    activityService.emit(
+      AgentActivityMessageModel(
+        id: 1,
+        type: AgentActivityType.info,
+        title: 'Updating PKM',
+        content: 'Writing local notes',
+        agentName: 'PKM Agent',
+        agentId: 'pkm',
+        timestamp: DateTime(2026, 1, 1),
+      ),
+    );
+    await _waitUntil(() => platform.updates.length == 2);
+
+    expect(platform.updates.last.stage, 'Updating PKM');
+    expect(platform.updates.last.detail, 'Writing local notes');
+    expect(scheduler.scheduleCount, 1);
+  });
+
+  test('defers WorkManager drain while app is foregrounded', () async {
+    coordinator = AgentBackgroundCoordinator(
+      platform: platform,
+      scheduler: scheduler,
+      initialLifecycleState: AppLifecycleState.resumed,
+    );
+    coordinator.start(executor: executor, activityService: activityService);
+
+    await _insertTask(db, id: 'pending-a', status: 'pending');
+    await _waitUntil(() => platform.updates.isNotEmpty);
+
+    expect(platform.updates.single.state, AgentBackgroundRunState.active);
+    expect(scheduler.scheduleCount, 0);
+
+    coordinator.didChangeAppLifecycleState(AppLifecycleState.paused);
+    await _waitUntil(() => scheduler.scheduleCount == 1);
+
+    expect(scheduler.events.last, 'schedule:true:0');
+  });
+
+  test(
+    'finishes terminal status and cancels drain when queue empties',
+    () async {
+      coordinator.start(executor: executor, activityService: activityService);
+      await _insertTask(db, id: 'pending-a', status: 'pending');
+      await _waitUntil(() => platform.updates.isNotEmpty);
+
+      activityService.emit(
+        AgentActivityMessageModel(
+          id: 2,
+          type: AgentActivityType.agent_stop,
+          title: 'Done',
+          agentName: 'Card Agent',
+          agentId: 'card',
+          timestamp: DateTime(2026, 1, 1),
+        ),
+      );
+      await (db.update(db.tasks)..where((t) => t.id.equals('pending-a'))).write(
+        TasksCompanion(
+          status: const Value('completed'),
+          updatedAt: Value(DateTime.now().millisecondsSinceEpoch ~/ 1000),
+        ),
+      );
+
+      await _waitUntil(() => platform.finished.isNotEmpty);
+
+      expect(platform.finished.last.state, AgentBackgroundRunState.completed);
+      expect(scheduler.cancelCount, greaterThanOrEqualTo(1));
+    },
+  );
+
+  test('forwards notification tap requests to listeners', () async {
+    final opened = Completer<void>();
+    coordinator.openActivityRequests.listen((_) {
+      if (!opened.isCompleted) opened.complete();
+    });
+    coordinator.start(executor: executor, activityService: activityService);
+
+    platform.emitAction('agent_activity');
+
+    await opened.future.timeout(const Duration(seconds: 1));
+  });
+
+  test('buffers initial notification tap until a listener attaches', () async {
+    platform.initialAction = 'agent_activity';
+    coordinator.start(executor: executor, activityService: activityService);
+
+    await platform.initialActionConsumed.future.timeout(
+      const Duration(seconds: 1),
+    );
+
+    final opened = Completer<void>();
+    coordinator.openActivityRequests.listen((_) {
+      if (!opened.isCompleted) opened.complete();
+    });
+
+    await opened.future.timeout(const Duration(seconds: 1));
+  });
+
+  test(
+    'keeps system surface active when error arrives with retryable tasks',
+    () async {
+      coordinator.start(executor: executor, activityService: activityService);
+      await _insertTask(db, id: 'retry-a', status: 'retrying');
+      await _waitUntil(() => platform.updates.isNotEmpty);
+      final cancelCountBeforeError = scheduler.cancelCount;
+
+      activityService.emit(
+        AgentActivityMessageModel(
+          id: 3,
+          type: AgentActivityType.error,
+          title: 'Provider timeout',
+          content: 'Will retry automatically',
+          agentName: 'Insight Agent',
+          agentId: 'insight',
+          timestamp: DateTime(2026, 1, 1),
+        ),
+      );
+      await _waitUntil(() => platform.updates.length == 2);
+
+      expect(platform.updates.last.state, AgentBackgroundRunState.active);
+      expect(platform.updates.last.detail, 'Will retry automatically');
+      expect(platform.finished, isEmpty);
+      expect(scheduler.cancelCount, cancelCountBeforeError);
+    },
+  );
+
+  test('retries publishing after platform update failure', () async {
+    coordinator.start(executor: executor, activityService: activityService);
+    platform.failNextUpdate = true;
+
+    await _insertTask(db, id: 'pending-a', status: 'pending');
+    await _waitUntil(() => platform.updateAttempts == 1);
+
+    expect(platform.updates, isEmpty);
+    expect(scheduler.scheduleCount, 0);
+
+    activityService.emit(
+      AgentActivityMessageModel(
+        id: 4,
+        type: AgentActivityType.info,
+        title: 'Retrying visible status',
+        content: 'The platform recovered',
+        agentName: 'Card Agent',
+        agentId: 'card',
+        timestamp: DateTime(2026, 1, 1),
+      ),
+    );
+    await _waitUntil(() => platform.updates.isNotEmpty);
+
+    expect(platform.updateAttempts, 2);
+    expect(platform.updates.single.detail, 'The platform recovered');
+    expect(scheduler.scheduleCount, 1);
+  });
+
+  test('serializes delayed active publish before terminal publish', () async {
+    platform.updateGate = Completer<void>();
+    coordinator.start(executor: executor, activityService: activityService);
+
+    await _insertTask(db, id: 'pending-a', status: 'pending');
+    await _waitUntil(() => platform.updateAttempts == 1);
+    platform.events.clear();
+    scheduler.events.clear();
+
+    activityService.emit(
+      AgentActivityMessageModel(
+        id: 5,
+        type: AgentActivityType.agent_stop,
+        title: 'Done',
+        agentName: 'Card Agent',
+        agentId: 'card',
+        timestamp: DateTime(2026, 1, 1),
+      ),
+    );
+    await (db.update(db.tasks)..where((t) => t.id.equals('pending-a'))).write(
+      TasksCompanion(
+        status: const Value('completed'),
+        updatedAt: Value(DateTime.now().millisecondsSinceEpoch ~/ 1000),
+      ),
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(platform.finished, isEmpty);
+
+    platform.updateGate!.complete();
+    await _waitUntil(() => platform.finished.isNotEmpty);
+
+    expect(platform.events, ['update:active', 'finish:completed']);
+    expect(scheduler.events, ['cancel']);
+  });
+}
+
+class _FakePlatform implements AgentBackgroundPlatform {
+  final updates = <AgentBackgroundStatus>[];
+  final finished = <AgentBackgroundStatus>[];
+  final events = <String>[];
+  final initialActionConsumed = Completer<void>();
+  var stopCount = 0;
+  var updateAttempts = 0;
+  var failNextUpdate = false;
+  Completer<void>? updateGate;
+  String? initialAction;
+  final _actions = StreamController<String>.broadcast();
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Stream<String> get actionStream => _actions.stream;
+
+  @override
+  Future<String?> consumeInitialAction() async {
+    if (!initialActionConsumed.isCompleted) {
+      initialActionConsumed.complete();
+    }
+    return initialAction;
+  }
+
+  @override
+  Future<void> finishStatus(AgentBackgroundStatus status) async {
+    events.add('finish:${status.state.name}');
+    finished.add(status);
+  }
+
+  @override
+  Future<void> stopStatus() async {
+    stopCount++;
+  }
+
+  @override
+  Future<void> updateStatus(AgentBackgroundStatus status) async {
+    updateAttempts++;
+    await updateGate?.future;
+    if (failNextUpdate) {
+      failNextUpdate = false;
+      throw StateError('platform temporarily unavailable');
+    }
+    events.add('update:${status.state.name}');
+    updates.add(status);
+  }
+
+  void emitAction(String action) {
+    _actions.add(action);
+  }
+}
+
+class _FakeScheduler implements AgentQueueDrainScheduler {
+  final events = <String>[];
+  var scheduleCount = 0;
+  var cancelCount = 0;
+
+  @override
+  Future<void> cancel() async {
+    cancelCount++;
+    events.add('cancel');
+  }
+
+  @override
+  Future<void> schedule({
+    Duration? initialDelay,
+    bool expedited = false,
+  }) async {
+    scheduleCount++;
+    events.add('schedule:$expedited:${initialDelay?.inMilliseconds ?? 0}');
+  }
+}
+
+class _FakeActivityService implements AgentActivityService {
+  final _messages = StreamController<AgentActivityMessageModel>.broadcast();
+  final history = <AgentActivityMessageModel>[];
+
+  @override
+  Stream<AgentActivityMessageModel> get messageStream => _messages.stream;
+
+  @override
+  Future<List<AgentActivityMessageModel>> getHistory({int limit = 10}) async {
+    return history.take(limit).toList();
+  }
+
+  @override
+  Future<void> pushMessage({
+    required AgentActivityType type,
+    required String title,
+    String? content,
+    String? icon,
+    required String agentName,
+    required String agentId,
+    String? scene,
+    String? sceneId,
+    String? userId,
+  }) async {
+    emit(
+      AgentActivityMessageModel(
+        id: history.length + 1,
+        type: type,
+        title: title,
+        content: content,
+        icon: icon,
+        agentName: agentName,
+        agentId: agentId,
+        scene: scene,
+        sceneId: sceneId,
+        userId: userId,
+        timestamp: DateTime(2026, 1, 1),
+      ),
+    );
+  }
+
+  void emit(AgentActivityMessageModel message) {
+    history.insert(0, message);
+    _messages.add(message);
+  }
+
+  Future<void> dispose() => _messages.close();
+}
+
+Future<void> _insertTask(
+  AppDatabase db, {
+  required String id,
+  required String status,
+}) async {
+  final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  await db
+      .into(db.tasks)
+      .insert(
+        TasksCompanion.insert(
+          id: id,
+          type: 'agent_task',
+          payload: const Value('{}'),
+          status: status,
+          createdAt: Value(now),
+          updatedAt: Value(now),
+        ),
+      );
+}
+
+Future<void> _waitUntil(
+  bool Function() predicate, {
+  Duration timeout = const Duration(seconds: 3),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!predicate()) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw TimeoutException('Condition was not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+}

--- a/test/data/services/agent_background_status_test.dart
+++ b/test/data/services/agent_background_status_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/agent_background_status.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+
+void main() {
+  group('AgentBackgroundStatus', () {
+    test('stays idle when there are no tasks or terminal messages', () {
+      final status = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot.empty(),
+        now: DateTime(2026, 1, 1),
+      );
+
+      expect(status.state, AgentBackgroundRunState.idle);
+      expect(status.shouldShowSystemSurface, isFalse);
+      expect(status.remainingTasks, 0);
+      expect(status.detail, 'No background tasks.');
+    });
+
+    test('uses task snapshot counts for active status', () {
+      final status = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot(
+          pending: 2,
+          processing: 1,
+          retrying: 1,
+        ),
+        now: DateTime(2026, 1, 1),
+      );
+
+      expect(status.state, AgentBackgroundRunState.active);
+      expect(status.remainingTasks, 4);
+      expect(status.title, 'Memex is processing');
+      expect(status.detail, '4 remaining: 1 running, 2 waiting, 1 retrying');
+      expect(status.toPlatformMap()['remainingTasks'], 4);
+    });
+
+    test('keeps retryable error visible as active while tasks remain', () {
+      final status = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot(
+          pending: 0,
+          processing: 0,
+          retrying: 1,
+        ),
+        latestMessage: AgentActivityMessageModel(
+          id: 1,
+          type: AgentActivityType.error,
+          title: 'Provider timeout',
+          content: 'Will retry automatically',
+          agentName: 'Insight Agent',
+          agentId: 'insight',
+          timestamp: DateTime(2026, 1, 1),
+        ),
+        now: DateTime(2026, 1, 1),
+      );
+
+      expect(status.state, AgentBackgroundRunState.active);
+      expect(status.stage, 'Provider timeout');
+      expect(status.detail, 'Will retry automatically');
+    });
+
+    test('marks terminal stop as completed only after queue is empty', () {
+      final message = AgentActivityMessageModel(
+        id: 2,
+        type: AgentActivityType.agent_stop,
+        title: 'Done',
+        agentName: 'Card Agent',
+        agentId: 'card',
+        timestamp: DateTime(2026, 1, 1),
+      );
+
+      final stillRunning = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot(
+          pending: 1,
+          processing: 0,
+          retrying: 0,
+        ),
+        latestMessage: message,
+        now: DateTime(2026, 1, 1),
+      );
+      final completed = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot.empty(),
+        latestMessage: message,
+        now: DateTime(2026, 1, 1),
+      );
+
+      expect(stillRunning.state, AgentBackgroundRunState.active);
+      expect(completed.state, AgentBackgroundRunState.completed);
+      expect(completed.detail, 'All background tasks finished.');
+    });
+
+    test('trims multi-line content before sending to platform', () {
+      final status = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot(
+          pending: 0,
+          processing: 1,
+          retrying: 0,
+        ),
+        latestMessage: AgentActivityMessageModel(
+          id: 3,
+          type: AgentActivityType.info,
+          title: 'Long output',
+          content: '${'a' * 80}\n${'b' * 80}',
+          agentName: 'PKM Agent',
+          agentId: 'pkm',
+          timestamp: DateTime(2026, 1, 1),
+        ),
+        now: DateTime(2026, 1, 1),
+      );
+
+      expect(status.detail, hasLength(140));
+      expect(status.detail, endsWith('...'));
+      expect(status.detail.contains('\n'), isFalse);
+    });
+  });
+}

--- a/test/data/services/agent_queue_background_worker_test.dart
+++ b/test/data/services/agent_queue_background_worker_test.dart
@@ -1,0 +1,223 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/agent_queue_background_worker.dart';
+import 'package:memex/data/services/agent_queue_drain_scheduler.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AgentQueueBackgroundWorker', () {
+    late AppDatabase db;
+    late LocalTaskExecutor executor;
+    late _FakeDrainScheduler scheduler;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({'user_id': 'worker-user'});
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      AppDatabase.setTestInstance(db);
+      executor = LocalTaskExecutor.forTesting();
+      scheduler = _FakeDrainScheduler();
+    });
+
+    tearDown(() async {
+      executor.stop();
+      await db.close();
+    });
+
+    test('recognizes both WorkManager task name and unique work name', () {
+      expect(
+        AgentQueueBackgroundWorker.isAgentQueueDrainTask(
+          WorkmanagerAgentQueueDrainScheduler.taskName,
+        ),
+        isTrue,
+      );
+      expect(
+        AgentQueueBackgroundWorker.isAgentQueueDrainTask(
+          WorkmanagerAgentQueueDrainScheduler.uniqueName,
+        ),
+        isTrue,
+      );
+      expect(
+        AgentQueueBackgroundWorker.isAgentQueueDrainTask(
+          'workmanager.background.task',
+        ),
+        isFalse,
+      );
+    });
+
+    test('clamps immediate retry delay to at least thirty seconds', () {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      expect(
+        AgentQueueBackgroundWorker.clampNextDelay(now - 120),
+        const Duration(seconds: 30),
+      );
+      expect(
+        AgentQueueBackgroundWorker.clampNextDelay(now + 10),
+        const Duration(seconds: 30),
+      );
+    });
+
+    test('keeps future retry delay when it is longer than the clamp', () {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      expect(
+        AgentQueueBackgroundWorker.clampNextDelay(now + 600),
+        const Duration(seconds: 600),
+      );
+    });
+
+    test('does not initialize task queue when no user is active', () async {
+      SharedPreferences.setMockInitialValues({});
+      var initialized = false;
+
+      final completed = await AgentQueueBackgroundWorker.run(
+        initializeTaskQueue: (_) async {
+          initialized = true;
+        },
+        executor: executor,
+        scheduler: scheduler,
+      );
+
+      expect(completed, isTrue);
+      expect(initialized, isFalse);
+      expect(scheduler.scheduleCalls, 0);
+    });
+
+    test('retries a transient database lock before draining queue', () async {
+      var attempts = 0;
+
+      final completed = await AgentQueueBackgroundWorker.run(
+        initializeTaskQueue: (_) async {
+          attempts++;
+          if (attempts == 1) {
+            throw Exception('SqliteException(5): database is locked (code 5)');
+          }
+        },
+        executor: executor,
+        scheduler: scheduler,
+        databaseRetryDelay: Duration.zero,
+      );
+
+      expect(completed, isTrue);
+      expect(attempts, 2);
+      expect(scheduler.scheduleCalls, 0);
+    });
+
+    test('does not retry non-database initialization failures', () async {
+      var attempts = 0;
+
+      final completed = await AgentQueueBackgroundWorker.run(
+        initializeTaskQueue: (_) async {
+          attempts++;
+          throw StateError('bad background setup');
+        },
+        executor: executor,
+        scheduler: scheduler,
+        databaseRetryDelay: Duration.zero,
+      );
+
+      expect(completed, isFalse);
+      expect(attempts, 1);
+    });
+
+    test('reschedules when only future retrying tasks remain', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await db.into(db.tasks).insert(
+            TasksCompanion.insert(
+              id: 'future-retry',
+              type: 'unknown_task',
+              payload: const Value('{}'),
+              status: 'retrying',
+              createdAt: Value(now),
+              scheduledAt: Value(now + 600),
+            ),
+          );
+
+      final completed = await AgentQueueBackgroundWorker.run(
+        initializeTaskQueue: (_) async {},
+        executor: executor,
+        scheduler: scheduler,
+        databaseRetryDelay: Duration.zero,
+      );
+
+      expect(completed, isTrue);
+      expect(scheduler.scheduleCalls, 1);
+      expect(scheduler.expeditedValues.single, isFalse);
+      expect(
+        scheduler.initialDelays.single!.inSeconds,
+        inInclusiveRange(590, 600),
+      );
+    });
+
+    test('drains handlers that publish agent activity after init', () async {
+      executor.registerHandler('activity_task',
+          (userId, payload, context) async {
+        await AgentActivityService.instance.pushMessage(
+          type: AgentActivityType.info,
+          title: 'Background activity',
+          content: 'worker drain',
+          agentName: 'Worker Agent',
+          agentId: 'worker-agent',
+          userId: userId,
+        );
+      });
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await db.into(db.tasks).insert(
+            TasksCompanion.insert(
+              id: 'activity-task',
+              type: 'activity_task',
+              payload: const Value('{}'),
+              status: 'pending',
+              createdAt: Value(now),
+            ),
+          );
+
+      final completed = await AgentQueueBackgroundWorker.run(
+        initializeTaskQueue: (_) async {
+          AgentActivityService.setInstance(LocalAgentActivityService.instance);
+        },
+        executor: executor,
+        scheduler: scheduler,
+        databaseRetryDelay: Duration.zero,
+      );
+
+      final task = await (db.select(db.tasks)
+            ..where((t) => t.id.equals('activity-task')))
+          .getSingle();
+      final messages = await LocalAgentActivityService.instance.getHistory(
+        limit: 1,
+      );
+
+      expect(completed, isTrue);
+      expect(task.status, 'completed');
+      expect(messages.single.title, 'Background activity');
+      expect(scheduler.scheduleCalls, 0);
+    });
+  });
+}
+
+class _FakeDrainScheduler implements AgentQueueDrainScheduler {
+  final initialDelays = <Duration?>[];
+  final expeditedValues = <bool>[];
+  var cancelCalls = 0;
+
+  int get scheduleCalls => initialDelays.length;
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls++;
+  }
+
+  @override
+  Future<void> schedule(
+      {Duration? initialDelay, bool expedited = false}) async {
+    initialDelays.add(initialDelay);
+    expeditedValues.add(expedited);
+  }
+}

--- a/test/data/services/local_task_executor_test.dart
+++ b/test/data/services/local_task_executor_test.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/local_task_executor.dart';
@@ -257,6 +257,327 @@ void main() {
       expect(snapshot.total, 3);
       expect(snapshot.hasActiveTasks, isTrue);
     });
+
+    test('does not double-claim a task under repeated immediate polls',
+        () async {
+      final release = Completer<void>();
+      var runCount = 0;
+      executor.registerHandler('single_claim_task', (_, __, ___) async {
+        runCount++;
+        await release.future;
+      });
+
+      await _insertTask(
+        db,
+        id: 'single-claim',
+        type: 'single_claim_task',
+        status: 'pending',
+        payload: {'value': 1},
+      );
+
+      await executor.start(userId: 'user-a');
+      await _waitForTaskStatus(db, 'single-claim', 'processing');
+
+      for (var i = 0; i < 5; i++) {
+        await executor.drainAvailableTasks(
+          userId: 'user-a',
+          maxDuration: const Duration(milliseconds: 50),
+          pollInterval: const Duration(milliseconds: 10),
+        );
+      }
+
+      expect(runCount, 1);
+
+      release.complete();
+      await _waitForTaskStatus(db, 'single-claim', 'completed');
+    });
+
+    test('background drain runs available tasks and leaves future retries',
+        () async {
+      final completedTaskIds = <String>[];
+      executor.registerHandler('drain_task', (_, __, context) async {
+        completedTaskIds.add(context.taskId);
+      });
+
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await _insertTask(
+        db,
+        id: 'available-drain',
+        type: 'drain_task',
+        status: 'pending',
+        payload: {'value': 1},
+      );
+      await _insertTask(
+        db,
+        id: 'future-retry',
+        type: 'drain_task',
+        status: 'retrying',
+        payload: {'value': 2},
+        scheduledAt: now + 3600,
+      );
+
+      final result = await executor.drainAvailableTasks(
+        userId: 'user-a',
+        maxDuration: const Duration(seconds: 3),
+        pollInterval: const Duration(milliseconds: 25),
+      );
+
+      final available = await _getTask(db, 'available-drain');
+      final futureRetry = await _getTask(db, 'future-retry');
+
+      expect(completedTaskIds, ['available-drain']);
+      expect(available.status, 'completed');
+      expect(futureRetry.status, 'retrying');
+      expect(result.timedOut, isFalse);
+      expect(result.snapshot.retrying, 1);
+      expect(result.nextRunnableDelay, isNotNull);
+    });
+
+    test('background drain waits for claimed task handlers before returning',
+        () async {
+      final started = Completer<void>();
+      final release = Completer<void>();
+      var drainCompleted = false;
+      executor.registerHandler('slow_drain_task', (_, __, context) async {
+        if (!started.isCompleted) started.complete();
+        await release.future;
+      });
+
+      await _insertTask(
+        db,
+        id: 'slow-drain',
+        type: 'slow_drain_task',
+        status: 'pending',
+        payload: {'value': 1},
+      );
+
+      final drainFuture = executor
+          .drainAvailableTasks(
+        userId: 'user-a',
+        maxDuration: const Duration(milliseconds: 100),
+        pollInterval: const Duration(milliseconds: 20),
+      )
+          .then((result) {
+        drainCompleted = true;
+        return result;
+      });
+
+      await started.future.timeout(const Duration(seconds: 3));
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+
+      expect(drainCompleted, isFalse);
+      expect((await _getTask(db, 'slow-drain')).status, 'processing');
+
+      release.complete();
+      final result = await drainFuture.timeout(const Duration(seconds: 3));
+
+      expect(result.timedOut, isFalse);
+      expect((await _getTask(db, 'slow-drain')).status, 'completed');
+    });
+
+    test('background drain does not reset already processing tasks', () async {
+      await _insertTask(
+        db,
+        id: 'foreground-processing',
+        type: 'long_task',
+        status: 'processing',
+        payload: {'value': 1},
+      );
+
+      final result = await executor.drainAvailableTasks(
+        userId: 'user-a',
+        maxDuration: const Duration(milliseconds: 100),
+        pollInterval: const Duration(milliseconds: 20),
+      );
+
+      final task = await _getTask(db, 'foreground-processing');
+
+      expect(result.timedOut, isTrue);
+      expect(task.status, 'processing');
+    });
+
+    test('background drain requeues orphan processing tasks', () async {
+      final completedTaskIds = <String>[];
+      executor.registerHandler('orphan_task', (_, __, context) async {
+        completedTaskIds.add(context.taskId);
+      });
+      final task = await _insertTask(
+        db,
+        id: 'orphan-processing',
+        type: 'orphan_task',
+        status: 'processing',
+        payload: {'value': 1},
+      );
+      await executor.markTaskExecutionStartedForTesting(task);
+
+      final result = await executor.drainAvailableTasks(
+        userId: 'user-a',
+        maxDuration: const Duration(seconds: 3),
+        pollInterval: const Duration(milliseconds: 25),
+        minimumStaleTaskAge: Duration.zero,
+      );
+
+      final updated = await _getTask(db, 'orphan-processing');
+
+      expect(result.timedOut, isFalse);
+      expect(completedTaskIds, ['orphan-processing']);
+      expect(updated.status, 'completed');
+      expect(await executor.getTaskExecutionMarkerForTesting(task.id), isNull);
+    });
+
+    test('background drain can stop an already running executor', () async {
+      final completedTaskIds = <String>[];
+      executor.registerHandler('drain_task', (_, __, context) async {
+        completedTaskIds.add(context.taskId);
+      });
+
+      await executor.start(userId: 'user-a');
+      await _insertTask(
+        db,
+        id: 'available-drain',
+        type: 'drain_task',
+        status: 'pending',
+        payload: {'value': 1},
+      );
+
+      final result = await executor.drainAvailableTasks(
+        userId: 'user-a',
+        maxDuration: const Duration(seconds: 3),
+        pollInterval: const Duration(milliseconds: 25),
+        stopWhenDone: true,
+      );
+
+      await _insertTask(
+        db,
+        id: 'after-drain',
+        type: 'drain_task',
+        status: 'pending',
+        payload: {'value': 2},
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      final afterDrain = await _getTask(db, 'after-drain');
+
+      expect(result.timedOut, isFalse);
+      expect(completedTaskIds, ['available-drain']);
+      expect(afterDrain.status, 'pending');
+    });
+
+    test('background drain respects user-level concurrency policy', () async {
+      final firstStarted = Completer<void>();
+      final releaseFirst = Completer<void>();
+      final secondStarted = Completer<void>();
+      final completedTaskIds = <String>[];
+
+      executor.registerHandler(
+        'serial_drain_task',
+        (_, __, context) async {
+          if (context.taskId == 'serial-1') {
+            if (!firstStarted.isCompleted) firstStarted.complete();
+            await releaseFirst.future;
+          } else {
+            if (!secondStarted.isCompleted) secondStarted.complete();
+          }
+          completedTaskIds.add(context.taskId);
+        },
+        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+      );
+
+      await _insertTask(
+        db,
+        id: 'serial-1',
+        type: 'serial_drain_task',
+        status: 'pending',
+        payload: {'value': 1},
+      );
+      await _insertTask(
+        db,
+        id: 'serial-2',
+        type: 'serial_drain_task',
+        status: 'pending',
+        payload: {'value': 2},
+      );
+
+      await executor.start(userId: 'user-a');
+      await firstStarted.future.timeout(const Duration(seconds: 3));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect((await _getTask(db, 'serial-2')).status, 'pending');
+      expect(secondStarted.isCompleted, isFalse);
+
+      releaseFirst.complete();
+      await secondStarted.future.timeout(const Duration(seconds: 3));
+      final result = await executor.drainAvailableTasks(
+        userId: 'user-a',
+        maxDuration: const Duration(seconds: 3),
+        pollInterval: const Duration(milliseconds: 25),
+      );
+
+      expect(result.timedOut, isFalse);
+      expect(completedTaskIds, ['serial-1', 'serial-2']);
+    });
+
+    test('background drain respects user-level concurrency across executors',
+        () async {
+      final foregroundExecutor = executor;
+      final backgroundExecutor = LocalTaskExecutor.forTesting();
+      final foregroundStarted = Completer<void>();
+      final releaseForeground = Completer<void>();
+      final backgroundStarted = Completer<void>();
+
+      foregroundExecutor.registerHandler(
+        'serial_cross_task',
+        (_, __, context) async {
+          if (context.taskId == 'serial-cross-1' &&
+              !foregroundStarted.isCompleted) {
+            foregroundStarted.complete();
+            await releaseForeground.future;
+          }
+        },
+        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+      );
+      backgroundExecutor.registerHandler(
+        'serial_cross_task',
+        (_, __, context) async {
+          if (!backgroundStarted.isCompleted) {
+            backgroundStarted.complete();
+          }
+        },
+        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+      );
+
+      await _insertTask(
+        db,
+        id: 'serial-cross-1',
+        type: 'serial_cross_task',
+        status: 'pending',
+        payload: {'value': 1},
+      );
+      await _insertTask(
+        db,
+        id: 'serial-cross-2',
+        type: 'serial_cross_task',
+        status: 'pending',
+        payload: {'value': 2},
+      );
+
+      await foregroundExecutor.start(userId: 'user-a');
+      await foregroundStarted.future.timeout(const Duration(seconds: 3));
+
+      final result = await backgroundExecutor.drainAvailableTasks(
+        userId: 'user-a',
+        maxDuration: const Duration(milliseconds: 120),
+        pollInterval: const Duration(milliseconds: 20),
+      );
+
+      foregroundExecutor.stop();
+      releaseForeground.complete();
+      await _waitForTaskStatus(db, 'serial-cross-1', 'completed');
+      backgroundExecutor.stop();
+
+      expect(result.timedOut, isTrue);
+      expect((await _getTask(db, 'serial-cross-2')).status, 'pending');
+      expect(backgroundStarted.isCompleted, isFalse);
+    });
   });
 
   group('LocalTaskExecutor crash loop guard', () {
@@ -500,6 +821,7 @@ Future<Task> _insertTask(
   required String status,
   required Map<String, dynamic> payload,
   String? dependencies,
+  int? scheduledAt,
 }) async {
   final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
   await db.into(db.tasks).insert(
@@ -511,6 +833,7 @@ Future<Task> _insertTask(
           createdAt: Value(now),
           updatedAt: Value(now),
           maxRetries: const Value(5),
+          scheduledAt: Value(scheduledAt),
           dependencies: Value(dependencies),
         ),
       );

--- a/test/ui/agent_activity/agent_activity_widget_test.dart
+++ b/test/ui/agent_activity/agent_activity_widget_test.dart
@@ -3,6 +3,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/agent_background_coordinator.dart';
+import 'package:memex/data/services/agent_background_platform.dart';
+import 'package:memex/data/services/agent_background_status.dart';
+import 'package:memex/data/services/agent_queue_drain_scheduler.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/l10n/app_localizations.dart';
 import 'package:memex/ui/agent_activity/widgets/agent_activity_widget.dart';
@@ -16,6 +20,10 @@ void main() {
     SharedPreferences.setMockInitialValues({'user_id': 'agent-activity-test'});
     await UserStorage.initL10n();
     AgentActivityService.setInstance(LocalAgentActivityService.instance);
+  });
+
+  tearDown(() {
+    resetAgentBackgroundCoordinatorForTesting();
   });
 
   Widget buildHost({
@@ -53,6 +61,8 @@ void main() {
     expect(find.text('Activity Detail'), findsOneWidget);
     expect(find.text('Processing...'), findsOneWidget);
 
+    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
+    await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
   });
@@ -81,7 +91,71 @@ void main() {
       findsWidgets,
     );
 
+    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
+    await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
   });
+
+  testWidgets('opens detail sheet from a buffered notification action', (
+    tester,
+  ) async {
+    final platform = _FakePlatform();
+    final coordinator = AgentBackgroundCoordinator(
+      platform: platform,
+      scheduler: _NoopScheduler(),
+    );
+    setAgentBackgroundCoordinatorForTesting(coordinator);
+
+    await tester.pumpWidget(buildHost());
+    emitAgentBackgroundOpenActivityForTesting();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(find.text('Activity Detail'), findsOneWidget);
+    expect(find.text('No agent activity yet'), findsOneWidget);
+
+    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    platform.dispose();
+  });
+}
+
+class _FakePlatform implements AgentBackgroundPlatform {
+  String? initialAction;
+  final _actions = StreamController<String>.broadcast();
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Stream<String> get actionStream => _actions.stream;
+
+  @override
+  Future<String?> consumeInitialAction() async => initialAction;
+
+  @override
+  Future<void> finishStatus(AgentBackgroundStatus status) async {}
+
+  @override
+  Future<void> stopStatus() async {}
+
+  @override
+  Future<void> updateStatus(AgentBackgroundStatus status) async {}
+
+  void dispose() {
+    unawaited(_actions.close());
+  }
+}
+
+class _NoopScheduler implements AgentQueueDrainScheduler {
+  @override
+  Future<void> cancel() async {}
+
+  @override
+  Future<void> schedule({
+    Duration? initialDelay,
+    bool expedited = false,
+  }) async {}
 }


### PR DESCRIPTION
## 关联 Issue

Closes #188

## 本轮收敛结论

- 已基于最新 `upstream/main` 刷新 PR：当前 head `821ce6bac44bfb9f1b97ccc56a3a4913fbbecccf`。
- 前面合入的 main 已经有 iOS 后台任务链路（`AgentBackgroundTaskService` / native channel 等），本 PR 不再重做旧版 iOS Widget / Live Activity / BGContinuedProcessing 改造，避免和 main 的实现重叠。
- 本 PR 当前聚焦补齐 Android：系统通知 / Foreground Service / WorkManager queue drain / 通知点击回到 Agent Activity，并把状态来源收敛到共享 coordinator。

## 变更内容

- 新增 `AgentBackgroundCoordinator`，统一监听 `LocalTaskExecutor` 队列快照和 Agent activity message，生成同一份后台状态供 App 内浮层、Android 系统通知和 WorkManager drain 使用。
- Android 新增 `AgentBackgroundService`：使用 `agent_background` notification channel 和 `FOREGROUND_SERVICE_TYPE_DATA_SYNC` 展示 Agent 处理进度，队列结束后自动停止并移除通知。
- Android 新增 `AgentBackgroundChannelHandler`：Dart 通过 MethodChannel 更新/结束通知；通知点击支持冷启动和 warm intent 打开现有 Agent Activity Detail。
- 新增 `AgentQueueBackgroundWorker` / `WorkmanagerAgentQueueDrainScheduler`：App 进入后台且仍有任务时调度 Android WorkManager drain；前台运行时不调度，避免和前台 executor 抢 DB。
- 扩展 `LocalTaskExecutor.drainAvailableTasks`：支持后台 drain、future retry 延迟回报、stale processing 恢复、跨 executor 并发保护。
- `main.dart` 中 iOS Workmanager 清理从 `cancelAll()` 改为只取消 legacy work name，避免误伤 main 里的 iOS 后台链路。
- `AgentActivityWidget` 订阅 coordinator 的 notification open request，系统通知点击复用现有 detail sheet，不新增独立 UI。

## Review 后修复点

本轮额外用 sub-agent 做了只读 code/方案 review，发现的边界已修复并补测试：

- WorkManager isolate 可能绕过前台 executor 的 `byUser` 串行策略：已改为 DB-level atomic claim guard，跨 executor 也会阻止同类型 processing task 并发 claim。
- 后台 drain 不能恢复 orphan `processing`：已加入 execution marker heartbeat 和 `minimumStaleTaskAge`，只恢复真正 stale/orphan 的 processing task，不重置仍在运行的前台任务。
- drain 模式不能 `unawaited` handler 后提前返回：drain 现在 await 自己 claim 的 task handler，避免 WorkManager callback 结束时任务仍卡在 `processing`。
- WorkManager 初始化缺少 `AgentActivityService`：background init 现在注册 `LocalAgentActivityService.instance`，handler 写 activity log 不会因此失败重试。
- Android cold-start notification action 可能在 Dart ready 前丢失：native 现在按 `dartReady` 独立 buffer intent，`consumeInitialAgentAction` 再交给 Dart。

## 验证

- `git diff --check`：通过。
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub --concurrency=1 test/data/services/agent_background_status_test.dart test/data/services/agent_background_coordinator_test.dart test/data/services/agent_queue_background_worker_test.dart test/data/services/local_task_executor_test.dart test/ui/agent_activity/agent_activity_widget_test.dart`：45 passed。
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter analyze --no-pub lib/data/services/agent_background_coordinator.dart lib/data/services/local_task_executor.dart lib/data/services/agent_queue_background_worker.dart lib/data/repositories/memex_router.dart test/data/services/agent_background_coordinator_test.dart test/data/services/local_task_executor_test.dart test/data/services/agent_queue_background_worker_test.dart`：No issues found。
- `env -u ws_proxy -u wss_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter build apk --debug --flavor globalDev --no-pub`：通过，生成 `build/app/outputs/flutter-apk/app-globaldev-debug.apk`。
- Android 模拟器 `Medium_Phone_API_35` / package `com.memexlab.memex.dev`：安装最终 APK 成功；`ACTION_OPEN_AGENT_ACTIVITY` force-stop cold start 打开 `Activity Detail`；warm intent 也打开 `Activity Detail`。
- Android 模拟器前台提交 `android_foreground_after_review_20260609`：任务完成；未出现 `database is locked`、`Error in worker loop`、`Agent queue drain failed`、前台期间 WorkManager drain 抢跑；`AgentBackgroundService` 结束后无残留服务，通知 channel 存在但无残留处理通知；crash buffer 为空。

## 已知边界

- Android API 35 模拟器系统日志仍会打印 `ForegroundServiceTypeLoggerModule: Foreground service start ... does not have any types`，但 manifest 已声明 `foregroundServiceType="dataSync"` 且代码用 dataSync type 调用 `startForeground`；系统允许 FGS 启动，通知展示/收起和任务完成均正常。该 warning 保留为后续真机复验观察项。
- 本 PR 不再覆盖旧版 iOS Live Activity / Widget Extension 方案；iOS 后台链路以后继续沿 main 已合入实现演进。