### PR TITLE
[codex] 日程聚合隐式处理重复冲突

### DIFF
--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -702,7 +702,7 @@ Please use the `get_available_insight_card_templates` tool to check for all avai
 update_schedule_aggregation
 
 ## Persona
-You are a "Personal Schedule Curator" — an empathetic time coach who sees patterns in the user's schedule. You don't just list events; you tell the story of their time. You highlight what's important, warn about conflicts, and celebrate progress.
+You are a "Personal Schedule Curator" — an empathetic time coach who sees patterns in the user's schedule. You don't just list events; you tell the story of their time. You highlight what's important, quietly reconcile duplicate schedule versions, and celebrate progress.
 
 ## Quality Standard: "Magazine Bar"
 - ❌ BANNED: "You have 3 meetings today"
@@ -710,16 +710,18 @@ You are a "Personal Schedule Curator" — an empathetic time coach who sees patt
 
 ## Core Protocol: "Editorial Flow"
 1. **Discovery**: Use `get_schedule_cards` tool to read all temporal cards in the time window (past 3 days ~ future 30 days)
-2. **Prioritization**: Identify the hero item (most important upcoming event), deadlines, conflicts
+2. **Prioritization**: Identify the hero item (most important upcoming event), deadlines, and real scheduling pressure
 3. **Narrative**: Write an editorial intro that captures the week's story
 4. **Presentation**: Structure output as YAML and call `save_schedule_aggregation` tool
 
 ## Completion Semantics
 - `get_schedule_cards.status` is the schedule item status, not the timeline card processing status.
 - `get_schedule_cards.start_time` is the schedule display time. For task cards, it falls back to `due_date` when the original card has no explicit `start_time`.
+- The current `schedule_cards` result is the authoritative schedule source. Any previous/latest aggregation is continuity context only; do not copy its items as another source.
 - For task cards, `is_completed: true` means the user's task is done. For grouped tasks, all source subtasks completed also means the parent task is done.
 - If `is_completed` is absent/false and not all subtasks are completed, keep the task pending even if the AI card generation has finished.
 - Non-task cards with no concrete day or start time are long-term reference items. The system will add a stable `display_until` deadline and expire them; do not renew or reinterpret them as tasks just to keep them visible.
+- If an item appears in both a previous aggregation and the current rebuilt output, silently keep the current card version once. Do not create conflict descriptions, warning quote blocks, or duplicate timeline entries about rebuilt/previous versions.
 
 ## Output Schema
 When calling `save_schedule_aggregation`, the `yaml_data` object MUST follow this structure:
@@ -772,17 +774,17 @@ conflicts:
 ## Visual Presentation Strategy
 - Magazine Style: One hero, one narrative, selective highlights
 - Hero Item: The single most important upcoming event (not necessarily the closest). Choose based on priority, impact, and user context.
-- Quote Blocks: Urgent deadlines, time conflicts, or important reminders. Max 2 items.
+- Quote Blocks: Urgent deadlines, real scheduling pressure, or important reminders. Max 2 items.
 - Timeline: Group by day. Max 7 days. Preserve original card IDs for navigation.
 - Task Subtasks: If a source task card has `subtasks`, include them on that task's timeline item with each original title and completion state. Do not split one task card into multiple timeline cards, and do not invent subtasks for cards that do not have them.
 - Completed: Separate section, faded but acknowledged.
-- Conflicts: Detect overlapping events and highlight them.
+- Conflicts: Reserve for genuine time overlaps between distinct source cards. Never use conflicts for duplicate, rebuilt, previous, or regenerated versions of the same real item.
 
 ## AI-Driven Presentation Rules
 - Let CONTENT drive the layout, not a fixed template
 - If one event is clearly dominant (investor meeting, product launch, deadline), make it the hero
 - If multiple items compete for attention, use quote blocks to elevate key ones
-- If there's a time conflict, it becomes a quote block warning
+- If there's real scheduling pressure, mention it gently in a quote block
 - If the user has completed many tasks, celebrate it in the editorial intro
 - If the schedule is light, suggest opportunities or encourage rest
 
@@ -790,6 +792,7 @@ conflicts:
 - Only use data from user's actual cards (no hallucination)
 - Preserve original card IDs (fact_id) for navigation
 - Preserve returned `start_time` values in hero/timeline items whenever they are present, including task deadlines normalized from `due_date`.
+- Output each source card at most once across timeline/completed. If two records represent the same rebuilt item, choose the current `schedule_cards` version and do not explain that reconciliation to the user.
 - Use Chinese if user's data is in Chinese
 - Never expose internal IDs or file paths to the user-facing content
 - Do not put task cards in `completed` unless the source card's `is_completed` field is true.

--- a/lib/agent/schedule_aggregator_agent/prompt.dart
+++ b/lib/agent/schedule_aggregator_agent/prompt.dart
@@ -5,7 +5,7 @@ You are the Schedule Aggregator, a specialized agent with the `update_schedule_a
 
 ## Core Task
 1. Read recent temporal cards from the user's timeline (past 3 days ~ future 30 days)
-2. Analyze priorities, deadlines, time conflicts, and completion status
+2. Analyze priorities, deadlines, scheduling pressure, and completion status
 3. Generate a schedule aggregation in magazine editorial style
 4. Output as a structured YAML file via the `save_schedule_aggregation` tool
 
@@ -33,6 +33,12 @@ You are the Schedule Aggregator, a specialized agent with the `update_schedule_a
   items. They may be surfaced briefly, but the system will add a stable
   `display_until` deadline and expire them instead of letting them renew on
   every refresh.
+- Treat `schedule_cards` as the authoritative current source. The latest
+  aggregation is continuity context only; never copy its items as a second
+  schedule source.
+- If the same event/task appears in both a previous aggregation and the current
+  rebuilt output, silently keep the current card version and include it once.
+  Do not create user-facing conflict warnings about duplicate/rebuilt versions.
 
 ## Language Consistency Rule (CRITICAL)
 - Respect User Language: If user's input is Chinese, output MUST be Chinese

--- a/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
+++ b/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
@@ -4,6 +4,7 @@ import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/agent/prompts.dart';
 import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_retention.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/schedule_aggregation_normalizer.dart';
 import 'package:memex/data/services/schedule_refresh_state_service.dart';
 import 'package:memex/data/services/system_action_service.dart';
 import 'package:memex/db/app_database.dart';
@@ -263,11 +264,14 @@ Tool buildSaveScheduleAggregationTool() {
           userId: userId,
           yamlData: yamlData,
         );
+        final reconciledYamlData = normalizeScheduleAggregationYaml(
+          normalizedYamlData,
+        );
         final previousAggregations = await fileSystem.listScheduleAggregations(
           userId,
         );
         final retainedYamlData = applyScheduleDisplayRetention(
-          yamlData: normalizedYamlData,
+          yamlData: reconciledYamlData,
           previousAggregations: previousAggregations,
         );
 

--- a/lib/data/repositories/get_schedule_aggregation.dart
+++ b/lib/data/repositories/get_schedule_aggregation.dart
@@ -1,5 +1,6 @@
 import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_retention.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/schedule_aggregation_normalizer.dart';
 import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/domain/models/schedule_aggregation_model.dart';
 import 'package:memex/utils/logger.dart';
@@ -34,7 +35,9 @@ Future<ScheduleAggregationModel?> getScheduleAggregation() async {
       userId: userId,
       aggregation: retained,
     );
-    return ScheduleAggregationModel.fromYaml(hydrated);
+    return ScheduleAggregationModel.fromYaml(
+      normalizeScheduleAggregationYaml(hydrated),
+    );
   } catch (e) {
     _logger.severe('Failed to get schedule aggregation: $e');
     return null;

--- a/lib/data/services/schedule_aggregation_normalizer.dart
+++ b/lib/data/services/schedule_aggregation_normalizer.dart
@@ -1,0 +1,279 @@
+Map<String, dynamic> normalizeScheduleAggregationYaml(
+  Map<String, dynamic> yaml,
+) {
+  final normalized = Map<String, dynamic>.from(yaml);
+  final conflictResult = _normalizeConflicts(normalized['conflicts']);
+  final completed = _normalizeCompleted(normalized['completed']);
+
+  normalized['completed'] = completed;
+  normalized['timeline'] = _normalizeTimeline(
+    normalized['timeline'],
+    completedIds: _collectItemIds(completed),
+    duplicateConflictIds: conflictResult.duplicateItemIds,
+    hasGlobalDuplicateAdvisory: conflictResult.hasDuplicateAdvisory,
+  );
+  normalized['conflicts'] = conflictResult.conflicts;
+
+  return normalized;
+}
+
+List<Map<String, dynamic>> _normalizeCompleted(dynamic value) {
+  if (value is! List) return const [];
+
+  final mergedByKey = <String, Map<String, dynamic>>{};
+  final order = <String>[];
+  var fallbackIndex = 0;
+
+  for (final itemValue in value) {
+    final item = _asMap(itemValue);
+    if (item == null) continue;
+    final id = _readItemId(item);
+    final key = id == null ? 'completed_index_${fallbackIndex++}' : 'id:$id';
+    if (!mergedByKey.containsKey(key)) {
+      order.add(key);
+      mergedByKey[key] = item;
+    } else {
+      mergedByKey[key] = _mergeScheduleItem(mergedByKey[key]!, item);
+    }
+  }
+
+  return [
+    for (final key in order)
+      if (mergedByKey[key] != null) mergedByKey[key]!,
+  ];
+}
+
+List<Map<String, dynamic>> _normalizeTimeline(
+  dynamic value, {
+  required Set<String> completedIds,
+  required Set<String> duplicateConflictIds,
+  required bool hasGlobalDuplicateAdvisory,
+}) {
+  if (value is! List) return const [];
+
+  final mergedByKey = <String, Map<String, dynamic>>{};
+  final winnerByKey = <String, _TimelineEntry>{};
+
+  for (final dayEntry in value.indexed) {
+    final day = _asMap(dayEntry.$2);
+    if (day == null) continue;
+    final items = day['items'];
+    if (items is! List) continue;
+
+    for (final itemEntry in items.indexed) {
+      final item = _asMap(itemEntry.$2);
+      if (item == null) continue;
+      final id = _readItemId(item);
+      if (id != null && completedIds.contains(id)) continue;
+
+      final key = _timelineItemKey(
+        item,
+        duplicateConflictIds: duplicateConflictIds,
+        hasGlobalDuplicateAdvisory: hasGlobalDuplicateAdvisory,
+      );
+      if (key == null) continue;
+
+      final entry = _TimelineEntry(
+        dayIndex: dayEntry.$1,
+        itemIndex: itemEntry.$1,
+      );
+      mergedByKey[key] = mergedByKey.containsKey(key)
+          ? _mergeScheduleItem(mergedByKey[key]!, item)
+          : item;
+      winnerByKey[key] = entry;
+    }
+  }
+
+  final normalizedDays = <Map<String, dynamic>>[];
+  for (final dayEntry in value.indexed) {
+    final day = _asMap(dayEntry.$2);
+    if (day == null) continue;
+    final items = day['items'];
+    if (items is! List) continue;
+
+    final normalizedItems = <Map<String, dynamic>>[];
+    for (final itemEntry in items.indexed) {
+      final item = _asMap(itemEntry.$2);
+      if (item == null) continue;
+      final id = _readItemId(item);
+      if (id != null && completedIds.contains(id)) continue;
+
+      final key = _timelineItemKey(
+        item,
+        duplicateConflictIds: duplicateConflictIds,
+        hasGlobalDuplicateAdvisory: hasGlobalDuplicateAdvisory,
+      );
+      if (key == null) {
+        normalizedItems.add(item);
+        continue;
+      }
+
+      final winner = winnerByKey[key];
+      if (winner != null &&
+          winner.dayIndex == dayEntry.$1 &&
+          winner.itemIndex == itemEntry.$1) {
+        normalizedItems.add(mergedByKey[key]!);
+      }
+    }
+
+    if (normalizedItems.isNotEmpty) {
+      normalizedDays.add({...day, 'items': normalizedItems});
+    }
+  }
+
+  return normalizedDays;
+}
+
+_ConflictNormalization _normalizeConflicts(dynamic value) {
+  if (value is! List) {
+    return const _ConflictNormalization(conflicts: []);
+  }
+
+  final conflicts = <Map<String, dynamic>>[];
+  final duplicateItemIds = <String>{};
+  var hasDuplicateAdvisory = false;
+
+  for (final conflictValue in value) {
+    final conflict = _asMap(conflictValue);
+    if (conflict == null) continue;
+    final itemIds = _readItemIds(conflict);
+    if (_isDuplicateAdvisoryConflict(conflict, itemIds)) {
+      duplicateItemIds.addAll(itemIds);
+      hasDuplicateAdvisory = true;
+      continue;
+    }
+    conflicts.add(conflict);
+  }
+
+  return _ConflictNormalization(
+    conflicts: conflicts,
+    duplicateItemIds: duplicateItemIds,
+    hasDuplicateAdvisory: hasDuplicateAdvisory,
+  );
+}
+
+bool _isDuplicateAdvisoryConflict(
+  Map<String, dynamic> conflict,
+  List<String> itemIds,
+) {
+  if (itemIds.toSet().length != itemIds.length) return true;
+
+  final description = (conflict['description'] ?? '').toString().toLowerCase();
+  return _duplicateAdvisoryTerms.any(description.contains);
+}
+
+String? _timelineItemKey(
+  Map<String, dynamic> item, {
+  required Set<String> duplicateConflictIds,
+  required bool hasGlobalDuplicateAdvisory,
+}) {
+  final id = _readItemId(item);
+  final semanticKey = _semanticTimelineItemKey(item);
+  if (semanticKey != null &&
+      ((id != null && duplicateConflictIds.contains(id)) ||
+          (id == null && hasGlobalDuplicateAdvisory))) {
+    return 'semantic:$semanticKey';
+  }
+  if (id != null) return 'id:$id';
+  if (semanticKey != null) return 'semantic:$semanticKey';
+  return null;
+}
+
+String? _semanticTimelineItemKey(Map<String, dynamic> item) {
+  final title = _normalizeText(item['title']);
+  final startTime = _normalizeText(item['start_time']);
+  if (title.isEmpty || startTime.isEmpty) return null;
+
+  final type = _normalizeText(item['type']);
+  return '${type.isEmpty ? 'item' : type}|$startTime|$title';
+}
+
+Map<String, dynamic> _mergeScheduleItem(
+  Map<String, dynamic> base,
+  Map<String, dynamic> incoming,
+) {
+  final merged = Map<String, dynamic>.from(base);
+  for (final entry in incoming.entries) {
+    if (_hasMeaningfulValue(entry.value)) {
+      merged[entry.key] = entry.value;
+    }
+  }
+  return merged;
+}
+
+bool _hasMeaningfulValue(dynamic value) {
+  if (value == null) return false;
+  if (value is String) return value.trim().isNotEmpty;
+  if (value is Iterable) return value.isNotEmpty;
+  if (value is Map) return value.isNotEmpty;
+  return true;
+}
+
+Map<String, dynamic>? _asMap(dynamic value) {
+  if (value is! Map) return null;
+  return Map<String, dynamic>.from(value);
+}
+
+String? _readItemId(Map<String, dynamic> value) {
+  final id = (value['card_id'] ?? value['id'])?.toString().trim();
+  return id == null || id.isEmpty ? null : id;
+}
+
+List<String> _readItemIds(Map<String, dynamic> conflict) {
+  final itemIds = conflict['item_ids'];
+  if (itemIds is! List) return const [];
+  return itemIds
+      .map((item) => item.toString().trim())
+      .where((item) => item.isNotEmpty)
+      .toList();
+}
+
+Set<String> _collectItemIds(List<Map<String, dynamic>> items) {
+  return {
+    for (final item in items)
+      if (_readItemId(item) != null) _readItemId(item)!,
+  };
+}
+
+String _normalizeText(dynamic value) {
+  if (value == null) return '';
+  return value.toString().trim().toLowerCase();
+}
+
+const _duplicateAdvisoryTerms = [
+  'duplicate',
+  'duplicated',
+  'duplication',
+  'rebuild',
+  'rebuilt',
+  'regenerated',
+  'recreated',
+  'previous version',
+  'current version',
+  '重复',
+  '重建',
+  '重新生成',
+  '再生成',
+  '旧版本',
+  '新版本',
+  '当前版本',
+];
+
+class _ConflictNormalization {
+  const _ConflictNormalization({
+    required this.conflicts,
+    this.duplicateItemIds = const {},
+    this.hasDuplicateAdvisory = false,
+  });
+
+  final List<Map<String, dynamic>> conflicts;
+  final Set<String> duplicateItemIds;
+  final bool hasDuplicateAdvisory;
+}
+
+class _TimelineEntry {
+  const _TimelineEntry({required this.dayIndex, required this.itemIndex});
+
+  final int dayIndex;
+  final int itemIndex;
+}

--- a/lib/ui/core/cards/templates/system/schedule_briefing_card.dart
+++ b/lib/ui/core/cards/templates/system/schedule_briefing_card.dart
@@ -117,14 +117,6 @@ class ScheduleBriefingCard extends StatelessWidget {
                   data['completed_count'] ?? 0,
                 ),
               ),
-              const SizedBox(width: 8),
-              if ((data['conflict_count'] as int? ?? 0) > 0)
-                _buildCountChip(
-                  Icons.warning_amber_rounded,
-                  UserStorage.l10n.scheduleBriefingConflictCount(
-                    data['conflict_count'] ?? 0,
-                  ),
-                ),
               const Spacer(),
               Text(
                 UserStorage.l10n.scheduleBriefingOpen,

--- a/lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart
+++ b/lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart
@@ -60,15 +60,6 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
         const SizedBox(height: 18),
       ],
 
-      // Conflicts
-      if (agg.conflicts.isNotEmpty) ...[
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: agg.conflicts.map(_buildAgentConflict).toList(),
-        ),
-        const SizedBox(height: 18),
-      ],
-
       // Timeline
       if (agg.timeline.isNotEmpty)
         for (final entry in agg.timeline.indexed) ...[
@@ -339,30 +330,6 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
           ),
         ),
       ],
-    );
-  }
-
-  Widget _buildAgentConflict(Conflict conflict) {
-    return Container(
-      margin: const EdgeInsets.only(bottom: 12),
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: const Color(0xFFFEF2F2),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: const Color(0xFFFCA5A5)),
-      ),
-      child: Row(
-        children: [
-          const Icon(Icons.warning_amber, size: 20, color: Color(0xFFF87171)),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              conflict.description,
-              style: const TextStyle(fontSize: 14, color: Color(0xFFB91C1C)),
-            ),
-          ),
-        ],
-      ),
     );
   }
 

--- a/test/data/services/schedule_aggregation_normalizer_test.dart
+++ b/test/data/services/schedule_aggregation_normalizer_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/schedule_aggregation_normalizer.dart';
+
+void main() {
+  group('normalizeScheduleAggregationYaml', () {
+    test(
+      'silently keeps one rebuilt duplicate and drops advisory conflicts',
+      () {
+        final normalized = normalizeScheduleAggregationYaml({
+          'timeline': [
+            {
+              'day_label': 'Today',
+              'day_date': '2026-05-26',
+              'items': [
+                {
+                  'card_id': 'event-visa',
+                  'title': '签证预约',
+                  'type': 'event',
+                  'start_time': '2026-05-26T10:00:00+08:00',
+                  'description': '旧版本',
+                },
+              ],
+            },
+            {
+              'day_label': 'Today',
+              'day_date': '2026-05-26',
+              'items': [
+                {
+                  'card_id': 'event-visa',
+                  'title': '签证预约',
+                  'type': 'event',
+                  'start_time': '2026-05-26T10:00:00+08:00',
+                  'description': '重建版本',
+                },
+              ],
+            },
+          ],
+          'completed': [],
+          'conflicts': [
+            {
+              'description': '签证预约事件重复，建议以重建版本为准',
+              'item_ids': ['event-visa', 'event-visa'],
+            },
+          ],
+        });
+
+        final timeline = normalized['timeline'] as List;
+        final items = (timeline.single as Map)['items'] as List;
+
+        expect(items, hasLength(1));
+        expect((items.single as Map)['card_id'], 'event-visa');
+        expect((items.single as Map)['description'], '重建版本');
+        expect(normalized['conflicts'], isEmpty);
+      },
+    );
+
+    test(
+      'dedupes semantic duplicates only when conflict marked them duplicate',
+      () {
+        final normalized = normalizeScheduleAggregationYaml({
+          'timeline': [
+            {
+              'day_label': 'Today',
+              'day_date': '2026-05-26',
+              'items': [
+                {
+                  'card_id': 'event-old',
+                  'title': '牙医预约',
+                  'type': 'event',
+                  'start_time': '2026-05-26T10:00:00+08:00',
+                },
+                {
+                  'card_id': 'event-new',
+                  'title': '牙医预约',
+                  'type': 'event',
+                  'start_time': '2026-05-26T10:00:00+08:00',
+                  'location': '诊所',
+                },
+              ],
+            },
+          ],
+          'completed': [],
+          'conflicts': [
+            {
+              'description': '重复事件，保留重建版本',
+              'item_ids': ['event-old', 'event-new'],
+            },
+          ],
+        });
+
+        final items =
+            (((normalized['timeline'] as List).single as Map)['items'] as List);
+
+        expect(items, hasLength(1));
+        expect((items.single as Map)['card_id'], 'event-new');
+        expect((items.single as Map)['location'], '诊所');
+        expect(normalized['conflicts'], isEmpty);
+      },
+    );
+
+    test('keeps real overlap conflicts between distinct source cards', () {
+      final normalized = normalizeScheduleAggregationYaml({
+        'timeline': [
+          {
+            'day_label': 'Today',
+            'items': [
+              {
+                'card_id': 'event-a',
+                'title': 'Design review',
+                'type': 'event',
+                'start_time': '2026-05-26T10:00:00+08:00',
+              },
+              {
+                'card_id': 'event-b',
+                'title': 'Dentist',
+                'type': 'event',
+                'start_time': '2026-05-26T10:30:00+08:00',
+              },
+            ],
+          },
+        ],
+        'completed': [],
+        'conflicts': [
+          {
+            'description': 'Two fixed events overlap at 10:30.',
+            'item_ids': ['event-a', 'event-b'],
+          },
+        ],
+      });
+
+      expect(normalized['conflicts'], hasLength(1));
+      expect(
+        ((normalized['timeline'] as List).single as Map)['items'],
+        hasLength(2),
+      );
+    });
+
+    test('completed items suppress duplicate pending timeline entries', () {
+      final normalized = normalizeScheduleAggregationYaml({
+        'timeline': [
+          {
+            'day_label': 'Today',
+            'items': [
+              {
+                'card_id': 'task-done',
+                'title': '同步发布稿',
+                'type': 'task',
+                'status': 'pending',
+              },
+            ],
+          },
+        ],
+        'completed': [
+          {'card_id': 'task-done', 'title': '同步发布稿'},
+        ],
+        'conflicts': [],
+      });
+
+      expect(normalized['timeline'], isEmpty);
+      expect(normalized['completed'], hasLength(1));
+    });
+  });
+}

--- a/test/ui/schedule/widgets/schedule_widgets_test.dart
+++ b/test/ui/schedule/widgets/schedule_widgets_test.dart
@@ -60,13 +60,9 @@ void main() {
         );
         expect(find.text('Deadline pressure'), findsOneWidget);
 
-        await tester.ensureVisible(
-          find.text('Two fixed events overlap with the cleaning window.'),
-        );
-        await tester.pumpAndSettle();
         expect(
           find.text('Two fixed events overlap with the cleaning window.'),
-          findsOneWidget,
+          findsNothing,
         );
 
         await tester.ensureVisible(find.text('Clean the apartment'));
@@ -465,7 +461,7 @@ void main() {
       expect(find.textContaining('2026-05-15T10:00'), findsNothing);
       expect(
         find.text(UserStorage.l10n.scheduleBriefingConflictCount(1)),
-        findsOneWidget,
+        findsNothing,
       );
     });
   });


### PR DESCRIPTION
Closes #193

## 变更内容

- 调整 Schedule Aggregator prompt：明确 `schedule_cards` 是当前事实源，上一版聚合只作为连续性上下文，不应复制成第二份日程来源。
- 新增日程聚合归一化逻辑：保存和读取聚合结果时隐式去重 timeline/completed，过滤“重复 / 重建版本”类 advisory conflict，同时保留真实时间重叠冲突的结构化数据。
- 日程页移除红色 conflict 警示块，Schedule Briefing 不再展示冲突数量 chip，避免把内部恢复细节推给用户。
- 补充归一化单测，并更新日程页面 widget 断言。

## 验证

- `flutter pub get --offline`
- `flutter test --no-pub test/data/services/schedule_aggregation_normalizer_test.dart test/data/repositories/get_schedule_aggregation_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart`
- `dart analyze lib/agent/schedule_aggregator_agent/prompt.dart lib/agent/prompts.dart lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart lib/data/repositories/get_schedule_aggregation.dart lib/data/services/schedule_aggregation_normalizer.dart lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart lib/ui/core/cards/templates/system/schedule_briefing_card.dart test/data/services/schedule_aggregation_normalizer_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart`

## 备注

本地 Flutter 验证前 `.dart_tool/package_config.json` 缺失，已按本地缓存执行 `flutter pub get --offline` 恢复；测试命令执行时同时取消 `ws_proxy/wss_proxy` 并设置 localhost bypass，避免 flutter_tester WebSocket 被代理干扰。
