### PR TITLE
[codex] 修复输入发送后草稿残留

### DIFF
--- a/lib/ui/main_screen/widgets/input_sheet.dart
+++ b/lib/ui/main_screen/widgets/input_sheet.dart
@@ -369,13 +369,16 @@ class _InputSheetState extends State<InputSheet>
   }
 
   void _scheduleDraftSave() {
+    if (_isSubmitting) return;
     _draftSaveDebounce?.cancel();
     _draftSaveDebounce = Timer(const Duration(milliseconds: 400), () {
+      if (_isSubmitting) return;
       unawaited(_draftService.saveTextDraft(_textController.text));
     });
   }
 
   Future<void> _flushDraft() async {
+    if (_isSubmitting) return;
     _draftSaveDebounce?.cancel();
     if (!widget.isOpen && _textController.text.trim().isEmpty) return;
     await _draftService.saveTextDraft(_textController.text);
@@ -426,7 +429,8 @@ class _InputSheetState extends State<InputSheet>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _draftSaveDebounce?.cancel();
-    if (widget.isOpen || _textController.text.trim().isNotEmpty) {
+    if (!_isSubmitting &&
+        (widget.isOpen || _textController.text.trim().isNotEmpty)) {
       unawaited(_draftService.saveTextDraft(_textController.text));
     }
     _audioStreamSub?.cancel();
@@ -1204,9 +1208,10 @@ class _InputSheetState extends State<InputSheet>
     }
 
     setState(() => _isSubmitting = true);
-    await _flushDraft();
+    final submittedDraftText = _textController.text;
+    _draftSaveDebounce?.cancel();
+    await _draftService.clearActiveDraft();
     final submitted = await widget.onSubmit(inputData);
-    if (!mounted) return;
 
     if (submitted) {
       await _draftService.clearActiveDraft();
@@ -1214,6 +1219,8 @@ class _InputSheetState extends State<InputSheet>
       _resetForm();
       _setRestoredDraft(false);
     } else {
+      await _draftService.saveTextDraft(submittedDraftText);
+      if (!mounted) return;
       setState(() => _isSubmitting = false);
     }
   }
@@ -1762,7 +1769,9 @@ class _InputSheetState extends State<InputSheet>
                                               key: DemoService.instance.isActive
                                                   ? DemoService
                                                       .instance.sendButtonKey
-                                                  : null,
+                                                  : const ValueKey(
+                                                      'input_sheet_submit_button',
+                                                    ),
                                               onTap: _handleSubmit,
                                               child: Container(
                                                 padding:

--- a/test/ui/main_screen/widgets/input_sheet_test.dart
+++ b/test/ui/main_screen/widgets/input_sheet_test.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/input_draft_service.dart';
 import 'package:memex/data/services/local_asset_server.dart';
 import 'package:memex/l10n/app_localizations.dart';
 import 'package:memex/ui/main_screen/widgets/input_sheet.dart';
@@ -15,11 +18,55 @@ void main() {
   late Directory testDataRoot;
 
   setUpAll(() async {
+    const recordChannel = MethodChannel('com.llfbandit.record/messages');
+    const audioGlobalChannel = MethodChannel('xyz.luan/audioplayers.global');
+    const audioPlayerChannel = MethodChannel('xyz.luan/audioplayers');
+    final messenger = TestDefaultBinaryMessengerBinding
+        .instance
+        .defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(recordChannel, (call) async {
+      switch (call.method) {
+        case 'hasPermission':
+        case 'isPaused':
+        case 'isRecording':
+        case 'isEncoderSupported':
+          return false;
+        case 'listInputDevices':
+          return <Object>[];
+        case 'getAmplitude':
+          return {'current': 0.0, 'max': 0.0};
+        default:
+          return null;
+      }
+    });
+    messenger.setMockMethodCallHandler(audioGlobalChannel, (_) async => null);
+    messenger.setMockStreamHandler(
+      const EventChannel('xyz.luan/audioplayers.global/events'),
+      MockStreamHandler.inline(onListen: (arguments, events) {}),
+    );
+    messenger.setMockMethodCallHandler(audioPlayerChannel, (call) async {
+      if (call.method == 'create') {
+        final arguments = call.arguments as Map<Object?, Object?>?;
+        final playerId = arguments?['playerId'] as String?;
+        if (playerId != null) {
+          messenger.setMockStreamHandler(
+            EventChannel('xyz.luan/audioplayers/events/$playerId'),
+            MockStreamHandler.inline(onListen: (arguments, events) {}),
+          );
+        }
+      }
+      return null;
+    });
+
     SharedPreferences.setMockInitialValues({'user_id': 'input-sheet-test'});
     await UserStorage.initL10n();
 
     testDataRoot = await Directory.systemTemp.createTemp('memex_input_sheet_');
     await FileSystemService.init(testDataRoot.path);
+  });
+
+  setUp(() async {
+    await InputDraftService.instance.clearActiveDraft();
   });
 
   tearDownAll(() async {
@@ -81,5 +128,143 @@ void main() {
     expect(find.text('Home content'), findsOneWidget);
     expect(find.byType(TextField), findsNothing);
     expect(find.text('close count: 1'), findsOneWidget);
+  });
+
+  testWidgets(
+    'successful submit clears draft and suppresses dispose saves',
+    (tester) async {
+      final submitCompleter = Completer<bool>();
+      InputData? submittedData;
+
+      await tester.pumpWidget(
+        buildSubmitHost(
+          onSubmit: (data, closeSheet) {
+            submittedData = data;
+            closeSheet();
+            return submitCompleter.future;
+          },
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+
+      await tester.enterText(find.byType(TextField), 'sent note');
+      await tester.pump();
+      await saveActiveDraft(tester, 'sent note');
+      expect(await activeDraftText(tester), 'sent note');
+
+      final submitButton = find.byKey(
+        const ValueKey('input_sheet_submit_button'),
+      );
+      await tester.runAsync<void>(() async {
+        tester.widget<GestureDetector>(submitButton).onTap!();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      });
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(submittedData?.text, 'sent note');
+      expect(await activeDraftText(tester), isNull);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(await activeDraftText(tester), isNull);
+
+      await tester.runAsync<void>(() async {
+        submitCompleter.complete(true);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      });
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(await activeDraftText(tester), isNull);
+    },
+  );
+
+  testWidgets('failed submit writes the submitted text back to draft', (
+    tester,
+  ) async {
+    final submitCompleter = Completer<bool>();
+
+    await tester.pumpWidget(
+      buildSubmitHost(
+        onSubmit: (data, closeSheet) {
+          closeSheet();
+          return submitCompleter.future;
+        },
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 350));
+
+    await tester.enterText(find.byType(TextField), 'keep on failure');
+    await tester.pump();
+    await saveActiveDraft(tester, 'keep on failure');
+
+    final submitButton = find.byKey(
+      const ValueKey('input_sheet_submit_button'),
+    );
+    await tester.runAsync<void>(() async {
+      tester.widget<GestureDetector>(submitButton).onTap!();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(await activeDraftText(tester), isNull);
+
+    await tester.runAsync<void>(() async {
+      submitCompleter.complete(false);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(await activeDraftText(tester), 'keep on failure');
+  });
+}
+
+typedef SubmitHostCallback = Future<bool> Function(
+  InputData data,
+  VoidCallback closeSheet,
+);
+
+Widget buildSubmitHost({required SubmitHostCallback onSubmit}) {
+  var isOpen = true;
+
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: StatefulBuilder(
+        builder: (context, setState) {
+          return Stack(
+            children: [
+              InputSheet(
+                isOpen: isOpen,
+                onClose: () {
+                  setState(() => isOpen = false);
+                },
+                onSubmit: (data) {
+                  return onSubmit(data, () {
+                    setState(() => isOpen = false);
+                  });
+                },
+              ),
+            ],
+          );
+        },
+      ),
+    ),
+  );
+}
+
+Future<String?> activeDraftText(WidgetTester tester) {
+  return tester.runAsync<String?>(() async {
+    final draft = await InputDraftService.instance.loadActiveDraft();
+    return draft?.text;
+  });
+}
+
+Future<void> saveActiveDraft(WidgetTester tester, String text) {
+  return tester.runAsync<void>(() {
+    return InputDraftService.instance.saveTextDraft(text);
   });
 }


### PR DESCRIPTION
## 背景
Closes #197

用户在输入框发送文字后，卡片已经生成成功，但切回桌面再回到应用时，同一段文字仍出现在草稿箱里。这会让用户误以为内容没有发送，并可能造成重复提交。

## 根因
`InputSheet._handleSubmit()` 原先会在提交前调用 `_flushDraft()`，把即将发送的内容写入 active draft。随后主界面会立即关闭输入框并异步提交；如果提交期间应用退后台、widget dispose 或 pending debounce 触发，旧文本仍可能被再次保存为草稿。卡片生成成功后，草稿状态就可能与真实提交状态不一致。

## 改动
- 发送开始后取消 pending draft debounce，并立即清理 active draft。
- `_scheduleDraftSave()`、`_flushDraft()`、`dispose()` 在 `_isSubmitting` 时跳过草稿写入，避免发送中的旧文本被重新保存。
- 提交失败时恢复点击发送时的文本，保留用户输入。
- 为发送按钮补充稳定 key，覆盖提交路径的 widget test。
- 增加成功提交和失败提交两条草稿行为测试，并 mock 录音/播放器通道，避免测试环境 MethodChannel 干扰。

## 预检
- Blockers：无。
- Review risks：这是生命周期/状态恢复类修复，主要风险是失败路径不能丢输入；已用失败提交测试覆盖。
- Excluded changes：无 unrelated/generated 文件。

## 验证
- `flutter test test/ui/main_screen/widgets/input_sheet_test.dart --timeout=60s`
- `flutter analyze lib/ui/main_screen/widgets/input_sheet.dart test/ui/main_screen/widgets/input_sheet_test.dart`
