### PR TITLE
Fix PR AI review for MIMO gateway

### DIFF
--- a/.github/workflows/pr-ai-review.yml
+++ b/.github/workflows/pr-ai-review.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check out trusted base branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.repository.default_branch }}
           fetch-depth: 0
 
       - name: Resolve PR metadata
@@ -131,15 +131,22 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_MODEL: mimo-v2.5-pro
+          ANTHROPIC_CUSTOM_MODEL_OPTION: mimo-v2.5-pro
+          ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: MIMO v2.5 Pro
+          ANTHROPIC_DEFAULT_OPUS_MODEL: mimo-v2.5-pro
+          ANTHROPIC_DEFAULT_SONNET_MODEL: mimo-v2.5-pro
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: mimo-v2.5-pro
+          CLAUDE_CODE_DISABLE_1M_CONTEXT: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
           prompt: |
             Read `.github/claude/pr-ai-review-prompt.md` and perform that review now.
           claude_args: >-
+            --model "mimo-v2.5-pro"
             --tools "Read"
             --allowedTools "Read"
-            --json-schema '{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Memex PR AI Review Result","type":"object","additionalProperties":false,"required":["schema_version","risk_level","human_review_required","golden_path_impact","summary_zh","summary_en","affected_areas","findings","test_gaps","confidence"],"properties":{"schema_version":{"type":"integer","const":1},"risk_level":{"type":"string","enum":["low","medium","high","critical"]},"human_review_required":{"type":"boolean"},"golden_path_impact":{"type":"object","additionalProperties":false,"required":["level","paths","reason_zh","reason_en"],"properties":{"level":{"type":"string","enum":["none","possible","likely","confirmed"]},"paths":{"type":"array","items":{"type":"string","enum":["record_capture","timeline","agent_pipeline","knowledge_pkm","llm_configuration","local_first_data","platform_entry","none"]},"uniqueItems":true},"reason_zh":{"type":"string"},"reason_en":{"type":"string"}}},"summary_zh":{"type":"string"},"summary_en":{"type":"string"},"affected_areas":{"type":"array","items":{"type":"string","enum":["docs","ci","ui","view_model","router","repository","service","agent","llm_provider","storage","database","backup_restore","i18n","platform_android","platform_ios","tests","unknown"]},"uniqueItems":true},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["severity","category","title_zh","title_en","evidence","recommendation_zh","recommendation_en","blocks_merge"],"properties":{"severity":{"type":"string","enum":["info","warn","high","critical"]},"category":{"type":"string","enum":["architecture","golden_path","testing","security_privacy","data_integrity","maintainability","review_context","other"]},"title_zh":{"type":"string"},"title_en":{"type":"string"},"evidence":{"type":"array","items":{"type":"string"}},"recommendation_zh":{"type":"string"},"recommendation_en":{"type":"string"},"blocks_merge":{"type":"boolean"}}}},"test_gaps":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["area","gap_zh","gap_en","suggested_check"],"properties":{"area":{"type":"string"},"gap_zh":{"type":"string"},"gap_en":{"type":"string"},"suggested_check":{"type":"string"}}}},"confidence":{"type":"string","enum":["low","medium","high"]}}}'
           display_report: "false"
           show_full_output: "false"
 
@@ -147,26 +154,14 @@ jobs:
         if: always() && env.HAS_ANTHROPIC_API_KEY == 'true'
         env:
           STRUCTURED_OUTPUT: ${{ steps.claude-ai-review.outputs.structured_output }}
+          EXECUTION_FILE: ${{ steps.claude-ai-review.outputs.execution_file }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
+          python3 scripts/extract_claude_structured_review.py \
+            --output ai-review-raw.json
 
-          raw = os.environ.get("STRUCTURED_OUTPUT", "").strip()
-          if not raw:
-              print("::warning::Claude structured output is empty.")
-              raise SystemExit(0)
-          try:
-              data = json.loads(raw)
-          except json.JSONDecodeError as exc:
-              print(f"::warning::Claude structured output is not valid JSON: {exc}")
-              raise SystemExit(0)
-          Path("ai-review-raw.json").write_text(
-              json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
-          PY
+          if [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
+            cp "$EXECUTION_FILE" claude-execution-output.json
+          fi
 
       - name: Write fallback result when Claude did not produce JSON
         if: always() && env.HAS_ANTHROPIC_API_KEY == 'true'
@@ -287,3 +282,4 @@ jobs:
             ai-review-raw.json
             ai-review.json
             ai-review.md
+            claude-execution-output.json

--- a/scripts/extract_claude_structured_review.py
+++ b/scripts/extract_claude_structured_review.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Extract Memex PR AI review JSON from Claude Code Action output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any, Iterable
+
+
+REQUIRED_KEYS = {
+    "schema_version",
+    "risk_level",
+    "human_review_required",
+    "golden_path_impact",
+    "summary_zh",
+    "summary_en",
+    "affected_areas",
+    "findings",
+    "test_gaps",
+    "confidence",
+}
+
+
+def parse_json_object(text: str) -> dict[str, Any] | None:
+    text = text.strip()
+    if not text:
+        return None
+
+    fenced = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", text, flags=re.DOTALL)
+    if fenced:
+        text = fenced.group(1).strip()
+
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict) and REQUIRED_KEYS.issubset(value):
+            return value
+    return None
+
+
+def extract_texts(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from extract_texts(item)
+        return
+    if not isinstance(value, dict):
+        return
+
+    text = value.get("text")
+    if isinstance(text, str):
+        yield text
+
+    structured = value.get("structured_output")
+    if isinstance(structured, dict):
+        yield json.dumps(structured, ensure_ascii=False)
+
+    result = value.get("result")
+    if isinstance(result, str):
+        yield result
+
+    message = value.get("message")
+    if isinstance(message, dict):
+        yield from extract_texts(message.get("content"))
+
+    content = value.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and isinstance(block.get("text"), str):
+                yield block["text"]
+            else:
+                yield from extract_texts(block)
+    elif isinstance(content, str):
+        yield content
+
+
+def extract_from_execution_file(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    value = json.loads(path.read_text(encoding="utf-8"))
+    messages = value if isinstance(value, list) else [value]
+    for message in reversed(messages):
+        for text in extract_texts(message):
+            parsed = parse_json_object(text)
+            if parsed:
+                return parsed
+    return None
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract Claude PR review JSON.")
+    parser.add_argument("--structured-env", default="STRUCTURED_OUTPUT")
+    parser.add_argument("--execution-file-env", default="EXECUTION_FILE")
+    parser.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    structured = os.environ.get(args.structured_env, "").strip()
+    parsed = parse_json_object(structured)
+
+    if parsed is None:
+        execution_file = os.environ.get(args.execution_file_env, "").strip()
+        if execution_file:
+            parsed = extract_from_execution_file(Path(execution_file))
+
+    if parsed is None:
+        print("::warning::Could not extract Claude PR review JSON.")
+        return 0
+
+    Path(args.output).write_text(
+        json.dumps(parsed, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/tools/test_extract_claude_structured_review.py
+++ b/tests/tools/test_extract_claude_structured_review.py
@@ -1,0 +1,79 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.extract_claude_structured_review import (
+    extract_from_execution_file,
+    parse_json_object,
+)
+
+
+def review(**overrides):
+    data = {
+        "schema_version": 1,
+        "risk_level": "low",
+        "human_review_required": False,
+        "golden_path_impact": {
+            "level": "none",
+            "paths": ["none"],
+            "reason_zh": "无。",
+            "reason_en": "None.",
+        },
+        "summary_zh": "低风险。",
+        "summary_en": "Low risk.",
+        "affected_areas": ["docs"],
+        "findings": [],
+        "test_gaps": [],
+        "confidence": "high",
+    }
+    data.update(overrides)
+    return data
+
+
+class ExtractClaudeStructuredReviewTest(unittest.TestCase):
+    def test_parse_json_object_from_fenced_text(self):
+        data = review(risk_level="medium")
+        parsed = parse_json_object(f"```json\n{json.dumps(data)}\n```")
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["risk_level"], "medium")
+
+    def test_extracts_last_assistant_json_from_execution_file(self):
+        first = review(risk_level="high")
+        second = review(risk_level="low")
+        messages = [
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": json.dumps(first)},
+                    ]
+                },
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Here is the result:\n"
+                            + json.dumps(second, ensure_ascii=False),
+                        }
+                    ]
+                },
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "claude-execution-output.json"
+            path.write_text(json.dumps(messages), encoding="utf-8")
+
+            parsed = extract_from_execution_file(path)
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["risk_level"], "low")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Pin `PR AI Review` Claude Code runs to `mimo-v2.5-pro` for the configured MIMO Anthropic-compatible gateway.
- Remove SDK `--json-schema` dependence because the gateway/model completes successfully but does not populate Claude Agent SDK `structured_output`.
- Add `scripts/extract_claude_structured_review.py` to extract the final review JSON from Claude Code Action's `execution_file`.
- Keep `pull_request_target` on trusted default-branch checkout, while allowing `workflow_dispatch` branch testing to checkout the selected ref.

## Why

Manual testing on #198 showed the initial workflow could run but fell back to "AI review unavailable":

- default Claude model caused `API Error: 400 Param Incorrect` with the gateway;
- after pinning MIMO, Claude completed, but `structured_output` stayed empty;
- parsing `execution_file` produced the intended structured AI review result.

## Validation

- `python3 -m unittest tests.tools.test_extract_claude_structured_review tests.tools.test_pr_ai_review_report tests.tools.test_pr_policy_check tests.tools.test_pr_preflight_summary_comment`
- `python3 -m py_compile scripts/extract_claude_structured_review.py scripts/pr_ai_review_report.py scripts/pr_policy_check.py scripts/pr_preflight_summary_comment.py`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-ai-review.yml"); puts "ok"'`
- Manual workflow run on #198 using this branch: https://github.com/memex-lab/memex/actions/runs/26525282624

## Result from #198 smoke test

- Risk: `low`
- Human review required: `false`
- Golden path impact: `possible` / `record_capture`
- Comment and labels were updated on #198 from the real structured review output.
