### PR TITLE
[codex] 优化洞察统计页周期切换交互

### DIFF
--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -83,6 +83,12 @@ class FileSystemService {
         .info('FileSystemService switched to new data root: $dataRoot');
   }
 
+  /// Creates a file-system service for background workers without replacing
+  /// the app singleton or starting the local asset server.
+  factory FileSystemService.detached({required String dataRoot}) {
+    return FileSystemService._(dataRoot: dataRoot);
+  }
+
   FileSystemService._({required this.dataRoot}) {
     if (!path.isAbsolute(dataRoot)) {
       throw ArgumentError('dataRoot must be an absolute path: $dataRoot');

--- a/lib/data/services/user_stats_service.dart
+++ b/lib/data/services/user_stats_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:path/path.dart' as path;
 
@@ -9,11 +10,31 @@ import 'package:memex/utils/logger.dart';
 
 final _logger = getLogger('UserStatsService');
 
+Future<UserStatsSnapshot> _fetchUserStatsSnapshotInWorker(
+  String dataRoot,
+  String userId,
+  DateTime start,
+  DateTime end,
+) {
+  final fileSystemService = FileSystemService.detached(dataRoot: dataRoot);
+  return UserStatsService(
+    fileSystemService: fileSystemService,
+    useBackgroundIsolate: false,
+  ).fetchSnapshot(
+    userId: userId,
+    range: UserStatsDateRange(start: start, end: end),
+  );
+}
+
 class UserStatsService {
-  UserStatsService({FileSystemService? fileSystemService})
-      : _fileSystemService = fileSystemService ?? FileSystemService.instance;
+  UserStatsService({
+    FileSystemService? fileSystemService,
+    bool useBackgroundIsolate = true,
+  }) : _fileSystemService = fileSystemService ?? FileSystemService.instance,
+       _useBackgroundIsolate = useBackgroundIsolate;
 
   final FileSystemService _fileSystemService;
+  final bool _useBackgroundIsolate;
 
   Future<UserStatsSnapshot> fetchSnapshot({
     required String userId,
@@ -27,6 +48,25 @@ class UserStatsService {
       return UserStatsSnapshot.empty(normalizedRange);
     }
 
+    if (_useBackgroundIsolate) {
+      final dataRoot = _fileSystemService.dataRoot;
+      final start = normalizedRange.start;
+      final end = normalizedRange.end;
+      return Isolate.run(
+        () => _fetchUserStatsSnapshotInWorker(dataRoot, userId, start, end),
+      );
+    }
+
+    return _fetchSnapshotOnCurrentIsolate(
+      userId: userId,
+      normalizedRange: normalizedRange,
+    );
+  }
+
+  Future<UserStatsSnapshot> _fetchSnapshotOnCurrentIsolate({
+    required String userId,
+    required UserStatsDateRange normalizedRange,
+  }) async {
     final daily = <String, _DailyStatsAccumulator>{};
     final details = <String, _DayDetailAccumulator>{};
     for (var i = 0; i < normalizedRange.dayCount; i++) {
@@ -447,14 +487,16 @@ class UserStatsService {
   }
 
   List<_FactEntryStats> _parseFactEntries(String content, DateTime date) {
-    final matches = RegExp(r'^## <id:([^>]+)>.*$', multiLine: true)
-        .allMatches(content)
-        .toList();
+    final matches = RegExp(
+      r'^## <id:([^>]+)>.*$',
+      multiLine: true,
+    ).allMatches(content).toList();
     final entries = <_FactEntryStats>[];
     for (var i = 0; i < matches.length; i++) {
       final start = matches[i].end;
-      final end =
-          i + 1 < matches.length ? matches[i + 1].start : content.length;
+      final end = i + 1 < matches.length
+          ? matches[i + 1].start
+          : content.length;
       final simpleId = matches[i].group(1) ?? '';
       entries.add(
         _FactEntryStats(
@@ -582,14 +624,14 @@ class _DailyStatsAccumulator {
   final Map<String, int> tagCounts = {};
 
   UserStatsDailyPoint toPoint() => UserStatsDailyPoint(
-        date: date,
-        inputs: inputs,
-        words: words,
-        cards: cards,
-        knowledgeUnits: knowledgeUnits,
-        insights: insights,
-        completedTodos: completedTodos,
-      );
+    date: date,
+    inputs: inputs,
+    words: words,
+    cards: cards,
+    knowledgeUnits: knowledgeUnits,
+    insights: insights,
+    completedTodos: completedTodos,
+  );
 }
 
 class _DayDetailAccumulator {
@@ -602,12 +644,12 @@ class _DayDetailAccumulator {
   final List<String> completedTodoTitles = [];
 
   UserStatsDayDetail toDetail() => UserStatsDayDetail(
-        date: date,
-        cardTitles: _dedupe(cardTitles),
-        knowledgePaths: _dedupe(knowledgePaths),
-        insightTitles: _dedupe(insightTitles),
-        completedTodoTitles: _dedupe(completedTodoTitles),
-      );
+    date: date,
+    cardTitles: _dedupe(cardTitles),
+    knowledgePaths: _dedupe(knowledgePaths),
+    insightTitles: _dedupe(insightTitles),
+    completedTodoTitles: _dedupe(completedTodoTitles),
+  );
 
   List<String> _dedupe(List<String> values) {
     final seen = <String>{};

--- a/lib/domain/models/user_stats_model.dart
+++ b/lib/domain/models/user_stats_model.dart
@@ -25,10 +25,10 @@ class UserStatsDateRange {
   int get dayCount => end.difference(start).inDays + 1;
 
   Map<String, dynamic> toJson() => {
-        'start': _dateKey(start),
-        'end': _dateKey(end),
-        'day_count': dayCount,
-      };
+    'start': _dateKey(start),
+    'end': _dateKey(end),
+    'day_count': dayCount,
+  };
 }
 
 class UserStatsSummary {
@@ -56,16 +56,16 @@ class UserStatsSummary {
       totalCards + totalKnowledgeUnits + totalInsights + totalCompletedTodos;
 
   Map<String, dynamic> toJson() => {
-        'total_inputs': totalInputs,
-        'total_words': totalWords,
-        'total_cards': totalCards,
-        'total_knowledge_units': totalKnowledgeUnits,
-        'total_insights': totalInsights,
-        'total_completed_todos': totalCompletedTodos,
-        'total_outputs': totalOutputs,
-        'active_days': activeDays,
-        'current_streak_days': currentStreakDays,
-      };
+    'total_inputs': totalInputs,
+    'total_words': totalWords,
+    'total_cards': totalCards,
+    'total_knowledge_units': totalKnowledgeUnits,
+    'total_insights': totalInsights,
+    'total_completed_todos': totalCompletedTodos,
+    'total_outputs': totalOutputs,
+    'active_days': activeDays,
+    'current_streak_days': currentStreakDays,
+  };
 }
 
 class UserStatsDailyPoint {
@@ -112,15 +112,96 @@ class UserStatsDailyPoint {
   }
 
   Map<String, dynamic> toJson() => {
-        'date': _dateKey(date),
-        'inputs': inputs,
-        'words': words,
-        'cards': cards,
-        'knowledge_units': knowledgeUnits,
-        'insights': insights,
-        'completed_todos': completedTodos,
-        'is_active': isActive,
-      };
+    'date': _dateKey(date),
+    'inputs': inputs,
+    'words': words,
+    'cards': cards,
+    'knowledge_units': knowledgeUnits,
+    'insights': insights,
+    'completed_todos': completedTodos,
+    'is_active': isActive,
+  };
+}
+
+class UserStatsTrendBucket {
+  final DateTime start;
+  final DateTime end;
+  final List<UserStatsDailyPoint> dailyPoints;
+  final int inputs;
+  final int words;
+  final int cards;
+  final int knowledgeUnits;
+  final int insights;
+  final int completedTodos;
+
+  const UserStatsTrendBucket({
+    required this.start,
+    required this.end,
+    required this.dailyPoints,
+    required this.inputs,
+    required this.words,
+    required this.cards,
+    required this.knowledgeUnits,
+    required this.insights,
+    required this.completedTodos,
+  });
+
+  factory UserStatsTrendBucket.fromPoints(List<UserStatsDailyPoint> points) {
+    if (points.isEmpty) {
+      throw ArgumentError.value(points, 'points', 'Must not be empty');
+    }
+    return UserStatsTrendBucket(
+      start: points.first.date,
+      end: points.last.date,
+      dailyPoints: List.unmodifiable(points),
+      inputs: points.fold(0, (sum, point) => sum + point.inputs),
+      words: points.fold(0, (sum, point) => sum + point.words),
+      cards: points.fold(0, (sum, point) => sum + point.cards),
+      knowledgeUnits: points.fold(
+        0,
+        (sum, point) => sum + point.knowledgeUnits,
+      ),
+      insights: points.fold(0, (sum, point) => sum + point.insights),
+      completedTodos: points.fold(
+        0,
+        (sum, point) => sum + point.completedTodos,
+      ),
+    );
+  }
+
+  bool get isSingleDay => _dateKey(start) == _dateKey(end);
+
+  String get key =>
+      isSingleDay ? _dateKey(start) : '${_dateKey(start)}_${_dateKey(end)}';
+
+  int valueFor(UserStatsMetric metric) {
+    switch (metric) {
+      case UserStatsMetric.inputs:
+        return inputs;
+      case UserStatsMetric.words:
+        return words;
+      case UserStatsMetric.cards:
+        return cards;
+      case UserStatsMetric.knowledgeUnits:
+        return knowledgeUnits;
+      case UserStatsMetric.insights:
+        return insights;
+      case UserStatsMetric.completedTodos:
+        return completedTodos;
+    }
+  }
+
+  UserStatsDailyPoint toAggregatePoint() {
+    return UserStatsDailyPoint(
+      date: start,
+      inputs: inputs,
+      words: words,
+      cards: cards,
+      knowledgeUnits: knowledgeUnits,
+      insights: insights,
+      completedTodos: completedTodos,
+    );
+  }
 }
 
 class UserStatsSourceBreakdown {
@@ -137,11 +218,11 @@ class UserStatsSourceBreakdown {
   int get total => textInputs + imageInputs + audioInputs;
 
   Map<String, dynamic> toJson() => {
-        'text_inputs': textInputs,
-        'image_inputs': imageInputs,
-        'audio_inputs': audioInputs,
-        'total': total,
-      };
+    'text_inputs': textInputs,
+    'image_inputs': imageInputs,
+    'audio_inputs': audioInputs,
+    'total': total,
+  };
 }
 
 class UserStatsTopTag {
@@ -169,12 +250,12 @@ class UserStatsDayDetail {
   });
 
   Map<String, dynamic> toJson() => {
-        'date': _dateKey(date),
-        'card_titles': cardTitles,
-        'knowledge_paths': knowledgePaths,
-        'insight_titles': insightTitles,
-        'completed_todo_titles': completedTodoTitles,
-      };
+    'date': _dateKey(date),
+    'card_titles': cardTitles,
+    'knowledge_paths': knowledgePaths,
+    'insight_titles': insightTitles,
+    'completed_todo_titles': completedTodoTitles,
+  };
 }
 
 class UserStatsSnapshot {
@@ -249,16 +330,77 @@ class UserStatsSnapshot {
     return max;
   }
 
+  int get preferredTrendBucketSizeDays => range.dayCount >= 90 ? 7 : 1;
+
+  List<UserStatsTrendBucket> trendBuckets({int? bucketSizeDays}) {
+    final size = bucketSizeDays ?? preferredTrendBucketSizeDays;
+    if (daily.isEmpty) return const [];
+    if (size <= 1) {
+      return daily
+          .map((point) => UserStatsTrendBucket.fromPoints([point]))
+          .toList();
+    }
+
+    final buckets = <UserStatsTrendBucket>[];
+    for (var index = 0; index < daily.length; index += size) {
+      final end = index + size > daily.length ? daily.length : index + size;
+      buckets.add(UserStatsTrendBucket.fromPoints(daily.sublist(index, end)));
+    }
+    return buckets;
+  }
+
+  int maxTrendValueFor(UserStatsMetric metric, {int? bucketSizeDays}) {
+    var max = 0;
+    for (final bucket in trendBuckets(bucketSizeDays: bucketSizeDays)) {
+      final value = bucket.valueFor(metric);
+      if (value > max) max = value;
+    }
+    return max;
+  }
+
+  UserStatsDayDetail detailForBucket(UserStatsTrendBucket bucket) {
+    final cardTitles = <String>[];
+    final knowledgePaths = <String>[];
+    final insightTitles = <String>[];
+    final completedTodoTitles = <String>[];
+
+    for (final point in bucket.dailyPoints) {
+      final detail = dayDetails[_dateKey(point.date)];
+      if (detail == null) continue;
+      cardTitles.addAll(detail.cardTitles);
+      knowledgePaths.addAll(detail.knowledgePaths);
+      insightTitles.addAll(detail.insightTitles);
+      completedTodoTitles.addAll(detail.completedTodoTitles);
+    }
+
+    return UserStatsDayDetail(
+      date: bucket.start,
+      cardTitles: _dedupe(cardTitles),
+      knowledgePaths: _dedupe(knowledgePaths),
+      insightTitles: _dedupe(insightTitles),
+      completedTodoTitles: _dedupe(completedTodoTitles),
+    );
+  }
+
   Map<String, dynamic> toJson() => {
-        'range': range.toJson(),
-        'summary': summary.toJson(),
-        'daily': daily.map((point) => point.toJson()).toList(),
-        'source_breakdown': sourceBreakdown.toJson(),
-        'top_tags': topTags.map((tag) => tag.toJson()).toList(),
-        'day_details': dayDetails.map((key, value) {
-          return MapEntry(key, value.toJson());
-        }),
-      };
+    'range': range.toJson(),
+    'summary': summary.toJson(),
+    'daily': daily.map((point) => point.toJson()).toList(),
+    'source_breakdown': sourceBreakdown.toJson(),
+    'top_tags': topTags.map((tag) => tag.toJson()).toList(),
+    'day_details': dayDetails.map((key, value) {
+      return MapEntry(key, value.toJson());
+    }),
+  };
+}
+
+List<String> _dedupe(List<String> values) {
+  final seen = <String>{};
+  final result = <String>[];
+  for (final value in values) {
+    if (seen.add(value)) result.add(value);
+  }
+  return result;
 }
 
 String _dateKey(DateTime date) {

--- a/lib/ui/insight/view_models/insight_viewmodel.dart
+++ b/lib/ui/insight/view_models/insight_viewmodel.dart
@@ -12,17 +12,18 @@ import 'package:memex/utils/user_storage.dart';
 
 enum InsightSection { insights, stats }
 
-typedef UserStatsFetcher = Future<Result<UserStatsSnapshot>> Function(
-    UserStatsDateRange range);
+typedef UserStatsFetcher =
+    Future<Result<UserStatsSnapshot>> Function(UserStatsDateRange range);
 
 /// ViewModel for the Insight page. Holds insight list, pin/delete/reorder state.
 class InsightViewModel extends ChangeNotifier {
   InsightViewModel({
     required MemexRouter router,
     UserStatsFetcher? userStatsFetcher,
-  })  : _router = router,
-        _userStatsFetcher = userStatsFetcher ??
-            ((range) => router.fetchUserStats(range: range)) {
+  }) : _router = router,
+       _userStatsFetcher =
+           userStatsFetcher ??
+           ((range) => router.fetchUserStats(range: range)) {
     EventBusService.instance.addHandler(
       EventBusMessageType.newInsight,
       _handleNewInsightEvent,
@@ -55,6 +56,7 @@ class InsightViewModel extends ChangeNotifier {
   bool isStatsLoading = false;
   String? statsErrorMessage;
   UserStatsMetric selectedStatsMetric = UserStatsMetric.inputs;
+  int _statsLoadGeneration = 0;
 
   int get activeTaskCount => taskActivity.total;
   bool get hasActiveTaskBacklog => activeTaskCount > 0;
@@ -105,12 +107,21 @@ class InsightViewModel extends ChangeNotifier {
     if (notify) notifyListeners();
   }
 
-  Future<void> loadStats({bool notify = true}) async {
+  Future<void> loadStats({
+    bool notify = true,
+    UserStatsDateRange? range,
+  }) async {
+    final requestGeneration = ++_statsLoadGeneration;
+    final requestRange = range ?? statsRange;
     isStatsLoading = true;
     statsErrorMessage = null;
     if (notify) notifyListeners();
 
-    final result = await _userStatsFetcher(statsRange);
+    final result = await _userStatsFetcher(requestRange);
+    if (requestGeneration != _statsLoadGeneration) {
+      return;
+    }
+
     result.when(
       onOk: (snapshot) {
         statsSnapshot = snapshot;
@@ -150,7 +161,8 @@ class InsightViewModel extends ChangeNotifier {
       return;
     }
     statsRange = nextRange;
-    unawaited(loadStats());
+    notifyListeners();
+    unawaited(loadStats(range: nextRange));
   }
 
   Future<void> togglePin(KnowledgeInsightCard item) async {

--- a/lib/ui/insight/widgets/insight_screen.dart
+++ b/lib/ui/insight/widgets/insight_screen.dart
@@ -535,6 +535,7 @@ class _InsightScreenState extends State<InsightScreen> {
                               snapshot: vm.statsSnapshot,
                               isLoading: vm.isStatsLoading,
                               errorMessage: vm.statsErrorMessage,
+                              selectedDays: vm.statsRange.dayCount,
                               selectedMetric: vm.selectedStatsMetric,
                               onMetricChanged: vm.setStatsMetric,
                               onPresetSelected: (days) =>

--- a/lib/ui/insight/widgets/user_stats_page.dart
+++ b/lib/ui/insight/widgets/user_stats_page.dart
@@ -10,6 +10,7 @@ class UserStatsPage extends StatelessWidget {
     required this.snapshot,
     required this.isLoading,
     required this.errorMessage,
+    required this.selectedDays,
     required this.selectedMetric,
     required this.onMetricChanged,
     required this.onPresetSelected,
@@ -20,6 +21,7 @@ class UserStatsPage extends StatelessWidget {
   final UserStatsSnapshot? snapshot;
   final bool isLoading;
   final String? errorMessage;
+  final int selectedDays;
   final UserStatsMetric selectedMetric;
   final ValueChanged<UserStatsMetric> onMetricChanged;
   final ValueChanged<int> onPresetSelected;
@@ -72,7 +74,8 @@ class UserStatsPage extends StatelessWidget {
         const SizedBox(height: 16),
         if (header != null) ...[header!, const SizedBox(height: 16)],
         _RangeSelector(
-          selectedDays: data.range.dayCount,
+          selectedDays: selectedDays,
+          isLoading: isLoading,
           onSelected: onPresetSelected,
         ),
         const SizedBox(height: 16),
@@ -97,9 +100,14 @@ class UserStatsPage extends StatelessWidget {
 }
 
 class _RangeSelector extends StatelessWidget {
-  const _RangeSelector({required this.selectedDays, required this.onSelected});
+  const _RangeSelector({
+    required this.selectedDays,
+    required this.isLoading,
+    required this.onSelected,
+  });
 
   final int selectedDays;
+  final bool isLoading;
   final ValueChanged<int> onSelected;
 
   @override
@@ -110,33 +118,46 @@ class _RangeSelector extends StatelessWidget {
       (90, UserStorage.l10n.last90Days),
     ];
     return Row(
-      children: items.map((item) {
-        final selected = selectedDays == item.$1;
-        return Padding(
-          padding: const EdgeInsets.only(right: 8),
-          child: ChoiceChip(
-            key: ValueKey('stats_range_${item.$1}'),
-            label: Text(item.$2),
-            selected: selected,
-            onSelected: (_) => onSelected(item.$1),
-            selectedColor: const Color(0xFF111827),
-            backgroundColor: Colors.white,
-            labelStyle: TextStyle(
-              color: selected ? Colors.white : const Color(0xFF4B5563),
-              fontWeight: FontWeight.w700,
-              fontSize: 12,
-            ),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-              side: BorderSide(
-                color: selected
-                    ? const Color(0xFF111827)
-                    : const Color(0xFFE5E7EB),
+      children: [
+        ...items.map((item) {
+          final selected = selectedDays == item.$1;
+          return Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: ChoiceChip(
+              key: ValueKey('stats_range_${item.$1}'),
+              label: Text(item.$2),
+              selected: selected,
+              onSelected: (_) => onSelected(item.$1),
+              selectedColor: const Color(0xFF111827),
+              backgroundColor: Colors.white,
+              labelStyle: TextStyle(
+                color: selected ? Colors.white : const Color(0xFF4B5563),
+                fontWeight: FontWeight.w700,
+                fontSize: 12,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+                side: BorderSide(
+                  color: selected
+                      ? const Color(0xFF111827)
+                      : const Color(0xFFE5E7EB),
+                ),
               ),
             ),
+          );
+        }),
+        const Spacer(),
+        if (isLoading)
+          const SizedBox(
+            key: ValueKey('stats_range_loading'),
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF9CA3AF)),
+            ),
           ),
-        );
-      }).toList(),
+      ],
     );
   }
 }
@@ -344,11 +365,15 @@ class _DailyBars extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final maxValue = snapshot.maxValueFor(metric).clamp(1, 1 << 30);
+    final buckets = snapshot.trendBuckets();
+    final maxValue = snapshot.maxTrendValueFor(metric).clamp(1, 1 << 30);
     final formatter = DateFormat.Md(UserStorage.l10n.localeName);
-    final contentWidth = snapshot.daily.length <= 14
-        ? MediaQuery.sizeOf(context).width - 80
-        : snapshot.daily.length * 28.0;
+    final bucketWidth = snapshot.preferredTrendBucketSizeDays > 1 ? 44.0 : 28.0;
+    final minContentWidth = buckets.length * bucketWidth;
+    final viewportWidth = MediaQuery.sizeOf(context).width - 80;
+    final contentWidth = buckets.length <= 14
+        ? (viewportWidth < minContentWidth ? minContentWidth : viewportWidth)
+        : minContentWidth;
 
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
@@ -357,14 +382,17 @@ class _DailyBars extends StatelessWidget {
         height: 172,
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.end,
-          children: snapshot.daily.map((point) {
-            final value = point.valueFor(metric);
+          children: buckets.map((bucket) {
+            final value = bucket.valueFor(metric);
             final height = value == 0 ? 8.0 : 20 + value / maxValue * 100;
+            final key = bucket.isSingleDay
+                ? 'stats_day_${_dateKey(bucket.start)}'
+                : 'stats_bucket_${bucket.key}';
             return Expanded(
               child: GestureDetector(
-                key: ValueKey('stats_day_${_dateKey(point.date)}'),
+                key: ValueKey(key),
                 behavior: HitTestBehavior.opaque,
-                onTap: () => _showDayDetails(context, snapshot, point),
+                onTap: () => _showBucketDetails(context, snapshot, bucket),
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 3),
                   child: Column(
@@ -392,9 +420,9 @@ class _DailyBars extends StatelessWidget {
                       ),
                       const SizedBox(height: 8),
                       Text(
-                        formatter.format(point.date),
+                        formatter.format(bucket.start),
                         maxLines: 1,
-                        overflow: TextOverflow.visible,
+                        overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
                           fontSize: 10,
                           color: Color(0xFF9CA3AF),
@@ -794,16 +822,16 @@ String _metricLabel(UserStatsMetric metric) {
   }
 }
 
-void _showDayDetails(
+void _showBucketDetails(
   BuildContext context,
   UserStatsSnapshot snapshot,
-  UserStatsDailyPoint point,
+  UserStatsTrendBucket bucket,
 ) {
-  final key = _dateKey(point.date);
-  final detail = snapshot.dayDetails[key];
-  final dateLabel = DateFormat.yMMMd(
-    UserStorage.l10n.localeName,
-  ).format(point.date);
+  final detail = snapshot.detailForBucket(bucket);
+  final formatter = DateFormat.yMMMd(UserStorage.l10n.localeName);
+  final dateLabel = bucket.isSingleDay
+      ? formatter.format(bucket.start)
+      : '${formatter.format(bucket.start)} - ${formatter.format(bucket.end)}';
 
   showModalBottomSheet<void>(
     context: context,
@@ -838,26 +866,24 @@ void _showDayDetails(
                   ),
                 ),
                 const SizedBox(height: 16),
-                _DetailCountRow(point: point),
+                _DetailCountRow(point: bucket.toAggregatePoint()),
                 const SizedBox(height: 18),
-                if (detail != null) ...[
-                  _DetailList(
-                    title: UserStorage.l10n.cards,
-                    items: detail.cardTitles,
-                  ),
-                  _DetailList(
-                    title: UserStorage.l10n.knowledgeUnits,
-                    items: detail.knowledgePaths,
-                  ),
-                  _DetailList(
-                    title: UserStorage.l10n.knowledgeInsight,
-                    items: detail.insightTitles,
-                  ),
-                  _DetailList(
-                    title: UserStorage.l10n.completedTodos,
-                    items: detail.completedTodoTitles,
-                  ),
-                ],
+                _DetailList(
+                  title: UserStorage.l10n.cards,
+                  items: detail.cardTitles,
+                ),
+                _DetailList(
+                  title: UserStorage.l10n.knowledgeUnits,
+                  items: detail.knowledgePaths,
+                ),
+                _DetailList(
+                  title: UserStorage.l10n.knowledgeInsight,
+                  items: detail.insightTitles,
+                ),
+                _DetailList(
+                  title: UserStorage.l10n.completedTodos,
+                  items: detail.completedTodoTitles,
+                ),
               ],
             ),
           ),

--- a/test/domain/models/user_stats_model_test.dart
+++ b/test/domain/models/user_stats_model_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/user_stats_model.dart';
+
+void main() {
+  group('UserStatsSnapshot trend buckets', () {
+    test('uses daily buckets for shorter ranges', () {
+      final snapshot = _snapshot(start: DateTime(2026, 1, 1), dayCount: 30);
+
+      final buckets = snapshot.trendBuckets();
+
+      expect(snapshot.preferredTrendBucketSizeDays, 1);
+      expect(buckets, hasLength(30));
+      expect(buckets.first.isSingleDay, isTrue);
+      expect(buckets.first.key, '2026-01-01');
+      expect(buckets.first.inputs, 1);
+      expect(snapshot.maxTrendValueFor(UserStatsMetric.inputs), 30);
+    });
+
+    test('groups ninety-day ranges into seven-day buckets', () {
+      final snapshot = _snapshot(start: DateTime(2026, 1, 1), dayCount: 90);
+
+      final buckets = snapshot.trendBuckets();
+
+      expect(snapshot.preferredTrendBucketSizeDays, 7);
+      expect(buckets, hasLength(13));
+      expect(buckets.first.key, '2026-01-01_2026-01-07');
+      expect(buckets.first.start, DateTime(2026, 1, 1));
+      expect(buckets.first.end, DateTime(2026, 1, 7));
+      expect(buckets.first.inputs, 28);
+      expect(buckets.first.cards, 7);
+      expect(buckets.last.dailyPoints, hasLength(6));
+      expect(buckets.last.start, DateTime(2026, 3, 26));
+      expect(buckets.last.end, DateTime(2026, 3, 31));
+      expect(snapshot.maxTrendValueFor(UserStatsMetric.inputs), 567);
+    });
+
+    test('combines and deduplicates details for a bucket', () {
+      final snapshot = _snapshot(start: DateTime(2026, 1, 1), dayCount: 90);
+
+      final detail = snapshot.detailForBucket(snapshot.trendBuckets().first);
+
+      expect(detail.date, DateTime(2026, 1, 1));
+      expect(detail.cardTitles, ['Card 0', 'Card 1']);
+      expect(detail.knowledgePaths, ['PKM/Area 0.md', 'PKM/Area 1.md']);
+      expect(detail.insightTitles, ['Insight 0', 'Insight 1']);
+      expect(detail.completedTodoTitles, ['Todo 0', 'Todo 1']);
+    });
+  });
+}
+
+UserStatsSnapshot _snapshot({required DateTime start, required int dayCount}) {
+  final daily = List.generate(dayCount, (index) {
+    return UserStatsDailyPoint(
+      date: start.add(Duration(days: index)),
+      inputs: index + 1,
+      words: (index + 1) * 10,
+      cards: 1,
+      knowledgeUnits: index.isEven ? 1 : 0,
+      insights: index % 3 == 0 ? 1 : 0,
+      completedTodos: index % 4 == 0 ? 1 : 0,
+    );
+  });
+
+  return UserStatsSnapshot(
+    range: UserStatsDateRange(
+      start: start,
+      end: start.add(Duration(days: dayCount - 1)),
+    ),
+    summary: UserStatsSummary(
+      totalInputs: daily.fold(0, (sum, point) => sum + point.inputs),
+      totalWords: daily.fold(0, (sum, point) => sum + point.words),
+      totalCards: daily.fold(0, (sum, point) => sum + point.cards),
+      totalKnowledgeUnits: daily.fold(
+        0,
+        (sum, point) => sum + point.knowledgeUnits,
+      ),
+      totalInsights: daily.fold(0, (sum, point) => sum + point.insights),
+      totalCompletedTodos: daily.fold(
+        0,
+        (sum, point) => sum + point.completedTodos,
+      ),
+      activeDays: daily.where((point) => point.isActive).length,
+      currentStreakDays: daily.where((point) => point.isActive).length,
+    ),
+    daily: daily,
+    sourceBreakdown: const UserStatsSourceBreakdown(
+      textInputs: 1,
+      imageInputs: 0,
+      audioInputs: 0,
+    ),
+    topTags: const [],
+    dayDetails: {
+      for (var index = 0; index < dayCount; index++)
+        _dateKey(daily[index].date): UserStatsDayDetail(
+          date: daily[index].date,
+          cardTitles: ['Card ${index % 2}'],
+          knowledgePaths: ['PKM/Area ${index % 2}.md'],
+          insightTitles: ['Insight ${index % 2}'],
+          completedTodoTitles: ['Todo ${index % 2}'],
+        ),
+    },
+  );
+}
+
+String _dateKey(DateTime date) {
+  final year = date.year.toString().padLeft(4, '0');
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '$year-$month-$day';
+}

--- a/test/ui/insight/user_stats_page_test.dart
+++ b/test/ui/insight/user_stats_page_test.dart
@@ -168,6 +168,7 @@ void main() {
               snapshot: _snapshot(),
               isLoading: false,
               errorMessage: null,
+              selectedDays: 3,
               selectedMetric: selectedMetric,
               onMetricChanged: (metric) => setState(() {
                 selectedMetric = metric;
@@ -202,6 +203,108 @@ void main() {
     expect(find.text('Day details'), findsOneWidget);
     expect(find.text('Weekly review'), findsOneWidget);
     expect(find.text('Clean desk'), findsOneWidget);
+  });
+
+  testWidgets('groups ninety-day rhythm chart into seven-day buckets', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(800, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      _wrap(
+        UserStatsPage(
+          snapshot: _ninetyDaySnapshot(),
+          isLoading: false,
+          errorMessage: null,
+          selectedDays: 90,
+          selectedMetric: UserStatsMetric.inputs,
+          onMetricChanged: (_) {},
+          onPresetSelected: (_) {},
+          onReload: () {},
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('stats_bucket_2026-03-01_2026-03-07')),
+      220,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('stats_bucket_2026-03-01_2026-03-07')),
+    );
+    await tester.drag(
+      find.byKey(const ValueKey('user_stats_page')),
+      const Offset(0, -260),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('stats_bucket_2026-03-01_2026-03-07')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('stats_day_2026-03-01')), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey('stats_bucket_2026-03-01_2026-03-07')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Day details'), findsOneWidget);
+    expect(find.text('Mar 1, 2026 - Mar 7, 2026'), findsOneWidget);
+    expect(find.text('Weekly pattern'), findsOneWidget);
+    expect(find.text('Planning note'), findsOneWidget);
+  });
+
+  testWidgets('updates selected range immediately while preset reloads', (
+    tester,
+  ) async {
+    final statsCompleter = Completer<Result<UserStatsSnapshot>>();
+    final vm = _buildViewModelWithFetcher((range) {
+      if (range.dayCount == 90) return statsCompleter.future;
+      return Future.value(Ok(_snapshot()));
+    });
+    vm.statsRange = UserStatsDateRange(
+      start: DateTime(2026, 5, 18),
+      end: DateTime(2026, 5, 20),
+    );
+    vm.statsSnapshot = _snapshot();
+
+    await tester.pumpWidget(
+      _wrap(InsightScreen(viewModel: vm, isEmbedded: true)),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.tap(find.byKey(const ValueKey('user_stats_overview_card')));
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.byKey(const ValueKey('stats_range_90')));
+    await tester.pump();
+
+    final selectedChip = tester.widget<ChoiceChip>(
+      find.byKey(const ValueKey('stats_range_90')),
+    );
+    expect(selectedChip.selected, isTrue);
+    expect(find.byKey(const ValueKey('stats_range_loading')), findsOneWidget);
+
+    statsCompleter.complete(Ok(_ninetyDaySnapshot()));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('stats_bucket_2026-03-01_2026-03-07')),
+      220,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    expect(find.byKey(const ValueKey('stats_range_loading')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('stats_bucket_2026-03-01_2026-03-07')),
+      findsOneWidget,
+    );
+
+    vm.dispose();
   });
 }
 
@@ -326,7 +429,8 @@ UserStatsSnapshot _singleInputSnapshot() {
   final range = UserStatsDateRange.lastDays(7, now: today);
   final daily = List.generate(range.dayCount, (index) {
     final date = range.start.add(Duration(days: index));
-    final isToday = date.year == today.year &&
+    final isToday =
+        date.year == today.year &&
         date.month == today.month &&
         date.day == today.day;
     return UserStatsDailyPoint(
@@ -362,6 +466,62 @@ UserStatsSnapshot _singleInputSnapshot() {
     dayDetails: {
       for (final point in daily)
         _dateKey(point.date): UserStatsDayDetail(date: point.date),
+    },
+  );
+}
+
+UserStatsSnapshot _ninetyDaySnapshot() {
+  final range = UserStatsDateRange(
+    start: DateTime(2026, 3, 1),
+    end: DateTime(2026, 5, 29),
+  );
+  final daily = List.generate(range.dayCount, (index) {
+    final value = index + 1;
+    return UserStatsDailyPoint(
+      date: range.start.add(Duration(days: index)),
+      inputs: value,
+      words: value * 2,
+      cards: 1,
+      knowledgeUnits: index.isEven ? 1 : 0,
+      insights: index == 0 ? 1 : 0,
+      completedTodos: index == 1 ? 1 : 0,
+    );
+  });
+
+  return UserStatsSnapshot(
+    range: range,
+    summary: UserStatsSummary(
+      totalInputs: daily.fold(0, (sum, point) => sum + point.inputs),
+      totalWords: daily.fold(0, (sum, point) => sum + point.words),
+      totalCards: daily.fold(0, (sum, point) => sum + point.cards),
+      totalKnowledgeUnits: daily.fold(
+        0,
+        (sum, point) => sum + point.knowledgeUnits,
+      ),
+      totalInsights: daily.fold(0, (sum, point) => sum + point.insights),
+      totalCompletedTodos: daily.fold(
+        0,
+        (sum, point) => sum + point.completedTodos,
+      ),
+      activeDays: daily.where((point) => point.isActive).length,
+      currentStreakDays: daily.where((point) => point.isActive).length,
+    ),
+    daily: daily,
+    sourceBreakdown: const UserStatsSourceBreakdown(
+      textInputs: 90,
+      imageInputs: 0,
+      audioInputs: 0,
+    ),
+    topTags: const [],
+    dayDetails: {
+      for (var index = 0; index < daily.length; index++)
+        _dateKey(daily[index].date): UserStatsDayDetail(
+          date: daily[index].date,
+          cardTitles: index == 0 ? const ['Weekly pattern'] : const [],
+          knowledgePaths: const [],
+          insightTitles: index == 1 ? const ['Planning note'] : const [],
+          completedTodoTitles: const [],
+        ),
     },
   );
 }

--- a/test/ui/insight/view_models/insight_viewmodel_test.dart
+++ b/test/ui/insight/view_models/insight_viewmodel_test.dart
@@ -22,15 +22,15 @@ void main() {
     tempDir = await Directory.systemTemp.createTemp('memex_insight_vm_');
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(pathProviderChannel, (call) async {
-      switch (call.method) {
-        case 'getApplicationDocumentsDirectory':
-        case 'getApplicationSupportDirectory':
-        case 'getTemporaryDirectory':
-          return tempDir.path;
-        default:
-          return null;
-      }
-    });
+          switch (call.method) {
+            case 'getApplicationDocumentsDirectory':
+            case 'getApplicationSupportDirectory':
+            case 'getTemporaryDirectory':
+              return tempDir.path;
+            default:
+              return null;
+          }
+        });
   });
 
   setUp(() async {
@@ -53,30 +53,32 @@ void main() {
     }
   });
 
-  test('visible stats refresh notifies listeners on insight overview',
-      () async {
-    final firstSnapshot = _snapshot(totalInputs: 3);
-    final secondSnapshot = _snapshot(totalInputs: 8);
-    var calls = 0;
-    final vm = _buildViewModel((_) async {
-      calls += 1;
-      return Ok(secondSnapshot);
-    });
-    vm.statsSnapshot = firstSnapshot;
-    vm.selectedSection = InsightSection.insights;
+  test(
+    'visible stats refresh notifies listeners on insight overview',
+    () async {
+      final firstSnapshot = _snapshot(totalInputs: 3);
+      final secondSnapshot = _snapshot(totalInputs: 8);
+      var calls = 0;
+      final vm = _buildViewModel((_) async {
+        calls += 1;
+        return Ok(secondSnapshot);
+      });
+      vm.statsSnapshot = firstSnapshot;
+      vm.selectedSection = InsightSection.insights;
 
-    var notifications = 0;
-    vm.addListener(() => notifications += 1);
+      var notifications = 0;
+      vm.addListener(() => notifications += 1);
 
-    await vm.refreshStatsForVisibleInsightPage();
+      await vm.refreshStatsForVisibleInsightPage();
 
-    expect(calls, 1);
-    expect(vm.statsSnapshot, secondSnapshot);
-    expect(vm.isStatsLoading, isFalse);
-    expect(notifications, greaterThanOrEqualTo(2));
+      expect(calls, 1);
+      expect(vm.statsSnapshot, secondSnapshot);
+      expect(vm.isStatsLoading, isFalse);
+      expect(notifications, greaterThanOrEqualTo(2));
 
-    vm.dispose();
-  });
+      vm.dispose();
+    },
+  );
 
   test('stats loading state is visible while refresh is in flight', () async {
     final completer = Completer<Result<UserStatsSnapshot>>();
@@ -100,38 +102,42 @@ void main() {
     vm.dispose();
   });
 
-  test('failed stats refresh keeps previous snapshot and exposes error',
-      () async {
-    final existing = _snapshot(totalInputs: 4);
-    final vm = _buildViewModel(
-      (_) async => Error<UserStatsSnapshot>(StateError('boom')),
-    );
-    vm.statsSnapshot = existing;
+  test(
+    'failed stats refresh keeps previous snapshot and exposes error',
+    () async {
+      final existing = _snapshot(totalInputs: 4);
+      final vm = _buildViewModel(
+        (_) async => Error<UserStatsSnapshot>(StateError('boom')),
+      );
+      vm.statsSnapshot = existing;
 
-    await vm.refreshStatsForVisibleInsightPage();
+      await vm.refreshStatsForVisibleInsightPage();
 
-    expect(vm.statsSnapshot, existing);
-    expect(vm.statsErrorMessage, UserStorage.l10n.dataLoadFailedRetry);
-    expect(vm.isStatsLoading, isFalse);
+      expect(vm.statsSnapshot, existing);
+      expect(vm.statsErrorMessage, UserStorage.l10n.dataLoadFailedRetry);
+      expect(vm.isStatsLoading, isFalse);
 
-    vm.dispose();
-  });
+      vm.dispose();
+    },
+  );
 
-  test('failed first stats refresh leaves no snapshot and exits loading',
-      () async {
-    final vm = _buildViewModel(
-      (_) async => Error<UserStatsSnapshot>(StateError('boom')),
-    );
-    vm.statsSnapshot = null;
+  test(
+    'failed first stats refresh leaves no snapshot and exits loading',
+    () async {
+      final vm = _buildViewModel(
+        (_) async => Error<UserStatsSnapshot>(StateError('boom')),
+      );
+      vm.statsSnapshot = null;
 
-    await vm.refreshStatsForVisibleInsightPage();
+      await vm.refreshStatsForVisibleInsightPage();
 
-    expect(vm.statsSnapshot, isNull);
-    expect(vm.statsErrorMessage, UserStorage.l10n.dataLoadFailedRetry);
-    expect(vm.isStatsLoading, isFalse);
+      expect(vm.statsSnapshot, isNull);
+      expect(vm.statsErrorMessage, UserStorage.l10n.dataLoadFailedRetry);
+      expect(vm.isStatsLoading, isFalse);
 
-    vm.dispose();
-  });
+      vm.dispose();
+    },
+  );
 
   test('selecting the current stats preset does not reload', () async {
     var calls = 0;
@@ -149,24 +155,84 @@ void main() {
     vm.dispose();
   });
 
-  test('selecting a different stats preset updates range and reloads',
-      () async {
-    var calls = 0;
-    final vm = _buildViewModel((range) async {
-      calls += 1;
-      return Ok(_snapshot(totalInputs: calls, range: range));
-    });
-    vm.statsRange = UserStatsDateRange.lastDays(7);
+  test(
+    'selecting a different stats preset updates range and reloads',
+    () async {
+      var calls = 0;
+      final vm = _buildViewModel((range) async {
+        calls += 1;
+        return Ok(_snapshot(totalInputs: calls, range: range));
+      });
+      vm.statsRange = UserStatsDateRange.lastDays(7);
 
-    vm.setStatsPresetDays(30);
-    await Future<void>.delayed(Duration.zero);
+      vm.setStatsPresetDays(30);
+      await Future<void>.delayed(Duration.zero);
 
-    expect(calls, 1);
-    expect(vm.statsRange.dayCount, 30);
-    expect(vm.statsSnapshot?.range.dayCount, 30);
+      expect(calls, 1);
+      expect(vm.statsRange.dayCount, 30);
+      expect(vm.statsSnapshot?.range.dayCount, 30);
 
-    vm.dispose();
-  });
+      vm.dispose();
+    },
+  );
+
+  test(
+    'selecting a stats preset updates selection before fetch completes',
+    () async {
+      final completer = Completer<Result<UserStatsSnapshot>>();
+      final vm = _buildViewModel((range) => completer.future);
+      vm.statsRange = UserStatsDateRange.lastDays(7);
+
+      vm.setStatsPresetDays(90);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.statsRange.dayCount, 90);
+      expect(vm.isStatsLoading, isTrue);
+      expect(vm.statsSnapshot, isNull);
+
+      completer.complete(Ok(_snapshot(totalInputs: 9, range: vm.statsRange)));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.isStatsLoading, isFalse);
+      expect(vm.statsSnapshot?.range.dayCount, 90);
+
+      vm.dispose();
+    },
+  );
+
+  test(
+    'ignores stale stats responses when presets are changed quickly',
+    () async {
+      final completers = <int, Completer<Result<UserStatsSnapshot>>>{};
+      final vm = _buildViewModel((range) {
+        final completer = Completer<Result<UserStatsSnapshot>>();
+        completers[range.dayCount] = completer;
+        return completer.future;
+      });
+      vm.statsRange = UserStatsDateRange.lastDays(7);
+
+      vm.setStatsPresetDays(30);
+      await Future<void>.delayed(Duration.zero);
+      vm.setStatsPresetDays(90);
+      await Future<void>.delayed(Duration.zero);
+
+      completers[90]!.complete(
+        Ok(_snapshot(totalInputs: 90, range: UserStatsDateRange.lastDays(90))),
+      );
+      await Future<void>.delayed(Duration.zero);
+      completers[30]!.complete(
+        Ok(_snapshot(totalInputs: 30, range: UserStatsDateRange.lastDays(30))),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.statsRange.dayCount, 90);
+      expect(vm.statsSnapshot?.range.dayCount, 90);
+      expect(vm.statsSnapshot?.summary.totalInputs, 90);
+      expect(vm.isStatsLoading, isFalse);
+
+      vm.dispose();
+    },
+  );
 }
 
 InsightViewModel _buildViewModel(UserStatsFetcher fetcher) {
@@ -178,9 +244,12 @@ UserStatsSnapshot _snapshot({
   required int totalInputs,
   UserStatsDateRange? range,
 }) {
-  final resolvedRange = range ??
+  final resolvedRange =
+      range ??
       UserStatsDateRange(
-          start: DateTime(2026, 5, 18), end: DateTime(2026, 5, 20));
+        start: DateTime(2026, 5, 18),
+        end: DateTime(2026, 5, 20),
+      );
   return UserStatsSnapshot(
     range: resolvedRange,
     summary: UserStatsSummary(


### PR DESCRIPTION
## 变更内容
- 将用户统计快照计算切到后台 isolate，避免 7/30/90 天切换时在 UI isolate 上做重文件扫描与解析。
- 周期切换后立即更新选中态，并在旧数据保留期间显示轻量加载反馈；同时加入请求序号保护，避免快速切换时旧请求覆盖新结果。
- 为统计趋势图增加 7 天桶聚合：90 天范围显示 13 个左右的周桶，点击后展示该桶内的聚合明细。

## 测试
- `flutter test --no-pub --concurrency=1 test/domain/models/user_stats_model_test.dart test/data/services/user_stats_service_test.dart test/ui/insight/view_models/insight_viewmodel_test.dart test/ui/insight/user_stats_page_test.dart test/ui/insight/user_stats_overview_card_test.dart`
- `flutter analyze --no-pub --no-fatal-infos lib/data/services/file_system_service.dart lib/data/services/user_stats_service.dart lib/domain/models/user_stats_model.dart lib/ui/insight/view_models/insight_viewmodel.dart lib/ui/insight/widgets/insight_screen.dart lib/ui/insight/widgets/user_stats_page.dart test/domain/models/user_stats_model_test.dart test/ui/insight/view_models/insight_viewmodel_test.dart test/ui/insight/user_stats_page_test.dart test/ui/insight/user_stats_overview_card_test.dart`

备注：不带 `--no-fatal-infos` 的 analyze 会被 `insight_screen.dart` 既有 info 级 lint 拦住（如旧的 `withOpacity` 与省略花括号），本次改动没有新增 error/warning。

Closes #208