### PR TITLE
支持取消已完成的日程待办

### DIFF
--- a/lib/data/repositories/get_schedule_view_data.dart
+++ b/lib/data/repositories/get_schedule_view_data.dart
@@ -140,6 +140,7 @@ ScheduleViewPendingItem _pendingForState(SchedulePendingItem item) {
 ScheduleViewCompletedItem _completedForState(ScheduleCompletedItem item) {
   return ScheduleViewCompletedItem(
     cardId: item.sourceFactIds.isEmpty ? item.id : item.sourceFactIds.first,
+    itemId: item.id,
     title: item.title,
     completedAt: item.closedAt,
   );

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -1125,11 +1125,7 @@ class MemexRouter {
         );
       });
 
-  Future<Result<void>> setScheduleSubtaskCompletion({
-    required String itemId,
-    required String subtaskTitle,
-    required bool completed,
-  }) =>
+  Future<Result<void>> restoreScheduleItem(String itemId) =>
       runResultVoid(() async {
         await _ensureInitialized();
         final userId = await UserStorage.getUserId();
@@ -1137,16 +1133,36 @@ class MemexRouter {
           throw Exception('User not logged in');
         }
 
-        await ScheduleStateService.instance.setSubtaskCompletion(
+        await ScheduleStateService.instance.restoreCompletedItem(
           userId: userId,
-          pendingId: itemId,
-          subtaskTitle: subtaskTitle,
-          completed: completed,
+          completedId: itemId,
         );
         EventBusService.instance.emitEvent(
           ScheduleAggregationUpdatedMessage(aggregationId: 'schedule_state'),
         );
       });
+
+  Future<Result<void>> setScheduleSubtaskCompletion({
+    required String itemId,
+    required String subtaskTitle,
+    required bool completed,
+  }) => runResultVoid(() async {
+    await _ensureInitialized();
+    final userId = await UserStorage.getUserId();
+    if (userId == null) {
+      throw Exception('User not logged in');
+    }
+
+    await ScheduleStateService.instance.setSubtaskCompletion(
+      userId: userId,
+      pendingId: itemId,
+      subtaskTitle: subtaskTitle,
+      completed: completed,
+    );
+    EventBusService.instance.emitEvent(
+      ScheduleAggregationUpdatedMessage(aggregationId: 'schedule_state'),
+    );
+  });
 
   Future<bool> updateCardTime(String cardId, int timestamp) async {
     await _ensureInitialized();

--- a/lib/data/services/schedule_state_projector.dart
+++ b/lib/data/services/schedule_state_projector.dart
@@ -17,6 +17,7 @@ ScheduleState sweepPastEventsInState(
           kind: item.kind,
           title: item.title,
           closedAt: pastAfter,
+          pendingSnapshot: item.copyWith(clearDeviceActionId: true),
           sourceFactIds: item.sourceFactIds,
         ),
       );

--- a/lib/data/services/schedule_state_service.dart
+++ b/lib/data/services/schedule_state_service.dart
@@ -36,14 +36,19 @@ class ScheduleStateService {
       return ScheduleState.fromJson(raw);
     } catch (e, st) {
       _logger.warning(
-          'Failed to decode schedule_state, falling back to empty', e, st);
+        'Failed to decode schedule_state, falling back to empty',
+        e,
+        st,
+      );
       return ScheduleState.empty();
     }
   }
 
   Future<void> write(String userId, ScheduleState state) async {
-    await FileSystemService.instance
-        .writeScheduleStateRaw(userId, state.toJson());
+    await FileSystemService.instance.writeScheduleStateRaw(
+      userId,
+      state.toJson(),
+    );
   }
 
   bool isCardCompletionSyncSuppressed({
@@ -57,8 +62,10 @@ class ScheduleStateService {
 
   /// Ensure a schedule_state file exists for this user. Existing files are left
   /// intact and only receive the time-based past-event sweep.
-  Future<ScheduleState> ensureInitialized(String userId,
-      {DateTime? now}) async {
+  Future<ScheduleState> ensureInitialized(
+    String userId, {
+    DateTime? now,
+  }) async {
     return _lock.synchronized(() async {
       final raw = await FileSystemService.instance.readScheduleStateRaw(userId);
       if (raw == null) {
@@ -89,10 +96,7 @@ class ScheduleStateService {
 
   /// Fully rebuild the schedule_state from no external inputs. This is for
   /// explicit repair/debug flows.
-  Future<ScheduleState> rebuildFromCards(
-    String userId, {
-    DateTime? now,
-  }) async {
+  Future<ScheduleState> rebuildFromCards(String userId, {DateTime? now}) async {
     return _lock.synchronized(() async {
       final clock = now ?? DateTime.now();
       final state = ScheduleState(generatedAt: clock);
@@ -113,9 +117,7 @@ class ScheduleStateService {
       final clock = now ?? DateTime.now();
       final current = await read(userId);
       final matching = current.pending
-          .where(
-            (item) => item.isTodo && item.sourceFactIds.contains(factId),
-          )
+          .where((item) => item.isTodo && item.sourceFactIds.contains(factId))
           .toList();
       if (matching.isEmpty) {
         _logger.info(
@@ -136,6 +138,7 @@ class ScheduleStateService {
             title: item.title,
             closedAt: clock,
             closedByFactId: factId,
+            pendingSnapshot: item.copyWith(clearDeviceActionId: true),
             sourceFactIds: item.sourceFactIds,
           ),
         ...current.completed,
@@ -301,6 +304,7 @@ class ScheduleStateService {
           title: item.title,
           closedAt: clock,
           closedByFactId: closedByFactId,
+          pendingSnapshot: item.copyWith(clearDeviceActionId: true),
           sourceFactIds: item.sourceFactIds,
         ),
         ...state.completed,
@@ -315,15 +319,78 @@ class ScheduleStateService {
         completed: completed,
       );
 
-      final sourceFactId =
-          item.sourceFactIds.isEmpty ? null : item.sourceFactIds.first;
+      final sourceFactId = item.sourceFactIds.isEmpty
+          ? null
+          : item.sourceFactIds.first;
       if (sourceFactId != null && item.isTodo) {
         await _withSuppressedCardCompletionSync(
           userId: userId,
           factId: sourceFactId,
-          action: () => _markSourceTaskCompleted(userId, sourceFactId),
+          action: () =>
+              _setSourceTaskCompletion(userId, sourceFactId, completed: true),
         );
       }
+      await write(userId, updated);
+      return updated;
+    });
+  }
+
+  Future<ScheduleState> restoreCompletedItem({
+    required String userId,
+    required String completedId,
+    DateTime? now,
+  }) async {
+    return _lock.synchronized(() async {
+      final clock = now ?? DateTime.now();
+      final state = await read(userId);
+      final item = state.completed.firstWhere(
+        (candidate) => candidate.id == completedId,
+        orElse: () =>
+            throw StateError('No completed schedule item found: $completedId'),
+      );
+
+      var restored =
+          (item.pendingSnapshot ??
+                  SchedulePendingItem(
+                    id: item.id,
+                    kind: item.kind,
+                    title: item.title,
+                    sourceFactIds: item.sourceFactIds,
+                    createdAt: item.closedAt,
+                    updatedAt: clock,
+                  ))
+              .copyWith(updatedAt: clock, clearDeviceActionId: true);
+      restored = await _maintainDeviceAction(userId, restored);
+
+      final pending = [
+        ...state.pending.where((candidate) => candidate.id != restored.id),
+        restored,
+      ]..sort(compareSchedulePendingItems);
+      final completed = state.completed
+          .where((candidate) => candidate.id != completedId)
+          .toList();
+      final updated = state.copyWith(
+        generatedAt: clock,
+        pending: pending,
+        completed: completed,
+      );
+
+      final sourceFactId = restored.sourceFactIds.isEmpty
+          ? null
+          : restored.sourceFactIds.first;
+      if (sourceFactId != null && restored.isTodo) {
+        await _withSuppressedCardCompletionSync(
+          userId: userId,
+          factId: sourceFactId,
+          action: () => _setSourceTaskCompletion(
+            userId,
+            sourceFactId,
+            completed: false,
+            restoredItem: restored,
+          ),
+        );
+      }
+
       await write(userId, updated);
       return updated;
     });
@@ -386,14 +453,15 @@ class ScheduleStateService {
         );
       }
 
-      final pending = state.pending
-          .map(
-            (candidate) => candidate.id == pendingId
-                ? candidate.copyWith(subtasks: subtasks, updatedAt: clock)
-                : candidate,
-          )
-          .toList()
-        ..sort(compareSchedulePendingItems);
+      final pending =
+          state.pending
+              .map(
+                (candidate) => candidate.id == pendingId
+                    ? candidate.copyWith(subtasks: subtasks, updatedAt: clock)
+                    : candidate,
+              )
+              .toList()
+            ..sort(compareSchedulePendingItems);
       final updated = state.copyWith(generatedAt: clock, pending: pending);
       await write(userId, updated);
       return updated;
@@ -433,8 +501,7 @@ class ScheduleStateService {
       if (since != null && item.closedAt.isBefore(since)) return false;
       if (normalizedQuery == null || normalizedQuery.isEmpty) return true;
       return _normalizeTitle(item.title).contains(normalizedQuery);
-    }).toList()
-      ..sort((a, b) => b.closedAt.compareTo(a.closedAt));
+    }).toList()..sort((a, b) => b.closedAt.compareTo(a.closedAt));
     return matches.take(limit).toList();
   }
 
@@ -450,8 +517,9 @@ class ScheduleStateService {
     }
 
     if (item.deviceActionId != null) {
-      final existingAction =
-          await SystemActionService.instance.getAction(item.deviceActionId!);
+      final existingAction = await SystemActionService.instance.getAction(
+        item.deviceActionId!,
+      );
       if (existingAction != null && existingAction.status != 'pending') {
         return item;
       }
@@ -465,8 +533,9 @@ class ScheduleStateService {
 
     try {
       final actionId = const Uuid().v4();
-      final sourceFactId =
-          item.sourceFactIds.isEmpty ? null : item.sourceFactIds.first;
+      final sourceFactId = item.sourceFactIds.isEmpty
+          ? null
+          : item.sourceFactIds.first;
       if (item.isEvent) {
         await SystemActionService.instance.createAction(
           id: actionId,
@@ -505,11 +574,19 @@ class ScheduleStateService {
       await SystemActionService.instance.cancelPendingAction(actionId);
     } catch (e, st) {
       _logger.warning(
-          'Failed to cancel pending device action $actionId', e, st);
+        'Failed to cancel pending device action $actionId',
+        e,
+        st,
+      );
     }
   }
 
-  Future<void> _markSourceTaskCompleted(String userId, String cardId) async {
+  Future<void> _setSourceTaskCompletion(
+    String userId,
+    String cardId, {
+    required bool completed,
+    SchedulePendingItem? restoredItem,
+  }) async {
     await FileSystemService.instance.updateCardFile(userId, cardId, (card) {
       final taskIndex = card.uiConfigs.indexWhere(
         (config) => config.templateId == 'task',
@@ -517,14 +594,24 @@ class ScheduleStateService {
       if (taskIndex < 0) return card;
       final config = card.uiConfigs[taskIndex];
       final data = Map<String, dynamic>.from(config.data);
-      data['is_completed'] = true;
+      data['is_completed'] = completed;
       final rawSubtasks = data['subtasks'];
       if (rawSubtasks is List) {
-        data['subtasks'] = rawSubtasks
-            .whereType<Map>()
-            .map((subtask) =>
-                {...Map<String, dynamic>.from(subtask), 'completed': true})
-            .toList();
+        final restoredSubtasks = {
+          for (final subtask in restoredItem?.subtasks ?? const [])
+            _normalizeTitle(subtask.title): subtask.completed,
+        };
+        data['subtasks'] = rawSubtasks.whereType<Map>().map((subtask) {
+          final normalized = _normalizeTitle(
+            subtask['title']?.toString() ?? '',
+          );
+          return {
+            ...Map<String, dynamic>.from(subtask),
+            'completed': completed
+                ? true
+                : (restoredSubtasks[normalized] ?? false),
+          };
+        }).toList();
       }
       final configs = card.uiConfigs.toList();
       configs[taskIndex] = UiConfig(templateId: config.templateId, data: data);

--- a/lib/domain/models/schedule_state.dart
+++ b/lib/domain/models/schedule_state.dart
@@ -18,9 +18,9 @@ class ScheduleState {
     List<SchedulePendingItem>? pending,
     List<ScheduleCompletedItem>? completed,
     this.presentation,
-  })  : generatedAt = generatedAt ?? DateTime.now(),
-        pending = pending ?? <SchedulePendingItem>[],
-        completed = completed ?? <ScheduleCompletedItem>[];
+  }) : generatedAt = generatedAt ?? DateTime.now(),
+       pending = pending ?? <SchedulePendingItem>[],
+       completed = completed ?? <ScheduleCompletedItem>[];
 
   final int version;
   final DateTime generatedAt;
@@ -35,14 +35,8 @@ class ScheduleState {
     return ScheduleState(
       version: (json['version'] as num?)?.toInt() ?? 1,
       generatedAt: _parseDateTime(json['generated_at']) ?? DateTime.now(),
-      pending: _parseList(
-        json['pending'],
-        SchedulePendingItem.fromJson,
-      ),
-      completed: _parseList(
-        json['completed'],
-        ScheduleCompletedItem.fromJson,
-      ),
+      pending: _parseList(json['pending'], SchedulePendingItem.fromJson),
+      completed: _parseList(json['completed'], ScheduleCompletedItem.fromJson),
       presentation: json['presentation'] is Map
           ? SchedulePresentation.fromJson(
               Map<String, dynamic>.from(json['presentation'] as Map),
@@ -77,8 +71,9 @@ class ScheduleState {
       generatedAt: generatedAt ?? this.generatedAt,
       pending: pending ?? this.pending,
       completed: completed ?? this.completed,
-      presentation:
-          clearPresentation ? null : (presentation ?? this.presentation),
+      presentation: clearPresentation
+          ? null
+          : (presentation ?? this.presentation),
     );
   }
 }
@@ -101,14 +96,14 @@ class SchedulePendingItem {
     DateTime? updatedAt,
     this.syncDeviceAction = false,
     this.deviceActionId,
-  })  : assert(
-          kind == kindTodo || kind == kindEvent,
-          'kind must be "todo" or "event"',
-        ),
-        subtasks = subtasks ?? const <ScheduleSubtask>[],
-        sourceFactIds = sourceFactIds ?? const <String>[],
-        createdAt = createdAt ?? DateTime.now(),
-        updatedAt = updatedAt ?? createdAt ?? DateTime.now();
+  }) : assert(
+         kind == kindTodo || kind == kindEvent,
+         'kind must be "todo" or "event"',
+       ),
+       subtasks = subtasks ?? const <ScheduleSubtask>[],
+       sourceFactIds = sourceFactIds ?? const <String>[],
+       createdAt = createdAt ?? DateTime.now(),
+       updatedAt = updatedAt ?? createdAt ?? DateTime.now();
 
   static const String kindTodo = 'todo';
   static const String kindEvent = 'event';
@@ -232,8 +227,9 @@ class SchedulePendingItem {
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       syncDeviceAction: syncDeviceAction ?? this.syncDeviceAction,
-      deviceActionId:
-          clearDeviceActionId ? null : (deviceActionId ?? this.deviceActionId),
+      deviceActionId: clearDeviceActionId
+          ? null
+          : (deviceActionId ?? this.deviceActionId),
     );
   }
 }
@@ -258,10 +254,7 @@ class ScheduleSubtask {
   }
 
   Map<String, dynamic> toJson() {
-    final m = <String, dynamic>{
-      'title': title,
-      'completed': completed,
-    };
+    final m = <String, dynamic>{'title': title, 'completed': completed};
     if (closedByFactId != null) m['closed_by_fact_id'] = closedByFactId;
     return m;
   }
@@ -275,8 +268,9 @@ class ScheduleSubtask {
     return ScheduleSubtask(
       title: title ?? this.title,
       completed: completed ?? this.completed,
-      closedByFactId:
-          clearClosedByFactId ? null : (closedByFactId ?? this.closedByFactId),
+      closedByFactId: clearClosedByFactId
+          ? null
+          : (closedByFactId ?? this.closedByFactId),
     );
   }
 }
@@ -288,18 +282,20 @@ class ScheduleCompletedItem {
     required this.title,
     required this.closedAt,
     this.closedByFactId,
+    this.pendingSnapshot,
     List<String>? sourceFactIds,
-  })  : assert(
-          kind == SchedulePendingItem.kindTodo ||
-              kind == SchedulePendingItem.kindEvent,
-        ),
-        sourceFactIds = sourceFactIds ?? const <String>[];
+  }) : assert(
+         kind == SchedulePendingItem.kindTodo ||
+             kind == SchedulePendingItem.kindEvent,
+       ),
+       sourceFactIds = sourceFactIds ?? const <String>[];
 
   final String id;
   final String kind;
   final String title;
   final DateTime closedAt;
   final String? closedByFactId;
+  final SchedulePendingItem? pendingSnapshot;
   final List<String> sourceFactIds;
 
   factory ScheduleCompletedItem.fromJson(Map<String, dynamic> json) {
@@ -309,6 +305,11 @@ class ScheduleCompletedItem {
       title: json['title'] as String? ?? '',
       closedAt: _parseDateTime(json['closed_at']) ?? DateTime.now(),
       closedByFactId: json['closed_by_fact_id'] as String?,
+      pendingSnapshot: json['pending_snapshot'] is Map
+          ? SchedulePendingItem.fromJson(
+              Map<String, dynamic>.from(json['pending_snapshot'] as Map),
+            )
+          : null,
       sourceFactIds: _parseStringList(json['source_fact_ids']),
     );
   }
@@ -321,6 +322,9 @@ class ScheduleCompletedItem {
       'closed_at': closedAt.toIso8601String(),
     };
     if (closedByFactId != null) m['closed_by_fact_id'] = closedByFactId;
+    if (pendingSnapshot != null) {
+      m['pending_snapshot'] = pendingSnapshot!.toJson();
+    }
     if (sourceFactIds.isNotEmpty) m['source_fact_ids'] = sourceFactIds;
     return m;
   }
@@ -332,8 +336,8 @@ class SchedulePresentation {
     this.editorialIntro,
     List<ScheduleQuoteBlock>? quoteBlocks,
     List<ScheduleTimelineDay>? timeline,
-  })  : quoteBlocks = quoteBlocks ?? const <ScheduleQuoteBlock>[],
-        timeline = timeline ?? const <ScheduleTimelineDay>[];
+  }) : quoteBlocks = quoteBlocks ?? const <ScheduleQuoteBlock>[],
+       timeline = timeline ?? const <ScheduleTimelineDay>[];
 
   final SchedulePresentationHero? hero;
   final String? editorialIntro;
@@ -348,8 +352,10 @@ class SchedulePresentation {
             )
           : null,
       editorialIntro: json['editorial_intro'] as String?,
-      quoteBlocks:
-          _parseList(json['quote_blocks'], ScheduleQuoteBlock.fromJson),
+      quoteBlocks: _parseList(
+        json['quote_blocks'],
+        ScheduleQuoteBlock.fromJson,
+      ),
       timeline: _parseList(json['timeline'], ScheduleTimelineDay.fromJson),
     );
   }
@@ -388,10 +394,7 @@ class SchedulePresentationHero {
   }
 
   Map<String, dynamic> toJson() {
-    final m = <String, dynamic>{
-      'item_id': itemId,
-      'title': title,
-    };
+    final m = <String, dynamic>{'item_id': itemId, 'title': title};
     if (description != null) m['description'] = description;
     return m;
   }
@@ -491,10 +494,7 @@ bool _parseBool(dynamic value) {
   return false;
 }
 
-List<T> _parseList<T>(
-  dynamic raw,
-  T Function(Map<String, dynamic>) fromJson,
-) {
+List<T> _parseList<T>(dynamic raw, T Function(Map<String, dynamic>) fromJson) {
   if (raw is! List) return <T>[];
   final out = <T>[];
   for (final item in raw) {

--- a/lib/domain/models/schedule_view_data.dart
+++ b/lib/domain/models/schedule_view_data.dart
@@ -23,10 +23,7 @@ class ScheduleViewData {
 }
 
 class ScheduleViewTimeRange {
-  const ScheduleViewTimeRange({
-    required this.from,
-    required this.to,
-  });
+  const ScheduleViewTimeRange({required this.from, required this.to});
 
   final DateTime from;
   final DateTime to;
@@ -110,10 +107,12 @@ class ScheduleViewCompletedItem {
   const ScheduleViewCompletedItem({
     required this.cardId,
     required this.title,
+    this.itemId,
     this.completedAt,
   });
 
   final String cardId;
+  final String? itemId;
   final String title;
   final DateTime? completedAt;
 }

--- a/lib/ui/schedule/models/schedule_item.dart
+++ b/lib/ui/schedule/models/schedule_item.dart
@@ -142,6 +142,7 @@ class ScheduleItem {
 
     for (final completedItem in data.completed) {
       final sourceFactId = completedItem.cardId;
+      final completedItemId = completedItem.itemId ?? completedItem.cardId;
       final existingEntry = itemsByItemId.entries.where((entry) {
         return entry.value.sourceFactId == sourceFactId;
       }).firstOrNull;
@@ -154,6 +155,7 @@ class ScheduleItem {
       } else {
         upsert(
           ScheduleItem(
+            itemId: completedItemId,
             sourceFactId: sourceFactId,
             title: completedItem.title,
             type: ScheduleItemType.todo,
@@ -204,10 +206,12 @@ class ScheduleItem {
   }
 
   static ScheduleItem _merge(ScheduleItem base, ScheduleItem incoming) {
-    final type =
-        incoming.type == ScheduleItemType.todo ? incoming.type : base.type;
-    final subtasks =
-        base.subtasks.isNotEmpty ? base.subtasks : incoming.subtasks;
+    final type = incoming.type == ScheduleItemType.todo
+        ? incoming.type
+        : base.type;
+    final subtasks = base.subtasks.isNotEmpty
+        ? base.subtasks
+        : incoming.subtasks;
     final status = type == ScheduleItemType.todo
         ? deriveTodoStatus(
             subtasks,
@@ -216,8 +220,8 @@ class ScheduleItem {
         : _higherPriorityStatus(base.status, incoming.status);
     final sourceType =
         base.sourceType == 'event' && incoming.sourceType != 'event'
-            ? incoming.sourceType
-            : base.sourceType;
+        ? incoming.sourceType
+        : base.sourceType;
     return base.copyWith(
       itemId: incoming.type == ScheduleItemType.todo ? incoming.itemId : null,
       type: type,
@@ -242,8 +246,9 @@ class ScheduleItem {
       return fallback;
     }
 
-    final completedCount =
-        subtasks.where((subtask) => subtask.completed).length;
+    final completedCount = subtasks
+        .where((subtask) => subtask.completed)
+        .length;
     if (completedCount == subtasks.length) {
       return ScheduleItemStatus.completed;
     }
@@ -269,8 +274,7 @@ class ScheduleItem {
       'completed' || 'done' => ScheduleItemStatus.completed,
       'in_progress' ||
       'inprogress' ||
-      'active' =>
-        ScheduleItemStatus.inProgress,
+      'active' => ScheduleItemStatus.inProgress,
       'overdue' => ScheduleItemStatus.overdue,
       _ => ScheduleItemStatus.pending,
     };

--- a/lib/ui/schedule/view_models/schedule_aggregator_view_model.dart
+++ b/lib/ui/schedule/view_models/schedule_aggregator_view_model.dart
@@ -25,16 +25,18 @@ String _localizedOrFallback(
 }
 
 typedef ScheduleAggregationLoader = Future<ScheduleViewData?> Function();
-typedef ScheduleAggregationFreshnessChecker = Future<bool> Function({
-  Duration? maxAge,
-});
+typedef ScheduleAggregationFreshnessChecker =
+    Future<bool> Function({Duration? maxAge});
 typedef ScheduleAggregationRefresher = Future<Result<void>> Function();
 typedef ScheduleItemCompleter = Future<Result<void>> Function(String itemId);
-typedef ScheduleSubtaskCompletionSetter = Future<Result<void>> Function(
-  String itemId,
-  String subtaskTitle,
-  bool completed,
-);
+typedef ScheduleCompletedItemRestorer =
+    Future<Result<void>> Function(String itemId);
+typedef ScheduleSubtaskCompletionSetter =
+    Future<Result<void>> Function(
+      String itemId,
+      String subtaskTitle,
+      bool completed,
+    );
 
 class ScheduleAggregatorViewModel extends ChangeNotifier {
   ScheduleAggregatorViewModel({
@@ -42,24 +44,31 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
     ScheduleAggregationFreshnessChecker? needsRefresh,
     ScheduleAggregationRefresher? refreshAggregation,
     ScheduleItemCompleter? completeScheduleItem,
+    ScheduleCompletedItemRestorer? restoreScheduleItem,
     ScheduleSubtaskCompletionSetter? setScheduleSubtaskCompletion,
     Duration refreshReloadDelay = const Duration(seconds: 90),
     bool listenToEvents = true,
-  })  : _loadAggregation = loadAggregation ?? getScheduleViewData,
-        _needsRefresh = needsRefresh ?? scheduleViewDataNeedsRefresh,
-        _refreshAggregation = refreshAggregation ??
-            (() => MemexRouter().refreshScheduleAggregation()),
-        _completeScheduleItem = completeScheduleItem ??
-            ((itemId) => MemexRouter().completeScheduleItem(itemId)),
-        _setScheduleSubtaskCompletion = setScheduleSubtaskCompletion ??
-            ((itemId, subtaskTitle, completed) =>
-                MemexRouter().setScheduleSubtaskCompletion(
-                  itemId: itemId,
-                  subtaskTitle: subtaskTitle,
-                  completed: completed,
-                )),
-        _refreshReloadDelay = refreshReloadDelay,
-        _listenToEvents = listenToEvents {
+  }) : _loadAggregation = loadAggregation ?? getScheduleViewData,
+       _needsRefresh = needsRefresh ?? scheduleViewDataNeedsRefresh,
+       _refreshAggregation =
+           refreshAggregation ??
+           (() => MemexRouter().refreshScheduleAggregation()),
+       _completeScheduleItem =
+           completeScheduleItem ??
+           ((itemId) => MemexRouter().completeScheduleItem(itemId)),
+       _restoreScheduleItem =
+           restoreScheduleItem ??
+           ((itemId) => MemexRouter().restoreScheduleItem(itemId)),
+       _setScheduleSubtaskCompletion =
+           setScheduleSubtaskCompletion ??
+           ((itemId, subtaskTitle, completed) =>
+               MemexRouter().setScheduleSubtaskCompletion(
+                 itemId: itemId,
+                 subtaskTitle: subtaskTitle,
+                 completed: completed,
+               )),
+       _refreshReloadDelay = refreshReloadDelay,
+       _listenToEvents = listenToEvents {
     if (_listenToEvents) {
       EventBusService.instance.addHandler(
         EventBusMessageType.scheduleAggregationUpdated,
@@ -72,6 +81,7 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
   final ScheduleAggregationFreshnessChecker _needsRefresh;
   final ScheduleAggregationRefresher _refreshAggregation;
   final ScheduleItemCompleter _completeScheduleItem;
+  final ScheduleCompletedItemRestorer _restoreScheduleItem;
   final ScheduleSubtaskCompletionSetter _setScheduleSubtaskCompletion;
   final Duration _refreshReloadDelay;
   final bool _listenToEvents;
@@ -94,7 +104,8 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
       final status = _statusOverrides[item.itemId];
       if (status == null && subtasks == null) return item;
       final effectiveSubtasks = subtasks ?? item.subtasks;
-      final effectiveStatus = status ??
+      final effectiveStatus =
+          status ??
           (subtasks == null
               ? item.status
               : ScheduleItem.deriveTodoStatus(
@@ -202,8 +213,8 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
     final optimisticSubtasks = item.subtasks.isEmpty
         ? null
         : item.subtasks
-            .map((subtask) => subtask.copyWith(completed: nextCompleted))
-            .toList();
+              .map((subtask) => subtask.copyWith(completed: nextCompleted))
+              .toList();
     _applyTaskOverride(
       item.itemId,
       status: nextStatus,
@@ -231,7 +242,25 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
         'Failed to toggle schedule item ${item.sourceFactId}: $e',
       );
       _restoreTaskOverrides(
-          item.itemId, previousStatusOverride, previousSubtaskOverride);
+        item.itemId,
+        previousStatusOverride,
+        previousSubtaskOverride,
+      );
+      _error = _localizedOrFallback(
+        (l10n) => l10n.scheduleTaskUpdateFailed,
+        'Failed to update task',
+      );
+      notifyListeners();
+    }
+  }
+
+  Future<void> restoreCompletedItem(String itemId) async {
+    try {
+      _throwOnError(await _restoreScheduleItem(itemId));
+      _error = null;
+      await loadAggregation();
+    } catch (e) {
+      _logger.warning('Failed to restore schedule item $itemId: $e');
       _error = _localizedOrFallback(
         (l10n) => l10n.scheduleTaskUpdateFailed,
         'Failed to update task',
@@ -255,11 +284,7 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
       nextSubtasks,
       fallback: item.status,
     );
-    _applyTaskOverride(
-      item.itemId,
-      status: nextStatus,
-      subtasks: nextSubtasks,
-    );
+    _applyTaskOverride(item.itemId, status: nextStatus, subtasks: nextSubtasks);
 
     try {
       _throwOnError(
@@ -275,7 +300,10 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
         'Failed to toggle schedule subtask $subtaskIndex for ${item.sourceFactId}: $e',
       );
       _restoreTaskOverrides(
-          item.itemId, previousStatusOverride, previousSubtaskOverride);
+        item.itemId,
+        previousStatusOverride,
+        previousSubtaskOverride,
+      );
       _error = _localizedOrFallback(
         (l10n) => l10n.scheduleTaskUpdateFailed,
         'Failed to update task',
@@ -354,8 +382,5 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
 }
 
 void _throwOnError(Result<void> result) {
-  result.when(
-    onOk: (_) {},
-    onError: (e, st) => throw e,
-  );
+  result.when(onOk: (_) {}, onError: (e, st) => throw e);
 }

--- a/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
+++ b/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
@@ -33,7 +33,8 @@ class _ScheduleAggregatorScreenBody extends StatefulWidget {
 }
 
 class _ScheduleAggregatorScreenState
-    extends State<_ScheduleAggregatorScreenBody> with WidgetsBindingObserver {
+    extends State<_ScheduleAggregatorScreenBody>
+    with WidgetsBindingObserver {
   DateTime _relativeDate = DateTime.now();
   Timer? _dayRefreshTimer;
 
@@ -118,6 +119,10 @@ class _ScheduleAggregatorScreenState
     vm.toggleCompletion(vm.items[index]);
   }
 
+  void _restoreCompletedTask(String itemId) {
+    context.read<ScheduleAggregatorViewModel>().restoreCompletedItem(itemId);
+  }
+
   void _toggleSubtask(String itemId, int subtaskIndex) {
     final vm = context.read<ScheduleAggregatorViewModel>();
     final index = vm.items.indexWhere((item) => item.itemId == itemId);
@@ -160,6 +165,7 @@ class _ScheduleAggregatorScreenState
                       onTapCardId: _navigateToCard,
                       itemStatuses: itemStatuses,
                       onToggleTask: _toggleTaskCompletion,
+                      onToggleCompletedTask: _restoreCompletedTask,
                       itemSubtasks: itemSubtasks,
                       onToggleSubtask: _toggleSubtask,
                     ),

--- a/lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart
+++ b/lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart
@@ -16,6 +16,7 @@ class MagazineNarrativeTab extends StatefulWidget {
   final Map<String, ScheduleItemStatus> itemStatuses;
   final Map<String, List<ScheduleSubtask>> itemSubtasks;
   final void Function(String itemId)? onToggleTask;
+  final void Function(String itemId)? onToggleCompletedTask;
   final void Function(String itemId, int subtaskIndex)? onToggleSubtask;
   final DateTime? referenceDate;
 
@@ -26,6 +27,7 @@ class MagazineNarrativeTab extends StatefulWidget {
     this.itemStatuses = const {},
     this.itemSubtasks = const {},
     this.onToggleTask,
+    this.onToggleCompletedTask,
     this.onToggleSubtask,
     this.referenceDate,
   });
@@ -204,10 +206,7 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
     );
   }
 
-  Widget _buildHeroMetaRow({
-    required IconData icon,
-    required String text,
-  }) {
+  Widget _buildHeroMetaRow({required IconData icon, required String text}) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -276,8 +275,9 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
 
   Widget _buildAgentReminderRow(ScheduleViewQuoteBlock block) {
     final isHighPriority = block.priority == 'high';
-    final accentColor =
-        isHighPriority ? const Color(0xFFD97706) : const Color(0xFF64748B);
+    final accentColor = isHighPriority
+        ? const Color(0xFFD97706)
+        : const Color(0xFF64748B);
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -333,8 +333,9 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
   }) {
     final isTask = _isTaskItem(item);
     final itemKey = _itemKey(item);
-    final subtasks =
-        isTask ? _resolveSubtasks(item) : const <ScheduleSubtask>[];
+    final subtasks = isTask
+        ? _resolveSubtasks(item)
+        : const <ScheduleSubtask>[];
     final status = _resolveStatus(item, subtasks);
     final isCompleted = status == ScheduleItemStatus.completed;
 
@@ -354,18 +355,19 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
                     color: isCompleted
                         ? const Color(0xFF99A1AF)
                         : item.priority == 3
-                            ? const Color(0xFFF43F5E)
-                            : const Color(0xFF5B6CFF),
+                        ? const Color(0xFFF43F5E)
+                        : const Color(0xFF5B6CFF),
                     shape: BoxShape.circle,
                     border: Border.all(color: Colors.white, width: 2),
                     boxShadow: [
                       BoxShadow(
-                        color: (isCompleted
-                                ? const Color(0xFF99A1AF)
-                                : item.priority == 3
+                        color:
+                            (isCompleted
+                                    ? const Color(0xFF99A1AF)
+                                    : item.priority == 3
                                     ? const Color(0xFFF43F5E)
                                     : const Color(0xFF5B6CFF))
-                            .withValues(alpha: 0.3),
+                                .withValues(alpha: 0.3),
                         blurRadius: 6,
                       ),
                     ],
@@ -461,6 +463,7 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
   }
 
   Widget _buildAgentDoneCard(ScheduleViewCompletedItem item) {
+    final itemId = item.itemId ?? item.cardId;
     return Padding(
       padding: const EdgeInsets.only(bottom: 10),
       child: GestureDetector(
@@ -471,15 +474,20 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Padding(
-                padding: EdgeInsets.only(top: 1),
-                child: Icon(
-                  Icons.check_circle_rounded,
-                  size: 17,
-                  color: Color(0xFF94A3B8),
+              GestureDetector(
+                key: ValueKey('schedule_completed_toggle_$itemId'),
+                onTap: () => widget.onToggleCompletedTask?.call(itemId),
+                behavior: HitTestBehavior.opaque,
+                child: const Padding(
+                  padding: EdgeInsets.fromLTRB(0, 1, 8, 8),
+                  child: Icon(
+                    Icons.check_circle_rounded,
+                    size: 17,
+                    color: Color(0xFF94A3B8),
+                  ),
                 ),
               ),
-              const SizedBox(width: 10),
+              const SizedBox(width: 2),
               Expanded(
                 child: Text(
                   item.title,
@@ -529,23 +537,24 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
           shape: BoxShape.circle,
           color: isCompleted ? const Color(0xFF5B6CFF) : Colors.transparent,
           border: Border.all(
-            color:
-                isCompleted ? const Color(0xFF5B6CFF) : const Color(0xFFCBD5E1),
+            color: isCompleted
+                ? const Color(0xFF5B6CFF)
+                : const Color(0xFFCBD5E1),
             width: 2,
           ),
         ),
         child: isCompleted
             ? const Icon(Icons.check, size: 13, color: Colors.white)
             : isInProgress
-                ? Container(
-                    width: 8,
-                    height: 8,
-                    decoration: const BoxDecoration(
-                      color: Color(0xFF5B6CFF),
-                      shape: BoxShape.circle,
-                    ),
-                  )
-                : null,
+            ? Container(
+                width: 8,
+                height: 8,
+                decoration: const BoxDecoration(
+                  color: Color(0xFF5B6CFF),
+                  shape: BoxShape.circle,
+                ),
+              )
+            : null,
       ),
     );
   }
@@ -767,8 +776,7 @@ class _MagazineNarrativeTabState extends State<MagazineNarrativeTab> {
       'completed' || 'done' => ScheduleItemStatus.completed,
       'in_progress' ||
       'inprogress' ||
-      'active' =>
-        ScheduleItemStatus.inProgress,
+      'active' => ScheduleItemStatus.inProgress,
       'overdue' => ScheduleItemStatus.overdue,
       _ => ScheduleItemStatus.pending,
     };

--- a/test/data/services/schedule_state_service_test.dart
+++ b/test/data/services/schedule_state_service_test.dart
@@ -34,143 +34,245 @@ void main() {
     });
 
     test(
-        'completePendingItem moves item to completed and writes back task card',
-        () async {
-      const userId = 'test_user';
-      const factId = '2026/05/26.md#ts_1';
-      final card = _taskCard(factId: factId, isCompleted: false);
-      await FileSystemService.instance.safeWriteCardFile(userId, factId, card);
-
-      await ScheduleStateService.instance.addPendingItem(
-        userId: userId,
-        kind: SchedulePendingItem.kindTodo,
-        title: 'Buy skincare',
-        sourceFactId: factId,
-        dueAt: DateTime.parse('2020-05-27T09:00:00'),
-        now: DateTime.parse('2026-05-26T10:00:00'),
-      );
-      final pending = await ScheduleStateService.instance.read(userId);
-      GlobalEventBus.instance.subscribeSync<DataChangeRecord>(
-        eventType: SystemEventTypes.dataChanged,
-        subscription: EventSyncSubscription<DataChangeRecord>(
-          subscriptionId: 'schedule_state_service_test_completion_sync',
-          handler: handleScheduleStateOnCardChanged,
-        ),
-      );
-      addTearDown(() {
-        GlobalEventBus.instance.unsubscribeSync(
-          eventType: SystemEventTypes.dataChanged,
-          subscriptionId: 'schedule_state_service_test_completion_sync',
+      'completePendingItem moves item to completed and writes back task card',
+      () async {
+        const userId = 'test_user';
+        const factId = '2026/05/26.md#ts_1';
+        final card = _taskCard(factId: factId, isCompleted: false);
+        await FileSystemService.instance.safeWriteCardFile(
+          userId,
+          factId,
+          card,
         );
-      });
 
-      await ScheduleStateService.instance.completePendingItem(
-        userId: userId,
-        pendingId: pending.pending.single.id,
-        closedByFactId: '2026/05/26.md#ts_2',
-        closedAt: DateTime.parse('2026-05-26T11:00:00'),
-      );
+        await ScheduleStateService.instance.addPendingItem(
+          userId: userId,
+          kind: SchedulePendingItem.kindTodo,
+          title: 'Buy skincare',
+          sourceFactId: factId,
+          dueAt: DateTime.parse('2020-05-27T09:00:00'),
+          now: DateTime.parse('2026-05-26T10:00:00'),
+        );
+        final pending = await ScheduleStateService.instance.read(userId);
+        GlobalEventBus.instance.subscribeSync<DataChangeRecord>(
+          eventType: SystemEventTypes.dataChanged,
+          subscription: EventSyncSubscription<DataChangeRecord>(
+            subscriptionId: 'schedule_state_service_test_completion_sync',
+            handler: handleScheduleStateOnCardChanged,
+          ),
+        );
+        addTearDown(() {
+          GlobalEventBus.instance.unsubscribeSync(
+            eventType: SystemEventTypes.dataChanged,
+            subscriptionId: 'schedule_state_service_test_completion_sync',
+          );
+        });
 
-      final state = await ScheduleStateService.instance.read(userId);
-      expect(state.pending, isEmpty);
-      expect(state.completed, hasLength(1));
-      expect(state.completed.single.closedByFactId, '2026/05/26.md#ts_2');
+        await ScheduleStateService.instance.completePendingItem(
+          userId: userId,
+          pendingId: pending.pending.single.id,
+          closedByFactId: '2026/05/26.md#ts_2',
+          closedAt: DateTime.parse('2026-05-26T11:00:00'),
+        );
 
-      final updatedCard =
-          await FileSystemService.instance.readCardFile(userId, factId);
-      expect(updatedCard!.uiConfigs.single.data['is_completed'], isTrue);
-    });
+        final state = await ScheduleStateService.instance.read(userId);
+        expect(state.pending, isEmpty);
+        expect(state.completed, hasLength(1));
+        expect(state.completed.single.closedByFactId, '2026/05/26.md#ts_2');
 
-    test('setSubtaskCompletion persists state without touching task card',
-        () async {
-      const userId = 'test_user';
-      const factId = '2026/05/26.md#ts_1';
-      await FileSystemService.instance.safeWriteCardFile(
-        userId,
-        factId,
-        _taskCard(
-          factId: factId,
-          isCompleted: false,
+        final updatedCard = await FileSystemService.instance.readCardFile(
+          userId,
+          factId,
+        );
+        expect(updatedCard!.uiConfigs.single.data['is_completed'], isTrue);
+      },
+    );
+
+    test(
+      'restoreCompletedItem reopens item and restores task card snapshot',
+      () async {
+        const userId = 'test_user';
+        const factId = '2026/05/26.md#ts_1';
+        await FileSystemService.instance.safeWriteCardFile(
+          userId,
+          factId,
+          _taskCard(
+            factId: factId,
+            isCompleted: false,
+            subtasks: const [
+              {'title': 'Draft', 'completed': false},
+              {'title': 'Review', 'completed': true},
+            ],
+          ),
+        );
+
+        final created = await ScheduleStateService.instance.addPendingItem(
+          userId: userId,
+          kind: SchedulePendingItem.kindTodo,
+          title: 'Write launch plan',
+          description: 'Keep the draft short.',
+          sourceFactId: factId,
+          dueAt: DateTime.parse('2026-05-27T09:00:00'),
+          priority: 3,
           subtasks: const [
-            {'title': '整理今日工作进展要点', 'completed': false},
-            {'title': '撰写日报内容', 'completed': false},
-            {'title': '发送给主管', 'completed': false},
+            ScheduleSubtask(title: 'Draft', completed: false),
+            ScheduleSubtask(title: 'Review', completed: true),
           ],
-        ),
-      );
+          now: DateTime.parse('2026-05-26T10:00:00'),
+        );
+        final pendingId = created.pending.single.id;
 
-      final initial = await ScheduleStateService.instance.addPendingItem(
-        userId: userId,
-        kind: SchedulePendingItem.kindTodo,
-        title: '下午 6 点提交日报给主管',
-        sourceFactId: factId,
-        dueAt: DateTime.parse('2026-05-27T18:00:00'),
-        subtasks: const [
-          ScheduleSubtask(title: '整理今日工作进展要点'),
-          ScheduleSubtask(title: '撰写日报内容'),
-          ScheduleSubtask(title: '发送给主管'),
-        ],
-        now: DateTime.parse('2026-05-27T16:00:00'),
-      );
+        await ScheduleStateService.instance.completePendingItem(
+          userId: userId,
+          pendingId: pendingId,
+          closedAt: DateTime.parse('2026-05-26T11:00:00'),
+        );
+        final completed = await ScheduleStateService.instance.read(userId);
+        expect(completed.pending, isEmpty);
+        expect(completed.completed.single.pendingSnapshot?.priority, 3);
 
-      await ScheduleStateService.instance.setSubtaskCompletion(
-        userId: userId,
-        pendingId: initial.pending.single.id,
-        subtaskTitle: '整理今日工作进展要点',
-        completed: true,
-        changedAt: DateTime.parse('2026-05-27T16:10:00'),
-      );
+        final completedCard = await FileSystemService.instance.readCardFile(
+          userId,
+          factId,
+        );
+        final completedSubtasks =
+            completedCard!.uiConfigs.single.data['subtasks'] as List<dynamic>;
+        expect(completedCard.uiConfigs.single.data['is_completed'], isTrue);
+        expect(
+          completedSubtasks.map((subtask) => (subtask as Map)['completed']),
+          [true, true],
+        );
 
-      final state = await ScheduleStateService.instance.read(userId);
-      expect(state.pending.single.subtasks.first.completed, isTrue);
-      expect(state.pending.single.subtasks.first.closedByFactId, isNull);
+        await ScheduleStateService.instance.restoreCompletedItem(
+          userId: userId,
+          completedId: pendingId,
+          now: DateTime.parse('2026-05-26T11:05:00'),
+        );
 
-      final updatedCard =
-          await FileSystemService.instance.readCardFile(userId, factId);
-      final rawSubtasks =
-          updatedCard!.uiConfigs.single.data['subtasks'] as List<dynamic>;
-      expect(rawSubtasks.first as Map, containsPair('completed', false));
-      expect(updatedCard.uiConfigs.single.data['is_completed'], isFalse);
-    });
+        final restored = await ScheduleStateService.instance.read(userId);
+        expect(restored.completed, isEmpty);
+        expect(restored.pending.single.id, pendingId);
+        expect(restored.pending.single.description, 'Keep the draft short.');
+        expect(
+          restored.pending.single.dueAt,
+          DateTime.parse('2026-05-27T09:00:00'),
+        );
+        expect(restored.pending.single.priority, 3);
+        expect(
+          restored.pending.single.subtasks.map((subtask) => subtask.completed),
+          [false, true],
+        );
 
-    test('setPresentation and searchCompleted persist canonical state',
-        () async {
-      const userId = 'test_user';
-      await ScheduleStateService.instance.addPendingItem(
-        userId: userId,
-        kind: SchedulePendingItem.kindTodo,
-        title: 'Write launch plan',
-        sourceFactId: '2026/05/26.md#ts_1',
-        now: DateTime.parse('2026-05-26T10:00:00'),
-      );
-      final pending = await ScheduleStateService.instance.read(userId);
-      await ScheduleStateService.instance.completePendingItem(
-        userId: userId,
-        pendingId: pending.pending.single.id,
-        closedByFactId: '2026/05/26.md#ts_2',
-        closedAt: DateTime.parse('2026-05-26T11:00:00'),
-      );
+        final restoredCard = await FileSystemService.instance.readCardFile(
+          userId,
+          factId,
+        );
+        final restoredSubtasks =
+            restoredCard!.uiConfigs.single.data['subtasks'] as List<dynamic>;
+        expect(restoredCard.uiConfigs.single.data['is_completed'], isFalse);
+        expect(
+          restoredSubtasks.map((subtask) => (subtask as Map)['completed']),
+          [false, true],
+        );
+      },
+    );
 
-      await ScheduleStateService.instance.setPresentation(
-        userId: userId,
-        presentation: const SchedulePresentation(
-          editorialIntro: 'Clear morning, one completed planning task.',
-          timeline: [
-            ScheduleTimelineDay(dayLabel: 'Today', dayDate: '2026-05-26'),
+    test(
+      'setSubtaskCompletion persists state without touching task card',
+      () async {
+        const userId = 'test_user';
+        const factId = '2026/05/26.md#ts_1';
+        await FileSystemService.instance.safeWriteCardFile(
+          userId,
+          factId,
+          _taskCard(
+            factId: factId,
+            isCompleted: false,
+            subtasks: const [
+              {'title': '整理今日工作进展要点', 'completed': false},
+              {'title': '撰写日报内容', 'completed': false},
+              {'title': '发送给主管', 'completed': false},
+            ],
+          ),
+        );
+
+        final initial = await ScheduleStateService.instance.addPendingItem(
+          userId: userId,
+          kind: SchedulePendingItem.kindTodo,
+          title: '下午 6 点提交日报给主管',
+          sourceFactId: factId,
+          dueAt: DateTime.parse('2026-05-27T18:00:00'),
+          subtasks: const [
+            ScheduleSubtask(title: '整理今日工作进展要点'),
+            ScheduleSubtask(title: '撰写日报内容'),
+            ScheduleSubtask(title: '发送给主管'),
           ],
-        ),
-      );
+          now: DateTime.parse('2026-05-27T16:00:00'),
+        );
 
-      final state = await ScheduleStateService.instance.read(userId);
-      expect(state.presentation!.editorialIntro, contains('Clear morning'));
+        await ScheduleStateService.instance.setSubtaskCompletion(
+          userId: userId,
+          pendingId: initial.pending.single.id,
+          subtaskTitle: '整理今日工作进展要点',
+          completed: true,
+          changedAt: DateTime.parse('2026-05-27T16:10:00'),
+        );
 
-      final matches = await ScheduleStateService.instance.searchCompleted(
-        userId: userId,
-        query: 'launch',
-      );
-      expect(matches, hasLength(1));
-      expect(matches.single.title, 'Write launch plan');
-    });
+        final state = await ScheduleStateService.instance.read(userId);
+        expect(state.pending.single.subtasks.first.completed, isTrue);
+        expect(state.pending.single.subtasks.first.closedByFactId, isNull);
+
+        final updatedCard = await FileSystemService.instance.readCardFile(
+          userId,
+          factId,
+        );
+        final rawSubtasks =
+            updatedCard!.uiConfigs.single.data['subtasks'] as List<dynamic>;
+        expect(rawSubtasks.first as Map, containsPair('completed', false));
+        expect(updatedCard.uiConfigs.single.data['is_completed'], isFalse);
+      },
+    );
+
+    test(
+      'setPresentation and searchCompleted persist canonical state',
+      () async {
+        const userId = 'test_user';
+        await ScheduleStateService.instance.addPendingItem(
+          userId: userId,
+          kind: SchedulePendingItem.kindTodo,
+          title: 'Write launch plan',
+          sourceFactId: '2026/05/26.md#ts_1',
+          now: DateTime.parse('2026-05-26T10:00:00'),
+        );
+        final pending = await ScheduleStateService.instance.read(userId);
+        await ScheduleStateService.instance.completePendingItem(
+          userId: userId,
+          pendingId: pending.pending.single.id,
+          closedByFactId: '2026/05/26.md#ts_2',
+          closedAt: DateTime.parse('2026-05-26T11:00:00'),
+        );
+
+        await ScheduleStateService.instance.setPresentation(
+          userId: userId,
+          presentation: const SchedulePresentation(
+            editorialIntro: 'Clear morning, one completed planning task.',
+            timeline: [
+              ScheduleTimelineDay(dayLabel: 'Today', dayDate: '2026-05-26'),
+            ],
+          ),
+        );
+
+        final state = await ScheduleStateService.instance.read(userId);
+        expect(state.presentation!.editorialIntro, contains('Clear morning'));
+
+        final matches = await ScheduleStateService.instance.searchCompleted(
+          userId: userId,
+          query: 'launch',
+        );
+        expect(matches, hasLength(1));
+        expect(matches.single.title, 'Write launch plan');
+      },
+    );
 
     test('ensureInitialized creates empty canonical schedule state', () async {
       const userId = 'test_user';
@@ -203,38 +305,40 @@ void main() {
       expect(actions, isEmpty);
     });
 
-    test('syncDeviceAction controls device action creation and cancellation',
-        () async {
-      const userId = 'test_user';
+    test(
+      'syncDeviceAction controls device action creation and cancellation',
+      () async {
+        const userId = 'test_user';
 
-      final state = await ScheduleStateService.instance.addPendingItem(
-        userId: userId,
-        kind: SchedulePendingItem.kindEvent,
-        title: 'Dentist appointment',
-        sourceFactId: '2026/05/26.md#ts_1',
-        startTime: DateTime.parse('2099-05-27T09:00:00'),
-        now: DateTime.parse('2026-05-26T10:00:00'),
-        syncDeviceAction: true,
-      );
+        final state = await ScheduleStateService.instance.addPendingItem(
+          userId: userId,
+          kind: SchedulePendingItem.kindEvent,
+          title: 'Dentist appointment',
+          sourceFactId: '2026/05/26.md#ts_1',
+          startTime: DateTime.parse('2099-05-27T09:00:00'),
+          now: DateTime.parse('2026-05-26T10:00:00'),
+          syncDeviceAction: true,
+        );
 
-      expect(state.pending.single.syncDeviceAction, isTrue);
-      expect(state.pending.single.deviceActionId, isNotNull);
-      var actions = await db.select(db.systemActions).get();
-      expect(actions, hasLength(1));
-      expect(actions.single.actionType, 'calendar');
+        expect(state.pending.single.syncDeviceAction, isTrue);
+        expect(state.pending.single.deviceActionId, isNotNull);
+        var actions = await db.select(db.systemActions).get();
+        expect(actions, hasLength(1));
+        expect(actions.single.actionType, 'calendar');
 
-      final updated = await ScheduleStateService.instance.updatePendingItem(
-        userId: userId,
-        pendingId: state.pending.single.id,
-        syncDeviceAction: false,
-        now: DateTime.parse('2026-05-26T10:05:00'),
-      );
+        final updated = await ScheduleStateService.instance.updatePendingItem(
+          userId: userId,
+          pendingId: state.pending.single.id,
+          syncDeviceAction: false,
+          now: DateTime.parse('2026-05-26T10:05:00'),
+        );
 
-      expect(updated.pending.single.syncDeviceAction, isFalse);
-      expect(updated.pending.single.deviceActionId, isNull);
-      actions = await db.select(db.systemActions).get();
-      expect(actions, isEmpty);
-    });
+        expect(updated.pending.single.syncDeviceAction, isFalse);
+        expect(updated.pending.single.deviceActionId, isNull);
+        actions = await db.select(db.systemActions).get();
+        expect(actions, isEmpty);
+      },
+    );
 
     test('disabling sync preserves completed device action history', () async {
       const userId = 'test_user';
@@ -249,9 +353,9 @@ void main() {
         syncDeviceAction: true,
       );
       final actionId = state.pending.single.deviceActionId!;
-      await db.update(db.systemActions).write(
-            const SystemActionsCompanion(status: Value('completed')),
-          );
+      await db
+          .update(db.systemActions)
+          .write(const SystemActionsCompanion(status: Value('completed')));
 
       final updated = await ScheduleStateService.instance.updatePendingItem(
         userId: userId,
@@ -281,9 +385,9 @@ void main() {
         syncDeviceAction: true,
       );
       final actionId = state.pending.single.deviceActionId!;
-      await db.update(db.systemActions).write(
-            const SystemActionsCompanion(status: Value('completed')),
-          );
+      await db
+          .update(db.systemActions)
+          .write(const SystemActionsCompanion(status: Value('completed')));
 
       final updated = await ScheduleStateService.instance.updatePendingItem(
         userId: userId,
@@ -299,39 +403,41 @@ void main() {
       expect(actions.single.status, 'completed');
     });
 
-    test('cards and aggregation are not imported after initialization',
-        () async {
-      const userId = 'test_user';
-      const secondTaskId = '2026/05/27.md#ts_1';
+    test(
+      'cards and aggregation are not imported after initialization',
+      () async {
+        const userId = 'test_user';
+        const secondTaskId = '2026/05/27.md#ts_1';
 
-      final first = await ScheduleStateService.instance.ensureInitialized(
-        userId,
-        now: DateTime.parse('2026-05-26T09:00:00'),
-      );
-      expect(first.pending, isEmpty);
-      expect(first.presentation, isNull);
+        final first = await ScheduleStateService.instance.ensureInitialized(
+          userId,
+          now: DateTime.parse('2026-05-26T09:00:00'),
+        );
+        expect(first.pending, isEmpty);
+        expect(first.presentation, isNull);
 
-      await FileSystemService.instance.safeWriteCardFile(
-        userId,
-        secondTaskId,
-        _taskCard(factId: secondTaskId, isCompleted: false),
-      );
+        await FileSystemService.instance.safeWriteCardFile(
+          userId,
+          secondTaskId,
+          _taskCard(factId: secondTaskId, isCompleted: false),
+        );
 
-      final second = await ScheduleStateService.instance.ensureInitialized(
-        userId,
-        now: DateTime.parse('2026-05-27T09:00:00'),
-      );
+        final second = await ScheduleStateService.instance.ensureInitialized(
+          userId,
+          now: DateTime.parse('2026-05-27T09:00:00'),
+        );
 
-      expect(second.pending, isEmpty);
-      expect(second.presentation, isNull);
+        expect(second.pending, isEmpty);
+        expect(second.presentation, isNull);
 
-      final rebuilt = await ScheduleStateService.instance.rebuildFromCards(
-        userId,
-        now: DateTime.parse('2026-05-28T09:00:00'),
-      );
-      expect(rebuilt.pending, isEmpty);
-      expect(rebuilt.presentation, isNull);
-    });
+        final rebuilt = await ScheduleStateService.instance.rebuildFromCards(
+          userId,
+          now: DateTime.parse('2026-05-28T09:00:00'),
+        );
+        expect(rebuilt.pending, isEmpty);
+        expect(rebuilt.presentation, isNull);
+      },
+    );
   });
 }
 

--- a/test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart
+++ b/test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart
@@ -238,26 +238,23 @@ void main() {
       },
     );
 
-    test(
-      'toggleCompletion reverts plain tasks when write fails',
-      () async {
-        final vm = ScheduleAggregatorViewModel(
-          loadAggregation: () async => _aggregation(),
-          completeScheduleItem: (_) async => Error(Exception('failed')),
-          listenToEvents: false,
-        );
+    test('toggleCompletion reverts plain tasks when write fails', () async {
+      final vm = ScheduleAggregatorViewModel(
+        loadAggregation: () async => _aggregation(),
+        completeScheduleItem: (_) async => Error(Exception('failed')),
+        listenToEvents: false,
+      );
 
-        await vm.loadAggregation();
-        final item = vm.items.single;
+      await vm.loadAggregation();
+      final item = vm.items.single;
 
-        await vm.toggleCompletion(item);
+      await vm.toggleCompletion(item);
 
-        expect(vm.items.single.status, ScheduleItemStatus.pending);
-        expect(vm.error, 'Failed to update task');
+      expect(vm.items.single.status, ScheduleItemStatus.pending);
+      expect(vm.error, 'Failed to update task');
 
-        vm.dispose();
-      },
-    );
+      vm.dispose();
+    });
 
     test('toggleCompletion ignores event items', () async {
       var didComplete = false;
@@ -280,39 +277,61 @@ void main() {
       vm.dispose();
     });
 
-    test(
-      'toggleSubtask writes one subtask to schedule state',
-      () async {
-        String? updatedItemId;
-        String? updatedSubtaskTitle;
-        bool? updatedCompleted;
-        final vm = ScheduleAggregatorViewModel(
-          loadAggregation: () async => _aggregationWithSubtasks(),
-          setScheduleSubtaskCompletion: (itemId, title, completed) async {
-            updatedItemId = itemId;
-            updatedSubtaskTitle = title;
-            updatedCompleted = completed;
-            return const Ok.v();
-          },
-          listenToEvents: false,
-        );
+    test('restoreCompletedItem writes canonical restore and reloads', () async {
+      String? restoredItemId;
+      var loadCount = 0;
+      final vm = ScheduleAggregatorViewModel(
+        loadAggregation: () async {
+          loadCount += 1;
+          return _completedAggregation(id: 'completed_$loadCount');
+        },
+        restoreScheduleItem: (itemId) async {
+          restoredItemId = itemId;
+          return const Ok.v();
+        },
+        listenToEvents: false,
+      );
 
-        await vm.loadAggregation();
-        final item = vm.items.single;
+      await vm.loadAggregation();
+      await vm.restoreCompletedItem('schedule-task-1');
 
-        final toggle = vm.toggleSubtask(item, 0);
-        expect(vm.items.single.status, ScheduleItemStatus.inProgress);
-        expect(vm.items.single.subtasks.first.completed, isTrue);
-        await toggle;
+      expect(restoredItemId, 'schedule-task-1');
+      expect(loadCount, 2);
+      expect(vm.error, isNull);
 
-        expect(updatedItemId, 'schedule-task-1');
-        expect(updatedSubtaskTitle, 'Collect documents');
-        expect(updatedCompleted, isTrue);
-        expect(vm.error, isNull);
+      vm.dispose();
+    });
 
-        vm.dispose();
-      },
-    );
+    test('toggleSubtask writes one subtask to schedule state', () async {
+      String? updatedItemId;
+      String? updatedSubtaskTitle;
+      bool? updatedCompleted;
+      final vm = ScheduleAggregatorViewModel(
+        loadAggregation: () async => _aggregationWithSubtasks(),
+        setScheduleSubtaskCompletion: (itemId, title, completed) async {
+          updatedItemId = itemId;
+          updatedSubtaskTitle = title;
+          updatedCompleted = completed;
+          return const Ok.v();
+        },
+        listenToEvents: false,
+      );
+
+      await vm.loadAggregation();
+      final item = vm.items.single;
+
+      final toggle = vm.toggleSubtask(item, 0);
+      expect(vm.items.single.status, ScheduleItemStatus.inProgress);
+      expect(vm.items.single.subtasks.first.completed, isTrue);
+      await toggle;
+
+      expect(updatedItemId, 'schedule-task-1');
+      expect(updatedSubtaskTitle, 'Collect documents');
+      expect(updatedCompleted, isTrue);
+      expect(vm.error, isNull);
+
+      vm.dispose();
+    });
 
     test(
       'toggleSubtask marks parent completed when last subtask is done',
@@ -365,29 +384,26 @@ void main() {
       },
     );
 
-    test(
-      'toggleSubtask reverts optimistic state when write fails',
-      () async {
-        final vm = ScheduleAggregatorViewModel(
-          loadAggregation: () async => _aggregationWithSubtasks(),
-          setScheduleSubtaskCompletion: (_, __, ___) async =>
-              Error(Exception('failed')),
-          listenToEvents: false,
-        );
+    test('toggleSubtask reverts optimistic state when write fails', () async {
+      final vm = ScheduleAggregatorViewModel(
+        loadAggregation: () async => _aggregationWithSubtasks(),
+        setScheduleSubtaskCompletion: (_, __, ___) async =>
+            Error(Exception('failed')),
+        listenToEvents: false,
+      );
 
-        await vm.loadAggregation();
-        await vm.toggleSubtask(vm.items.single, 1);
+      await vm.loadAggregation();
+      await vm.toggleSubtask(vm.items.single, 1);
 
-        expect(vm.items.single.status, ScheduleItemStatus.pending);
-        expect(vm.items.single.subtasks.map((subtask) => subtask.completed), [
-          false,
-          false,
-        ]);
-        expect(vm.error, 'Failed to update task');
+      expect(vm.items.single.status, ScheduleItemStatus.pending);
+      expect(vm.items.single.subtasks.map((subtask) => subtask.completed), [
+        false,
+        false,
+      ]);
+      expect(vm.error, 'Failed to update task');
 
-        vm.dispose();
-      },
-    );
+      vm.dispose();
+    });
   });
 }
 
@@ -401,7 +417,9 @@ ScheduleViewData _aggregation({
     id: id,
     generatedAt: DateTime(2026, 4, 26, 8),
     timeRange: ScheduleViewTimeRange(
-        from: DateTime(2026, 4, 26), to: DateTime(2026, 5, 3)),
+      from: DateTime(2026, 4, 26),
+      to: DateTime(2026, 5, 3),
+    ),
     timeline: [
       ScheduleViewTimelineDay(
         dayLabel: 'Today',
@@ -432,7 +450,9 @@ ScheduleViewData _aggregationWithSubtasks({
     id: 'agg_subtasks',
     generatedAt: DateTime(2026, 4, 26, 8),
     timeRange: ScheduleViewTimeRange(
-        from: DateTime(2026, 4, 26), to: DateTime(2026, 5, 3)),
+      from: DateTime(2026, 4, 26),
+      to: DateTime(2026, 5, 3),
+    ),
     timeline: [
       ScheduleViewTimelineDay(
         dayLabel: 'Today',
@@ -459,7 +479,9 @@ ScheduleViewData _eventAggregation() {
     id: 'event_agg',
     generatedAt: DateTime(2026, 4, 26, 8),
     timeRange: ScheduleViewTimeRange(
-        from: DateTime(2026, 4, 26), to: DateTime(2026, 5, 3)),
+      from: DateTime(2026, 4, 26),
+      to: DateTime(2026, 5, 3),
+    ),
     timeline: [
       ScheduleViewTimelineDay(
         dayLabel: 'Today',
@@ -473,6 +495,25 @@ ScheduleViewData _eventAggregation() {
             type: 'event',
           ),
         ],
+      ),
+    ],
+  );
+}
+
+ScheduleViewData _completedAggregation({String id = 'completed_agg'}) {
+  return ScheduleViewData(
+    id: id,
+    generatedAt: DateTime(2026, 4, 26, 8),
+    timeRange: ScheduleViewTimeRange(
+      from: DateTime(2026, 4, 26),
+      to: DateTime(2026, 5, 3),
+    ),
+    completed: [
+      ScheduleViewCompletedItem(
+        cardId: 'task-1',
+        itemId: 'schedule-task-1',
+        title: 'Submitted visa form',
+        completedAt: DateTime(2026, 4, 26, 12),
       ),
     ],
   );

--- a/test/ui/schedule/widgets/schedule_widgets_test.dart
+++ b/test/ui/schedule/widgets/schedule_widgets_test.dart
@@ -34,16 +34,18 @@ void main() {
       (tester) async {
         final tappedCards = <String>[];
         final toggledTasks = <String>[];
+        final restoredTasks = <String>[];
 
         await tester.pumpWidget(
           buildHost(
             MagazineNarrativeTab(
               aggregation: _complexAggregation(),
               itemStatuses: const {
-                'pi_task_clean': ScheduleItemStatus.completed
+                'pi_task_clean': ScheduleItemStatus.completed,
               },
               onTapCardId: tappedCards.add,
               onToggleTask: toggledTasks.add,
+              onToggleCompletedTask: restoredTasks.add,
             ),
           ),
         );
@@ -87,6 +89,12 @@ void main() {
         await tester.scrollUntilVisible(find.text('Done grocery order'), 240);
         await tester.pumpAndSettle();
         expect(find.text('Done grocery order'), findsOneWidget);
+
+        await tester.tap(
+          find.byKey(const ValueKey('schedule_completed_toggle_pi_done')),
+        );
+        await tester.pump();
+        expect(restoredTasks, ['pi_done']);
       },
     );
 
@@ -478,6 +486,7 @@ ScheduleViewData _complexAggregation({
     completed: [
       ScheduleViewCompletedItem(
         cardId: 'task-grocery',
+        itemId: 'pi_done',
         title: 'Done grocery order',
         completedAt: DateTime(2026, 5, 14, 21, 15),
       ),


### PR DESCRIPTION
## 背景

Closes #211。

日程/待办页里，待办完成后会进入 completed 区，但 completed cell 原先没有恢复入口；同时 completed 记录只保留标题和来源，恢复时容易丢上下文。

## 修改

- `ScheduleCompletedItem` 增加 `pending_snapshot`，完成待办或扫过期事件时保留可恢复快照，并兼容旧 YAML 中没有快照的记录。
- `ScheduleStateService` 增加 `restoreCompletedItem`，可把 completed 记录恢复回 pending，并同步把源任务卡片恢复为未完成。
- completed 区的勾选图标支持点击恢复，ViewModel/Router 接入新的恢复路径。
- 恢复源任务卡片时按快照恢复子任务完成状态。

## 验证

- `flutter test test/data/services/schedule_state_service_test.dart test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart test/data/repositories/get_schedule_view_data_test.dart test/ui/schedule/models/schedule_item_test.dart`
- `flutter analyze lib/domain/models/schedule_state.dart lib/domain/models/schedule_view_data.dart lib/data/services/schedule_state_projector.dart lib/data/services/schedule_state_service.dart lib/data/repositories/get_schedule_view_data.dart lib/data/repositories/memex_router.dart lib/ui/schedule/models/schedule_item.dart lib/ui/schedule/view_models/schedule_aggregator_view_model.dart lib/ui/schedule/widgets/schedule_aggregator_screen.dart lib/ui/schedule/widgets/tabs/magazine_narrative_tab.dart test/data/services/schedule_state_service_test.dart test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart test/ui/schedule/widgets/schedule_widgets_test.dart`

## 备注

这次使用当前 SDK 的 `dart format` 格式化 touched files，会带来部分缩进/折行 diff；未改生成文件、依赖文件或平台资源。