### PR TITLE
限制用户级 Agent 任务并发

### DIFF
--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -151,6 +151,7 @@ class MemexRouter {
       LocalTaskExecutor.instance.registerHandler(
         'reprocess_cards_task',
         handleReprocessCardsImpl,
+        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
       );
       LocalTaskExecutor.instance.registerHandler(
         'comment_agent_task',
@@ -159,10 +160,12 @@ class MemexRouter {
       LocalTaskExecutor.instance.registerHandler(
         'reprocess_comments_task',
         handleReprocessCommentsImpl,
+        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
       );
       LocalTaskExecutor.instance.registerHandler(
         'reprocess_knowledge_base_task',
         handleReprocessKnowledgeBaseImpl,
+        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
       );
       LocalTaskExecutor.instance.registerHandler(
         'process_ai_reply',
@@ -171,10 +174,12 @@ class MemexRouter {
       LocalTaskExecutor.instance.registerHandler(
         'knowledge_insight_task',
         handleKnowledgeInsight,
+        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
       );
       LocalTaskExecutor.instance.registerHandler(
         'schedule_aggregator_task',
         handleScheduleAggregation,
+        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
       );
       LocalTaskExecutor.instance.registerHandler(
         'post_card_router_task',

--- a/lib/data/services/local_task_executor.dart
+++ b/lib/data/services/local_task_executor.dart
@@ -59,6 +59,34 @@ class TaskActivitySnapshot {
 typedef TaskHandler = Future<void> Function(
     String userId, Map<String, dynamic> payload, TaskContext context);
 
+typedef TaskConcurrencyKeyBuilder = String Function(
+  String userId,
+  Map<String, dynamic> payload,
+  TaskContext context,
+);
+
+/// Per-task-type concurrency policy. The executor prefixes the returned key
+/// with the task type, so [byUser] means "one task of this type per user".
+class TaskConcurrencyPolicy {
+  TaskConcurrencyPolicy._(this._keyBuilder);
+
+  final TaskConcurrencyKeyBuilder _keyBuilder;
+
+  factory TaskConcurrencyPolicy.byUser() {
+    return TaskConcurrencyPolicy._(
+      (userId, payload, context) => userId,
+    );
+  }
+
+  String keyFor(
+    String userId,
+    Map<String, dynamic> payload,
+    TaskContext context,
+  ) {
+    return _keyBuilder(userId, payload, context);
+  }
+}
+
 /// Failure handler function type - called when all retries are exhausted
 typedef TaskFailureHandler = Future<void> Function(
     String userId,
@@ -88,6 +116,8 @@ class LocalTaskExecutor {
 
   // Handlers registry
   final Map<String, TaskHandler> _handlers = {};
+  final Map<String, TaskConcurrencyPolicy> _concurrencyPolicies = {};
+  final Set<String> _activeConcurrencyKeys = <String>{};
 
   // Failure handlers registry
   final Map<String, TaskFailureHandler> _failureHandlers = {};
@@ -151,8 +181,17 @@ class LocalTaskExecutor {
     );
   }
 
-  void registerHandler(String taskType, TaskHandler handler) {
+  void registerHandler(
+    String taskType,
+    TaskHandler handler, {
+    TaskConcurrencyPolicy? concurrencyPolicy,
+  }) {
     _handlers[taskType] = handler;
+    if (concurrencyPolicy == null) {
+      _concurrencyPolicies.remove(taskType);
+    } else {
+      _concurrencyPolicies[taskType] = concurrencyPolicy;
+    }
   }
 
   /// Register a failure handler for a task type
@@ -327,14 +366,41 @@ class LocalTaskExecutor {
       // 3. Claim tasks before starting handlers so immediate polling cannot
       // pick the same pending row again while execution starts asynchronously.
       final claimedTasks = <Task>[];
+      final claimedConcurrencyKeys = <String, String?>{};
       for (final task in tasksToRun) {
-        if (await _claimTaskForExecution(task, now)) {
-          claimedTasks.add(task);
+        final concurrencyKey = _concurrencyKeyForTask(task);
+        final acquiredConcurrencyKey = concurrencyKey == null
+            ? false
+            : _activeConcurrencyKeys.add(concurrencyKey);
+        if (concurrencyKey != null && !acquiredConcurrencyKey) {
+          _logger.info(
+            'Deferring task ${task.id} (${task.type}) because $concurrencyKey is already running',
+          );
+          continue;
+        }
+
+        try {
+          if (await _claimTaskForExecution(task, now)) {
+            claimedTasks.add(task);
+            claimedConcurrencyKeys[task.id] = concurrencyKey;
+          } else if (acquiredConcurrencyKey) {
+            _activeConcurrencyKeys.remove(concurrencyKey);
+          }
+        } catch (_) {
+          if (acquiredConcurrencyKey) {
+            _activeConcurrencyKeys.remove(concurrencyKey);
+          }
+          rethrow;
         }
       }
 
       for (final task in claimedTasks) {
-        unawaited(_executeTask(task));
+        unawaited(
+          _executeTask(
+            task,
+            concurrencyKey: claimedConcurrencyKeys[task.id],
+          ),
+        );
       }
 
       // Loop immediately to check for more tasks or completion
@@ -355,6 +421,7 @@ class LocalTaskExecutor {
     required int now,
   }) async {
     final tasksToRun = <Task>[];
+    final reservedConcurrencyKeys = <String>{};
     var offset = 0;
     var scanned = 0;
 
@@ -383,6 +450,14 @@ class LocalTaskExecutor {
       for (final task in candidates) {
         if (tasksToRun.length >= slotsAvailable) break;
         if (await _dependenciesMet(task)) {
+          final concurrencyKey = _concurrencyKeyForTask(task);
+          if (concurrencyKey != null) {
+            if (_activeConcurrencyKeys.contains(concurrencyKey) ||
+                reservedConcurrencyKeys.contains(concurrencyKey)) {
+              continue;
+            }
+            reservedConcurrencyKeys.add(concurrencyKey);
+          }
           tasksToRun.add(task);
         }
       }
@@ -394,6 +469,36 @@ class LocalTaskExecutor {
     }
 
     return tasksToRun;
+  }
+
+  String? _concurrencyKeyForTask(Task task) {
+    final policy = _concurrencyPolicies[task.type];
+    if (policy == null) return null;
+    final currentUserId = _currentUserId;
+    if (currentUserId == null) return null;
+
+    try {
+      final payloadMap = _decodePayload(task);
+      final context = TaskContext(
+        taskId: task.id,
+        taskType: task.type,
+        bizId: task.bizId,
+      );
+      return '${task.type}:${policy.keyFor(currentUserId, payloadMap, context)}';
+    } catch (e, st) {
+      _logger.warning(
+        'Failed to build concurrency key for task ${task.id}',
+        e,
+        st,
+      );
+      return null;
+    }
+  }
+
+  Map<String, dynamic> _decodePayload(Task task) {
+    return task.payload != null
+        ? jsonDecode(task.payload!) as Map<String, dynamic>
+        : <String, dynamic>{};
   }
 
   Future<bool> _dependenciesMet(Task task) async {
@@ -418,16 +523,14 @@ class LocalTaskExecutor {
     }
   }
 
-  Future<void> _executeTask(Task task) async {
+  Future<void> _executeTask(Task task, {String? concurrencyKey}) async {
     try {
       final handler = _handlers[task.type];
       if (handler == null) {
         throw Exception('No handler registered for task type: ${task.type}');
       }
 
-      final payloadMap = task.payload != null
-          ? jsonDecode(task.payload!) as Map<String, dynamic>
-          : <String, dynamic>{};
+      final payloadMap = _decodePayload(task);
 
       final currentUserId = _currentUserId;
       if (currentUserId == null) {
@@ -520,6 +623,9 @@ class LocalTaskExecutor {
       }
     } finally {
       await _clearTaskExecutionMarker(task.id);
+      if (concurrencyKey != null) {
+        _activeConcurrencyKeys.remove(concurrencyKey);
+      }
 
       // Trigger poll to pick up next tasks immediately upon completion of one
       if (_isRunning) {

--- a/test/data/services/local_task_executor_test.dart
+++ b/test/data/services/local_task_executor_test.dart
@@ -150,6 +150,63 @@ void main() {
       executor.stop();
     });
 
+    test('serializes tasks that share a concurrency policy key', () async {
+      final firstStarted = Completer<void>();
+      final releaseFirst = Completer<void>();
+      final secondStarted = Completer<void>();
+      final otherCompleted = Completer<void>();
+
+      executor.registerHandler(
+        'serial_task',
+        (_, __, context) async {
+          if (context.taskId == 'serial-1') {
+            if (!firstStarted.isCompleted) firstStarted.complete();
+            await releaseFirst.future;
+          } else if (context.taskId == 'serial-2') {
+            if (!secondStarted.isCompleted) secondStarted.complete();
+          }
+        },
+        concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+      );
+      executor.registerHandler('other_task', (_, __, ___) async {
+        if (!otherCompleted.isCompleted) otherCompleted.complete();
+      });
+
+      await _insertTask(
+        db,
+        id: 'serial-1',
+        type: 'serial_task',
+        status: 'pending',
+        payload: {'value': 1},
+      );
+      await _insertTask(
+        db,
+        id: 'serial-2',
+        type: 'serial_task',
+        status: 'pending',
+        payload: {'value': 2},
+      );
+      await _insertTask(
+        db,
+        id: 'other',
+        type: 'other_task',
+        status: 'pending',
+        payload: {'value': 3},
+      );
+
+      await executor.start(userId: 'user-a');
+      await firstStarted.future.timeout(const Duration(seconds: 3));
+      await otherCompleted.future.timeout(const Duration(seconds: 3));
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+
+      expect((await _getTask(db, 'serial-2')).status, 'pending');
+
+      releaseFirst.complete();
+      await secondStarted.future.timeout(const Duration(seconds: 3));
+      await _waitForTaskStatus(db, 'serial-1', 'completed');
+      await _waitForTaskStatus(db, 'serial-2', 'completed');
+    });
+
     test('reports active task activity snapshot', () async {
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 


### PR DESCRIPTION
## 背景

Closes #212。

备份排查里，同一条远程工作任务只有一个事实和一张任务卡片，但 `schedule_state.yaml` 出现了两条相近 pending item。根因不是卡片识别出两条，而是多个 `schedule_aggregator_task` 在相近时间并发处理同一批输入，并分别追加了事项。

## 修改

- 在 `LocalTaskExecutor` 增加可复用的 `TaskConcurrencyPolicy`。
- 支持按当前用户对同一 task type 做 single-flight：已有同 key 任务运行时，后续任务保持 pending，等下一轮 poll 再执行。
- 为 `schedule_aggregator_task`、`knowledge_insight_task`、`reprocess_cards_task`、`reprocess_comments_task`、`reprocess_knowledge_base_task` 启用同用户串行。
- 保留 `card_agent_task`、`pkm_agent_task` 等按输入并行的任务，不做全局串行。

## 验证

- `flutter test test/data/services/local_task_executor_test.dart`
- `flutter analyze lib/data/services/local_task_executor.dart lib/data/repositories/memex_router.dart test/data/services/local_task_executor_test.dart`

## 备注

这个改动不需要修改 `dart_agent_core`；限制点放在 Memex 的持久任务执行层，可以覆盖内置 Agent 和重处理任务。