### PR TITLE
eval(pkm): use framework transcript recording

### DIFF
--- a/lib/agent/pkm_agent/pkm_agent.dart
+++ b/lib/agent/pkm_agent/pkm_agent.dart
@@ -71,6 +71,7 @@ class PkmAgent {
     required ModelConfig modelConfig,
     required String userId,
     required String factId,
+    AgentController? controller,
   }) async {
     final fileService = FileSystemService.instance;
 
@@ -86,9 +87,9 @@ class PkmAgent {
       'sceneId': factId,
     });
 
-    final controller = AgentController();
-    addAgentLogger(controller);
-    addAgentActivityCollector(controller);
+    final agentController = controller ?? AgentController();
+    addAgentLogger(agentController);
+    addAgentActivityCollector(agentController);
 
     final stopAfterUpdateCardInsightRef = [true];
     final skills = [
@@ -295,7 +296,7 @@ class PkmAgent {
         skills: skills,
         systemPrompts: [pkmAgentSystemPrompt],
         disableSubAgents: true,
-        controller: controller,
+        controller: agentController,
         withGeneralPrinciples: true,
         planMode: PlanMode.none,
         autoSaveStateFunc: (state) async {
@@ -315,6 +316,7 @@ class PkmAgent {
     required String userId,
     required String factId,
     required String instruction,
+    AgentController? controller,
   }) async {
     // Ensure we have a valid cached responseId with matching hashCode
     final cachedResponseId = await AgentCacheHelper.ensureValidCachedResponseId(
@@ -354,6 +356,7 @@ class PkmAgent {
       modelConfig: finalModelConfig,
       userId: userId,
       factId: factId,
+      controller: controller,
     );
 
     final pkmOverview = await _getPkmOverview(userId);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -357,10 +357,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_agent_core
-      sha256: "41ca0bcec3d47b15719405b569e6fc5a8bf0cb9676590b56b60d473708dbf141"
+      sha256: efab58dbf87bd411406a68ec8b06ec5b295f4c17136d5cae5494c7857ccc3cc4
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.11"
+    version: "1.0.13"
   dart_jsonwebtoken:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
   health: ^13.2.1
   pedometer: ^4.0.0
   workmanager: ^0.9.0
-  dart_agent_core: ^1.0.11
+  dart_agent_core: ^1.0.13
   flutter_js: ^0.8.7
   drift: ^2.30.0
   sqlite3_flutter_libs: ^0.5.41

--- a/test/agent/eval/pkm_agent/environment.dart
+++ b/test/agent/eval/pkm_agent/environment.dart
@@ -139,6 +139,7 @@ class PkmAgentEvalEnvironment implements EvalEnvironment {
       metadata: {
         'user_id': userId,
         'suite_dir': suiteDir.path,
+        'task_input_content': task.input['content'] as String? ?? '',
       },
     );
   }

--- a/test/agent/eval/pkm_agent/graders.dart
+++ b/test/agent/eval/pkm_agent/graders.dart
@@ -13,11 +13,6 @@ abstract class _OutcomeKeys {
   static const successfulMutation = 'successful_pkm_mutation';
   static const missingRequirements = 'missing_requirements';
 
-  static const writtenFiles =
-      'written_files'; // List<String> rel paths under PKM/
-  static const editedFiles = 'edited_files'; // List<String>
-  static const readFiles = 'read_files'; // List<String> in transcript order
-  static const writeOrder = 'write_order'; // List<String> in transcript order
   static const fileContents = 'file_contents'; // Map<String, String> rel → body
 }
 
@@ -147,11 +142,12 @@ class PkmRoutedCorrectlyGrader implements Grader {
       );
     }
 
-    final written =
-        (s[_OutcomeKeys.writtenFiles] as List?)?.cast<String>() ?? const [];
-    final edited =
-        (s[_OutcomeKeys.editedFiles] as List?)?.cast<String>() ?? const [];
-    final all = {...written, ...edited}.map(_normPath).toList();
+    final diff = outcome.workspaceDiff;
+    final changed = <String>{
+      ...?diff?.created,
+      ...?diff?.modified,
+    }.toList();
+    final all = changed.map(_normPath).toList();
     final expectedFilesNorm = expectedFiles.map(_normPath).toList();
     final expectedBucketsNorm = expectedBuckets.map(_normPath).toList();
 
@@ -197,8 +193,8 @@ class PkmRoutedCorrectlyGrader implements Grader {
       value = 0.0;
       passed = false;
       rationale = all.isEmpty
-          ? 'agent made no writes/edits'
-          : 'wrote/edited $all but none under expected buckets '
+          ? 'workspace diff contains no created/modified PKM files'
+          : 'created/modified $all but none under expected buckets '
               '$expectedBuckets';
     }
 
@@ -209,13 +205,13 @@ class PkmRoutedCorrectlyGrader implements Grader {
       assertions: [
         if (expectedFiles.isNotEmpty)
           Assertion(
-            description: 'wrote/edited one of $expectedFiles',
+            description: 'created/modified one of $expectedFiles',
             passed: specificHit != null,
             actual: '$all',
             expected: 'one of $expectedFiles',
           ),
         Assertion(
-          description: 'wrote/edited under one of $expectedBuckets',
+          description: 'created/modified under one of $expectedBuckets',
           passed: bucketHit != null || specificHit != null,
           actual: '$all',
           expected: 'starts with one of $expectedBuckets',
@@ -263,17 +259,26 @@ class PkmReadBeforeWriteGrader extends CodeGrader {
     required EvalContext context,
     ReferenceSolution? referenceSolution,
   }) async {
-    final s = outcome.environmentState;
-    final reads =
-        (s[_OutcomeKeys.readFiles] as List?)?.cast<String>() ?? const [];
-    final writes =
-        (s[_OutcomeKeys.writeOrder] as List?)?.cast<String>() ?? const [];
-
     bool norm(String a, String b) =>
         _trimSlash(a).toLowerCase() == _trimSlash(b).toLowerCase();
 
-    final readIdx = reads.indexWhere((r) => norm(r, requiredReadPath));
-    final firstWriteIdx = writes.indexWhere((_) => true);
+    final calls = transcript.toolCalls.where((c) => !c.isError).toList();
+    final readIdx = calls.indexWhere(
+      (c) => c.toolName == 'Read' && norm(_toolPath(c), requiredReadPath),
+    );
+    final firstWriteIdx = calls.indexWhere(
+      (c) => c.toolName == 'Write' || c.toolName == 'Edit',
+    );
+    final reads = calls
+        .where((c) => c.toolName == 'Read')
+        .map(_toolPath)
+        .where((p) => p.isNotEmpty)
+        .toList();
+    final writes = calls
+        .where((c) => c.toolName == 'Write' || c.toolName == 'Edit')
+        .map(_toolPath)
+        .where((p) => p.isNotEmpty)
+        .toList();
 
     final readBeforeWrite =
         readIdx >= 0 && (firstWriteIdx < 0 || readIdx <= firstWriteIdx);
@@ -342,17 +347,25 @@ class PkmNoOverwriteGrader extends CodeGrader {
   }
 }
 
-/// Outcome keys produced by the harness for LLM graders. Kept private to
-/// the graders module so the harness contract stays in one place.
+ToolCallRecord? _lastSuccessfulToolCall(
+  Transcript transcript,
+  String toolName,
+) {
+  for (var i = transcript.toolCalls.length - 1; i >= 0; i--) {
+    final call = transcript.toolCalls[i];
+    if (!call.isError && call.toolName == toolName) return call;
+  }
+  return null;
+}
+
+String _toolPath(ToolCallRecord? call) {
+  if (call == null) return '';
+  final value = call.arguments['file_path'] ?? call.arguments['path'];
+  return value is String ? value : '';
+}
+
 abstract class _LlmKeys {
-  static const insightText = 'insight_text';
-  static const fileEdits = 'file_edits'; // List<Map<file_path/old/new>>
-  static const fileWrites = 'file_writes'; // List<Map<file_path/content>>
-  static const fileContents = 'file_contents';
-  static const taskInputContent = 'task_input_content';
   static const skippedPkm = 'skipped_pkm';
-  static const writtenFiles = 'written_files';
-  static const editedFiles = 'edited_files';
 }
 
 /// LLM-as-judge grader for the `update_timeline_card_insight` payload.
@@ -448,20 +461,27 @@ Respond with EXACTLY this JSON shape, no extra prose:
       );
     }
 
-    final insight = (state[_LlmKeys.insightText] as String? ?? '').trim();
+    final insightCall = _lastSuccessfulToolCall(
+      transcript,
+      'update_timeline_card_insight',
+    );
+    final insight =
+        (insightCall?.arguments['insight_text'] as String? ?? '').trim();
     if (insight.isEmpty) {
       return Score(
         graderName: name,
         value: 0.0,
         passed: false,
-        rationale: 'no insight_text captured (insight tool likely not called)',
+        rationale:
+            'no insight_text in transcript (insight tool likely not called)',
       );
     }
 
-    final factText = (state[_LlmKeys.taskInputContent] as String? ?? '').trim();
+    final factText =
+        (context.metadata['task_input_content'] as String? ?? '').trim();
     final targets = <String>{
-      ...((state[_LlmKeys.writtenFiles] as List?)?.cast<String>() ?? const []),
-      ...((state[_LlmKeys.editedFiles] as List?)?.cast<String>() ?? const []),
+      ...?outcome.workspaceDiff?.created,
+      ...?outcome.workspaceDiff?.modified,
     }.toList();
 
     final judge = _resolveJudge(context);
@@ -621,49 +641,23 @@ Respond with EXACTLY this JSON shape, no extra prose:
       );
     }
 
-    // Prefer an Edit (we have explicit before+after). Fall back to a
-    // Write only if there's no Edit (then we evaluate against the
-    // pre-existing file content, if any).
-    final edits = ((state[_LlmKeys.fileEdits] as List?) ?? const [])
-        .cast<Map>()
-        .map((e) => e.cast<String, String>())
-        .toList();
-    final writes = ((state[_LlmKeys.fileWrites] as List?) ?? const [])
-        .cast<Map>()
-        .map((e) => e.cast<String, String>())
-        .toList();
-
-    Map<String, String>? sample;
-    String? originalFile;
-    String? newContent;
-    if (edits.isNotEmpty) {
-      sample = edits.first;
-      // We don't have the file's original content captured at edit time,
-      // but the surviving final contents include the new chunk. The
-      // agent's "old_string" is verbatim what it found in the file at
-      // edit time, so use that as the "original-style sample" for
-      // coherence judging.
-      originalFile = sample['old_string'];
-      newContent = sample['new_string'];
-    } else if (writes.isNotEmpty) {
-      sample = writes.first;
-      // For a Write, we look up whether a file existed under that path
-      // before. If yes (rare for a Write, but possible), use that as
-      // original; otherwise return "unknown".
-      final contents =
-          (state[_LlmKeys.fileContents] as Map?)?.cast<String, String>() ??
-              const {};
-      final fp = sample['file_path'] ?? '';
-      originalFile = contents[_relPathFromAbsolute(fp)] ?? '';
-      newContent = sample['content'];
+    ToolCallRecord? editCall;
+    for (final call in transcript.toolCalls) {
+      if (!call.isError && call.toolName == 'Edit') {
+        editCall = call;
+        break;
+      }
     }
+    final originalFile = editCall?.arguments['old_string'] as String?;
+    final newContent = editCall?.arguments['new_string'] as String?;
 
     if (newContent == null || newContent.isEmpty) {
       return Score(
         graderName: name,
         value: null,
         passed: null,
-        rationale: 'no Edit/Write recorded — coherence rubric does not apply',
+        rationale:
+            'no Edit recorded in transcript — coherence rubric does not apply',
       );
     }
     if ((originalFile ?? '').trim().isEmpty) {
@@ -685,7 +679,8 @@ Respond with EXACTLY this JSON shape, no extra prose:
       );
     }
 
-    final factText = (state[_LlmKeys.taskInputContent] as String? ?? '').trim();
+    final factText =
+        (context.metadata['task_input_content'] as String? ?? '').trim();
     final prompt = '$_rubric\n\nORIGINAL_FILE:\n$originalFile\n\n'
         'NEW_CONTENT:\n$newContent\n\nUSER_FACT:\n$factText';
 
@@ -718,16 +713,10 @@ Respond with EXACTLY this JSON shape, no extra prose:
       rationale: parsed.rationale ?? 'judge did not provide a rationale',
       metadata: {
         'coherence': parsed.coherence,
-        'sample_file': sample?['file_path'],
+        'sample_file': _toolPath(editCall),
         'raw_reply': reply,
       },
     );
-  }
-
-  String _relPathFromAbsolute(String p) {
-    final i = p.indexOf('/PKM/');
-    if (i >= 0) return p.substring(i + '/PKM/'.length);
-    return p.startsWith('/') ? p.substring(1) : p;
   }
 
   JudgeResources? _resolveJudge(EvalContext ctx) {

--- a/test/agent/eval/pkm_agent/graders_test.dart
+++ b/test/agent/eval/pkm_agent/graders_test.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+import 'graders.dart';
+
+void main() {
+  group('PKM eval graders', () {
+    test('routes from workspace diff, not outcome trajectory fields', () async {
+      final grader = PkmRoutedCorrectlyGrader(
+        expectedBuckets: const ['Areas/Health/'],
+        expectedFiles: const ['Areas/Health/Sleep.md'],
+      );
+
+      final score = await grader.grade(
+        trial: _trial(),
+        transcript: _emptyTranscript(),
+        outcome: const Outcome(
+          environmentState: {'skipped_pkm': false},
+          workspaceDiff: WorkspaceDiff(
+            modified: ['Areas/Health/Sleep.md'],
+          ),
+        ),
+        context: _context(),
+      );
+
+      expect(score.value, 1.0);
+      expect(score.passed, isTrue);
+    });
+
+    test('read-before-write uses transcript tool-call order', () async {
+      final grader = PkmReadBeforeWriteGrader(
+        requiredReadPath: 'Areas/Health/Sleep.md',
+      );
+
+      final pass = await grader.grade(
+        trial: _trial(),
+        transcript: _transcript([
+          _toolCall('Read', {'file_path': 'Areas/Health/Sleep.md'}),
+          _toolCall('Edit', {'file_path': 'Areas/Health/Sleep.md'}),
+        ]),
+        outcome: const Outcome(environmentState: {}),
+        context: _context(),
+      );
+      expect(pass.value, 1.0);
+
+      final fail = await grader.grade(
+        trial: _trial(),
+        transcript: _transcript([
+          _toolCall('Edit', {'file_path': 'Areas/Health/Sleep.md'}),
+          _toolCall('Read', {'file_path': 'Areas/Health/Sleep.md'}),
+        ]),
+        outcome: const Outcome(environmentState: {}),
+        context: _context(),
+      );
+      expect(fail.value, 0.0);
+    });
+  });
+}
+
+Transcript _emptyTranscript() => _transcript(const []);
+
+Transcript _transcript(List<ToolCallRecord> toolCalls) => Transcript(
+      messages: const [],
+      toolCalls: toolCalls,
+      metrics: TranscriptMetrics(
+        nTurns: 0,
+        nToolCalls: toolCalls.length,
+        nTotalTokens: 0,
+      ),
+    );
+
+ToolCallRecord _toolCall(String toolName, Map<String, dynamic> arguments) {
+  final at = DateTime(2026, 5, 26);
+  return ToolCallRecord(
+    callId: '$toolName-1',
+    toolName: toolName,
+    arguments: arguments,
+    startedAt: at,
+    endedAt: at,
+  );
+}
+
+Trial _trial() {
+  final at = DateTime(2026, 5, 26);
+  return Trial(
+    runName: 'test',
+    suiteName: 'pkm',
+    taskId: 'task',
+    trialIndex: 0,
+    startedAt: at,
+    endedAt: at,
+    status: TrialStatus.passed,
+  );
+}
+
+EvalContext _context() => EvalContext(
+      workspaceDir: Directory.systemTemp,
+      clock: FixedEvalClock(DateTime(2026, 5, 26)),
+      llmClient: _NoopLLMClient(),
+      controller: AgentController(),
+    );
+
+class _NoopLLMClient implements LLMClient {
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Stream<StreamingMessage>> stream(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) {
+    throw UnimplementedError();
+  }
+}

--- a/test/agent/eval/pkm_agent/harness.dart
+++ b/test/agent/eval/pkm_agent/harness.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_agent_core/eval.dart';
@@ -14,8 +13,9 @@ import 'package:path/path.dart' as p;
 /// PKM Agent harness factory. One session per trial; each session
 /// 1. copies the task's `fixture_dir` into the per-user workspace
 /// 2. runs the production `PkmAgent.runWithContent` codepath
-/// 3. extracts read/write/edit history + final PKM file contents and
-///    assembles an [Outcome] for the graders to score
+/// 3. snapshots the final PKM state and workspace diff for outcome graders.
+/// Generic execution trajectory (messages, tool calls, token metrics) is
+/// recorded by dart_agent_core's eval runner through [EvalContext.controller].
 class PkmAgentHarnessFactory implements AgentHarnessFactory {
   const PkmAgentHarnessFactory();
 
@@ -74,6 +74,8 @@ class _PkmAgentSession implements AgentHarnessSession {
 
     final factId = task.input['fact_id'] as String;
     final content = task.input['content'] as String;
+    final pkmRoot = Directory(fs.getPkmPath(userId));
+    final beforePkmSnapshot = await _snapshotPkm(pkmRoot);
 
     // 2. Build the same instruction prompt the production handler uses,
     //    then run the agent. We bypass `processWithPkmAgent` because it
@@ -97,6 +99,7 @@ class _PkmAgentSession implements AgentHarnessSession {
         userId: userId,
         factId: factId,
         instruction: instruction,
+        controller: ctx.controller,
       );
     } catch (_) {
       // If the production retry loop gives up, inspect the workspace
@@ -109,40 +112,11 @@ class _PkmAgentSession implements AgentHarnessSession {
       );
     }
 
-    // 3. Walk the agent's tool-call history (via FunctionExecutionResult
-    //    messages stored on the agent state) to recover read/write order.
-    //    We can't easily get the agent state from here without re-loading
-    //    it from disk, so we instead reconstruct everything from the
-    //    workspace + the evidence we already have.
-    final readFiles = <String>[];
-    final writeOrder = <String>[];
-    final writtenFiles = <String>{};
-    final editedFiles = <String>{};
-    final insightPayload = <String, String>{};
-    final fileEdits = <Map<String, String>>[];
-    final fileWrites = <Map<String, String>>[];
-    await _replayToolHistoryFromState(
-      userId: userId,
-      factId: factId,
-      readFiles: readFiles,
-      writeOrder: writeOrder,
-      writtenFiles: writtenFiles,
-      editedFiles: editedFiles,
-      insightPayload: insightPayload,
-      fileEdits: fileEdits,
-      fileWrites: fileWrites,
-    );
-
-    // 4. Snapshot final PKM file contents (relative paths under PKM/).
-    final pkmRoot = Directory(fs.getPkmPath(userId));
-    final fileContents = <String, String>{};
-    if (pkmRoot.existsSync()) {
-      for (final entry in pkmRoot.listSync(recursive: true)) {
-        if (entry is! File) continue;
-        final rel = p.relative(entry.path, from: pkmRoot.path);
-        fileContents[rel] = entry.readAsStringSync();
-      }
-    }
+    // 3. Snapshot final PKM file contents (relative paths under PKM/) and
+    //    compute an outcome-level workspace diff. Tool ordering and payloads
+    //    belong to the transcript and are recorded by the framework.
+    final afterPkmSnapshot = await _snapshotPkm(pkmRoot);
+    final workspaceDiff = _diffSnapshots(beforePkmSnapshot, afterPkmSnapshot);
 
     return (
       transcript: Transcript(
@@ -162,121 +136,64 @@ class _PkmAgentSession implements AgentHarnessSession {
         'successful_pkm_mutation': evidence.successfulPkmMutation,
         'missing_requirements': evidence.missingRequirements,
         'skip_evidence': evidence.skipEvidence,
-        'read_files': readFiles,
-        'write_order': writeOrder,
-        'written_files': writtenFiles.toList(),
-        'edited_files': editedFiles.toList(),
-        'file_contents': fileContents,
-        'insight_summary': insightPayload['summary_text'] ?? '',
-        'insight_text': insightPayload['insight_text'] ?? '',
-        'file_edits': fileEdits,
-        'file_writes': fileWrites,
-        'task_input_content': content,
-      }),
+        'file_contents': afterPkmSnapshot,
+      }, workspaceDiff: workspaceDiff),
     );
   }
 
   @override
   Future<void> dispose() async {}
+}
 
-  /// Pull the agent's state file off disk and replay its tool-call history
-  /// to recover the order of read / write / edit calls. PkmAgent.createAgent
-  /// uses sessionId = `pkm_${userId}_${factIdSafe}` and saves through the
-  /// standard FileStateStorage path.
-  Future<void> _replayToolHistoryFromState({
-    required String userId,
-    required String factId,
-    required List<String> readFiles,
-    required List<String> writeOrder,
-    required Set<String> writtenFiles,
-    required Set<String> editedFiles,
-    required Map<String, String> insightPayload,
-    required List<Map<String, String>> fileEdits,
-    required List<Map<String, String>> fileWrites,
-  }) async {
-    final fs = FileSystemService.instance;
-    final factIdSafe = fs.makeFactIdSafe(factId);
-    final sessionId = 'pkm_${userId}_$factIdSafe';
+Future<Map<String, String>> _snapshotPkm(Directory pkmRoot) async {
+  final fileContents = <String, String>{};
+  if (!await pkmRoot.exists()) return fileContents;
+  await for (final entry in pkmRoot.list(recursive: true)) {
+    if (entry is! File) continue;
+    final rel = p.relative(entry.path, from: pkmRoot.path);
+    fileContents[rel] = await entry.readAsString();
+  }
+  return fileContents;
+}
 
-    // FileStateStorage path: <workspace>/_System/state_dir/<sessionId>.json
-    // (kept in sync with `FileSystemService.getAgentStateDirectory()`).
-    final statePath = p.join(
-      fs.getWorkspacePath(userId),
-      '_System',
-      'state_dir',
-      '$sessionId.json',
-    );
-    final stateFile = File(statePath);
-    if (!stateFile.existsSync()) return;
+WorkspaceDiff _diffSnapshots(
+  Map<String, String> before,
+  Map<String, String> after,
+) {
+  final created = <String>[];
+  final modified = <String>[];
+  final deleted = <String>[];
+  final snippets = <String, String>{};
 
-    Map<String, dynamic> state;
-    try {
-      state =
-          jsonDecode(await stateFile.readAsString()) as Map<String, dynamic>;
-    } catch (_) {
-      return;
-    }
-
-    final history = (state['history'] as Map?)?['messages'] as List?;
-    if (history == null) return;
-
-    for (final raw in history) {
-      if (raw is! Map) continue;
-      final msg = raw.cast<String, dynamic>();
-      if (msg['role'] != 'tool') continue;
-      final results = msg['results'] as List?;
-      if (results == null) continue;
-      for (final r in results) {
-        if (r is! Map) continue;
-        final rec = r.cast<String, dynamic>();
-        if (rec['isError'] == true) continue;
-        final name = rec['name'] as String?;
-        final argsStr = rec['arguments'] as String? ?? '{}';
-        Map<String, dynamic> args;
-        try {
-          args = jsonDecode(argsStr) as Map<String, dynamic>;
-        } catch (_) {
-          continue;
-        }
-        final filePath = args['file_path'] as String?;
-        switch (name) {
-          case 'Read':
-            if (filePath != null) readFiles.add(filePath);
-            break;
-          case 'Write':
-            if (filePath != null) {
-              writtenFiles.add(filePath);
-              writeOrder.add(filePath);
-              fileWrites.add({
-                'file_path': filePath,
-                'content': (args['content'] as String?) ?? '',
-              });
-            }
-            break;
-          case 'Edit':
-            if (filePath != null) {
-              editedFiles.add(filePath);
-              writeOrder.add(filePath);
-              fileEdits.add({
-                'file_path': filePath,
-                'old_string': (args['old_string'] as String?) ?? '',
-                'new_string': (args['new_string'] as String?) ?? '',
-              });
-            }
-            break;
-          case 'update_timeline_card_insight':
-            // Capture the most recent successful insight call. The pkm
-            // agent calls this once per run as the last step, but if it
-            // retries we only want the final payload that "stuck".
-            insightPayload['summary_text'] =
-                (args['summary_text'] as String?) ?? '';
-            insightPayload['insight_text'] =
-                (args['insight_text'] as String?) ?? '';
-            break;
-        }
-      }
+  for (final entry in after.entries) {
+    final old = before[entry.key];
+    if (old == null) {
+      created.add(entry.key);
+      snippets[entry.key] = _snippet(entry.value);
+    } else if (old != entry.value) {
+      modified.add(entry.key);
+      snippets[entry.key] = _snippet(entry.value);
     }
   }
+  for (final path in before.keys) {
+    if (!after.containsKey(path)) deleted.add(path);
+  }
+
+  created.sort();
+  modified.sort();
+  deleted.sort();
+  return WorkspaceDiff(
+    created: created,
+    modified: modified,
+    deleted: deleted,
+    contentSnippets: snippets,
+  );
+}
+
+String _snippet(String content) {
+  const maxChars = 4096;
+  if (content.length <= maxChars) return content;
+  return content.substring(0, maxChars);
 }
 
 /// Recursive `cp -R` for fixture seeding.


### PR DESCRIPTION
## Summary

- upgrade  to  so evals use the framework transcript recorder and EventBus close handling
- pass the eval  into  while preserving the default production controller path
- remove PKM harness-owned trajectory reconstruction from outcomes; keep outcomes focused on final state and 
- update PKM graders to read tool order and tool payloads from 
- add focused grader regression tests for workspace diff routing and read-before-write transcript ordering

## Validation

- Analyzing 2 items...                                            
No issues found! (ran in 5.6s)
- 00:00 +0: loading /Users/ming/Downloads/project/opensource/memex/test/agent/eval/pkm_agent/graders_test.dart
00:00 +0: PKM eval graders routes from workspace diff, not outcome trajectory fields
00:00 +1: PKM eval graders read-before-write uses transcript tool-call order
00:00 +2: All tests passed!
- Analyzing 4 items...                                            
No issues found! (ran in 3.9s)

Did not run the full live PKM suite because  runs the whole suite from a single test entrypoint.