### PR TITLE
Fix onboarding custom model completion flow

### DIFF
--- a/lib/ui/settings/widgets/ai_service_setup_page.dart
+++ b/lib/ui/settings/widgets/ai_service_setup_page.dart
@@ -117,11 +117,21 @@ class _AiServiceSetupPageState extends State<AiServiceSetupPage> {
     }
   }
 
-  void _openAdvancedConfig() {
-    Navigator.push(
+  Future<void> _openAdvancedConfig() async {
+    final configured = await Navigator.push<bool>(
       context,
-      MaterialPageRoute(builder: (context) => const ModelConfigListPage()),
+      MaterialPageRoute(
+        builder: (context) => ModelConfigListPage(
+          popOnConfigSaved: widget.onboardingMode,
+        ),
+      ),
     );
+    if (configured == true && mounted && widget.onboardingMode) {
+      widget.onComplete?.call();
+      if (widget.onComplete == null) {
+        Navigator.of(context).pop(true);
+      }
+    }
   }
 
   void _skip() {

--- a/lib/ui/settings/widgets/model_config_list_page.dart
+++ b/lib/ui/settings/widgets/model_config_list_page.dart
@@ -9,7 +9,12 @@ import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 
 class ModelConfigListPage extends StatefulWidget {
-  const ModelConfigListPage({super.key});
+  const ModelConfigListPage({
+    super.key,
+    this.popOnConfigSaved = false,
+  });
+
+  final bool popOnConfigSaved;
 
   @override
   State<ModelConfigListPage> createState() => _ModelConfigListPageState();
@@ -191,6 +196,12 @@ class _ModelConfigListPageState extends State<ModelConfigListPage> {
     );
 
     if (result == true) {
+      if (widget.popOnConfigSaved) {
+        if (mounted) {
+          Navigator.pop(context, true);
+        }
+        return;
+      }
       _loadConfigs();
     }
   }

--- a/test/ui/settings/widgets/ai_service_setup_page_test.dart
+++ b/test/ui/settings/widgets/ai_service_setup_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/ui/settings/widgets/ai_service_setup_page.dart';
 import 'package:memex/ui/settings/widgets/model_config_list_page.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -71,6 +72,53 @@ void main() {
     await tester.pump();
 
     expect(completed, isTrue);
+  });
+
+  testWidgets('onboarding custom model save completes setup flow', (
+    tester,
+  ) async {
+    var completed = false;
+    const customConfig = LLMConfig(
+      key: 'custom-openai',
+      type: LLMConfig.typeChatCompletion,
+      modelId: 'gpt-4o',
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.openai.com/v1',
+    );
+    await UserStorage.saveLLMConfigs([
+      LLMConfig.createDefaultClientConfig(),
+      customConfig,
+    ]);
+    await UserStorage.saveLLMConsent(
+      true,
+      providerType: LLMConfig.typeChatCompletion,
+    );
+
+    await _pumpPage(
+      tester,
+      AiServiceSetupPage(
+        onboardingMode: true,
+        onComplete: () => completed = true,
+      ),
+    );
+
+    final customModelAction =
+        find.text(UserStorage.l10n.advancedModelConfiguration);
+    await tester.scrollUntilVisible(
+      customModelAction,
+      200,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(customModelAction);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(customConfig.key));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.save));
+    await tester.pumpAndSettle();
+
+    expect(completed, isTrue);
+    expect(find.byType(ModelConfigListPage), findsNothing);
   });
 }
 


### PR DESCRIPTION
## Summary
- Complete the onboarding setup flow after saving a custom model from the Memex model service page
- Keep normal model configuration behavior unchanged outside onboarding
- Add widget coverage for the custom model onboarding path

## Tests
- dart analyze lib/ui/settings/widgets/ai_service_setup_page.dart lib/ui/settings/widgets/model_config_list_page.dart test/ui/settings/widgets/ai_service_setup_page_test.dart
- flutter test test/ui/settings/widgets/ai_service_setup_page_test.dart test/ui/settings/model_agent_config_pages_test.dart -r expanded