### PR TITLE
Improve PKM insight prompt and grader

### DIFF
--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -142,13 +142,15 @@ Call `skip_pkm_organization` only when the user explicitly asks not to save / re
 # Card Insights:
 Use the `update_timeline_card_insight` tool to update the insight section of the corresponding Timeline Card. This tool call must be included in your final message for the **New Raw Input Organization Task**, as it marks the completion of that specific workflow.
 - insight contains:
-  - insight_text (required): Combine the current input with historical facts in the P.A.R.A. knowledge base to discover underlying trends, patterns, associations, and insights. You should aim to analyze as many relevant historical facts as possible to draw a comprehensive conclusion. This section is user-facing, pay attention to tone, wording, etc., to make the user feel like you are a close friend. Do not mention any fact_id, knowledge base structure, or P.A.R.A. concepts. All information understanding, organization, and analysis work are internal processes; ensure the user experiences seamless insights without seeing the underlying system.
-  - summary_text (required): A summary of the operations performed on the P.A.R.A. knowledge base. Briefly describe how you organized and classified the current input using natural language. Do not mention any fact_id, knowledge base structure, or P.A.R.A. concepts. Only roughly describe your organization and classification of the current input. Users do not need to pay attention to the knowledge system.
-  - related_fact_ids (optional): A list of all historical fact_ids in the P.A.R.A. knowledge base that served as the basis and evidence for your `insight_text`, format: ['yyyy/mm/dd.md#ts_n']. The criteria for inclusion must be strictly unified with the insight's analytical context, regardless of how old they are or how many there are. You must NEVER guess fact_ids. Only `fact_id`s found within the format string `<!-- fact_id: yyyy/mm/dd.md#ts_n -->` are valid.
+  - insight_text (required): Search broadly, reason deeply, and synthesize what the current input means in relation to relevant history. The visible text may connect multiple records, time points, or themes, but it should read as a coherent observation rather than an evidence inventory. Do not mention any fact_id, knowledge base structure, or P.A.R.A. concepts. All information understanding, organization, and analysis work are internal processes; ensure the user experiences seamless insights without seeing the underlying system.
+  - related_fact_ids (optional): A complete coverage list of historical fact_ids in the P.A.R.A. knowledge base that are relevant to the current input, format: ['yyyy/mm/dd.md#ts_n']. Treat this as related-card discovery, not a citation list for `insight_text`: if a historical fact is related to the current input, include it even when the visible insight does not mention it. You must NEVER guess fact_ids. Only `fact_id`s found within the format string `<!-- fact_id: yyyy/mm/dd.md#ts_n -->` are valid.
 
 ## Card Insight Key Success Tips:
 - Use plain language and keep insight text concise and clear.
-- Balance brevity with engagement. Avoid being overly verbose or boring; aim to surprise the user with conclusions drawn from synthesizing their input with the P.A.R.A. knowledge base.
+- Tone: Write like a calm, perceptive memory companion: grounded, specific, and lightly warm. Do not sound like a coach, therapist, project manager, data analyst, product assistant, or role-play character. Avoid performative empathy, motivational slogans, and overfamiliar intimacy.
+- Balance depth with expression. The insight can be broad or deep, but do not list every supporting detail, date, task, or count unless that detail is itself the insight.
+- Compress evidence into patterns, tensions, changes, contrasts, or unresolved questions instead of writing a chronological recap, checklist recap, project-manager review, or therapy-style interpretation.
+- Advice is optional. Only include a next step when the record itself is about action or the next step is the insight.
 - Search the P.A.R.A. knowledge base to identify historical records relevant to the current input.
 - Avoid unnecessary opening or closing remarks (e.g., "Here is your insight").
 - **Language:** $insightLanguageInstruction
@@ -161,7 +163,7 @@ When the user provides new raw input, follow this sequence:
 2. **Categorize:** Determine the storage location in the P.A.R.A. knowledge base based on `LS` results. If those are insufficient, use `Grep`, `Read` to gather more context.
 3. **Inspect:** If the target file exists, use `Read` to plan the edit and retrieve related fact_ids.
 4. **Store:** Create or update the file content, ensuring proper association with `fact_id`.
-5. **Update Insight:** Use `update_timeline_card_insight` to update the timeline card’s insight, summary, and related facts.
+5. **Update Insight:** Use `update_timeline_card_insight` to update the timeline card’s insight and related facts.
 
 ## P.A.R.A. Maintenance Task
 When the user provides feedback regarding structure (e.g., "Move this", "Fix this") OR you identify a structural mess that needs explicit fixing, follow this sequence:
@@ -178,7 +180,7 @@ Examples:
   - If you need to make the final edit and update the timeline card's insight, you MUST send a single message containing both the `Edit` and `update_timeline_card_insight` tool calls to run the calls in parallel.''';
 
   static String get pkmAgentUpdateCardInsightToolDescription =>
-      'Updates the insight, summary and related facts of a timeline card.';
+      'Updates the insight and related facts of a timeline card.';
 
   static String get pkmAgentSkipOrganizationToolDescription =>
       'Skip P.A.R.A. organization for this input. Only call this when the user explicitly asks not to save / remember / persist this input.';
@@ -205,16 +207,17 @@ Examples:
           },
           'insight_text': {
             'type': 'string',
-          },
-          'summary_text': {
-            'type': 'string',
+            'description':
+                'User-facing insight text. Synthesize relevant history into a coherent observation; do not dump an evidence inventory.'
           },
           'related_fact_ids': {
             'type': 'array',
+            'description':
+                'Complete coverage list of historical fact_ids relevant to the current input. This is related-card discovery, not a citation list for insight_text.',
             'items': {'type': 'string'},
           },
         },
-        'required': ['fact_id', 'insight_text', 'summary_text']
+        'required': ['fact_id', 'insight_text']
       };
 
   static String pkmAgentUpdateCardInsightErrorCardNotFound(String factId) =>

--- a/lib/agent/skills/manage_pkm/pkm_skill.dart
+++ b/lib/agent/skills/manage_pkm/pkm_skill.dart
@@ -6,6 +6,9 @@ import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
 
+// Tool executable parameter names mirror JSON schema keys.
+// ignore_for_file: non_constant_identifier_names
+
 /// Skill for PKM Agent - organizes user input into P.A.R.A knowledge base structure
 class PkmSkill extends Skill {
   /// When provided, [stopAfterUpdateCardInsightRef] must be a single-element
@@ -38,8 +41,11 @@ class PkmSkill extends Skill {
         name: 'update_timeline_card_insight',
         description: Prompts.pkmAgentUpdateCardInsightToolDescription,
         parameters: Prompts.pkmAgentUpdateCardInsightToolParameters,
-        executable: (String fact_id, String insight_text, String summary_text,
-            List? related_fact_ids) async {
+        executable: (
+          String fact_id,
+          String insight_text,
+          List? related_fact_ids,
+        ) async {
           final context = AgentCallToolContext.current;
           if (context == null) {
             throw StateError(
@@ -66,7 +72,6 @@ class PkmSkill extends Skill {
           final insightData = CardInsight(
             characterId: '0',
             text: insight_text,
-            summary: summary_text,
             relatedFacts: relatedFacts,
           );
 

--- a/test/agent/eval/pkm_agent/graders.dart
+++ b/test/agent/eval/pkm_agent/graders.dart
@@ -379,8 +379,8 @@ abstract class _LlmKeys {
 ///    PKM, or is it generic life-coach advice?
 /// 2. **non-redundancy** — does it add an observation beyond restating
 ///    the fact?
-/// 3. **brevity** — short, scannable, ≤ ~200 chars (the tool's own
-///    contract).
+/// 3. **expression quality** — does it feel distilled and readable, or
+///    verbose, list-like, and report-ish?
 ///
 /// Anthropic Step 5: rubric must include an "Unknown" escape hatch so the
 /// judge can return null instead of fabricating a score. We return
@@ -410,8 +410,8 @@ class PkmInsightQualityGrader implements Grader {
 
   static const _rubric = '''
 You are grading the QUALITY of a single "insight" written by an automated
-PKM agent. The insight is a one-paragraph reflection (target ≤ 200 chars)
-that ties a new user-facing fact into the user's broader knowledge base.
+PKM agent. The insight ties a new user-facing fact into the user's broader
+knowledge base.
 
 You will receive:
 - USER_FACT       — the new fact the user just published
@@ -426,9 +426,14 @@ Score the insight on three dimensions, each in [0.0, 1.0]:
                      apply to anyone?
 2. non_redundancy  — does it add an observation beyond restating the
                      fact text, or is it just a paraphrase?
-3. brevity         — is it appropriately short (≤ ~200 chars, single
-                     coherent thought)? Long, multi-paragraph insights
-                     score lower here.
+3. expression_quality
+                   — is the writing distilled, natural, and easy to read?
+                     Penalize verbose evidence inventories, chronological
+                     recaps, checklist/report-like wording, filler, or
+                     over-explaining. Do NOT score by a fixed character or
+                     word limit; longer insights can score well when each
+                     part carries useful meaning, and short insights can
+                     score poorly when generic or awkward.
 
 If the insight is empty, malformed, missing, or you genuinely cannot tell
 (e.g. the rubric doesn't apply), return "unknown" for that dimension.
@@ -438,8 +443,8 @@ Respond with EXACTLY this JSON shape, no extra prose:
 {
   "groundedness":   <number in [0,1] or "unknown">,
   "non_redundancy": <number in [0,1] or "unknown">,
-  "brevity":        <number in [0,1] or "unknown">,
-  "rationale":      "<= 200 chars summarizing why"
+  "expression_quality": <number in [0,1] or "unknown">,
+  "rationale":      "<short explanation>"
 }
 ''';
 
@@ -514,7 +519,7 @@ Respond with EXACTLY this JSON shape, no extra prose:
     final dims = <String, double?>{
       'groundedness': parsed.groundedness,
       'non_redundancy': parsed.nonRedundancy,
-      'brevity': parsed.brevity,
+      'expression_quality': parsed.expressionQuality,
     };
     final present = dims.values.where((v) => v != null).cast<double>().toList();
     final avg = present.isEmpty
@@ -540,7 +545,7 @@ Respond with EXACTLY this JSON shape, no extra prose:
       metadata: {
         'groundedness': parsed.groundedness,
         'non_redundancy': parsed.nonRedundancy,
-        'brevity': parsed.brevity,
+        'expression_quality': parsed.expressionQuality,
         'raw_reply': reply,
       },
     );
@@ -619,7 +624,7 @@ Respond with EXACTLY this JSON shape, no extra prose:
 
 {
   "coherence": <number in [0,1] or "unknown">,
-  "rationale": "<= 200 chars"
+  "rationale": "<short explanation>"
 }
 ''';
 
@@ -740,10 +745,10 @@ Respond with EXACTLY this JSON shape, no extra prose:
 class _ParsedInsight {
   final double? groundedness;
   final double? nonRedundancy;
-  final double? brevity;
+  final double? expressionQuality;
   final String? rationale;
-  _ParsedInsight(
-      this.groundedness, this.nonRedundancy, this.brevity, this.rationale);
+  _ParsedInsight(this.groundedness, this.nonRedundancy, this.expressionQuality,
+      this.rationale);
 }
 
 class _ParsedCoherence {
@@ -771,7 +776,7 @@ _ParsedInsight? _parseJudge(String reply) {
     return _ParsedInsight(
       _readMaybeNumber(obj['groundedness']),
       _readMaybeNumber(obj['non_redundancy']),
-      _readMaybeNumber(obj['brevity']),
+      _readMaybeNumber(obj['expression_quality']),
       obj['rationale'] as String?,
     );
   } catch (_) {

--- a/test/agent/pkm_agent_skip_completion_test.dart
+++ b/test/agent/pkm_agent_skip_completion_test.dart
@@ -64,7 +64,6 @@ void main() {
             arguments: {
               'fact_id': factId,
               'insight_text': 'Keep the cadence small.',
-              'summary_text': 'Updated the related project note.',
             },
           ),
         ],
@@ -187,6 +186,46 @@ void main() {
       expect(prompt, isNot(contains('low_signal_noise')));
       expect(prompt, isNot(contains('temporary_state')));
       expect(prompt, isNot(contains('duplicate_existing_memory')));
+    });
+
+    test('insight prompt asks for synthesis without narrowing evidence', () {
+      final prompt = Prompts.pkmSkillSystemPrompt(
+        '/',
+        'P.A.R.A. example',
+        'Use user language for files.',
+        'Use user language for insight.',
+      );
+
+      expect(prompt,
+          contains('coherent observation rather than an evidence inventory'));
+      expect(prompt, contains('The insight can be broad or deep'));
+      expect(prompt, contains('calm, perceptive memory companion'));
+      expect(prompt, contains('Do not sound like a coach'));
+      expect(prompt, contains('project manager'));
+      expect(prompt, isNot(contains('Progress State')));
+      expect(prompt, isNot(contains('Preference / Identity')));
+
+      final parameters = Prompts.pkmAgentUpdateCardInsightToolParameters;
+      final properties = parameters['properties'] as Map<String, dynamic>;
+      expect(
+        properties['insight_text']['description'] as String,
+        contains('Synthesize relevant history'),
+      );
+      expect(
+        properties['related_fact_ids']['description'] as String,
+        contains('Complete coverage list of historical fact_ids'),
+      );
+      expect(
+        properties['related_fact_ids']['description'] as String,
+        contains('not a citation list for insight_text'),
+      );
+      expect(
+        prompt,
+        contains(
+            'include it even when the visible insight does not mention it'),
+      );
+      expect(properties, isNot(contains('summary_text')));
+      expect(parameters['required'], ['fact_id', 'insight_text']);
     });
 
     test('skip tool parameters require only an evidence quote', () {


### PR DESCRIPTION
## Summary
- remove unused PKM insight summary_text from the tool contract and implementation
- refine PKM insight prompt toward synthesized observations with complete related-card coverage
- replace fixed-length PKM insight eval scoring with model-judged expression_quality

## Tests
- dart analyze lib/agent/prompts.dart lib/agent/skills/manage_pkm/pkm_skill.dart test/agent/eval/pkm_agent/graders.dart test/agent/pkm_agent_skip_completion_test.dart
- flutter test test/agent/pkm_agent_skip_completion_test.dart
- sampled PKM live eval before removing local filter: 3 tasks, 100% pass, pkm_insight_quality 0.828