### PR TITLE
Fix no-model fallback and reduce FTS UI jank

### DIFF
--- a/lib/data/services/local_task_executor.dart
+++ b/lib/data/services/local_task_executor.dart
@@ -324,10 +324,17 @@ class LocalTaskExecutor {
         return;
       }
 
-      // 3. Mark and Execute
+      // 3. Claim tasks before starting handlers so immediate polling cannot
+      // pick the same pending row again while execution starts asynchronously.
+      final claimedTasks = <Task>[];
       for (final task in tasksToRun) {
-        // Fire and forget execution - don't await
-        _executeTask(task);
+        if (await _claimTaskForExecution(task, now)) {
+          claimedTasks.add(task);
+        }
+      }
+
+      for (final task in claimedTasks) {
+        unawaited(_executeTask(task));
       }
 
       // Loop immediately to check for more tasks or completion
@@ -413,17 +420,6 @@ class LocalTaskExecutor {
 
   Future<void> _executeTask(Task task) async {
     try {
-      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-
-      // Mark as processing
-      await (_db.update(_db.tasks)..where((t) => t.id.equals(task.id))).write(
-        TasksCompanion(
-          status: const Value('processing'),
-          updatedAt: Value(now),
-        ),
-      );
-      await _markTaskExecutionStarted(task);
-
       final handler = _handlers[task.type];
       if (handler == null) {
         throw Exception('No handler registered for task type: ${task.type}');
@@ -530,6 +526,22 @@ class LocalTaskExecutor {
         _scheduleNextPoll(immediate: true);
       }
     }
+  }
+
+  Future<bool> _claimTaskForExecution(Task task, int now) async {
+    final updated = await (_db.update(_db.tasks)
+          ..where((t) => t.id.equals(task.id))
+          ..where((t) => t.status.isIn(['pending', 'retrying'])))
+        .write(
+      TasksCompanion(
+        status: const Value('processing'),
+        updatedAt: Value(now),
+      ),
+    );
+    if (updated == 0) return false;
+
+    await _markTaskExecutionStarted(task);
+    return true;
   }
 
   Future<void> _handlePreviousExecutionMarkers() async {

--- a/lib/data/services/search/query_matcher.dart
+++ b/lib/data/services/search/query_matcher.dart
@@ -17,8 +17,7 @@ class QueryMatcher {
 
   static Future<String> tokenizeForIndex(String text) async {
     if (text.isEmpty) return text;
-    await JiebaSegmenter.instance.ensureLoaded();
-    if (JiebaSegmenter.instance.isLoaded && _containsCjk(text)) {
+    if (_containsCjk(text) && await JiebaSegmenter.instance.ensureLoaded()) {
       return JiebaSegmenter.instance.cutForSearch(text).join(' ');
     }
     return _tokenizeFallback(text);
@@ -28,8 +27,7 @@ class QueryMatcher {
     final trimmed = query.trim();
     if (trimmed.isEmpty) return trimmed;
 
-    await JiebaSegmenter.instance.ensureLoaded();
-    if (JiebaSegmenter.instance.isLoaded && _containsCjk(trimmed)) {
+    if (_containsCjk(trimmed) && await JiebaSegmenter.instance.ensureLoaded()) {
       final tokens = <String>[];
       for (final word in JiebaSegmenter.instance.cut(trimmed)) {
         final token = word.trim();
@@ -59,9 +57,8 @@ class QueryMatcher {
     final trimmed = query.trim().toLowerCase();
     if (trimmed.isEmpty) return const [];
 
-    await JiebaSegmenter.instance.ensureLoaded();
     final tokens = <String>[];
-    if (JiebaSegmenter.instance.isLoaded && _containsCjk(trimmed)) {
+    if (_containsCjk(trimmed) && await JiebaSegmenter.instance.ensureLoaded()) {
       for (final token in JiebaSegmenter.instance.cut(trimmed)) {
         _addToken(tokens, token);
       }

--- a/lib/data/services/task_handlers/card_agent_handler.dart
+++ b/lib/data/services/task_handlers/card_agent_handler.dart
@@ -58,12 +58,6 @@ Future<CardRunCompletionEvidence> processWithCardAgent({
         factId: factId,
         requireSaveToolCall: false,
       );
-      if (!evidence.isComplete) {
-        throw StateError(
-          'Rule-based card generation did not produce a completed card for '
-          '$factId. Evidence: ${jsonEncode(evidence.toJson())}',
-        );
-      }
       return evidence;
     }
 

--- a/lib/data/services/task_handlers/fts_index_handler.dart
+++ b/lib/data/services/task_handlers/fts_index_handler.dart
@@ -2,7 +2,6 @@ import 'package:logging/logging.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/db/daos/search_dao.dart';
 import 'package:memex/data/services/local_task_executor.dart';
-import 'package:memex/utils/jieba.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/domain/models/system_event.dart';
 
@@ -31,9 +30,6 @@ Future<void> handleFtsIndexUpdateImpl(
     _logger.warning('Database not initialized, skipping FTS update');
     return;
   }
-
-  // Ensure jieba is loaded for tokenization
-  await JiebaSegmenter.instance.ensureLoaded();
 
   final searchDao = AppDatabase.instance.searchDao;
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -555,7 +555,7 @@
       "count": {}
     }
   },
-  "insightProcessingBacklogMessage": "{count} background tasks are still processing. Insights may update after they finish.",
+  "insightProcessingBacklogMessage": "{count} background tasks are still processing.",
   "insightUnavailableMessage": "This insight is still being generated or was updated. Refresh insights and try again later.",
   "scheduleAggregation": "Schedule aggregation",
   "noScheduleAggregation": "No schedule aggregation",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2159,7 +2159,7 @@ abstract class AppLocalizations {
   /// No description provided for @insightProcessingBacklogMessage.
   ///
   /// In en, this message translates to:
-  /// **'{count} background tasks are still processing. Insights may update after they finish.'**
+  /// **'{count} background tasks are still processing.'**
   String insightProcessingBacklogMessage(Object count);
 
   /// No description provided for @insightUnavailableMessage.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1162,7 +1162,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String insightProcessingBacklogMessage(Object count) {
-    return '$count background tasks are still processing. Insights may update after they finish.';
+    return '$count background tasks are still processing.';
   }
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1130,7 +1130,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String insightProcessingBacklogMessage(Object count) {
-    return '还有 $count 个后台任务正在处理，洞察可能会在完成后更新。';
+    return '还有 $count 个后台任务正在处理。';
   }
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -555,7 +555,7 @@
       "count": {}
     }
   },
-  "insightProcessingBacklogMessage": "还有 {count} 个后台任务正在处理，洞察可能会在完成后更新。",
+  "insightProcessingBacklogMessage": "还有 {count} 个后台任务正在处理。",
   "insightUnavailableMessage": "这个洞察仍在生成中，或已被更新。请刷新洞察后稍后再试。",
   "scheduleAggregation": "日程聚合",
   "noScheduleAggregation": "暂无日程聚合",

--- a/lib/utils/jieba.dart
+++ b/lib/utils/jieba.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math' show log;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:logging/logging.dart';
 import 'package:memex/utils/logger.dart';
@@ -11,6 +12,36 @@ import 'package:memex/utils/logger.dart';
 class _TrieNode {
   final Map<int, _TrieNode> children = {};
   int freq = 0; // >0 means this node is a complete word
+}
+
+class _JiebaDictionary {
+  const _JiebaDictionary({
+    required this.root,
+    required this.total,
+  });
+
+  final _TrieNode root;
+  final int total;
+}
+
+_JiebaDictionary _buildJiebaDictionary(String raw) {
+  final root = _TrieNode();
+  int total = 0;
+  for (final line in raw.split('\n')) {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty) continue;
+    final parts = trimmed.split(' ');
+    if (parts.length < 2) continue;
+    final word = parts[0];
+    final freq = int.tryParse(parts[1]) ?? 0;
+    var node = root;
+    for (int i = 0; i < word.length; i++) {
+      node = node.children.putIfAbsent(word.codeUnitAt(i), () => _TrieNode());
+    }
+    node.freq = freq;
+    total += freq;
+  }
+  return _JiebaDictionary(root: root, total: total);
 }
 
 /// Pure-Dart port of jieba Chinese word segmentation (no-HMM mode).
@@ -34,6 +65,7 @@ class JiebaSegmenter {
   int _total = 0;
   double _logTotal = 0;
   Timer? _releaseTimer;
+  Future<bool>? _loading;
 
   /// Whether the dictionary is currently loaded in memory.
   bool get isLoaded => _root != null;
@@ -50,9 +82,29 @@ class JiebaSegmenter {
   Future<bool> ensureLoaded() async {
     _touchTimer();
     if (_root != null) return true;
+    final loading = _loading;
+    if (loading != null) return loading;
+
+    final future = _load();
+    _loading = future;
+    return future.whenComplete(() {
+      if (identical(_loading, future)) {
+        _loading = null;
+      }
+    });
+  }
+
+  Future<bool> _load() async {
     try {
       final raw = await rootBundle.loadString('assets/jieba_dict.txt');
-      _buildTrie(raw);
+      final dictionary = await compute(
+        _buildJiebaDictionary,
+        raw,
+        debugLabel: 'jieba_dictionary_build',
+      );
+      _root = dictionary.root;
+      _total = dictionary.total;
+      _logTotal = log(dictionary.total);
       _logger.info('Jieba dictionary loaded: total freq=$_total');
       return true;
     } catch (e) {
@@ -82,28 +134,6 @@ class JiebaSegmenter {
   // ---------------------------------------------------------------------------
   // Trie construction
   // ---------------------------------------------------------------------------
-
-  void _buildTrie(String raw) {
-    final root = _TrieNode();
-    int total = 0;
-    for (final line in raw.split('\n')) {
-      final trimmed = line.trim();
-      if (trimmed.isEmpty) continue;
-      final parts = trimmed.split(' ');
-      if (parts.length < 2) continue;
-      final word = parts[0];
-      final freq = int.tryParse(parts[1]) ?? 0;
-      var node = root;
-      for (int i = 0; i < word.length; i++) {
-        node = node.children.putIfAbsent(word.codeUnitAt(i), () => _TrieNode());
-      }
-      node.freq = freq;
-      total += freq;
-    }
-    _root = root;
-    _total = total;
-    _logTotal = log(total);
-  }
 
   int _getFreq(String word) {
     var node = _root;

--- a/test/ui/agent_activity/agent_activity_widget_test.dart
+++ b/test/ui/agent_activity/agent_activity_widget_test.dart
@@ -77,9 +77,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 350));
 
     expect(
-      find.text(
-        '1 background tasks are still processing. Insights may update after they finish.',
-      ),
+      find.text('1 background tasks are still processing.'),
       findsWidgets,
     );
 


### PR DESCRIPTION
## Summary
- allow no-model rule-based card generation to return fallback evidence without requiring completion validation
- claim local tasks before launching handlers to avoid duplicate execution during immediate polling
- reduce FTS/Jieba UI jank by loading Chinese segmentation only when needed, sharing concurrent loads, and building the dictionary on a background isolate
- remove the extra insight processing follow-up sentence

## Tests
- flutter analyze lib/data/services/local_task_executor.dart lib/data/services/search/query_matcher.dart lib/data/services/task_handlers/card_agent_handler.dart lib/data/services/task_handlers/fts_index_handler.dart lib/utils/jieba.dart
- flutter test test/data/services/local_task_executor_test.dart