### PR TITLE
Filter unnecessary FTS index update tasks

### DIFF
--- a/lib/data/services/global_event_bus.dart
+++ b/lib/data/services/global_event_bus.dart
@@ -13,6 +13,11 @@ typedef EventTaskDependencyBuilder = Future<List<String>> Function(
   SystemEvent event,
 );
 
+typedef EventTaskShouldEnqueue = Future<bool> Function(
+  String userId,
+  SystemEvent event,
+);
+
 typedef EventSyncHandler<T> = Future<void> Function(
   String userId,
   SystemEvent<T> event,
@@ -32,6 +37,7 @@ class EventTaskSubscription {
     this.priority = 0,
     this.maxRetries = 5,
     this.dependenciesBuilder,
+    this.shouldEnqueue,
   });
 
   final String subscriptionId;
@@ -41,6 +47,7 @@ class EventTaskSubscription {
   final int maxRetries;
   final EventTaskPayloadBuilder payloadBuilder;
   final EventTaskDependencyBuilder? dependenciesBuilder;
+  final EventTaskShouldEnqueue? shouldEnqueue;
 }
 
 /// 同步订阅：publish 时直接 await 执行 handler，而非入队任务。
@@ -197,8 +204,20 @@ class GlobalEventBus {
     final orderedSubscriptions = _resolveExecutionOrder(subscriptions);
     final enqueuedTaskIds = <String>[];
     final enqueuedTaskIdsBySubscription = <String, String>{};
+    final skippedSubscriptionIds = <String>{};
 
     for (final subscription in orderedSubscriptions) {
+      if (subscription.dependsOn.any(skippedSubscriptionIds.contains)) {
+        skippedSubscriptionIds.add(subscription.subscriptionId);
+        continue;
+      }
+
+      if (subscription.shouldEnqueue != null &&
+          !await subscription.shouldEnqueue!(userId, event)) {
+        skippedSubscriptionIds.add(subscription.subscriptionId);
+        continue;
+      }
+
       final payload = await subscription.payloadBuilder(userId, event);
       final dependencies = <String>[
         ...(baseDependencies ?? const []),

--- a/lib/data/services/search_service.dart
+++ b/lib/data/services/search_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:memex/db/app_database.dart';
@@ -407,12 +408,64 @@ class SearchService {
         taskType: 'fts_index_update',
         priority: -1, // Lower priority than agent tasks
         maxRetries: 3,
+        shouldEnqueue: (_, event) async {
+          final record = event.payload as DataChangeRecord;
+          return _shouldEnqueueFtsIndexUpdate(record);
+        },
         payloadBuilder: (_, event) async {
           final record = event.payload as DataChangeRecord;
           return dataChangeRecordToPayload(record);
         },
       ),
     );
+  }
+
+  bool _shouldEnqueueFtsIndexUpdate(DataChangeRecord record) {
+    if (record.ns == DataChangeNs.pkmFile) return true;
+    if (record.ns != DataChangeNs.card) return false;
+
+    switch (record.op) {
+      case DataChangeOp.insert:
+      case DataChangeOp.delete:
+        return true;
+      case DataChangeOp.update:
+        final before = record.before;
+        final after = record.after;
+        if (before == null || after == null) return true;
+        return _indexedCardFieldChanged(before, after);
+    }
+  }
+
+  bool _indexedCardFieldChanged(
+    Map<String, dynamic> before,
+    Map<String, dynamic> after,
+  ) {
+    return _stringValue(before['title']) != _stringValue(after['title']) ||
+        _stringListValue(before['tags']) != _stringListValue(after['tags']) ||
+        _insightText(before['insight']) != _insightText(after['insight']);
+  }
+
+  @visibleForTesting
+  bool shouldEnqueueFtsIndexUpdateForTesting(DataChangeRecord record) {
+    return _shouldEnqueueFtsIndexUpdate(record);
+  }
+
+  String _stringValue(Object? value) => value is String ? value : '';
+
+  String _stringListValue(Object? value) {
+    if (value is List) return value.whereType<String>().join(' ');
+    return '';
+  }
+
+  String _insightText(Object? value) {
+    if (value is Map<String, dynamic>) {
+      return value['text'] as String? ?? '';
+    }
+    if (value is Map) {
+      final text = value['text'];
+      return text is String ? text : '';
+    }
+    return '';
   }
 
   // ---------------------------------------------------------------------------

--- a/test/data/services/search_service_test.dart
+++ b/test/data/services/search_service_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/search_service.dart';
+import 'package:memex/domain/models/system_event.dart';
+
+void main() {
+  group('SearchService FTS enqueue filtering', () {
+    test('skips card updates when only comments change', () {
+      final record = DataChangeRecord(
+        op: DataChangeOp.update,
+        ns: DataChangeNs.card,
+        documentKey: '2026/05/29.md#ts_1',
+        before: {
+          'fact_id': '2026/05/29.md#ts_1',
+          'title': 'Title',
+          'tags': ['tag'],
+          'comments': <dynamic>[],
+        },
+        after: {
+          'fact_id': '2026/05/29.md#ts_1',
+          'title': 'Title',
+          'tags': ['tag'],
+          'comments': [
+            {'id': 'c1', 'content': 'new comment'},
+          ],
+          'content': 'raw fact content',
+          'asset_analyses': <String>[],
+          'asset_ocr': <String>[],
+        },
+      );
+
+      expect(
+        SearchService.instance.shouldEnqueueFtsIndexUpdateForTesting(record),
+        isFalse,
+      );
+    });
+
+    test('enqueues card updates when indexed fields change', () {
+      final record = DataChangeRecord(
+        op: DataChangeOp.update,
+        ns: DataChangeNs.card,
+        documentKey: '2026/05/29.md#ts_1',
+        before: {
+          'title': 'Before',
+          'tags': ['tag'],
+        },
+        after: {
+          'title': 'After',
+          'tags': ['tag'],
+        },
+      );
+
+      expect(
+        SearchService.instance.shouldEnqueueFtsIndexUpdateForTesting(record),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add an optional EventTaskSubscription.shouldEnqueue hook so task subscribers can skip enqueueing for irrelevant events
- use the hook for FTS data_changed subscriptions
- skip card update FTS tasks unless indexed card fields change: title, tags, or insight text
- keep card inserts/deletes and PKM file changes indexed

## Tests
- flutter analyze lib/data/services/global_event_bus.dart lib/data/services/search_service.dart test/data/services/search_service_test.dart
- flutter test test/data/services/search_service_test.dart