### PR TITLE
Fix timeline tab switching states

### DIFF
--- a/lib/ui/schedule/view_models/schedule_aggregator_view_model.dart
+++ b/lib/ui/schedule/view_models/schedule_aggregator_view_model.dart
@@ -78,6 +78,8 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
 
   ScheduleViewData? _aggregation;
   bool _isLoading = false;
+  bool _isRefreshing = false;
+  bool _hasLoaded = false;
   String? _error;
   Completer<void>? _pendingRefreshCompletion;
   final Map<String, ScheduleItemStatus> _statusOverrides = {};
@@ -85,6 +87,8 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
 
   ScheduleViewData? get aggregation => _aggregation;
   bool get isLoading => _isLoading;
+  bool get isRefreshing => _isRefreshing;
+  bool get hasLoaded => _hasLoaded;
   String? get error => _error;
   bool get hasData => _aggregation != null;
   List<ScheduleItem> get items {
@@ -138,6 +142,7 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
         'Failed to load schedule data',
       );
     } finally {
+      _hasLoaded = true;
       _setLoading(false);
     }
   }
@@ -145,6 +150,7 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
   /// Refresh schedule aggregation by triggering the Agent
   Future<void> refreshAggregation() async {
     _setLoading(true);
+    _setRefreshing(true);
     final completion = Completer<void>();
     _pendingRefreshCompletion = completion;
     try {
@@ -186,6 +192,7 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
       if (identical(_pendingRefreshCompletion, completion)) {
         _pendingRefreshCompletion = null;
       }
+      _setRefreshing(false);
       _setLoading(false);
     }
   }
@@ -332,7 +339,14 @@ class ScheduleAggregatorViewModel extends ChangeNotifier {
   }
 
   void _setLoading(bool value) {
+    if (_isLoading == value) return;
     _isLoading = value;
+    notifyListeners();
+  }
+
+  void _setRefreshing(bool value) {
+    if (_isRefreshing == value) return;
+    _isRefreshing = value;
     notifyListeners();
   }
 

--- a/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
+++ b/lib/ui/schedule/widgets/schedule_aggregator_screen.dart
@@ -136,7 +136,7 @@ class _ScheduleAggregatorScreenState
             Expanded(
               child: Consumer<ScheduleAggregatorViewModel>(
                 builder: (context, vm, child) {
-                  if (vm.isLoading && !vm.hasData) {
+                  if (!vm.hasData && (!vm.hasLoaded || vm.isLoading)) {
                     return _buildRefreshableState(_buildLoadingState());
                   }
                   if (!vm.hasData) {
@@ -313,7 +313,7 @@ class _ScheduleAggregatorScreenState
                   ),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
-                    children: vm.isLoading
+                    children: vm.isRefreshing
                         ? [
                             const SizedBox(
                               width: 16,

--- a/lib/ui/timeline/view_models/timeline_viewmodel.dart
+++ b/lib/ui/timeline/view_models/timeline_viewmodel.dart
@@ -89,6 +89,7 @@ class TimelineViewModel extends ChangeNotifier {
   bool isLoading = false;
   bool hasMore = true;
   int _currentPage = 1;
+  int _loadGeneration = 0;
   String? errorMessage;
   bool isSubmitting = false;
 
@@ -108,30 +109,57 @@ class TimelineViewModel extends ChangeNotifier {
 
   late final Command0<void> load = Command0<void>(_loadInitial)..execute();
 
-  Future<Result<void>> _loadInitial() async {
+  Future<Result<void>> _loadInitial({bool notifyLoading = false}) async {
+    final generation = ++_loadGeneration;
+    final filter = activeFilter;
+    final viewModeAtRequest = viewMode;
+    if (notifyLoading) {
+      isLoading = true;
+      notifyListeners();
+    }
     final cardsResult = await _router.fetchTimelineCards(
       page: 1,
       limit: pageLimit,
-      tags: activeFilter == 'all' ? null : [activeFilter],
+      tags: filter == 'all' ? null : [filter],
     );
     return cardsResult.when(
       onOk: (list) async {
+        if (_isStaleTimelineLoad(generation, filter)) {
+          return const Ok.v();
+        }
         _currentPage = 1;
         final loadedHasMore = list.length >= pageLimit;
-        cards = await _withScheduleBriefingCard(
+        final nextCards = await _withScheduleBriefingCard(
           list,
           hasMoreAfterList: loadedHasMore,
+          showScheduleBriefing:
+              viewModeAtRequest == TimelineViewMode.timeline && filter == 'all',
         );
+        if (_isStaleTimelineLoad(generation, filter)) {
+          return const Ok.v();
+        }
+        cards = nextCards;
         hasMore = loadedHasMore;
+        isLoading = false;
         errorMessage = null;
         _startPollingIfNeeded();
         // Load attachments for all cards in parallel
         await _loadAttachmentsForCards(list);
+        if (_isStaleTimelineLoad(generation, filter)) {
+          return const Ok.v();
+        }
         await _refreshPendingCount();
+        if (_isStaleTimelineLoad(generation, filter)) {
+          return const Ok.v();
+        }
         notifyListeners();
         return const Ok.v();
       },
       onError: (error, stackTrace) {
+        if (_isStaleTimelineLoad(generation, filter)) {
+          return const Ok.v();
+        }
+        isLoading = false;
         errorMessage = UserStorage.l10n.timelineLoadFailedRetry;
         notifyListeners();
         return Error<void>(error, stackTrace);
@@ -249,8 +277,8 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   Future<void> _refreshPendingCount() async {
-    final pending = await CardAttachmentService.instance
-        .getPendingAttachments();
+    final pending =
+        await CardAttachmentService.instance.getPendingAttachments();
     final failedCardCount = await _router.countFailedCardGenerations();
     pendingAttachmentCount = pending.length + (failedCardCount > 0 ? 1 : 0);
     notifyListeners();
@@ -285,10 +313,8 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   void _pollProcessingCards() {
-    final processingIds = cards
-        .where((c) => c.status == 'processing')
-        .map((c) => c.id)
-        .toList();
+    final processingIds =
+        cards.where((c) => c.status == 'processing').map((c) => c.id).toList();
     if (processingIds.isEmpty) {
       _stopPolling();
       return;
@@ -336,7 +362,14 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   void setActiveFilter(String tag) {
+    if (activeFilter == tag) return;
+    _loadGeneration++;
     activeFilter = tag;
+    cards = [];
+    attachments.clear();
+    hasMore = true;
+    _currentPage = 1;
+    isLoading = false;
     notifyListeners();
   }
 
@@ -348,31 +381,43 @@ class TimelineViewModel extends ChangeNotifier {
 
   Future<void> loadCards({bool refresh = false}) async {
     if (refresh) {
-      await load.execute();
+      await _loadInitial(notifyLoading: true);
       return;
     }
     if (isLoading || !hasMore) return;
+    final generation = _loadGeneration;
+    final filter = activeFilter;
+    final viewModeAtRequest = viewMode;
     isLoading = true;
     notifyListeners();
     final result = await _router.fetchTimelineCards(
       page: _currentPage,
       limit: pageLimit,
-      tags: activeFilter == 'all' ? null : [activeFilter],
+      tags: filter == 'all' ? null : [filter],
     );
-    result.when(
-      onOk: (newCards) async {
+    switch (result) {
+      case Ok(:final value):
+        if (_isStaleTimelineLoad(generation, filter)) return;
+        final newCards = value;
         _currentPage++;
         final loadedHasMore = newCards.length >= pageLimit;
-        cards = await _withScheduleBriefingCard([
+        final nextCards = await _withScheduleBriefingCard([
           ...cards,
           ...newCards,
-        ], hasMoreAfterList: loadedHasMore);
+        ],
+            hasMoreAfterList: loadedHasMore,
+            showScheduleBriefing:
+                viewModeAtRequest == TimelineViewMode.timeline &&
+                    filter == 'all');
+        if (_isStaleTimelineLoad(generation, filter)) return;
+        cards = nextCards;
         hasMore = loadedHasMore;
         _startPollingIfNeeded();
         await _loadAttachmentsForCards(newCards);
-      },
-      onError: (_, __) {},
-    );
+        if (_isStaleTimelineLoad(generation, filter)) return;
+      case Error():
+        break;
+    }
     isLoading = false;
     notifyListeners();
   }
@@ -380,11 +425,14 @@ class TimelineViewModel extends ChangeNotifier {
   Future<List<TimelineCardModel>> _withScheduleBriefingCard(
     List<TimelineCardModel> list, {
     required bool hasMoreAfterList,
+    bool? showScheduleBriefing,
   }) async {
     final withoutBriefing = dedupeTimelineCardsById(
       list,
     ).where((card) => card.id != scheduleBriefingCardId).toList();
-    if (!_shouldShowScheduleBriefing) return withoutBriefing;
+    if (!(showScheduleBriefing ?? _shouldShowScheduleBriefing)) {
+      return withoutBriefing;
+    }
 
     final briefingResult = await _router.fetchScheduleBriefingCard();
     return briefingResult.when(
@@ -413,28 +461,44 @@ class TimelineViewModel extends ChangeNotifier {
 
   Future<void> loadMore() async {
     if (isLoading || !hasMore) return;
+    final generation = _loadGeneration;
+    final filter = activeFilter;
+    final viewModeAtRequest = viewMode;
     isLoading = true;
     notifyListeners();
     final result = await _router.fetchTimelineCards(
       page: _currentPage + 1,
       limit: pageLimit,
-      tags: activeFilter == 'all' ? null : [activeFilter],
+      tags: filter == 'all' ? null : [filter],
     );
-    result.when(
-      onOk: (newCards) async {
+    switch (result) {
+      case Ok(:final value):
+        if (_isStaleTimelineLoad(generation, filter)) return;
+        final newCards = value;
         _currentPage++;
         final loadedHasMore = newCards.length >= pageLimit;
-        cards = await _withScheduleBriefingCard([
+        final nextCards = await _withScheduleBriefingCard([
           ...cards,
           ...newCards,
-        ], hasMoreAfterList: loadedHasMore);
+        ],
+            hasMoreAfterList: loadedHasMore,
+            showScheduleBriefing:
+                viewModeAtRequest == TimelineViewMode.timeline &&
+                    filter == 'all');
+        if (_isStaleTimelineLoad(generation, filter)) return;
+        cards = nextCards;
         hasMore = loadedHasMore;
         await _loadAttachmentsForCards(newCards);
-      },
-      onError: (_, __) {},
-    );
+        if (_isStaleTimelineLoad(generation, filter)) return;
+      case Error():
+        break;
+    }
     isLoading = false;
     notifyListeners();
+  }
+
+  bool _isStaleTimelineLoad(int generation, String filter) {
+    return generation != _loadGeneration || filter != activeFilter;
   }
 
   Future<void> fetchTags() async {

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -276,14 +276,12 @@ class TimelineScreenState extends State<TimelineScreen> {
     );
   }
 
-  /// Called when user taps a tag chip — animate PageView to that page.
-  void _animateToPage(int index) {
-    _currentPageIndex = index;
-    _pageController.animateToPage(
-      index,
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.easeInOut,
-    );
+  /// Called when user taps a tag chip.
+  void _jumpToPage(int index) {
+    setState(() {
+      _currentPageIndex = index;
+    });
+    _pageController.jumpToPage(index);
     _scrollTagIntoView(index, widget.viewModel);
   }
 
@@ -729,7 +727,7 @@ class TimelineScreenState extends State<TimelineScreen> {
                     });
                     // Also sync PageView
                     final pageIdx = _filterToPageIndex(vm);
-                    _animateToPage(pageIdx);
+                    _jumpToPage(pageIdx);
                     return true;
                   } else if (action['action'] == 'navigate_to_card' &&
                       action['card_id'] != null) {
@@ -758,14 +756,20 @@ class TimelineScreenState extends State<TimelineScreen> {
                   itemBuilder: (context, index) {
                     if (index == 1) {
                       // Insight page
-                      return InsightScreen(
-                        isEmbedded: true,
-                        viewModel: widget.insightViewModel,
+                      return _DeferredActivePage(
+                        isActive: _currentPageIndex == 1,
+                        builder: (_) => InsightScreen(
+                          isEmbedded: true,
+                          viewModel: widget.insightViewModel,
+                        ),
                       );
                     }
                     if (index == 2) {
                       // Schedule Aggregator page
-                      return const ScheduleAggregatorScreen();
+                      return _DeferredActivePage(
+                        isActive: _currentPageIndex == 2,
+                        builder: (_) => const ScheduleAggregatorScreen(),
+                      );
                     }
                     // Timeline page (All or filtered by tag)
                     return _buildTimelineBody(vm);
@@ -802,7 +806,7 @@ class TimelineScreenState extends State<TimelineScreen> {
               vm.setViewMode(TimelineViewMode.timeline);
               vm.setActiveFilter('all');
               vm.loadCards(refresh: true);
-              _animateToPage(0);
+              _jumpToPage(0);
             },
           );
         }
@@ -815,10 +819,10 @@ class TimelineScreenState extends State<TimelineScreen> {
             icon: '✨',
             isSelected: isSelected,
             onTap: () {
+              _jumpToPage(1);
               vm.setViewMode(TimelineViewMode.insight);
               vm.setActiveFilter('insight');
               widget.insightViewModel.refreshStatsForVisibleInsightPage();
-              _animateToPage(1);
               DemoService.instance.tryAdvance(DemoStep.tapInsightTab);
             },
           );
@@ -839,9 +843,9 @@ class TimelineScreenState extends State<TimelineScreen> {
             icon: '📅',
             isSelected: isSelected,
             onTap: () {
+              _jumpToPage(2);
               vm.setViewMode(TimelineViewMode.timeline);
               vm.setActiveFilter('schedule');
-              _animateToPage(2);
             },
           );
         }
@@ -858,7 +862,7 @@ class TimelineScreenState extends State<TimelineScreen> {
             vm.setViewMode(TimelineViewMode.timeline);
             vm.setActiveFilter(tag.name);
             vm.loadCards(refresh: true);
-            _animateToPage(index);
+            _jumpToPage(index);
           },
         );
       },
@@ -1043,9 +1047,9 @@ class TimelineScreenState extends State<TimelineScreen> {
               // Clarification Ask cards are self-contained; no detail page.
               if (_isClarificationAskCard(card)) return;
               if (_isScheduleBriefingCard(card)) {
+                _jumpToPage(2);
                 vm.setViewMode(TimelineViewMode.timeline);
                 vm.setActiveFilter('schedule');
-                _animateToPage(2);
                 return;
               }
               final result = await Navigator.push(
@@ -1111,6 +1115,56 @@ bool _isDemoTargetCard(List<TimelineCardModel> cards, int index) {
   final firstUserCardIndex =
       cards.indexWhere((card) => !_isScheduleBriefingCard(card));
   return index == firstUserCardIndex;
+}
+
+class _DeferredActivePage extends StatefulWidget {
+  const _DeferredActivePage({
+    required this.isActive,
+    required this.builder,
+  });
+
+  final bool isActive;
+  final WidgetBuilder builder;
+
+  @override
+  State<_DeferredActivePage> createState() => _DeferredActivePageState();
+}
+
+class _DeferredActivePageState extends State<_DeferredActivePage> {
+  bool _showChild = false;
+  bool _isScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleMountIfActive();
+  }
+
+  @override
+  void didUpdateWidget(covariant _DeferredActivePage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _scheduleMountIfActive();
+  }
+
+  void _scheduleMountIfActive() {
+    if (!widget.isActive || _showChild || _isScheduled) return;
+    _isScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {
+        _showChild = true;
+        _isScheduled = false;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_showChild) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return widget.builder(context);
+  }
 }
 
 class TimelineEntryItem extends StatefulWidget {

--- a/test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart
+++ b/test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/domain/models/schedule_state.dart' show ScheduleSubtask;
@@ -25,8 +27,10 @@ void main() {
         listenToEvents: false,
       );
 
+      expect(vm.hasLoaded, isFalse);
       await vm.loadAggregation();
 
+      expect(vm.hasLoaded, isTrue);
       expect(vm.hasData, isTrue);
       expect(vm.error, isNull);
       expect(vm.items, hasLength(1));
@@ -83,7 +87,42 @@ void main() {
       expect(loadCount, 1);
       expect(vm.aggregation?.id, 'fresh');
       expect(vm.isLoading, isFalse);
+      expect(vm.isRefreshing, isFalse);
+      expect(vm.hasLoaded, isTrue);
       expect(vm.error, isNull);
+
+      vm.dispose();
+    });
+
+    test('refreshing state only tracks agent-triggered refresh', () async {
+      final refreshCompleter = Completer<Result<void>>();
+      var loadCount = 0;
+      final vm = ScheduleAggregatorViewModel(
+        refreshAggregation: () => refreshCompleter.future,
+        loadAggregation: () async {
+          loadCount += 1;
+          return _aggregation(id: 'refreshed_$loadCount');
+        },
+        refreshReloadDelay: const Duration(seconds: 5),
+      );
+
+      final refresh = vm.refreshAggregation();
+
+      expect(vm.isLoading, isTrue);
+      expect(vm.isRefreshing, isTrue);
+      refreshCompleter.complete(const Ok<void>.v());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(vm.isRefreshing, isTrue);
+      EventBusService.instance.emitEvent(
+        ScheduleAggregationUpdatedMessage(aggregationId: 'refreshed'),
+      );
+      await refresh;
+
+      expect(loadCount, 1);
+      expect(vm.aggregation?.id, 'refreshed_1');
+      expect(vm.isLoading, isFalse);
+      expect(vm.isRefreshing, isFalse);
 
       vm.dispose();
     });
@@ -105,6 +144,7 @@ void main() {
       expect(loadCount, 0);
       expect(vm.hasData, isFalse);
       expect(vm.isLoading, isFalse);
+      expect(vm.isRefreshing, isFalse);
       expect(vm.error, contains('no model'));
 
       vm.dispose();


### PR DESCRIPTION
## Summary
- switch timeline tabs immediately and defer heavy insight/schedule page mounting
- discard stale timeline loads when users switch tabs quickly
- split schedule initial load, refresh, and loaded states to avoid misleading empty/update UI

## Tests
- flutter test test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart
- flutter analyze lib/ui/schedule/view_models/schedule_aggregator_view_model.dart lib/ui/schedule/widgets/schedule_aggregator_screen.dart lib/ui/timeline/view_models/timeline_viewmodel.dart lib/ui/timeline/widgets/timeline_screen.dart test/ui/schedule/view_models/schedule_aggregator_view_model_test.dart (existing info warnings in timeline_screen.dart)