### PR TITLE
补强资产安全防御链路

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -26,13 +26,73 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 
 flutter_ios_podfile_setup
 
+def memex_use_ios_simulator_mlkit_stubs
+  ENV['MEMEX_IOS_SIMULATOR_MLKIT_STUBS'] == '1'
+end
+
+def memex_ios_simulator_mlkit_stub_plugins
+  [
+    'google_mlkit_commons',
+    'google_mlkit_image_labeling',
+    'google_mlkit_text_recognition',
+  ]
+end
+
+def memex_install_ios_pods(application_path)
+  if memex_use_ios_simulator_mlkit_stubs
+    flutter_install_ios_engine_pod(application_path)
+    memex_install_ios_plugin_pods_with_mlkit_stubs(application_path, '.symlinks', 'ios')
+  else
+    flutter_install_all_ios_pods(application_path)
+  end
+end
+
+def memex_install_ios_plugin_pods_with_mlkit_stubs(application_path, relative_symlink_dir, platform)
+  symlink_dir = File.expand_path(relative_symlink_dir, application_path)
+  system('rm', '-rf', symlink_dir)
+
+  symlink_plugins_dir = File.expand_path('plugins', symlink_dir)
+  system('mkdir', '-p', symlink_plugins_dir)
+
+  plugins_file = File.join(application_path, '..', '.flutter-plugins-dependencies')
+  dependencies_hash = flutter_parse_plugins_file(plugins_file)
+  plugin_pods = flutter_get_plugins_list(dependencies_hash, platform)
+  swift_package_manager_enabled = flutter_get_swift_package_manager_enabled(dependencies_hash, platform)
+  stub_plugins = memex_ios_simulator_mlkit_stub_plugins
+
+  plugin_pods.each do |plugin_hash|
+    plugin_name = plugin_hash['name']
+    plugin_path = plugin_hash['path']
+    has_native_build = plugin_hash.fetch('native_build', true)
+    next unless plugin_name && plugin_path && has_native_build
+
+    if stub_plugins.include?(plugin_name)
+      stub_path = File.join(application_path, 'SimulatorPluginStubs', plugin_name, platform)
+      pod plugin_name, path: flutter_relative_path_from_podfile(stub_path)
+      next
+    end
+
+    shared_darwin_source = plugin_hash.fetch('shared_darwin_source', false)
+    platform_directory = shared_darwin_source ? 'darwin' : platform
+    symlink = File.join(symlink_plugins_dir, plugin_name)
+    File.symlink(plugin_path, symlink)
+
+    relative = flutter_relative_path_from_podfile(symlink)
+    swift_package_exists = File.exist?(File.join(relative, platform_directory, plugin_name, "Package.swift"))
+    next if swift_package_manager_enabled && swift_package_exists
+    next if swift_package_exists && !File.exist?(File.join(relative, platform_directory, plugin_name + ".podspec"))
+
+    pod plugin_name, path: File.join(relative, platform_directory)
+  end
+end
+
 target 'Runner' do
   use_frameworks!
 
   # Add ML Kit Chinese Text Recognition support
-  pod 'GoogleMLKit/TextRecognitionChinese'
+  pod 'GoogleMLKit/TextRecognitionChinese' unless memex_use_ios_simulator_mlkit_stubs
 
-  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  memex_install_ios_pods File.dirname(File.realpath(__FILE__))
 
   # share_handler addition start
   # This must match your Share Extension target name (ShareExtension).

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -50,6 +50,9 @@ PODS:
     - Flutter
   - flutter_native_splash (2.4.3):
     - Flutter
+  - geolocator_apple (1.2.0):
+    - Flutter
+    - FlutterMacOS
   - google_mlkit_commons (0.11.1):
     - Flutter
     - MLKitVision (~> 10.0.0)
@@ -253,6 +256,7 @@ DEPENDENCIES:
   - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
   - flutter_js (from `.symlinks/plugins/flutter_js/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_mlkit_commons (from `.symlinks/plugins/google_mlkit_commons/ios`)
   - google_mlkit_image_labeling (from `.symlinks/plugins/google_mlkit_image_labeling/ios`)
   - google_mlkit_text_recognition (from `.symlinks/plugins/google_mlkit_text_recognition/ios`)
@@ -325,6 +329,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_js/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
+  geolocator_apple:
+    :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_mlkit_commons:
     :path: ".symlinks/plugins/google_mlkit_commons/ios"
   google_mlkit_image_labeling:
@@ -385,6 +391,7 @@ SPEC CHECKSUMS:
   flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
   flutter_js: 867813c1830e1d9b2c5d547cdb6f61801e2f2145
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   google_mlkit_commons: a5e4ffae5bc59ea4c7b9025dc72cb6cb79dc1166
   google_mlkit_image_labeling: 6f6fdb11c14600e01898e59a8c4413b255ede272
   google_mlkit_text_recognition: b3de5adb786ad7a0fe8e13618387b8d2df0f3c70
@@ -434,6 +441,6 @@ SPEC CHECKSUMS:
   webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
   workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
 
-PODFILE CHECKSUM: c48b27dcb47d9d6ee9e8ff53c8e5254369bc4f9a
+PODFILE CHECKSUM: f4193023c33d658f510918db0c8dd03fe3298ff3
 
 COCOAPODS: 1.16.2

--- a/ios/SimulatorPluginStubs/google_mlkit_commons/ios/Classes/GoogleMlKitCommonsPlugin.h
+++ b/ios/SimulatorPluginStubs/google_mlkit_commons/ios/Classes/GoogleMlKitCommonsPlugin.h
@@ -1,0 +1,4 @@
+#import <Flutter/Flutter.h>
+
+@interface GoogleMlKitCommonsPlugin : NSObject<FlutterPlugin>
+@end

--- a/ios/SimulatorPluginStubs/google_mlkit_commons/ios/Classes/GoogleMlKitCommonsPlugin.m
+++ b/ios/SimulatorPluginStubs/google_mlkit_commons/ios/Classes/GoogleMlKitCommonsPlugin.m
@@ -1,0 +1,17 @@
+#import "GoogleMlKitCommonsPlugin.h"
+
+@implementation GoogleMlKitCommonsPlugin
+
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  FlutterMethodChannel* channel =
+      [FlutterMethodChannel methodChannelWithName:@"google_mlkit_commons"
+                                  binaryMessenger:[registrar messenger]];
+  GoogleMlKitCommonsPlugin* instance = [[GoogleMlKitCommonsPlugin alloc] init];
+  [registrar addMethodCallDelegate:instance channel:channel];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+  result(FlutterMethodNotImplemented);
+}
+
+@end

--- a/ios/SimulatorPluginStubs/google_mlkit_commons/ios/google_mlkit_commons.podspec
+++ b/ios/SimulatorPluginStubs/google_mlkit_commons/ios/google_mlkit_commons.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name = 'google_mlkit_commons'
+  s.version = '0.11.1'
+  s.summary = 'Simulator-only Memex stub for google_mlkit_commons.'
+  s.description = 'Registers the Flutter plugin without linking Google ML Kit native frameworks on iOS simulators.'
+  s.homepage = 'https://github.com/memex-lab/memex'
+  s.license = { :type => 'MIT' }
+  s.authors = { 'Memex' => 'memex' }
+  s.source = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.public_header_files = 'Classes/**/*.h'
+  s.dependency 'Flutter'
+  s.platform = :ios, '15.5'
+  s.ios.deployment_target = '15.5'
+  s.static_framework = true
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+  }
+end

--- a/ios/SimulatorPluginStubs/google_mlkit_image_labeling/ios/Classes/GoogleMlKitImageLabelingPlugin.h
+++ b/ios/SimulatorPluginStubs/google_mlkit_image_labeling/ios/Classes/GoogleMlKitImageLabelingPlugin.h
@@ -1,0 +1,4 @@
+#import <Flutter/Flutter.h>
+
+@interface GoogleMlKitImageLabelingPlugin : NSObject<FlutterPlugin>
+@end

--- a/ios/SimulatorPluginStubs/google_mlkit_image_labeling/ios/Classes/GoogleMlKitImageLabelingPlugin.m
+++ b/ios/SimulatorPluginStubs/google_mlkit_image_labeling/ios/Classes/GoogleMlKitImageLabelingPlugin.m
@@ -1,0 +1,26 @@
+#import "GoogleMlKitImageLabelingPlugin.h"
+
+@implementation GoogleMlKitImageLabelingPlugin
+
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  FlutterMethodChannel* channel =
+      [FlutterMethodChannel methodChannelWithName:@"google_mlkit_image_labeler"
+                                  binaryMessenger:[registrar messenger]];
+  GoogleMlKitImageLabelingPlugin* instance =
+      [[GoogleMlKitImageLabelingPlugin alloc] init];
+  [registrar addMethodCallDelegate:instance channel:channel];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if ([call.method isEqualToString:@"vision#startImageLabelDetector"]) {
+    result(@[]);
+    return;
+  }
+  if ([call.method isEqualToString:@"vision#closeImageLabelDetector"]) {
+    result(nil);
+    return;
+  }
+  result(FlutterMethodNotImplemented);
+}
+
+@end

--- a/ios/SimulatorPluginStubs/google_mlkit_image_labeling/ios/google_mlkit_image_labeling.podspec
+++ b/ios/SimulatorPluginStubs/google_mlkit_image_labeling/ios/google_mlkit_image_labeling.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name = 'google_mlkit_image_labeling'
+  s.version = '0.14.2'
+  s.summary = 'Simulator-only Memex stub for google_mlkit_image_labeling.'
+  s.description = 'Keeps the Flutter plugin registration path available without linking Google ML Kit native frameworks on iOS simulators.'
+  s.homepage = 'https://github.com/memex-lab/memex'
+  s.license = { :type => 'MIT' }
+  s.authors = { 'Memex' => 'memex' }
+  s.source = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.public_header_files = 'Classes/**/*.h'
+  s.dependency 'Flutter'
+  s.platform = :ios, '15.5'
+  s.ios.deployment_target = '15.5'
+  s.static_framework = true
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+  }
+end

--- a/ios/SimulatorPluginStubs/google_mlkit_text_recognition/ios/Classes/GoogleMlKitTextRecognitionPlugin.h
+++ b/ios/SimulatorPluginStubs/google_mlkit_text_recognition/ios/Classes/GoogleMlKitTextRecognitionPlugin.h
@@ -1,0 +1,4 @@
+#import <Flutter/Flutter.h>
+
+@interface GoogleMlKitTextRecognitionPlugin : NSObject<FlutterPlugin>
+@end

--- a/ios/SimulatorPluginStubs/google_mlkit_text_recognition/ios/Classes/GoogleMlKitTextRecognitionPlugin.m
+++ b/ios/SimulatorPluginStubs/google_mlkit_text_recognition/ios/Classes/GoogleMlKitTextRecognitionPlugin.m
@@ -1,0 +1,29 @@
+#import "GoogleMlKitTextRecognitionPlugin.h"
+
+@implementation GoogleMlKitTextRecognitionPlugin
+
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  FlutterMethodChannel* channel =
+      [FlutterMethodChannel methodChannelWithName:@"google_mlkit_text_recognizer"
+                                  binaryMessenger:[registrar messenger]];
+  GoogleMlKitTextRecognitionPlugin* instance =
+      [[GoogleMlKitTextRecognitionPlugin alloc] init];
+  [registrar addMethodCallDelegate:instance channel:channel];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if ([call.method isEqualToString:@"vision#startTextRecognizer"]) {
+    result(@{
+      @"text" : @"",
+      @"blocks" : @[],
+    });
+    return;
+  }
+  if ([call.method isEqualToString:@"vision#closeTextRecognizer"]) {
+    result(nil);
+    return;
+  }
+  result(FlutterMethodNotImplemented);
+}
+
+@end

--- a/ios/SimulatorPluginStubs/google_mlkit_text_recognition/ios/google_mlkit_text_recognition.podspec
+++ b/ios/SimulatorPluginStubs/google_mlkit_text_recognition/ios/google_mlkit_text_recognition.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name = 'google_mlkit_text_recognition'
+  s.version = '0.15.1'
+  s.summary = 'Simulator-only Memex stub for google_mlkit_text_recognition.'
+  s.description = 'Keeps the Flutter plugin registration path available without linking Google ML Kit native frameworks on iOS simulators.'
+  s.homepage = 'https://github.com/memex-lab/memex'
+  s.license = { :type => 'MIT' }
+  s.authors = { 'Memex' => 'memex' }
+  s.source = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.public_header_files = 'Classes/**/*.h'
+  s.dependency 'Flutter'
+  s.platform = :ios, '15.5'
+  s.ios.deployment_target = '15.5'
+  s.static_framework = true
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+  }
+end

--- a/lib/agent/built_in_tools/asset_analysis_tool.dart
+++ b/lib/agent/built_in_tools/asset_analysis_tool.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as path;
 import 'package:memex/utils/logger.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/data/services/speech_transcription_service.dart';
 
 class AssetAnalysisTool {
@@ -13,10 +14,7 @@ class AssetAnalysisTool {
   final LLMClient client;
   final ModelConfig modelConfig;
 
-  AssetAnalysisTool({
-    required this.client,
-    required this.modelConfig,
-  });
+  AssetAnalysisTool({required this.client, required this.modelConfig});
 
   /// The main tool method to analyze assets
   Future<String> tool({
@@ -43,10 +41,31 @@ class AssetAnalysisTool {
 
     final extension = path.extension(assetPath).toLowerCase();
     final assetName = path.basename(assetPath);
+    final safety = await AssetSafetyService.instance.inspectFile(assetPath);
 
     // Image Extensions
-    if ({'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.heic', '.heif'}
-        .contains(extension)) {
+    if ({
+      '.jpg',
+      '.jpeg',
+      '.png',
+      '.gif',
+      '.bmp',
+      '.webp',
+      '.heic',
+      '.heif',
+      '.tiff',
+      '.tif',
+    }.contains(extension)) {
+      if (!safety.safeForAnalysis) {
+        _logger.warning(
+          'Skipping unsafe image analysis for $assetPath: ${safety.reason}',
+        );
+        return (
+          '#Asset $assetName analysis result\n: ${safety.analysisSkipText(assetName)}',
+          null,
+          'asset-safety',
+        );
+      }
       return _analyzeImageWithUsage(assetPath, assetName, prompt);
     }
     // Audio Extensions
@@ -59,8 +78,18 @@ class AssetAnalysisTool {
       '.aiff',
       '.aif',
       '.m4a',
-      '.wma'
+      '.wma',
     }.contains(extension)) {
+      if (!safety.safeForAnalysis) {
+        _logger.warning(
+          'Skipping unsafe audio analysis for $assetPath: ${safety.reason}',
+        );
+        return (
+          '#Asset $assetName analysis result\n: ${safety.analysisSkipText(assetName)}',
+          null,
+          'asset-safety',
+        );
+      }
       return _analyzeAudioWithUsage(assetPath, assetName, prompt);
     }
     // TODO: Document support (PDF, Excel, PPT, Word, CSV) via MarkItDown or similar
@@ -70,8 +99,11 @@ class AssetAnalysisTool {
   }
 
   Future<(String result, ModelUsage? usage, String model)>
-      _analyzeImageWithUsage(
-          String assetPath, String assetName, String prompt) async {
+  _analyzeImageWithUsage(
+    String assetPath,
+    String assetName,
+    String prompt,
+  ) async {
     _logger.info('Starting analysis flow for: $assetPath');
 
     try {
@@ -82,15 +114,20 @@ class AssetAnalysisTool {
 
       // --- Step 1: compress and resize image ---
       // Target: convert to WebP, max side 2048, quality 85%
-      final compressedBytes = await _compressAndResizeImage(file.path,
-          targetSize: 2048, quality: 85);
+      final compressedBytes = await _compressAndResizeImage(
+        file.path,
+        targetSize: 2048,
+        quality: 85,
+      );
 
       if (compressedBytes == null) {
         throw Exception("Image compression failed");
       }
 
-      _logger.info("Original size: ${(await file.length()) / 1024} KB, "
-          "Compressed size: ${(compressedBytes.length / 1024).toStringAsFixed(2)} KB");
+      _logger.info(
+        "Original size: ${(await file.length()) / 1024} KB, "
+        "Compressed size: ${(compressedBytes.length / 1024).toStringAsFixed(2)} KB",
+      );
 
       // --- Step 2: Base64 encode ---
       // Encoding on a background isolate is still good practice even with smaller bytes
@@ -100,7 +137,8 @@ class AssetAnalysisTool {
       // Note: MimeType is fixed as image/webp since we converted to WebP
       const mimeType = 'image/webp';
 
-      final fullPrompt = """
+      final fullPrompt =
+          """
   ## Requirements:
   $prompt
 
@@ -108,16 +146,10 @@ class AssetAnalysisTool {
   """;
 
       _logger.info("Calling API...");
-      final response = await client.generate(
-        [
-          SystemMessage("You are an image analysis expert."),
-          UserMessage([
-            TextPart(fullPrompt),
-            ImagePart(base64Image, mimeType),
-          ])
-        ],
-        modelConfig: modelConfig,
-      );
+      final response = await client.generate([
+        SystemMessage("You are an image analysis expert."),
+        UserMessage([TextPart(fullPrompt), ImagePart(base64Image, mimeType)]),
+      ], modelConfig: modelConfig);
 
       final analysisResult = response.textOutput ?? "";
 
@@ -132,8 +164,11 @@ class AssetAnalysisTool {
     }
   }
 
-  Future<Uint8List?> _compressAndResizeImage(String path,
-      {int targetSize = 2048, int quality = 85}) async {
+  Future<Uint8List?> _compressAndResizeImage(
+    String path, {
+    int targetSize = 2048,
+    int quality = 85,
+  }) async {
     try {
       // compressWithFile reads path and returns Uint8List (bytes in memory),
       // no temp files, very efficient.
@@ -144,7 +179,6 @@ class AssetAnalysisTool {
         quality:
             quality, // 0-100, 85 is usually a good balance for visually lossless
         format: CompressFormat.webp, // output as WebP
-
         // Key: keep aspect ratio, auto-rotate (handles phone photo orientation)
         autoCorrectionAngle: true,
         keepExif:
@@ -162,8 +196,11 @@ class AssetAnalysisTool {
   }
 
   Future<(String result, ModelUsage? usage, String model)>
-      _analyzeAudioWithUsage(
-          String assetPath, String assetName, String prompt) async {
+  _analyzeAudioWithUsage(
+    String assetPath,
+    String assetName,
+    String prompt,
+  ) async {
     _logger.info('Analyzing audio: $assetPath');
 
     try {
@@ -172,7 +209,8 @@ class AssetAnalysisTool {
       final transcript = result.text;
       if (transcript != null && transcript.trim().isNotEmpty) {
         _logger.info(
-            'Audio transcribed via ${result.model}: ${transcript.substring(0, transcript.length.clamp(0, 100))}...');
+          'Audio transcribed via ${result.model}: ${transcript.substring(0, transcript.length.clamp(0, 100))}...',
+        );
         return (
           '#Asset $assetName analysis result\n: $transcript',
           result.usage,

--- a/lib/data/services/asset_safety_service.dart
+++ b/lib/data/services/asset_safety_service.dart
@@ -1,0 +1,521 @@
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:logging/logging.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:path/path.dart' as path;
+
+enum AssetSafetyType { image, audio, unsupported, missing }
+
+class AssetSafetyConfig {
+  final int maxPixelsForDecode;
+  final int maxLongEdgeForAnalysis;
+  final double maxAspectRatioForOcr;
+  final int maxFileBytesForInlineBase64;
+  final int maxUnknownImageBytesForPreview;
+  final int maxImageBytesForAnalysis;
+  final int maxAudioBytesForCloud;
+  final int maxAudioSecondsForAutoTranscribe;
+
+  const AssetSafetyConfig({
+    this.maxPixelsForDecode = 24000000,
+    this.maxLongEdgeForAnalysis = 12000,
+    this.maxAspectRatioForOcr = 12,
+    this.maxFileBytesForInlineBase64 = 8 * 1024 * 1024,
+    this.maxUnknownImageBytesForPreview = 8 * 1024 * 1024,
+    this.maxImageBytesForAnalysis = 30 * 1024 * 1024,
+    this.maxAudioBytesForCloud = 20 * 1024 * 1024,
+    this.maxAudioSecondsForAutoTranscribe = 300,
+  });
+}
+
+class AssetSafetyReport {
+  final String filePath;
+  final AssetSafetyType type;
+  final int fileSizeBytes;
+  final int? width;
+  final int? height;
+  final int? durationSeconds;
+  final bool safeForPreview;
+  final bool safeForAnalysis;
+  final bool safeForOcr;
+  final bool safeForInlineBase64;
+  final String reason;
+
+  const AssetSafetyReport({
+    required this.filePath,
+    required this.type,
+    required this.fileSizeBytes,
+    required this.width,
+    required this.height,
+    required this.durationSeconds,
+    required this.safeForPreview,
+    required this.safeForAnalysis,
+    required this.safeForOcr,
+    required this.safeForInlineBase64,
+    required this.reason,
+  });
+
+  bool get hasDimensions => width != null && height != null;
+
+  double get aspectRatio {
+    final w = width;
+    final h = height;
+    if (w == null || h == null || w <= 0 || h <= 0) return 0;
+    final longEdge = math.max(w, h);
+    final shortEdge = math.min(w, h);
+    return longEdge / shortEdge;
+  }
+
+  int? get pixelCount {
+    final w = width;
+    final h = height;
+    if (w == null || h == null || w <= 0 || h <= 0) return null;
+    return w * h;
+  }
+
+  String get metadataSummary {
+    final parts = <String>['size=${_formatBytes(fileSizeBytes)}'];
+    if (width != null && height != null) {
+      parts.add('dimensions=${width}x$height');
+      parts.add('aspect=${aspectRatio.toStringAsFixed(2)}');
+    }
+    if (durationSeconds != null) {
+      parts.add('duration=${durationSeconds}s');
+    }
+    return parts.join(', ');
+  }
+
+  String analysisSkipText(String assetName) {
+    return 'Automatic analysis skipped for $assetName: $reason. '
+        'The original file was preserved. $metadataSummary';
+  }
+
+  static String _formatBytes(int bytes) {
+    if (bytes >= 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)}MB';
+    }
+    if (bytes >= 1024) {
+      return '${(bytes / 1024).toStringAsFixed(1)}KB';
+    }
+    return '${bytes}B';
+  }
+}
+
+class AssetSafetyService {
+  AssetSafetyService._();
+
+  static final AssetSafetyService instance = AssetSafetyService._();
+
+  final Logger _logger = getLogger('AssetSafetyService');
+
+  static const imageExtensions = {
+    '.jpg',
+    '.jpeg',
+    '.png',
+    '.gif',
+    '.bmp',
+    '.webp',
+    '.heic',
+    '.heif',
+    '.tiff',
+    '.tif',
+  };
+
+  static const audioExtensions = {
+    '.mp3',
+    '.wav',
+    '.flac',
+    '.aac',
+    '.ogg',
+    '.aiff',
+    '.aif',
+    '.m4a',
+    '.wma',
+  };
+
+  Future<AssetSafetyReport> inspectFile(
+    String filePath, {
+    AssetSafetyConfig config = const AssetSafetyConfig(),
+  }) async {
+    return inspectFileSync(filePath, config: config);
+  }
+
+  AssetSafetyReport inspectFileSync(
+    String filePath, {
+    AssetSafetyConfig config = const AssetSafetyConfig(),
+  }) {
+    final file = File(filePath);
+    if (!file.existsSync()) {
+      return AssetSafetyReport(
+        filePath: filePath,
+        type: AssetSafetyType.missing,
+        fileSizeBytes: 0,
+        width: null,
+        height: null,
+        durationSeconds: null,
+        safeForPreview: false,
+        safeForAnalysis: false,
+        safeForOcr: false,
+        safeForInlineBase64: false,
+        reason: 'file is missing',
+      );
+    }
+
+    final fileSize = file.lengthSync();
+    final extension = path.extension(filePath).toLowerCase();
+    if (imageExtensions.contains(extension)) {
+      return _inspectImage(filePath, fileSize, config);
+    }
+    if (audioExtensions.contains(extension)) {
+      return _inspectAudio(filePath, fileSize, config);
+    }
+
+    return AssetSafetyReport(
+      filePath: filePath,
+      type: AssetSafetyType.unsupported,
+      fileSizeBytes: fileSize,
+      width: null,
+      height: null,
+      durationSeconds: null,
+      safeForPreview: false,
+      safeForAnalysis: false,
+      safeForOcr: false,
+      safeForInlineBase64: fileSize <= config.maxFileBytesForInlineBase64,
+      reason: 'unsupported asset type',
+    );
+  }
+
+  AssetSafetyReport _inspectImage(
+    String filePath,
+    int fileSize,
+    AssetSafetyConfig config,
+  ) {
+    final metadata = _readImageMetadata(filePath);
+    final width = metadata?.width;
+    final height = metadata?.height;
+    final reasons = <String>[];
+
+    bool safeForPreview;
+    bool safeForAnalysis;
+    bool safeForOcr;
+
+    if (width != null && height != null && width > 0 && height > 0) {
+      final pixels = width * height;
+      final longEdge = math.max(width, height);
+      final shortEdge = math.min(width, height);
+      final aspectRatio = longEdge / shortEdge;
+
+      if (pixels > config.maxPixelsForDecode) {
+        reasons.add(
+          'image pixel count $pixels exceeds ${config.maxPixelsForDecode}',
+        );
+      }
+      if (longEdge > config.maxLongEdgeForAnalysis) {
+        reasons.add(
+          'image long edge $longEdge exceeds ${config.maxLongEdgeForAnalysis}',
+        );
+      }
+      if (fileSize > config.maxImageBytesForAnalysis) {
+        reasons.add(
+          'image file size ${AssetSafetyReport._formatBytes(fileSize)} exceeds ${AssetSafetyReport._formatBytes(config.maxImageBytesForAnalysis)}',
+        );
+      }
+
+      final safeForDecode = reasons.isEmpty;
+      safeForPreview = safeForDecode;
+      safeForAnalysis = safeForDecode;
+      safeForOcr = safeForDecode && aspectRatio <= config.maxAspectRatioForOcr;
+      if (safeForDecode && !safeForOcr) {
+        reasons.add(
+          'image aspect ratio ${aspectRatio.toStringAsFixed(2)} exceeds OCR limit ${config.maxAspectRatioForOcr.toStringAsFixed(2)}',
+        );
+      }
+    } else {
+      safeForPreview = fileSize <= config.maxUnknownImageBytesForPreview;
+      safeForAnalysis = safeForPreview;
+      safeForOcr = false;
+      if (safeForPreview) {
+        reasons.add('image dimensions are unavailable; OCR skipped');
+      } else {
+        reasons.add(
+          'image dimensions are unavailable and file size ${AssetSafetyReport._formatBytes(fileSize)} exceeds ${AssetSafetyReport._formatBytes(config.maxUnknownImageBytesForPreview)}',
+        );
+      }
+    }
+
+    final inlineSafe =
+        fileSize <= config.maxFileBytesForInlineBase64 &&
+        safeForPreview &&
+        safeForAnalysis;
+
+    return AssetSafetyReport(
+      filePath: filePath,
+      type: AssetSafetyType.image,
+      fileSizeBytes: fileSize,
+      width: width,
+      height: height,
+      durationSeconds: null,
+      safeForPreview: safeForPreview,
+      safeForAnalysis: safeForAnalysis,
+      safeForOcr: safeForOcr,
+      safeForInlineBase64: inlineSafe,
+      reason: reasons.isEmpty
+          ? 'asset is within safety limits'
+          : reasons.join('; '),
+    );
+  }
+
+  AssetSafetyReport _inspectAudio(
+    String filePath,
+    int fileSize,
+    AssetSafetyConfig config,
+  ) {
+    final durationSeconds = _durationSecondsFromFileName(filePath);
+    final reasons = <String>[];
+    if (durationSeconds == null) {
+      reasons.add('audio duration is unavailable');
+    }
+    if (fileSize > config.maxAudioBytesForCloud) {
+      reasons.add(
+        'audio file size ${AssetSafetyReport._formatBytes(fileSize)} exceeds ${AssetSafetyReport._formatBytes(config.maxAudioBytesForCloud)}',
+      );
+    }
+    if (durationSeconds != null &&
+        durationSeconds > config.maxAudioSecondsForAutoTranscribe) {
+      reasons.add(
+        'audio duration ${durationSeconds}s exceeds ${config.maxAudioSecondsForAutoTranscribe}s',
+      );
+    }
+
+    final safeForAnalysis = reasons.isEmpty;
+    final inlineSafe =
+        fileSize <= config.maxFileBytesForInlineBase64 &&
+        durationSeconds != null &&
+        durationSeconds <= config.maxAudioSecondsForAutoTranscribe;
+
+    return AssetSafetyReport(
+      filePath: filePath,
+      type: AssetSafetyType.audio,
+      fileSizeBytes: fileSize,
+      width: null,
+      height: null,
+      durationSeconds: durationSeconds,
+      safeForPreview: true,
+      safeForAnalysis: safeForAnalysis,
+      safeForOcr: false,
+      safeForInlineBase64: inlineSafe,
+      reason: reasons.isEmpty
+          ? 'asset is within safety limits'
+          : reasons.join('; '),
+    );
+  }
+
+  _ImageMetadata? _readImageMetadata(String filePath) {
+    RandomAccessFile? raf;
+    try {
+      final file = File(filePath);
+      raf = file.openSync();
+      final length = raf.lengthSync();
+      final bytesToRead = math.min(length, 1024 * 1024);
+      final header = raf.readSync(bytesToRead);
+      return _parseImageMetadata(Uint8List.fromList(header));
+    } catch (e) {
+      _logger.fine('Failed to read image metadata for $filePath: $e');
+      return null;
+    } finally {
+      try {
+        raf?.closeSync();
+      } catch (_) {}
+    }
+  }
+
+  _ImageMetadata? _parseImageMetadata(Uint8List bytes) {
+    if (_isPng(bytes)) return _parsePng(bytes);
+    if (_isJpeg(bytes)) return _parseJpeg(bytes);
+    if (_isGif(bytes)) return _parseGif(bytes);
+    if (_isBmp(bytes)) return _parseBmp(bytes);
+    if (_isWebp(bytes)) return _parseWebp(bytes);
+    return null;
+  }
+
+  bool _isPng(Uint8List bytes) {
+    return bytes.length >= 24 &&
+        bytes[0] == 0x89 &&
+        bytes[1] == 0x50 &&
+        bytes[2] == 0x4e &&
+        bytes[3] == 0x47 &&
+        bytes[4] == 0x0d &&
+        bytes[5] == 0x0a &&
+        bytes[6] == 0x1a &&
+        bytes[7] == 0x0a;
+  }
+
+  _ImageMetadata? _parsePng(Uint8List bytes) {
+    if (bytes.length < 24) return null;
+    return _ImageMetadata(_readUint32Be(bytes, 16), _readUint32Be(bytes, 20));
+  }
+
+  bool _isJpeg(Uint8List bytes) {
+    return bytes.length >= 4 && bytes[0] == 0xff && bytes[1] == 0xd8;
+  }
+
+  _ImageMetadata? _parseJpeg(Uint8List bytes) {
+    var offset = 2;
+    while (offset + 9 < bytes.length) {
+      while (offset < bytes.length && bytes[offset] != 0xff) {
+        offset++;
+      }
+      while (offset < bytes.length && bytes[offset] == 0xff) {
+        offset++;
+      }
+      if (offset >= bytes.length) return null;
+
+      final marker = bytes[offset++];
+      if (marker == 0xd9 || marker == 0xda) return null;
+      if (_isStandaloneJpegMarker(marker)) continue;
+      if (offset + 2 > bytes.length) return null;
+
+      final segmentLength = _readUint16Be(bytes, offset);
+      if (segmentLength < 2 || offset + segmentLength > bytes.length) {
+        return null;
+      }
+
+      if (_isJpegSofMarker(marker) && segmentLength >= 7) {
+        final height = _readUint16Be(bytes, offset + 3);
+        final width = _readUint16Be(bytes, offset + 5);
+        return _ImageMetadata(width, height);
+      }
+
+      offset += segmentLength;
+    }
+    return null;
+  }
+
+  bool _isStandaloneJpegMarker(int marker) {
+    return marker == 0x01 || (marker >= 0xd0 && marker <= 0xd7);
+  }
+
+  bool _isJpegSofMarker(int marker) {
+    return marker == 0xc0 ||
+        marker == 0xc1 ||
+        marker == 0xc2 ||
+        marker == 0xc3 ||
+        marker == 0xc5 ||
+        marker == 0xc6 ||
+        marker == 0xc7 ||
+        marker == 0xc9 ||
+        marker == 0xca ||
+        marker == 0xcb ||
+        marker == 0xcd ||
+        marker == 0xce ||
+        marker == 0xcf;
+  }
+
+  bool _isGif(Uint8List bytes) {
+    if (bytes.length < 10) return false;
+    final header = String.fromCharCodes(bytes.sublist(0, 6));
+    return header == 'GIF87a' || header == 'GIF89a';
+  }
+
+  _ImageMetadata? _parseGif(Uint8List bytes) {
+    if (bytes.length < 10) return null;
+    return _ImageMetadata(_readUint16Le(bytes, 6), _readUint16Le(bytes, 8));
+  }
+
+  bool _isBmp(Uint8List bytes) {
+    return bytes.length >= 26 && bytes[0] == 0x42 && bytes[1] == 0x4d;
+  }
+
+  _ImageMetadata? _parseBmp(Uint8List bytes) {
+    if (bytes.length < 26) return null;
+    final width = _readInt32Le(bytes, 18).abs();
+    final height = _readInt32Le(bytes, 22).abs();
+    return _ImageMetadata(width, height);
+  }
+
+  bool _isWebp(Uint8List bytes) {
+    if (bytes.length < 30) return false;
+    return String.fromCharCodes(bytes.sublist(0, 4)) == 'RIFF' &&
+        String.fromCharCodes(bytes.sublist(8, 12)) == 'WEBP';
+  }
+
+  _ImageMetadata? _parseWebp(Uint8List bytes) {
+    var offset = 12;
+    while (offset + 8 <= bytes.length) {
+      final chunkType = String.fromCharCodes(bytes.sublist(offset, offset + 4));
+      final chunkSize = _readUint32Le(bytes, offset + 4);
+      final payload = offset + 8;
+      if (payload + chunkSize > bytes.length) return null;
+
+      if (chunkType == 'VP8X' && chunkSize >= 10) {
+        final width = 1 + _readUint24Le(bytes, payload + 4);
+        final height = 1 + _readUint24Le(bytes, payload + 7);
+        return _ImageMetadata(width, height);
+      }
+      if (chunkType == 'VP8L' && chunkSize >= 5 && bytes[payload] == 0x2f) {
+        final b1 = bytes[payload + 1];
+        final b2 = bytes[payload + 2];
+        final b3 = bytes[payload + 3];
+        final b4 = bytes[payload + 4];
+        final width = 1 + b1 + ((b2 & 0x3f) << 8);
+        final height = 1 + ((b2 >> 6) | (b3 << 2) | ((b4 & 0x0f) << 10));
+        return _ImageMetadata(width, height);
+      }
+      if (chunkType == 'VP8 ' && chunkSize >= 10) {
+        final width = _readUint16Le(bytes, payload + 6) & 0x3fff;
+        final height = _readUint16Le(bytes, payload + 8) & 0x3fff;
+        return _ImageMetadata(width, height);
+      }
+
+      offset = payload + chunkSize + (chunkSize.isOdd ? 1 : 0);
+    }
+    return null;
+  }
+
+  int? _durationSecondsFromFileName(String filePath) {
+    final name = path.basename(filePath);
+    final match = RegExp(r'_(\d+)(?=\.[^.]+$)').firstMatch(name);
+    if (match == null) return null;
+    return int.tryParse(match.group(1)!);
+  }
+
+  int _readUint16Be(Uint8List bytes, int offset) {
+    return (bytes[offset] << 8) | bytes[offset + 1];
+  }
+
+  int _readUint16Le(Uint8List bytes, int offset) {
+    return bytes[offset] | (bytes[offset + 1] << 8);
+  }
+
+  int _readUint24Le(Uint8List bytes, int offset) {
+    return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
+  }
+
+  int _readUint32Be(Uint8List bytes, int offset) {
+    return (bytes[offset] << 24) |
+        (bytes[offset + 1] << 16) |
+        (bytes[offset + 2] << 8) |
+        bytes[offset + 3];
+  }
+
+  int _readUint32Le(Uint8List bytes, int offset) {
+    return bytes[offset] |
+        (bytes[offset + 1] << 8) |
+        (bytes[offset + 2] << 16) |
+        (bytes[offset + 3] << 24);
+  }
+
+  int _readInt32Le(Uint8List bytes, int offset) {
+    final value = _readUint32Le(bytes, offset);
+    return value & 0x80000000 == 0 ? value : value - 0x100000000;
+  }
+}
+
+class _ImageMetadata {
+  final int width;
+  final int height;
+
+  const _ImageMetadata(this.width, this.height);
+}

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -7,7 +7,7 @@ import 'package:logging/logging.dart';
 import 'package:yaml/yaml.dart';
 import 'package:synchronized/synchronized.dart';
 import 'package:audioplayers/audioplayers.dart';
-import 'package:flutter/widgets.dart'; // For decodeImageFromList
+import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/utils/logger.dart';
 import 'base_file_service.dart';
 import 'api_exception.dart';
@@ -1416,9 +1416,11 @@ class FileSystemService {
     if (extraInfo == null) {
       if (assetType == 'img') {
         try {
-          final fileBytes = await File(sourcePath).readAsBytes();
-          final image = await decodeImageFromList(fileBytes);
-          extraInfo = '${image.width}x${image.height}';
+          final safety =
+              await AssetSafetyService.instance.inspectFile(sourcePath);
+          if (safety.width != null && safety.height != null) {
+            extraInfo = '${safety.width}x${safety.height}';
+          }
         } catch (e) {
           _logger.warning('Failed to extract image dimensions: $e');
         }

--- a/lib/data/services/media_service.dart
+++ b/lib/data/services/media_service.dart
@@ -1,9 +1,8 @@
 import 'dart:io';
-import 'dart:ui' as ui;
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
+import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/utils/logger.dart';
 
@@ -114,22 +113,17 @@ class MediaService {
     return '$base$extension';
   }
 
-  /// Decode an image file just far enough to learn its pixel dimensions.
-  /// Returns `(width, height)` or `null` if decoding fails.
+  /// Read image header metadata for pixel dimensions.
+  /// Returns `(width, height)` or `null` if metadata is unavailable.
   Future<(int, int)?> _probeImageDimensions(String imagePath) async {
     try {
-      final bytes = await File(imagePath).readAsBytes();
-      final codec = await ui.instantiateImageCodec(bytes);
-      final frame = await codec.getNextFrame();
-      final image = frame.image;
-      final result = (image.width, image.height);
-      image.dispose();
-      codec.dispose();
-      return result;
+      final safety = await AssetSafetyService.instance.inspectFile(imagePath);
+      final width = safety.width;
+      final height = safety.height;
+      if (width == null || height == null) return null;
+      return (width, height);
     } catch (e) {
-      if (kDebugMode) {
-        _logger.fine('Failed to probe image dimensions for $imagePath: $e');
-      }
+      _logger.fine('Failed to probe image dimensions for $imagePath: $e');
       return null;
     }
   }

--- a/lib/data/services/photo_suggestion_service.dart
+++ b/lib/data/services/photo_suggestion_service.dart
@@ -7,6 +7,7 @@ import 'dart:math';
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 import 'package:google_mlkit_image_labeling/google_mlkit_image_labeling.dart';
 import 'package:camera/camera.dart';
+import 'package:memex/data/services/asset_safety_service.dart';
 import 'publish_timestamp_service.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -243,8 +244,8 @@ class PhotoSuggestionService {
       if (xFile == null) continue;
 
       final length = await xFile.length();
-      final String? trueTitle = await asset.titleAsync;
-      final String effectiveName = trueTitle ?? xFile.name;
+      final trueTitle = await asset.titleAsync;
+      final effectiveName = trueTitle.isNotEmpty ? trueTitle : xFile.name;
       final rawHashStr = 'photo_${effectiveName}_$length';
 
       photoInfoList.add(
@@ -370,8 +371,9 @@ class PhotoSuggestionService {
         };
         prefetchFutures.add(() async {
           final latlng = await info.asset.latlngAsync();
-          final String? trueTitle = await info.asset.titleAsync;
-          final String effectiveName = trueTitle ?? info.xFile.name;
+          final trueTitle = await info.asset.titleAsync;
+          final effectiveName =
+              trueTitle.isNotEmpty ? trueTitle : info.xFile.name;
 
           processedData[i]['latlng'] = latlng;
           processedData[i]['effectiveName'] = effectiveName;
@@ -497,29 +499,55 @@ class PhotoSuggestionService {
         List<String> ocrBlocks,
         List<String> labels,
         DateTime modifiedTime
+      })> processImageOCRForTesting(XFile xFile) {
+    return _processImageOCR(xFile);
+  }
+
+  static Future<
+      ({
+        List<String> ocrBlocks,
+        List<String> labels,
+        DateTime modifiedTime
       })> _processImageOCR(XFile xFile) async {
     _logger.info('--- Starting OCR + Labeling for ${xFile.name} ---');
-    final textRecognizer =
-        TextRecognizer(script: TextRecognitionScript.chinese);
-    final imageLabeler = ImageLabeler(options: ImageLabelerOptions());
+    TextRecognizer? textRecognizer;
+    ImageLabeler? imageLabeler;
     try {
       final file = File(xFile.path);
       final stat = await file.stat();
       _logger.fine('Processing ${xFile.name}, modified: ${stat.modified}');
 
+      final safety = await AssetSafetyService.instance.inspectFile(xFile.path);
+      if (!safety.safeForAnalysis) {
+        _logger.warning(
+          'Skipping unsafe photo suggestion analysis for ${xFile.path}: ${safety.reason}',
+        );
+        return (
+          ocrBlocks: <String>[],
+          labels: <String>[],
+          modifiedTime: stat.modified
+        );
+      }
+
       final inputImage = InputImage.fromFilePath(xFile.path);
+      imageLabeler = ImageLabeler(options: ImageLabelerOptions());
+      final labelsFuture = imageLabeler.processImage(inputImage);
 
-      // Run both in parallel
-      final results = await Future.wait([
-        textRecognizer.processImage(inputImage),
-        imageLabeler.processImage(inputImage),
-      ]);
+      Future<RecognizedText>? recognizedTextFuture;
+      if (safety.safeForOcr) {
+        textRecognizer = TextRecognizer(script: TextRecognitionScript.chinese);
+        recognizedTextFuture = textRecognizer.processImage(inputImage);
+      } else {
+        _logger.warning(
+          'Skipping OCR for ${xFile.path}: ${safety.reason}',
+        );
+      }
 
-      final recognizedText = results[0] as RecognizedText;
-      final labels = results[1] as List<ImageLabel>;
+      final labels = await labelsFuture;
+      final recognizedText = await recognizedTextFuture;
       final List<String> labelNames = labels.map((l) => l.label).toList();
       final List<String> blockTexts =
-          recognizedText.blocks.map((b) => b.text).toList();
+          recognizedText?.blocks.map((b) => b.text).toList() ?? <String>[];
 
       return (
         ocrBlocks: blockTexts,
@@ -534,8 +562,8 @@ class PhotoSuggestionService {
         modifiedTime: DateTime.now()
       );
     } finally {
-      textRecognizer.close();
-      imageLabeler.close();
+      textRecognizer?.close();
+      imageLabeler?.close();
     }
   }
 }

--- a/lib/data/services/speech_transcription_service.dart
+++ b/lib/data/services/speech_transcription_service.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
+import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/data/services/whisper_service.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/domain/models/llm_config.dart';
@@ -67,8 +68,10 @@ class SpeechTranscriptionService {
     final useLocal = await UserStorage.getUseLocalSpeechToText();
 
     if (useLocal) {
-      return _transcribeFileLocally(audioPath,
-          skipLengthCheck: skipLengthCheck);
+      return _transcribeFileLocally(
+        audioPath,
+        skipLengthCheck: skipLengthCheck,
+      );
     }
 
     return _transcribeFileWithCloud(audioPath);
@@ -80,7 +83,8 @@ class SpeechTranscriptionService {
   }
 
   Future<SpeechTranscriptionResult> transcribeSamplesWithMetadata(
-      Float32List samples) async {
+    Float32List samples,
+  ) async {
     final useLocal = await UserStorage.getUseLocalSpeechToText();
 
     if (useLocal) {
@@ -94,6 +98,17 @@ class SpeechTranscriptionService {
     String audioPath, {
     bool skipLengthCheck = false,
   }) async {
+    final safety = await _inspectAudioForTranscription(audioPath);
+    if (!safety.safeForAnalysis) {
+      _logger.warning(
+        'Skipping unsafe local audio transcription for $audioPath: ${safety.reason}',
+      );
+      return const SpeechTranscriptionResult(
+        text: null,
+        usage: null,
+        model: 'asset-safety',
+      );
+    }
     final text = await WhisperService.instance.transcribe(
       audioPath,
       skipLengthCheck: skipLengthCheck,
@@ -106,7 +121,8 @@ class SpeechTranscriptionService {
   }
 
   Future<SpeechTranscriptionResult> _transcribeSamplesLocally(
-      Float32List samples) async {
+    Float32List samples,
+  ) async {
     final text = await WhisperService.instance.transcribeSamples(samples);
     return SpeechTranscriptionResult(
       text: text,
@@ -118,26 +134,38 @@ class SpeechTranscriptionService {
   Future<SpeechTranscriptionResult> _transcribeFileWithCloud(
     String audioPath,
   ) async {
+    final safety = await _inspectAudioForTranscription(audioPath);
+    if (!safety.safeForAnalysis) {
+      _logger.warning(
+        'Skipping unsafe cloud audio transcription for $audioPath: ${safety.reason}',
+      );
+      return const SpeechTranscriptionResult(
+        text: null,
+        usage: null,
+        model: 'asset-safety',
+      );
+    }
+    final file = File(audioPath);
+    final bytes = await file.readAsBytes();
+    final mimeType = _mimeTypeForPath(audioPath);
+    return _transcribeAudioBytesWithCloud(bytes, mimeType: mimeType);
+  }
+
+  Future<AssetSafetyReport> _inspectAudioForTranscription(
+    String audioPath,
+  ) async {
     final file = File(audioPath);
     if (!file.existsSync()) {
       throw Exception('Audio file not found: $audioPath');
     }
-    final bytes = await file.readAsBytes();
-    final mimeType = _mimeTypeForPath(audioPath);
-    return _transcribeAudioBytesWithCloud(
-      bytes,
-      mimeType: mimeType,
-    );
+    return AssetSafetyService.instance.inspectFile(audioPath);
   }
 
   Future<SpeechTranscriptionResult> _transcribeSamplesWithCloud(
     Float32List samples,
   ) async {
     final bytes = _samplesToWavBytes(samples);
-    return _transcribeAudioBytesWithCloud(
-      bytes,
-      mimeType: 'audio/wav',
-    );
+    return _transcribeAudioBytesWithCloud(bytes, mimeType: 'audio/wav');
   }
 
   Future<SpeechTranscriptionResult> _transcribeAudioBytesWithCloud(
@@ -160,16 +188,10 @@ Rules:
 - Do not add introductions, labels, translations, summaries, notes, or quotes.
 - Preserve the spoken language as-is.
 - If the audio contains no recognizable speech, return <transcript></transcript>.''';
-    final response = await resources.client.generate(
-      [
-        SystemMessage(systemPrompt),
-        UserMessage([
-          TextPart(prompt),
-          AudioPart(base64Encode(bytes), mimeType),
-        ])
-      ],
-      modelConfig: resources.modelConfig,
-    );
+    final response = await resources.client.generate([
+      SystemMessage(systemPrompt),
+      UserMessage([TextPart(prompt), AudioPart(base64Encode(bytes), mimeType)]),
+    ], modelConfig: resources.modelConfig);
 
     return SpeechTranscriptionResult(
       text: _normalizeCloudTranscript(response.textOutput),
@@ -192,7 +214,8 @@ Rules:
     }
 
     _logger.warning(
-        'Cloud speech transcription returned non-transcript text: $trimmed');
+      'Cloud speech transcription returned non-transcript text: $trimmed',
+    );
     return null;
   }
 

--- a/lib/data/services/task_handlers/analyze_assets_handler.dart
+++ b/lib/data/services/task_handlers/analyze_assets_handler.dart
@@ -7,7 +7,7 @@ import 'package:memex/utils/user_storage.dart';
 import 'package:path/path.dart' as path;
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/utils/exif_utils.dart';
-import 'package:memex/utils/image_utils.dart';
+import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/utils/logger.dart';
@@ -120,6 +120,28 @@ Future<List<AssetAnalysisResult>> analyzeAssetsForFact({
   }
 
   final fileSystem = FileSystemService.instance;
+  final preflightResults = <AssetAnalysisResult>[];
+  final safeAssetPaths = <(int, String)>[];
+
+  for (var i = 0; i < assetPaths.length; i++) {
+    final unsafeResult = await _writeUnsafeAssetSkipIfNeeded(
+      userId: userId,
+      factId: factId,
+      originalAssetPath: assetPaths[i],
+      index: i,
+      fileSystem: fileSystem,
+    );
+    if (unsafeResult != null) {
+      preflightResults.add(unsafeResult);
+    } else {
+      safeAssetPaths.add((i, assetPaths[i]));
+    }
+  }
+
+  if (safeAssetPaths.isEmpty) {
+    preflightResults.sort((a, b) => a.index.compareTo(b.index));
+    return preflightResults;
+  }
 
   // Skip LLM analysis if not configured — card agent will use rule-based matching.
   final llmConfig = await UserStorage.getAgentLLMConfig(
@@ -128,7 +150,8 @@ Future<List<AssetAnalysisResult>> analyzeAssetsForFact({
   );
   if (!llmConfig.isValid) {
     _logger.info('No LLM configured — skipping asset analysis for $factId');
-    return const [];
+    preflightResults.sort((a, b) => a.index.compareTo(b.index));
+    return preflightResults;
   }
 
   // 1. Get LLM Resources (Default to Gemini Flash for Asset Analysis)
@@ -139,13 +162,13 @@ Future<List<AssetAnalysisResult>> analyzeAssetsForFact({
 
   final futures = <Future<AssetAnalysisResult?>>[];
 
-  for (var i = 0; i < assetPaths.length; i++) {
+  for (final (index, assetPath) in safeAssetPaths) {
     futures.add(
       _analyzeSingleAsset(
         userId: userId,
         factId: factId,
-        originalAssetPath: assetPaths[i],
-        index: i,
+        originalAssetPath: assetPath,
+        index: index,
         fileSystem: fileSystem,
         client: resources.client,
         modelConfig: resources.modelConfig,
@@ -154,12 +177,55 @@ Future<List<AssetAnalysisResult>> analyzeAssetsForFact({
   }
 
   final results = await Future.wait(futures);
-  final assetAnalyses = results.whereType<AssetAnalysisResult>().toList();
+  final assetAnalyses = [
+    ...preflightResults,
+    ...results.whereType<AssetAnalysisResult>(),
+  ];
 
   // Sort by index to maintain order
   assetAnalyses.sort((a, b) => a.index.compareTo(b.index));
 
   return assetAnalyses;
+}
+
+Future<AssetAnalysisResult?> _writeUnsafeAssetSkipIfNeeded({
+  required String userId,
+  required String factId,
+  required String originalAssetPath,
+  required int index,
+  required FileSystemService fileSystem,
+}) async {
+  final assetPath = fileSystem.toAbsolutePath(originalAssetPath);
+  final file = File(assetPath);
+  if (!file.existsSync()) return null;
+
+  final extension = path.extension(assetPath).toLowerCase();
+  final isSupported =
+      AssetSafetyService.imageExtensions.contains(extension) ||
+      AssetSafetyService.audioExtensions.contains(extension);
+  if (!isSupported) return null;
+
+  final safety = await AssetSafetyService.instance.inspectFile(assetPath);
+  if (safety.safeForAnalysis) return null;
+
+  final assetName = path.basename(assetPath);
+  final skipText = safety.analysisSkipText(assetName);
+  await _saveAssetAnalysisText(
+    userId: userId,
+    factId: factId,
+    assetPath: assetPath,
+    fileSystem: fileSystem,
+    content: skipText,
+  );
+  _logger.warning('Skipped unsafe asset analysis for $assetPath: $skipText');
+  return AssetAnalysisResult(
+    factId: factId,
+    name: assetName,
+    path: assetPath,
+    index: index + 1,
+    analysis: skipText,
+    exifData: null,
+  );
 }
 
 Future<AssetAnalysisResult?> _analyzeSingleAsset({
@@ -220,6 +286,29 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
       return null;
     }
 
+    final safety = await AssetSafetyService.instance.inspectFile(assetPath);
+    if (!safety.safeForAnalysis) {
+      final skipText = safety.analysisSkipText(assetName);
+      await _saveAssetAnalysisText(
+        userId: userId,
+        factId: factId,
+        assetPath: assetPath,
+        fileSystem: fileSystem,
+        content: skipText,
+      );
+      _logger.warning(
+        'Skipped unsafe asset analysis for $assetPath: $skipText',
+      );
+      return AssetAnalysisResult(
+        factId: factId,
+        name: assetName,
+        path: assetPath,
+        index: index + 1,
+        analysis: skipText,
+        exifData: null,
+      );
+    }
+
     // 1. Extract EXIF Data (Images only)
     Map<String, dynamic> exif = {};
     String exifInfoText = "";
@@ -232,11 +321,9 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
         _logger.warning('Failed to extract EXIF data for $assetPath: $e');
       }
 
-      // Get image dimensions
-      final dimensions = await ImageUtils.getImageDimensions(assetPath);
-      final width = dimensions['width'] as int;
-      final height = dimensions['height'] as int;
-      final aspectRatio = dimensions['aspectRatio'] as double;
+      final width = safety.width ?? 0;
+      final height = safety.height ?? 0;
+      final aspectRatio = width > 0 && height > 0 ? width / height : 0.0;
 
       // Process EXIF Info
       final infoLines = <String>[];
@@ -282,7 +369,8 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
             if (geocoded != null) {
               final locationConfig =
                   await UserStorage.getLocationContextConfig();
-              address = geocoded.fullAddress ??
+              address =
+                  geocoded.fullAddress ??
                   geocoded.summary(locationConfig.granularity);
             }
             if (address != null) {
@@ -415,41 +503,17 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
 
     // 4. Save to file (using original filename + .analysis.txt suffix)
     if (finalAnalysisResult.isNotEmpty) {
-      try {
-        final assetFilename = path.basename(assetPath);
-        final analysisFilename = "$assetFilename.analysis.txt";
-        final analysisFile = File(
-          path.join(path.dirname(assetPath), analysisFilename),
-        );
-        await analysisFile.writeAsString(finalAnalysisResult);
-        _logger.info(
-          "Saved asset analysis (with EXIF info) to: ${analysisFile.path}",
-        );
-
-        // Log event
-        try {
-          final workspacePath = fileSystem.getWorkspacePath(userId);
-          final relativePath = fileSystem.toRelativePath(
-            analysisFile.path,
-            rootPath: workspacePath,
-          );
-          await fileSystem.eventLogService.logFileCreated(
-            userId: userId,
-            filePath: relativePath,
-            description: 'System created asset analysis file',
-            metadata: {'fact_id': factId, 'asset': assetFilename},
-          );
-        } catch (e) {
-          // Event logging failure should not break analysis
-        }
-      } catch (e) {
-        _logger.severe('Failed to save asset analysis for $assetPath: $e');
-        throw Exception('Failed to save asset analysis for $assetPath: $e');
-      }
+      await _saveAssetAnalysisText(
+        userId: userId,
+        factId: factId,
+        assetPath: assetPath,
+        fileSystem: fileSystem,
+        content: finalAnalysisResult,
+      );
     }
 
     // 4b. On-device OCR for images — persist as {filename}.ocr.txt
-    if (isImage) {
+    if (isImage && safety.safeForOcr) {
       try {
         final ocrText = await _performOnDeviceOcr(assetPath);
         if (ocrText.isNotEmpty) {
@@ -463,6 +527,8 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
         // OCR failure should not break the overall asset analysis
         _logger.warning('On-device OCR failed for $assetPath: $e');
       }
+    } else if (isImage) {
+      _logger.warning('Skipping OCR for $assetPath: ${safety.reason}');
     }
 
     // 5. Add to results (analysis field should include EXIF + tool analysis, matching backend)
@@ -471,13 +537,51 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
       name: assetName,
       path: assetPath,
       index: index + 1,
-      analysis:
-          finalAnalysisResult.isNotEmpty ? finalAnalysisResult : analysisResult,
+      analysis: finalAnalysisResult.isNotEmpty
+          ? finalAnalysisResult
+          : analysisResult,
       exifData: structuredExifData,
     );
   } catch (e, stack) {
     _logger.severe('Failed to analyze asset: $assetPath', e, stack);
     rethrowIfNonRetryable(e);
+  }
+}
+
+Future<void> _saveAssetAnalysisText({
+  required String userId,
+  required String factId,
+  required String assetPath,
+  required FileSystemService fileSystem,
+  required String content,
+}) async {
+  try {
+    final assetFilename = path.basename(assetPath);
+    final analysisFilename = "$assetFilename.analysis.txt";
+    final analysisFile = File(
+      path.join(path.dirname(assetPath), analysisFilename),
+    );
+    await analysisFile.writeAsString(content);
+    _logger.info("Saved asset analysis to: ${analysisFile.path}");
+
+    try {
+      final workspacePath = fileSystem.getWorkspacePath(userId);
+      final relativePath = fileSystem.toRelativePath(
+        analysisFile.path,
+        rootPath: workspacePath,
+      );
+      await fileSystem.eventLogService.logFileCreated(
+        userId: userId,
+        filePath: relativePath,
+        description: 'System created asset analysis file',
+        metadata: {'fact_id': factId, 'asset': assetFilename},
+      );
+    } catch (e) {
+      // Event logging failure should not break analysis.
+    }
+  } catch (e) {
+    _logger.severe('Failed to save asset analysis for $assetPath: $e');
+    throw Exception('Failed to save asset analysis for $assetPath: $e');
   }
 }
 

--- a/lib/data/services/task_handlers/custom_agent_task_handler.dart
+++ b/lib/data/services/task_handlers/custom_agent_task_handler.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:memex/agent/memex_skill_host_agent/memex_skill_host_agent.dart';
 import 'package:memex/agent/pure_skill_host_agent/pure_skill_host_agent.dart';
 import 'package:memex/agent/state_util.dart';
+import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/data/services/custom_agent_config_service.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
@@ -115,6 +116,14 @@ Future<List<UserContentPart>> _buildAssetPartsFromXml(
         continue;
       }
 
+      final safety = await AssetSafetyService.instance.inspectFile(absPath);
+      if (!safety.safeForInlineBase64) {
+        _logger.warning(
+          'Skipping unsafe custom-agent inline asset $absPath: ${safety.reason}',
+        );
+        continue;
+      }
+
       final bytes = await file.readAsBytes();
       final b64 = base64Encode(bytes);
 
@@ -128,6 +137,13 @@ Future<List<UserContentPart>> _buildAssetPartsFromXml(
     }
   }
   return parts;
+}
+
+Future<List<UserContentPart>> buildAssetPartsFromXmlForTesting(
+  String userId,
+  String eventXml,
+) {
+  return _buildAssetPartsFromXml(userId, eventXml);
 }
 
 Future<void> _handleCustomAgentTask(

--- a/lib/ui/character/widgets/character_config_screen.dart
+++ b/lib/ui/character/widgets/character_config_screen.dart
@@ -18,6 +18,7 @@ import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/main_screen/widgets/chat_input_bar.dart';
 import 'package:memex/ui/core/widgets/back_button.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
 
 /// AI character config screen. Receives [viewModel] from parent (Compass-style).
 class CharacterConfigScreen extends StatefulWidget {
@@ -298,7 +299,7 @@ class _CharacterConfigScreenState extends State<CharacterConfigScreen> {
                           value: character.enabled,
                           onChanged: (enabled) =>
                               _toggleCharacterEnabled(vm, character, enabled),
-                          activeColor: Colors.white,
+                          activeThumbColor: Colors.white,
                           activeTrackColor: AppColors.primary,
                           inactiveThumbColor: Colors.white,
                           inactiveTrackColor: const Color(0xFFE2E8F0),
@@ -545,7 +546,7 @@ class _CharacterEditPageState extends State<CharacterEditPage> {
           border: Border.all(color: const Color(0xFFE2E8F0)),
           image: hasBackground
               ? DecorationImage(
-                  image: FileImage(File(preview)),
+                  image: LocalImage.provider(preview),
                   fit: BoxFit.cover,
                 )
               : null,

--- a/lib/ui/character/widgets/persona_chat_screen.dart
+++ b/lib/ui/character/widgets/persona_chat_screen.dart
@@ -12,6 +12,7 @@ import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/data/services/character_service.dart';
 import 'package:memex/ui/core/widgets/character_avatar.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
 import 'package:memex/utils/tavern_macro.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
@@ -920,8 +921,8 @@ class _ChatAtmosphereBackground extends StatelessWidget {
       children: [
         if (hasCustomBg)
           Positioned.fill(
-            child: Image.file(
-              File(bgPath),
+            child: LocalImage(
+              url: bgPath,
               fit: BoxFit.cover,
             ),
           )

--- a/lib/ui/core/widgets/local_image.dart
+++ b/lib/ui/core/widgets/local_image.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:convert';
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -8,10 +9,81 @@ import 'package:path_provider/path_provider.dart';
 import 'package:http/http.dart' as http;
 import 'package:shimmer/shimmer.dart';
 import 'package:crypto/crypto.dart';
+import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/utils/logger.dart';
 
 final Logger _logger = getLogger('LocalImage');
+
+final Uint8List _transparentPng = Uint8List.fromList(const [
+  0x89,
+  0x50,
+  0x4e,
+  0x47,
+  0x0d,
+  0x0a,
+  0x1a,
+  0x0a,
+  0x00,
+  0x00,
+  0x00,
+  0x0d,
+  0x49,
+  0x48,
+  0x44,
+  0x52,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1f,
+  0x15,
+  0xc4,
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0a,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9c,
+  0x63,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x05,
+  0x00,
+  0x01,
+  0x0d,
+  0x0a,
+  0x2d,
+  0xb4,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4e,
+  0x44,
+  0xae,
+  0x42,
+  0x60,
+  0x82,
+]);
 
 /// Image widget that handles local server URL and local file path
 /// - If URL starts with http://127.0.0.1, parse as local file path and use Image.file
@@ -155,11 +227,15 @@ class LocalImage extends StatefulWidget {
     final isLocalFile = localFilePath != null || !url.startsWith('http');
 
     if (isLocalFile) {
-      // use local file load
-      // TODO: Cannot easily use compression cache here because ImageProvider is sync,
-      // while compression is async. May need custom ImageProvider for compressed images.
-      // For now return raw image provider.
-      return FileImage(File(localFilePath ?? url));
+      final filePath = localFilePath ?? url;
+      final safety = AssetSafetyService.instance.inspectFileSync(filePath);
+      if (!safety.safeForPreview) {
+        _logger.warning(
+          'LocalImage.provider blocked unsafe preview for $filePath: ${safety.reason}',
+        );
+        return MemoryImage(_transparentPng);
+      }
+      return FileImage(File(filePath));
     } else {
       // use network load
       return NetworkImage(url);
@@ -188,6 +264,8 @@ class LocalImage extends StatefulWidget {
 class _LocalImageState extends State<LocalImage> {
   File? _imageFile;
   bool _isLoading = true; // preload state for local images only
+  bool _previewUnavailable = false;
+  String? _previewUnavailableReason;
 
   @override
   void initState() {
@@ -204,11 +282,16 @@ class _LocalImageState extends State<LocalImage> {
   }
 
   Future<void> _loadImage() async {
+    _previewUnavailable = false;
+    _previewUnavailableReason = null;
+
     if (widget.url.isEmpty) {
       if (mounted) {
         setState(() {
           _imageFile = null;
           _isLoading = false;
+          _previewUnavailable = false;
+          _previewUnavailableReason = null;
         });
       }
       return;
@@ -225,13 +308,30 @@ class _LocalImageState extends State<LocalImage> {
       originalPath = localFilePath ?? widget.url;
       originalFile = File(originalPath);
 
-      if (!await originalFile.exists()) {
+      if (!originalFile.existsSync()) {
         // original file not found, cannot load
         if (mounted) {
           setState(() {
-            _imageFile =
-                File(originalPath); // still set so Image.file handles error
+            _imageFile = File(
+              originalPath,
+            ); // still set so Image.file handles error
             _isLoading = false;
+          });
+        }
+        return;
+      }
+
+      final safety = AssetSafetyService.instance.inspectFileSync(originalPath);
+      if (!safety.safeForPreview) {
+        _logger.warning(
+          'Local image preview blocked for $originalPath: ${safety.reason}',
+        );
+        if (mounted) {
+          setState(() {
+            _imageFile = null;
+            _isLoading = false;
+            _previewUnavailable = true;
+            _previewUnavailableReason = safety.reason;
           });
         }
         return;
@@ -278,8 +378,12 @@ class _LocalImageState extends State<LocalImage> {
         _logger.info('Downloading network image: $originalPath');
         final response = await http.get(Uri.parse(originalPath));
         if (response.statusCode == 200) {
-          tempDownloadFile = File(path.join(
-              cacheDir.path, 'temp_${DateTime.now().millisecondsSinceEpoch}'));
+          tempDownloadFile = File(
+            path.join(
+              cacheDir.path,
+              'temp_${DateTime.now().millisecondsSinceEpoch}',
+            ),
+          );
           await tempDownloadFile.writeAsBytes(response.bodyBytes);
           sourcePath = tempDownloadFile.path;
         } else {
@@ -287,20 +391,43 @@ class _LocalImageState extends State<LocalImage> {
         }
       }
 
+      final previewSafety = AssetSafetyService.instance.inspectFileSync(
+        sourcePath,
+      );
+      if (!previewSafety.safeForPreview) {
+        _logger.warning(
+          'Image preview blocked for $originalPath: ${previewSafety.reason}',
+        );
+        if (tempDownloadFile != null && await tempDownloadFile.exists()) {
+          await tempDownloadFile.delete();
+        }
+        if (mounted) {
+          setState(() {
+            _imageFile = null;
+            _isLoading = false;
+            _previewUnavailable = true;
+            _previewUnavailableReason = previewSafety.reason;
+          });
+        }
+        return;
+      }
+
       // check image size; if already <= 768, copy file to avoid re-compression quality loss
       String? resultPath;
       bool needCompress = true;
 
       try {
-        final bytes = await File(sourcePath).readAsBytes();
-        final decodedImage = await decodeImageFromList(bytes);
-        if (decodedImage.width <= 768 && decodedImage.height <= 768) {
+        if (previewSafety.width != null &&
+            previewSafety.height != null &&
+            previewSafety.width! <= 768 &&
+            previewSafety.height! <= 768) {
           needCompress = false;
         }
-        decodedImage.dispose();
       } catch (e) {
         _logger.warning(
-            'Failed to decode image to check size for $sourcePath', e);
+          'Failed to read image metadata to check size for $sourcePath',
+          e,
+        );
       }
 
       if (needCompress) {
@@ -314,8 +441,9 @@ class _LocalImageState extends State<LocalImage> {
         );
         resultPath = result?.path;
       } else {
-        _logger
-            .info('Image dimensions <= 768, skip compression: $originalPath');
+        _logger.info(
+          'Image dimensions <= 768, skip compression: $originalPath',
+        );
         final copiedFile = await File(sourcePath).copy(cacheFile.path);
         resultPath = copiedFile.path;
       }
@@ -335,21 +463,24 @@ class _LocalImageState extends State<LocalImage> {
           });
         } else {
           _logger.warning(
-              'Compression/Copy failed (null result) for image: $originalPath');
+            'Compression/Copy failed (null result) for image: $originalPath',
+          );
           setState(() {
-            // on failure (null resultPath), fallback to original image (local) or URL (network)
-            _imageFile = isLocalFile ? originalFile : null;
+            _imageFile = null;
             _isLoading = false;
+            _previewUnavailable = true;
+            _previewUnavailableReason = 'safe preview generation failed';
           });
         }
       }
     } catch (e) {
       _logger.severe('LocalImage processing error for image: $originalPath', e);
-      // on error, fallback
       if (mounted) {
         setState(() {
-          _imageFile = isLocalFile ? originalFile : null;
+          _imageFile = null;
           _isLoading = false;
+          _previewUnavailable = true;
+          _previewUnavailableReason = 'safe preview generation failed';
         });
       }
     }
@@ -384,13 +515,39 @@ class _LocalImageState extends State<LocalImage> {
     return skeleton;
   }
 
+  Widget _buildPreviewUnavailable() {
+    if (widget.errorBuilder != null) {
+      return widget.errorBuilder!(
+        context,
+        Exception(_previewUnavailableReason ?? 'Image preview unavailable'),
+        StackTrace.current,
+      );
+    }
+
+    return Container(
+      width: widget.width ?? double.infinity,
+      height: widget.height ?? double.infinity,
+      color: Colors.grey[100],
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.image_not_supported_outlined,
+        color: Colors.grey[500],
+        size: 28,
+      ),
+    );
+  }
+
   /// Wrap user frameBuilder or provide default skeleton
   Widget Function(BuildContext, Widget, int?, bool)? _getFrameBuilder() {
     if (widget.frameBuilder != null) return widget.frameBuilder;
 
     // default: show skeleton until first frame loaded
-    return (BuildContext context, Widget child, int? frame,
-        bool wasSynchronouslyLoaded) {
+    return (
+      BuildContext context,
+      Widget child,
+      int? frame,
+      bool wasSynchronouslyLoaded,
+    ) {
       if (wasSynchronouslyLoaded || frame != null) {
         return child;
       }
@@ -403,7 +560,10 @@ class _LocalImageState extends State<LocalImage> {
     if (widget.url.isEmpty) {
       if (widget.errorBuilder != null) {
         return widget.errorBuilder!(
-            context, Exception('Image url is empty'), StackTrace.current);
+          context,
+          Exception('Image url is empty'),
+          StackTrace.current,
+        );
       }
       return const Center(child: Icon(Icons.broken_image, color: Colors.grey));
     }
@@ -413,11 +573,16 @@ class _LocalImageState extends State<LocalImage> {
       return _buildSkeleton();
     }
 
+    if (_previewUnavailable) {
+      return _buildPreviewUnavailable();
+    }
+
     // local file mode
     if (_imageFile != null) {
       if (!_imageFile!.existsSync()) {
         _logger.severe(
-            'File not found when loading with Image.file: ${_imageFile!.path}');
+          'File not found when loading with Image.file: ${_imageFile!.path}',
+        );
       }
       return Image.file(
         _imageFile!,
@@ -433,14 +598,16 @@ class _LocalImageState extends State<LocalImage> {
         filterQuality: widget.filterQuality,
         errorBuilder: (context, error, stackTrace) {
           _logger.severe(
-              'Image.file failed to load local image: ${_imageFile!.path} - error: $error',
-              error,
-              stackTrace);
+            'Image.file failed to load local image: ${_imageFile!.path} - error: $error',
+            error,
+            stackTrace,
+          );
           if (widget.errorBuilder != null) {
             return widget.errorBuilder!(context, error, stackTrace);
           }
           return const Center(
-              child: Icon(Icons.broken_image, color: Colors.grey));
+            child: Icon(Icons.broken_image, color: Colors.grey),
+          );
         },
         frameBuilder: _getFrameBuilder(),
         semanticLabel: widget.semanticLabel,

--- a/lib/ui/main_screen/widgets/input_sheet.dart
+++ b/lib/ui/main_screen/widgets/input_sheet.dart
@@ -21,6 +21,7 @@ import 'package:memex/data/services/speech_transcription_service.dart';
 import 'package:memex/data/services/input_draft_service.dart';
 import 'package:memex/config/app_flavor.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
 import 'package:memex/data/services/demo_service.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -1096,16 +1097,10 @@ class _InputSheetState extends State<InputSheet>
           children: [
             Center(
               child: InteractiveViewer(
-                child: _assetsMap.containsKey(_selectedImages[index].path)
-                    ? AssetEntityImage(
-                        _assetsMap[_selectedImages[index].path]!,
-                        isOriginal: true,
-                        fit: BoxFit.contain,
-                      )
-                    : Image.file(
-                        File(_selectedImages[index].path),
-                        fit: BoxFit.contain,
-                      ),
+                child: _buildSelectedImagePreview(
+                  index: index,
+                  fit: BoxFit.contain,
+                ),
               ),
             ),
             SafeArea(
@@ -1134,6 +1129,20 @@ class _InputSheetState extends State<InputSheet>
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildSelectedImagePreview({
+    required int index,
+    required BoxFit fit,
+    double? width,
+    double? height,
+  }) {
+    return LocalImage(
+      url: _selectedImages[index].path,
+      fit: fit,
+      width: width,
+      height: height,
     );
   }
 
@@ -1451,43 +1460,13 @@ class _InputSheetState extends State<InputSheet>
                                                               _showImagePreview(
                                                             index,
                                                           ),
-                                                          child: _assetsMap
-                                                                  .containsKey(
-                                                            _selectedImages[
-                                                                    index]
-                                                                .path,
-                                                          )
-                                                              ? AssetEntityImage(
-                                                                  _assetsMap[
-                                                                      _selectedImages[
-                                                                              index]
-                                                                          .path]!,
-                                                                  width: 100,
-                                                                  height: 100,
-                                                                  fit: BoxFit
-                                                                      .cover,
-                                                                  isOriginal:
-                                                                      false,
-                                                                  thumbnailSize:
-                                                                      const ThumbnailSize
-                                                                          .square(
-                                                                    200,
-                                                                  ),
-                                                                  thumbnailFormat:
-                                                                      ThumbnailFormat
-                                                                          .jpeg,
-                                                                )
-                                                              : Image.file(
-                                                                  File(
-                                                                    _selectedImages[
-                                                                            index]
-                                                                        .path,
-                                                                  ),
-                                                                  width: 100,
-                                                                  height: 100,
-                                                                  fit: BoxFit
-                                                                      .cover,
-                                                                ),
+                                                          child:
+                                                              _buildSelectedImagePreview(
+                                                            index: index,
+                                                            width: 100,
+                                                            height: 100,
+                                                            fit: BoxFit.cover,
+                                                          ),
                                                         ),
                                                       ),
                                                       Positioned(

--- a/lib/utils/image_utils.dart
+++ b/lib/utils/image_utils.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-import 'dart:ui' as ui;
+import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/utils/logger.dart';
 
 /// Image handling utilities
@@ -9,39 +8,28 @@ class ImageUtils {
   /// Get image dimensions (width, height, aspect ratio).
   /// Returns map: width, height (pixels, 0 on failure), aspectRatio (0.0 on failure).
   static Future<Map<String, dynamic>> getImageDimensions(
-      String imagePath) async {
+    String imagePath,
+  ) async {
     int width = 0;
     int height = 0;
     double aspectRatio = 0.0;
 
     try {
-      final file = File(imagePath);
-      if (!await file.exists()) {
+      final safety = await AssetSafetyService.instance.inspectFile(imagePath);
+      if (safety.type == AssetSafetyType.missing) {
         _logger.warning("Image file not found: $imagePath");
-        return {
-          'width': width,
-          'height': height,
-          'aspectRatio': aspectRatio,
-        };
+        return {'width': width, 'height': height, 'aspectRatio': aspectRatio};
       }
 
-      final bytes = await file.readAsBytes();
-      final codec = await ui.instantiateImageCodec(bytes);
-      final frame = await codec.getNextFrame();
-      width = frame.image.width;
-      height = frame.image.height;
-      aspectRatio = width / height;
-      frame.image.dispose();
-      codec.dispose();
+      width = safety.width ?? 0;
+      height = safety.height ?? 0;
+      aspectRatio = safety.width != null && safety.height != null
+          ? safety.width! / safety.height!
+          : 0.0;
     } catch (e) {
       _logger.warning('Failed to get image dimensions for $imagePath: $e');
     }
 
-    return {
-      'width': width,
-      'height': height,
-      'aspectRatio': aspectRatio,
-    };
+    return {'width': width, 'height': height, 'aspectRatio': aspectRatio};
   }
 }
-

--- a/test/data/services/asset_safety_service_test.dart
+++ b/test/data/services/asset_safety_service_test.dart
@@ -1,0 +1,470 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/submit_input.dart';
+import 'package:memex/data/services/asset_safety_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+import 'package:memex/data/services/media_service.dart';
+import 'package:memex/data/services/photo_suggestion_service.dart';
+import 'package:memex/data/services/speech_transcription_service.dart';
+import 'package:memex/data/services/task_handlers/analyze_assets_handler.dart';
+import 'package:memex/data/services/task_handlers/custom_agent_task_handler.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('memex_asset_safety_');
+  });
+
+  tearDown(() async {
+    await LocalAssetServer.stopServer();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test(
+    'reads safe image dimensions from headers without full decode',
+    () async {
+      final image = File('${tempDir.path}/safe.png');
+      await image.writeAsBytes(_pngHeader(width: 800, height: 600));
+
+      final report = await AssetSafetyService.instance.inspectFile(image.path);
+
+      expect(report.type, AssetSafetyType.image);
+      expect(report.width, 800);
+      expect(report.height, 600);
+      expect(report.safeForPreview, isTrue);
+      expect(report.safeForAnalysis, isTrue);
+      expect(report.safeForOcr, isTrue);
+    },
+  );
+
+  test('marks long image unsafe while preserving metadata', () async {
+    final image = File('${tempDir.path}/long.png');
+    await image.writeAsBytes(_pngHeader(width: 1000, height: 13000));
+
+    final report = await AssetSafetyService.instance.inspectFile(image.path);
+
+    expect(report.width, 1000);
+    expect(report.height, 13000);
+    expect(report.safeForPreview, isFalse);
+    expect(report.safeForAnalysis, isFalse);
+    expect(report.safeForOcr, isFalse);
+    expect(report.safeForInlineBase64, isFalse);
+    expect(report.reason, contains('long edge'));
+  });
+
+  test('marks oversized audio unsafe for cloud transcription', () async {
+    final audio = File('${tempDir.path}/audio_20260602_ts_1_no_1_301.m4a');
+    await audio.create();
+    await _resizeFile(audio, 21 * 1024 * 1024);
+
+    final report = await AssetSafetyService.instance.inspectFile(audio.path);
+
+    expect(report.type, AssetSafetyType.audio);
+    expect(report.durationSeconds, 301);
+    expect(report.safeForPreview, isTrue);
+    expect(report.safeForAnalysis, isFalse);
+    expect(report.safeForInlineBase64, isFalse);
+    expect(report.reason, contains('file size'));
+    expect(report.reason, contains('duration'));
+  });
+
+  test('keeps narrow safe image analyzable while skipping OCR only', () async {
+    final image = File('${tempDir.path}/receipt_strip.png');
+    await image.writeAsBytes(_pngHeader(width: 100, height: 1300));
+
+    final report = await AssetSafetyService.instance.inspectFile(image.path);
+
+    expect(report.safeForPreview, isTrue);
+    expect(report.safeForAnalysis, isTrue);
+    expect(report.safeForOcr, isFalse);
+    expect(report.safeForInlineBase64, isTrue);
+    expect(report.reason, contains('aspect ratio'));
+  });
+
+  test('blocks unknown large image from preview and analysis', () async {
+    final image = File('${tempDir.path}/unknown_heic.heic');
+    await image.create();
+    await _resizeFile(image, 9 * 1024 * 1024);
+
+    final report = await AssetSafetyService.instance.inspectFile(image.path);
+
+    expect(report.type, AssetSafetyType.image);
+    expect(report.width, isNull);
+    expect(report.height, isNull);
+    expect(report.safeForPreview, isFalse);
+    expect(report.safeForAnalysis, isFalse);
+    expect(report.safeForOcr, isFalse);
+    expect(report.safeForInlineBase64, isFalse);
+    expect(report.reason, contains('dimensions are unavailable'));
+  });
+
+  test('marks small audio safe for analysis and inline agent use', () async {
+    final audio = File('${tempDir.path}/audio_20260602_ts_1_no_1_60.m4a');
+    await audio.create();
+    await _resizeFile(audio, 4 * 1024 * 1024);
+
+    final report = await AssetSafetyService.instance.inspectFile(audio.path);
+
+    expect(report.type, AssetSafetyType.audio);
+    expect(report.durationSeconds, 60);
+    expect(report.safeForAnalysis, isTrue);
+    expect(report.safeForInlineBase64, isTrue);
+    expect(report.reason, 'asset is within safety limits');
+  });
+
+  test('blocks audio with unknown duration from automatic analysis', () async {
+    final audio = File('${tempDir.path}/shared_audio.m4a');
+    await audio.create();
+    await _resizeFile(audio, 4 * 1024 * 1024);
+
+    final report = await AssetSafetyService.instance.inspectFile(audio.path);
+
+    expect(report.type, AssetSafetyType.audio);
+    expect(report.durationSeconds, isNull);
+    expect(report.safeForAnalysis, isFalse);
+    expect(report.safeForInlineBase64, isFalse);
+    expect(report.reason, contains('duration is unavailable'));
+  });
+
+  test('cloud transcription skips unsafe audio before LLM lookup', () async {
+    SharedPreferences.setMockInitialValues({
+      'use_local_speech_to_text': false,
+    });
+    final audio = File('${tempDir.path}/audio_20260602_ts_1_no_1_301.m4a');
+    await audio.create();
+    await _resizeFile(audio, 21 * 1024 * 1024);
+
+    final result = await SpeechTranscriptionService.instance
+        .transcribeFileWithMetadata(audio.path);
+
+    expect(result.model, 'asset-safety');
+    expect(result.text, isNull);
+    expect(result.usage, isNull);
+  });
+
+  test('local transcription also skips unsafe audio before model lookup',
+      () async {
+    SharedPreferences.setMockInitialValues({
+      'use_local_speech_to_text': true,
+    });
+    final audio = File('${tempDir.path}/audio_20260602_ts_1_no_1_301.m4a');
+    await audio.create();
+    await _resizeFile(audio, 21 * 1024 * 1024);
+
+    final result = await SpeechTranscriptionService.instance
+        .transcribeFileWithMetadata(audio.path, skipLengthCheck: true);
+
+    expect(result.model, 'asset-safety');
+    expect(result.text, isNull);
+    expect(result.usage, isNull);
+  });
+
+  test(
+    'saveAssetFromFile keeps long image and records dimensions safely',
+    () async {
+      await FileSystemService.init(tempDir.path);
+      final source = File('${tempDir.path}/source_long.png');
+      await source.writeAsBytes(_pngHeader(width: 1000, height: 13000));
+
+      final (filename, relativePath) =
+          await FileSystemService.instance.saveAssetFromFile(
+        userId: 'asset-user',
+        sourcePath: source.path,
+        assetType: 'img',
+        index: 1,
+        factId: '2026/06/02.md#ts_1',
+      );
+
+      expect(filename, contains('1000x13000'));
+      final copied = File(
+        FileSystemService.instance.toAbsolutePath(relativePath),
+      );
+      expect(await copied.exists(), isTrue);
+      expect(await copied.readAsBytes(), await source.readAsBytes());
+    },
+  );
+
+  test(
+    'audio asset analysis writes skip file and preserves original asset',
+    () async {
+      await FileSystemService.init(tempDir.path);
+      final source = File('${tempDir.path}/source_audio.m4a');
+      await source.create();
+      await _resizeFile(source, 21 * 1024 * 1024);
+
+      final (filename, relativePath) =
+          await FileSystemService.instance.saveAssetFromFile(
+        userId: 'audio-analysis-user',
+        sourcePath: source.path,
+        assetType: 'audio',
+        index: 1,
+        factId: '2026/06/02.md#ts_1',
+        extraInfo: '301',
+      );
+
+      final copied = File(
+        FileSystemService.instance.toAbsolutePath(relativePath),
+      );
+      expect(await copied.exists(), isTrue);
+      expect(await copied.length(), await source.length());
+
+      final results = await analyzeAssetsForFact(
+        userId: 'audio-analysis-user',
+        factId: '2026/06/02.md#ts_1',
+        assetPaths: [relativePath],
+      );
+
+      expect(results, hasLength(1));
+      expect(results.single.analysis, contains('Automatic analysis skipped'));
+      expect(results.single.analysis, contains('audio duration 301s'));
+      expect(await copied.exists(), isTrue);
+      expect(
+        await File('${copied.path}.analysis.txt').readAsString(),
+        contains('original file was preserved'),
+      );
+      expect(filename, contains('_301.'));
+    },
+  );
+
+  test('MediaService imports image using safe header dimensions', () async {
+    await FileSystemService.init(tempDir.path);
+    final source = File('${tempDir.path}/media_long.png');
+    await source.writeAsBytes(_pngHeader(width: 1000, height: 13000));
+
+    final imported = await MediaService.instance.importImage(
+      userId: 'media-user',
+      sourcePath: source.path,
+    );
+
+    expect(imported.absolutePath, contains('1000x13000'));
+    expect(await File(imported.absolutePath).exists(), isTrue);
+    expect(
+      FileSystemService.instance.toAbsolutePath(imported.relativePath),
+      imported.absolutePath,
+    );
+  });
+
+  test(
+    'unsafe asset analysis writes skip file without requiring llm config',
+    () async {
+      await FileSystemService.init(tempDir.path);
+      final source = File('${tempDir.path}/source_long.png');
+      await source.writeAsBytes(_pngHeader(width: 1000, height: 13000));
+
+      final (filename, relativePath) =
+          await FileSystemService.instance.saveAssetFromFile(
+        userId: 'analysis-user',
+        sourcePath: source.path,
+        assetType: 'img',
+        index: 1,
+        factId: '2026/06/02.md#ts_1',
+      );
+
+      final results = await analyzeAssetsForFact(
+        userId: 'analysis-user',
+        factId: '2026/06/02.md#ts_1',
+        assetPaths: [relativePath],
+      );
+
+      expect(results, hasLength(1));
+      expect(results.single.analysis, contains('Automatic analysis skipped'));
+      expect(results.single.analysis, contains('original file was preserved'));
+
+      final assetsPath = FileSystemService.instance.getAssetsPath(
+        'analysis-user',
+      );
+      final analysisFile = File('$assetsPath/$filename.analysis.txt');
+      expect(await analysisFile.exists(), isTrue);
+      expect(await analysisFile.readAsString(), contains('long edge'));
+    },
+  );
+
+  test(
+    'submitInput preserves unsafe image and downstream analysis skips it',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        'user_id': 'submit-user',
+        'language': 'en',
+      });
+      await UserStorage.initL10n();
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      AppDatabase.setTestInstance(db);
+      addTearDown(db.close);
+
+      await FileSystemService.init(tempDir.path);
+      final source = File('${tempDir.path}/shared_long.png');
+      source.writeAsBytesSync(_pngHeader(width: 1000, height: 13000));
+
+      final submitted = await submitInput('submit-user', [
+        {'type': 'text', 'text': 'I want to save this long screenshot.'},
+        {
+          'type': 'image_url',
+          'image_url': {'filePath': source.path},
+        },
+      ]);
+      final factId = submitted['fact_id'] as String;
+
+      final factFile = File(
+        FileSystemService.instance.getDailyFactPath(
+          'submit-user',
+          DateTime.now(),
+        ),
+      );
+      final factContent = await factFile.readAsString();
+      final match = RegExp(
+        r'!\[image\]\(fs://([^)]+)\)',
+      ).firstMatch(factContent);
+      expect(match, isNotNull);
+
+      final filename = match!.group(1)!;
+      final assetPath =
+          '${FileSystemService.instance.getAssetsPath('submit-user')}/$filename';
+      expect(await File(assetPath).exists(), isTrue);
+
+      final results = await analyzeAssetsForFact(
+        userId: 'submit-user',
+        factId: factId,
+        assetPaths: [FileSystemService.instance.toRelativePath(assetPath)],
+      );
+
+      expect(results, hasLength(1));
+      expect(results.single.analysis, contains('Automatic analysis skipped'));
+      expect(
+        await File('$assetPath.analysis.txt').readAsString(),
+        contains('original file was preserved'),
+      );
+    },
+  );
+
+  test('custom agent skips unsafe inline audio parts', () async {
+    await FileSystemService.init(tempDir.path);
+    final assetsPath = FileSystemService.instance.getAssetsPath('agent-user');
+    await Directory(assetsPath).create(recursive: true);
+    const filename = 'audio_20260602_ts_1_no_1_30.m4a';
+    final audio = File('$assetsPath/$filename');
+    await audio.create();
+    await _resizeFile(audio, 9 * 1024 * 1024);
+
+    final parts = await buildAssetPartsFromXmlForTesting(
+      'agent-user',
+      '<event>[audio](fs://$filename)</event>',
+    );
+
+    expect(parts.whereType<AudioPart>(), isEmpty);
+  });
+
+  test('custom agent skips unsafe inline image parts', () async {
+    await FileSystemService.init(tempDir.path);
+    final assetsPath = FileSystemService.instance.getAssetsPath('agent-user');
+    await Directory(assetsPath).create(recursive: true);
+    const filename = 'unsafe_inline.png';
+    await File('$assetsPath/$filename').writeAsBytes(
+      _pngHeader(width: 1000, height: 13000),
+    );
+
+    final parts = await buildAssetPartsFromXmlForTesting(
+      'agent-user',
+      '<event>![image](fs://$filename)</event>',
+    );
+
+    expect(parts.whereType<ImagePart>(), isEmpty);
+    expect(parts.whereType<AudioPart>(), isEmpty);
+  });
+
+  test('custom agent keeps safe inline image parts available', () async {
+    await FileSystemService.init(tempDir.path);
+    final assetsPath = FileSystemService.instance.getAssetsPath('agent-user');
+    await Directory(assetsPath).create(recursive: true);
+    const filename = 'safe_inline.png';
+    await File('$assetsPath/$filename').writeAsBytes(
+      _pngHeader(width: 320, height: 240),
+    );
+
+    final parts = await buildAssetPartsFromXmlForTesting(
+      'agent-user',
+      '<event>![image](fs://$filename)</event>',
+    );
+
+    expect(parts.whereType<ImagePart>(), hasLength(1));
+    expect(parts.whereType<AudioPart>(), isEmpty);
+  });
+
+  test('photo suggestion skips unsafe image before MLKit processing', () async {
+    final image = File('${tempDir.path}/unsafe_photo_suggestion.png');
+    image.writeAsBytesSync(_pngHeader(width: 1000, height: 13000));
+
+    final result = await PhotoSuggestionService.processImageOCRForTesting(
+      XFile(image.path),
+    );
+
+    expect(result.ocrBlocks, isEmpty);
+    expect(result.labels, isEmpty);
+    expect(result.modifiedTime, (await image.stat()).modified);
+  });
+}
+
+List<int> _pngHeader({required int width, required int height}) {
+  final bytes = Uint8List(33);
+  bytes.setAll(0, const [
+    0x89,
+    0x50,
+    0x4e,
+    0x47,
+    0x0d,
+    0x0a,
+    0x1a,
+    0x0a,
+    0x00,
+    0x00,
+    0x00,
+    0x0d,
+    0x49,
+    0x48,
+    0x44,
+    0x52,
+  ]);
+  _writeUint32Be(bytes, 16, width);
+  _writeUint32Be(bytes, 20, height);
+  bytes.setAll(24, const [
+    0x08,
+    0x02,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+  ]);
+  return bytes;
+}
+
+void _writeUint32Be(Uint8List bytes, int offset, int value) {
+  bytes[offset] = (value >> 24) & 0xff;
+  bytes[offset + 1] = (value >> 16) & 0xff;
+  bytes[offset + 2] = (value >> 8) & 0xff;
+  bytes[offset + 3] = value & 0xff;
+}
+
+Future<void> _resizeFile(File file, int length) async {
+  final raf = await file.open(mode: FileMode.write);
+  try {
+    await raf.truncate(length);
+  } finally {
+    await raf.close();
+  }
+}

--- a/test/ui/core/widgets/local_image_safety_test.dart
+++ b/test/ui/core/widgets/local_image_safety_test.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('memex_local_image_');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  testWidgets(
+    'shows a safe placeholder instead of rendering unsafe long image',
+    (tester) async {
+      final image = File('${tempDir.path}/long.png');
+      image.writeAsBytesSync(_pngHeader(width: 1000, height: 13000));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 160,
+            height: 120,
+            child: LocalImage(url: image.path, fit: BoxFit.cover),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+      expect(find.byType(Image), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'shows a safe placeholder for unsafe downloaded network images',
+    (tester) async {
+      late HttpServer server;
+      await tester.runAsync<void>(() async {
+        server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        server.listen((request) {
+          request.response.headers.contentType = ContentType(
+            'image',
+            'png',
+          );
+          request.response.add(_pngHeader(width: 1000, height: 13000));
+          request.response.close();
+        });
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 160,
+            height: 120,
+            child: LocalImage(
+              url: 'http://${server.address.host}:${server.port}/long.png',
+              fit: BoxFit.cover,
+            ),
+          ),
+        ),
+      );
+
+      await tester.runAsync<void>(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      });
+      await tester.pump();
+      await tester.runAsync<void>(() async {
+        await server.close(force: true);
+      });
+
+      expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+      expect(find.byType(Image), findsNothing);
+    },
+  );
+
+  test('provider returns memory placeholder for unsafe local images', () {
+    final image = File('${tempDir.path}/long.png');
+    image.writeAsBytesSync(_pngHeader(width: 1000, height: 13000));
+
+    final provider = LocalImage.provider(image.path);
+
+    expect(provider, isA<MemoryImage>());
+  });
+
+  test('provider keeps safe local images as file-backed providers', () {
+    final image = File('${tempDir.path}/safe.png');
+    image.writeAsBytesSync(_pngHeader(width: 320, height: 240));
+
+    final provider = LocalImage.provider(image.path);
+
+    expect(provider, isA<FileImage>());
+  });
+}
+
+List<int> _pngHeader({required int width, required int height}) {
+  final bytes = Uint8List(33);
+  bytes.setAll(0, const [
+    0x89,
+    0x50,
+    0x4e,
+    0x47,
+    0x0d,
+    0x0a,
+    0x1a,
+    0x0a,
+    0x00,
+    0x00,
+    0x00,
+    0x0d,
+    0x49,
+    0x48,
+    0x44,
+    0x52,
+  ]);
+  _writeUint32Be(bytes, 16, width);
+  _writeUint32Be(bytes, 20, height);
+  bytes.setAll(24, const [
+    0x08,
+    0x02,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+  ]);
+  return bytes;
+}
+
+void _writeUint32Be(Uint8List bytes, int offset, int value) {
+  bytes[offset] = (value >> 24) & 0xff;
+  bytes[offset + 1] = (value >> 16) & 0xff;
+  bytes[offset + 2] = (value >> 8) & 0xff;
+  bytes[offset + 3] = value & 0xff;
+}

--- a/test/ui/main_screen/widgets/input_sheet_test.dart
+++ b/test/ui/main_screen/widgets/input_sheet_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/input_draft_service.dart';
 import 'package:memex/data/services/local_asset_server.dart';
@@ -21,9 +22,8 @@ void main() {
     const recordChannel = MethodChannel('com.llfbandit.record/messages');
     const audioGlobalChannel = MethodChannel('xyz.luan/audioplayers.global');
     const audioPlayerChannel = MethodChannel('xyz.luan/audioplayers');
-    final messenger = TestDefaultBinaryMessengerBinding
-        .instance
-        .defaultBinaryMessenger;
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
     messenger.setMockMethodCallHandler(recordChannel, (call) async {
       switch (call.method) {
         case 'hasPermission':
@@ -76,7 +76,7 @@ void main() {
     }
   });
 
-  Widget buildHost() {
+  Widget buildHost({InputData? initialData}) {
     var isOpen = true;
     var closeCount = 0;
 
@@ -91,7 +91,7 @@ void main() {
                 const Center(child: Text('Home content')),
                 InputSheet(
                   isOpen: isOpen,
-                  initialData: InputData(text: 'started note'),
+                  initialData: initialData ?? InputData(text: 'started note'),
                   onClose: () {
                     setState(() {
                       isOpen = false;
@@ -128,6 +128,28 @@ void main() {
     expect(find.text('Home content'), findsOneWidget);
     expect(find.byType(TextField), findsNothing);
     expect(find.text('close count: 1'), findsOneWidget);
+  });
+
+  testWidgets('unsafe selected image uses safety placeholder in preview strip',
+      (
+    tester,
+  ) async {
+    final image = File('${testDataRoot.path}/unsafe_selected.png');
+    image.writeAsBytesSync(_pngHeader(width: 1000, height: 13000));
+
+    await tester.pumpWidget(
+      buildHost(
+        initialData: InputData(
+          text: 'long screenshot',
+          images: [XFile(image.path)],
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
   });
 
   testWidgets(
@@ -267,4 +289,47 @@ Future<void> saveActiveDraft(WidgetTester tester, String text) {
   return tester.runAsync<void>(() {
     return InputDraftService.instance.saveTextDraft(text);
   });
+}
+
+List<int> _pngHeader({required int width, required int height}) {
+  final bytes = Uint8List(33);
+  bytes.setAll(0, const [
+    0x89,
+    0x50,
+    0x4e,
+    0x47,
+    0x0d,
+    0x0a,
+    0x1a,
+    0x0a,
+    0x00,
+    0x00,
+    0x00,
+    0x0d,
+    0x49,
+    0x48,
+    0x44,
+    0x52,
+  ]);
+  _writeUint32Be(bytes, 16, width);
+  _writeUint32Be(bytes, 20, height);
+  bytes.setAll(24, const [
+    0x08,
+    0x02,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+  ]);
+  return bytes;
+}
+
+void _writeUint32Be(Uint8List bytes, int offset, int value) {
+  bytes[offset] = (value >> 24) & 0xff;
+  bytes[offset + 1] = (value >> 16) & 0xff;
+  bytes[offset + 2] = (value >> 8) & 0xff;
+  bytes[offset + 3] = value & 0xff;
 }


### PR DESCRIPTION
## 背景

关联 #66、#68，关闭 #225。

这次修复的核心目标是：不重写输入/任务/Agent 主链路，在资产进入预览、OCR、转写、LLM 分析和自定义 Agent inline 前加统一的防御性判定；不安全时保留原文件，并给用户一个可继续使用的降级体验。

## 改动

- 新增 `AssetSafetyService`，集中判断图片 header 维度、像素/长边/比例、文件大小、音频大小/时长和 inline base64 安全性。
- 文件保存、MediaService、ImageUtils 改为读取安全元数据，不再为了拿尺寸全量 decode 长图。
- 资产分析链路对 unsafe 图片/音频写入 `.analysis.txt` skip 说明，原始资产继续保留。
- OCR、相册建议、cloud/local speech transcription、自定义 Agent inline 都增加模型/原生调用前的安全 gate。
- `LocalImage` 统一本地/网络预览防线，unsafe 图片显示稳定占位，不继续下载后压缩或渲染。
- iOS 增加只由 `MEMEX_IOS_SIMULATOR_MLKIT_STUBS=1` 启用的 MLKit simulator stub，用于 Apple Silicon/iOS 26 simulator 无 arm64 slice 时完成真实启动验证；生产 Pod 解析保持原 MLKit 依赖。
- 补充 unit/widget tests 覆盖长图、未知大图、长音频、未知时长音频、safe inline、unsafe inline、submitInput 全链路、LocalImage 本地/网络预览和 InputSheet 预览条。

## 验证

- `flutter analyze --no-pub <changed files>`：No issues found。
- `env -u ws_proxy -u wss_proxy -u http_proxy -u https_proxy no_proxy=localhost,127.0.0.1,::1 NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub --concurrency=1`：436 passed，4 skipped。
- `flutter build apk --debug --flavor globalDev --no-pub`：通过。
- Android 模拟器 `Medium_Phone_API_35`：安装 `app-globaldev-debug.apk`，启动 `com.memexlab.memex.dev`，截图 `/tmp/memex-asset-safety-android-postfix.png`，logcat 未发现 Memex app fatal/crash。
- `flutter build ios --simulator --flavor cn --no-pub`：通过，bundle ID `com.memexlab.memex.cn`。
- iOS 直接安装默认 MLKit simulator 产物失败，原因是 MLKit 相关 pod 缺少 iOS 26 arm64 simulator slice；随后用 `MEMEX_IOS_SIMULATOR_MLKIT_STUBS=1` 走 simulator-only stub 构建，安装并启动 `com.memexlab.memex.cn` 成功，截图 `/var/folders/y0/xpyf8lh91_b3djfpxz94znc00000gn/T/screenshot_optimized_c78f776e-f5db-4063-a671-2a542e32f142.jpg`，日志未见实际 crash/abort。
- `git diff --check`：通过。

## 方案 review

整体保持了现有链路：提交、文件保存、任务执行、Agent 调用和 UI 渲染仍由原模块负责；新增安全服务只提供判定和解释文本，调用点只做薄 guard。用户体验上，不安全资产不会丢失，预览有占位，分析有可读 skip 文件，安全资产仍按原路径继续处理。
