### PR TITLE
Fix iOS background Agent processing

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -50,6 +50,9 @@ PODS:
     - Flutter
   - flutter_native_splash (2.4.3):
     - Flutter
+  - geolocator_apple (1.2.0):
+    - Flutter
+    - FlutterMacOS
   - google_mlkit_commons (0.11.1):
     - Flutter
     - MLKitVision (~> 10.0.0)
@@ -253,6 +256,7 @@ DEPENDENCIES:
   - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
   - flutter_js (from `.symlinks/plugins/flutter_js/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_mlkit_commons (from `.symlinks/plugins/google_mlkit_commons/ios`)
   - google_mlkit_image_labeling (from `.symlinks/plugins/google_mlkit_image_labeling/ios`)
   - google_mlkit_text_recognition (from `.symlinks/plugins/google_mlkit_text_recognition/ios`)
@@ -325,6 +329,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_js/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
+  geolocator_apple:
+    :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_mlkit_commons:
     :path: ".symlinks/plugins/google_mlkit_commons/ios"
   google_mlkit_image_labeling:
@@ -385,6 +391,7 @@ SPEC CHECKSUMS:
   flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
   flutter_js: 867813c1830e1d9b2c5d547cdb6f61801e2f2145
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   google_mlkit_commons: a5e4ffae5bc59ea4c7b9025dc72cb6cb79dc1166
   google_mlkit_image_labeling: 6f6fdb11c14600e01898e59a8c4413b255ede272
   google_mlkit_text_recognition: b3de5adb786ad7a0fe8e13618387b8d2df0f3c70

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AA0001051000000100000003 /* StorageChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001061000000100000003 /* StorageChannelHandler.swift */; };
 		AA0001071000000100000004 /* SystemActionsChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001081000000100000004 /* SystemActionsChannelHandler.swift */; };
 		AA0001091000000100000005 /* AudioConverterChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00010A1000000100000005 /* AudioConverterChannelHandler.swift */; };
+		AA00010B1000000100000006 /* AgentBackgroundTaskChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00010C1000000100000006 /* AgentBackgroundTaskChannelHandler.swift */; };
 		94D8E68DFAF0E975A7B3AAC9 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD25ADB84447B9A4366F6055 /* Pods_RunnerTests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -91,6 +92,7 @@
 		AA0001061000000100000003 /* StorageChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageChannelHandler.swift; sourceTree = "<group>"; };
 		AA0001081000000100000004 /* SystemActionsChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemActionsChannelHandler.swift; sourceTree = "<group>"; };
 		AA00010A1000000100000005 /* AudioConverterChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioConverterChannelHandler.swift; sourceTree = "<group>"; };
+		AA00010C1000000100000006 /* AgentBackgroundTaskChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBackgroundTaskChannelHandler.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		83F22F54729A29819701B85D /* Pods-ShareExtension.debug-cn.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShareExtension.debug-cn.xcconfig"; path = "Target Support Files/Pods-ShareExtension/Pods-ShareExtension.debug-cn.xcconfig"; sourceTree = "<group>"; };
 		8968E2D1ACE76EDC468CD1F2 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				AA0001061000000100000003 /* StorageChannelHandler.swift */,
 				AA0001081000000100000004 /* SystemActionsChannelHandler.swift */,
 				AA00010A1000000100000005 /* AudioConverterChannelHandler.swift */,
+				AA00010C1000000100000006 /* AgentBackgroundTaskChannelHandler.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -585,6 +588,7 @@
 				AA0001051000000100000003 /* StorageChannelHandler.swift in Sources */,
 				AA0001071000000100000004 /* SystemActionsChannelHandler.swift in Sources */,
 				AA0001091000000100000005 /* AudioConverterChannelHandler.swift in Sources */,
+				AA00010B1000000100000006 /* AgentBackgroundTaskChannelHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/AgentBackgroundTaskChannelHandler.swift
+++ b/ios/Runner/AgentBackgroundTaskChannelHandler.swift
@@ -1,0 +1,360 @@
+import BackgroundTasks
+import Flutter
+import UIKit
+
+/// Bridges Memex's local agent queue to iOS background execution primitives.
+///
+/// The stable path uses BGProcessingTask and UIApplication background task
+/// assertions. On iOS 26+, Continuous Background Tasks provide user-visible
+/// progress for foreground-started agent work.
+class AgentBackgroundTaskChannelHandler: NSObject {
+    private static var sharedInstance: AgentBackgroundTaskChannelHandler?
+
+    private let channel: FlutterMethodChannel
+    private let processingIdentifier: String
+    private let continuedIdentifierPattern: String
+    private let continuedIdentifierPrefix: String
+
+    private var dartReady = false
+    private var pendingNativeRunPayload: [String: Any]?
+    private var foregroundBackgroundTaskId = UIBackgroundTaskIdentifier.invalid
+    private var activeSnapshot: [String: Any] = [:]
+    private var bgProcessingTask: BGProcessingTask?
+    private var progressPulseTimer: Timer?
+    private var syntheticProgress: Int64 = 1
+    private var submittedContinuedIdentifier: String?
+    private var processingTaskRegistered = false
+    private var continuedProcessingRegistered = false
+    private var registeredContinuedIdentifiers = Set<String>()
+
+    @available(iOS 26.0, *)
+    private var continuedProcessingTask: BGContinuedProcessingTask? {
+        get { continuedProcessingTaskBox as? BGContinuedProcessingTask }
+        set { continuedProcessingTaskBox = newValue }
+    }
+    private var continuedProcessingTaskBox: Any?
+
+    static func register(with messenger: FlutterBinaryMessenger) {
+        let bundleId = Bundle.main.bundleIdentifier ?? "com.memexlab.memex"
+        let instance = AgentBackgroundTaskChannelHandler(
+            messenger: messenger,
+            bundleId: bundleId
+        )
+        sharedInstance = instance
+        instance.registerSchedulerHandlers()
+        instance.channel.setMethodCallHandler(instance.handle)
+    }
+
+    private init(messenger: FlutterBinaryMessenger, bundleId: String) {
+        channel = FlutterMethodChannel(
+            name: "com.memexlab.memex/agent_background_tasks",
+            binaryMessenger: messenger
+        )
+        processingIdentifier = "\(bundleId).agent.processing"
+        continuedIdentifierPattern = "\(bundleId).agent.continued.*"
+        continuedIdentifierPrefix = "\(bundleId).agent.continued"
+        super.init()
+    }
+
+    private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "initialize":
+            dartReady = true
+            flushPendingNativeRunIfNeeded()
+            result(capabilities())
+        case "setTaskActivity":
+            guard let args = call.arguments as? [String: Any] else {
+                result(FlutterError(
+                    code: "INVALID_ARGUMENTS",
+                    message: "Expected task activity snapshot",
+                    details: nil
+                ))
+                return
+            }
+            updateTaskActivity(args)
+            result(true)
+        case "completeBackgroundRun":
+            let args = call.arguments as? [String: Any]
+            let success = args?["success"] as? Bool ?? true
+            completeBackgroundRuns(success: success)
+            result(true)
+        case "cancelBackgroundRun":
+            cancelScheduledProcessing()
+            completeBackgroundRuns(success: false)
+            endForegroundBackgroundTask()
+            result(true)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func capabilities() -> [String: Any] {
+        var result: [String: Any] = [
+            "processingIdentifier": processingIdentifier,
+            "continuedIdentifierPattern": continuedIdentifierPattern,
+            "bgProcessingAvailable": processingTaskRegistered,
+            "continuedProcessingRuntimeAvailable": NSClassFromString("BGContinuedProcessingTaskRequest") != nil,
+            "continuedProcessingEnabled": continuedProcessingRegistered,
+        ]
+
+        result["continuedProcessingCompileSupport"] = true
+        result["continuedProcessingDynamicFallback"] = false
+
+        return result
+    }
+
+    private func registerSchedulerHandlers() {
+        let processingRegistered = BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: processingIdentifier,
+            using: DispatchQueue.main
+        ) { [weak self] task in
+            guard let self = self, let task = task as? BGProcessingTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            self.handleProcessingTask(task)
+        }
+
+        if !processingRegistered {
+            NSLog("Memex: failed to register BGProcessingTask handler for %@", processingIdentifier)
+        }
+        processingTaskRegistered = processingRegistered
+
+        registerContinuedProcessingHandlerIfSupported()
+    }
+
+    private func handleProcessingTask(_ task: BGProcessingTask) {
+        bgProcessingTask = task
+        beginForegroundBackgroundTaskIfNeeded(reason: "bg_processing_launch")
+
+        task.expirationHandler = { [weak self] in
+            self?.handleExpiration(reason: "bg_processing_expired")
+        }
+
+        invokeRunPendingTasks(reason: "bg_processing_launch")
+    }
+
+    private func updateTaskActivity(_ snapshot: [String: Any]) {
+        activeSnapshot = snapshot
+        let hasActiveTasks = snapshot["hasActiveTasks"] as? Bool ?? false
+
+        if hasActiveTasks {
+            beginForegroundBackgroundTaskIfNeeded(reason: snapshot["reason"] as? String ?? "active_tasks")
+            scheduleProcessingTask()
+            submitContinuedProcessingIfSupported(snapshot: snapshot)
+            updateContinuedProgress(snapshot: snapshot, completed: nil)
+        } else {
+            updateContinuedProgress(snapshot: snapshot, completed: 100)
+            cancelScheduledProcessing()
+            completeBackgroundRuns(success: true)
+            endForegroundBackgroundTask()
+        }
+    }
+
+    private func beginForegroundBackgroundTaskIfNeeded(reason: String) {
+        guard foregroundBackgroundTaskId == .invalid else { return }
+
+        foregroundBackgroundTaskId = UIApplication.shared.beginBackgroundTask(
+            withName: "Memex Agent Tasks"
+        ) { [weak self] in
+            self?.handleExpiration(reason: "ui_background_task_expired")
+        }
+
+        if foregroundBackgroundTaskId == .invalid {
+            NSLog("Memex: failed to begin UIApplication background task (%@)", reason)
+        }
+    }
+
+    private func endForegroundBackgroundTask() {
+        guard foregroundBackgroundTaskId != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(foregroundBackgroundTaskId)
+        foregroundBackgroundTaskId = .invalid
+    }
+
+    private func scheduleProcessingTask() {
+        guard processingTaskRegistered else { return }
+
+        let request = BGProcessingTaskRequest(identifier: processingIdentifier)
+        request.requiresExternalPower = false
+        request.requiresNetworkConnectivity = false
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 60)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            // Duplicate pending requests are expected while the queue stays active.
+            NSLog("Memex: BGProcessingTask submit failed: %@", String(describing: error))
+        }
+    }
+
+    private func cancelScheduledProcessing() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: processingIdentifier)
+    }
+
+    private func invokeRunPendingTasks(reason: String) {
+        let payload: [String: Any] = [
+            "reason": reason,
+            "processingIdentifier": processingIdentifier,
+            "continuedIdentifierPattern": continuedIdentifierPattern,
+        ]
+
+        DispatchQueue.main.async {
+            if self.dartReady {
+                self.channel.invokeMethod("runPendingAgentTasks", arguments: payload)
+            } else {
+                self.pendingNativeRunPayload = payload
+            }
+        }
+    }
+
+    private func flushPendingNativeRunIfNeeded() {
+        guard let payload = pendingNativeRunPayload else { return }
+        pendingNativeRunPayload = nil
+        channel.invokeMethod("runPendingAgentTasks", arguments: payload)
+    }
+
+    private func handleExpiration(reason: String) {
+        let expire = {
+            self.channel.invokeMethod("backgroundTaskExpired", arguments: ["reason": reason])
+
+            self.scheduleProcessingTask()
+            self.completeBackgroundRuns(success: false)
+            self.endForegroundBackgroundTask()
+        }
+
+        if Thread.isMainThread {
+            expire()
+        } else {
+            DispatchQueue.main.async(execute: expire)
+        }
+    }
+
+    private func completeBackgroundRuns(success: Bool) {
+        bgProcessingTask?.setTaskCompleted(success: success)
+        bgProcessingTask = nil
+
+        completeContinuedProcessingIfSupported(success: success)
+        stopProgressPulse()
+    }
+
+    private func startProgressPulse() {
+        guard progressPulseTimer == nil else { return }
+        syntheticProgress = max(1, syntheticProgress)
+        progressPulseTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            self.syntheticProgress = min(95, self.syntheticProgress + 1)
+            self.updateContinuedProgress(snapshot: self.activeSnapshot, completed: self.syntheticProgress)
+        }
+    }
+
+    private func stopProgressPulse() {
+        progressPulseTimer?.invalidate()
+        progressPulseTimer = nil
+        syntheticProgress = 1
+    }
+
+    private func registerContinuedProcessingHandlerIfSupported() {
+        if #available(iOS 26.0, *) {
+            continuedProcessingRegistered = true
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func handleContinuedProcessingTask(_ task: BGContinuedProcessingTask) {
+        continuedProcessingTask = task
+        task.progress.totalUnitCount = 100
+        task.progress.completedUnitCount = max(1, syntheticProgress)
+
+        task.expirationHandler = { [weak self] in
+            self?.handleExpiration(reason: "continued_processing_expired")
+        }
+
+        startProgressPulse()
+        invokeRunPendingTasks(reason: "continued_processing_launch")
+    }
+
+    private func submitContinuedProcessingIfSupported(snapshot: [String: Any]) {
+        guard submittedContinuedIdentifier == nil else { return }
+        guard continuedProcessingRegistered else { return }
+        guard UIApplication.shared.applicationState == .active else { return }
+
+        if #available(iOS 26.0, *) {
+            let identifier = "\(continuedIdentifierPrefix).\(UUID().uuidString)"
+            guard registerContinuedProcessingHandler(identifier: identifier) else {
+                return
+            }
+            let request = BGContinuedProcessingTaskRequest(
+                identifier: identifier,
+                title: "Memex Agent",
+                subtitle: subtitle(for: snapshot)
+            )
+            request.strategy = .queue
+
+            do {
+                try BGTaskScheduler.shared.submit(request)
+                submittedContinuedIdentifier = identifier
+                startProgressPulse()
+            } catch {
+                NSLog("Memex: BGContinuedProcessingTask submit failed: %@", String(describing: error))
+            }
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func registerContinuedProcessingHandler(identifier: String) -> Bool {
+        if registeredContinuedIdentifiers.contains(identifier) {
+            return true
+        }
+
+        let registered = BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: identifier,
+            using: DispatchQueue.main
+        ) { [weak self] task in
+            guard let self = self, let task = task as? BGContinuedProcessingTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            self.handleContinuedProcessingTask(task)
+        }
+
+        if registered {
+            registeredContinuedIdentifiers.insert(identifier)
+        } else {
+            NSLog("Memex: failed to register BGContinuedProcessingTask handler for %@", identifier)
+        }
+
+        return registered
+    }
+
+    private func updateContinuedProgress(snapshot: [String: Any], completed: Int64?) {
+        if #available(iOS 26.0, *) {
+            guard let task = continuedProcessingTask else { return }
+            task.progress.totalUnitCount = 100
+            if let completed = completed {
+                task.progress.completedUnitCount = min(100, max(task.progress.completedUnitCount, completed))
+            } else {
+                task.progress.completedUnitCount = min(95, max(task.progress.completedUnitCount, syntheticProgress))
+            }
+            task.updateTitle(task.title, subtitle: subtitle(for: snapshot))
+        }
+    }
+
+    private func completeContinuedProcessingIfSupported(success: Bool) {
+        if #available(iOS 26.0, *) {
+            if success {
+                continuedProcessingTask?.progress.completedUnitCount = 100
+            }
+            continuedProcessingTask?.setTaskCompleted(success: success)
+            continuedProcessingTask = nil
+            submittedContinuedIdentifier = nil
+        }
+    }
+
+    private func subtitle(for snapshot: [String: Any]) -> String {
+        let total = snapshot["total"] as? Int ?? 0
+        if total <= 0 {
+            return "Finishing current work"
+        }
+        return "Processing \(total) queued task\(total == 1 ? "" : "s")"
+    }
+}

--- a/ios/Runner/ChannelRegistrar.swift
+++ b/ios/Runner/ChannelRegistrar.swift
@@ -15,5 +15,6 @@ class ChannelRegistrar {
         StorageChannelHandler.register(with: messenger)
         SystemActionsChannelHandler.register(with: messenger)
         AudioConverterChannelHandler.register(with: messenger)
+        AgentBackgroundTaskChannelHandler.register(with: messenger)
     }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -107,6 +107,8 @@
 		<key>BGTaskSchedulerPermittedIdentifiers</key>
 		<array>
 			<string>workmanager.background.task</string>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER).agent.processing</string>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER).agent.continued.*</string>
 		</array>
 		<key>UIApplicationShortcutItems</key>
 		<array>

--- a/lib/agent/agent_controller.util.dart
+++ b/lib/agent/agent_controller.util.dart
@@ -2,7 +2,7 @@ import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/data/services/agent_activity_service.dart';
 import 'package:memex/data/services/llm_call_record_service.dart';
 import 'package:memex/utils/logger.dart';
-import 'package:wakelock_plus/wakelock_plus.dart';
+import 'package:memex/utils/wakelock_manager.dart';
 
 final _logger = getLogger('AgentControllerUtil');
 
@@ -253,11 +253,7 @@ void addAgentActivityCollector(AgentController controller) {
         agentName: info.name,
         agentId: info.id,
       );
-      try {
-        await WakelockPlus.enable();
-      } catch (_) {
-        // Ignore in non-UI / test runtimes where plugin channel is unavailable.
-      }
+      await WakelockManager.acquire('agent:${info.id}');
     },
   );
 
@@ -291,11 +287,7 @@ void addAgentActivityCollector(AgentController controller) {
         agentName: info.name,
         agentId: info.id,
       );
-      try {
-        await WakelockPlus.disable();
-      } catch (_) {
-        // Ignore in non-UI / test runtimes where plugin channel is unavailable.
-      }
+      await WakelockManager.release('agent:${info.id}');
     },
   );
 }

--- a/lib/agent/agent_utils.dart
+++ b/lib/agent/agent_utils.dart
@@ -27,6 +27,20 @@ String formatAssetAnalysis(List<Map<String, dynamic>>? assetAnalyses,
       // Add EXIF data (especially GPS coordinates) for card agent to use
       final exifData = analysis['exif_data'] as Map<String, dynamic>?;
       if (exifData != null) {
+        final captureTime = exifData['datetime_original'] as String?;
+        if (captureTime != null && captureTime.trim().isNotEmpty) {
+          assetInfo += 'Photo Capture Time: $captureTime\n';
+        }
+        final address = exifData['address'] as String?;
+        if (address != null && address.trim().isNotEmpty) {
+          assetInfo += 'Photo Capture Location: $address\n';
+        }
+        final userMarkedLocation = exifData['user_marked_location'] as String?;
+        if (userMarkedLocation != null &&
+            userMarkedLocation.trim().isNotEmpty) {
+          assetInfo +=
+              'Nearby User-Marked Location: $userMarkedLocation (within 50 meters)\n';
+        }
         final gpsCoords = exifData['gps_coordinates'] as List<dynamic>?;
         if (gpsCoords != null && gpsCoords.length >= 2) {
           final lat = (gpsCoords[0] as num).toDouble();

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -53,9 +53,22 @@ Example: An image of a receipt should use the `transaction` template, not a gene
 # Title Guidelines
 - **Concise:** Summarize the core content (e.g., "Morning Run 5km", not "I went for a run this morning").
 - **Clean:** Remove redundant modifiers.
+- **Specific and useful:** Prefer concrete entities from the raw input or asset
+  analysis: place names, venues, people, objects, actions, projects, purchases,
+  or outcomes. Avoid generic mood-only titles such as "Weekend Family Time",
+  "Sunday Leisure", or "Daily Snapshot" when a concrete clue is available.
+- **Photo/video location clues:** If asset analysis contains a reliable venue,
+  OCR place text, Nearby User-Marked Location, Photo Capture Location, or GPS
+  reverse-geocoded place, use the most meaningful concrete place in the title
+  when it helps distinguish the memory. Prefer "CETC Family Walk" over
+  "Sunday Family Leisure" when the venue clue is present.
 - **Examples:**
   - ✅ "Keychron K3 Pro Purchase Record"
+  - ✅ "CETC Family Walk"
+  - ✅ "电科东信周末散步"
   - ❌ "Bought a keyboard" (Vague)
+  - ❌ "Weekend Family Time" (Generic)
+  - ❌ "周日家庭休闲时光" (Generic)
   - ❌ "Keychron K3 Pro Mechanical Keyboard... Purchase Record" (Too long)
 
 # Workflow

--- a/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
@@ -95,7 +95,7 @@ class TimelineCardSkill extends Skill {
             'title': {
               'type': 'string',
               'description':
-                  'A concise summary displayed on detail page header.'
+                  'A concise but specific summary displayed on detail page header. Prefer concrete entities from the raw input or asset analysis: venues, named places, people, objects, actions, projects, purchases, or outcomes. For photo/video cards, if asset analysis contains OCR place text, Photo Capture Location, Nearby User-Marked Location, GPS reverse-geocoded place, or another reliable venue clue, use the most meaningful place when it helps distinguish the memory. Avoid generic mood-only titles such as "Weekend Family Time", "Sunday Family Leisure", or "Daily Snapshot" when concrete clues are available.'
             },
             'ui_configs': {
               'type': 'array',
@@ -120,7 +120,7 @@ class TimelineCardSkill extends Skill {
             'address': {
               'type': 'string',
               'description':
-                  'Location information for where the recorded card actually happened. Use raw input named places only when they are the actual occurrence, check-in, visit, photo capture, or activity location. For tasks, todos, reminders, plans, wishes, future destinations, or places the user merely wants to go to, omit address even if a place is mentioned. If raw input describes an immediate present-time event, check-in, photo capture, or daily activity and current_location_context is available, use its location_summary or full_address_candidate as a conservative default. Do not use current_location_context for memories, plans, remote events, or when raw input names a conflicting place. Do not be too specific. Use the format "City · Specific Location" (e.g., Beijing · Chaoyang Park) if possible, otherwise just the specific location name is fine.'
+                  'Location information for where the recorded card actually happened. Use raw input named places only when they are the actual occurrence, check-in, visit, photo capture, or activity location. For photo or video cards, if asset analysis includes Photo Capture Location, Nearby User-Marked Location, GPS Coordinates, OCR place text, or another concrete capture-place clue, prefer that media capture location for both address and location-bearing titles. Do not replace a media capture location with current_location_context. For tasks, todos, reminders, plans, wishes, future destinations, or places the user merely wants to go to, omit address even if a place is mentioned. If raw input describes an immediate present-time event, check-in, photo capture, or daily activity and current_location_context is available, use it only as a conservative fallback when the media/raw input has no conflicting location. Do not use current_location_context for memories, plans, remote events, selected old photos, or when raw input/media names a conflicting place. Do not be too specific. Use the format "City · Specific Location" (e.g., Beijing · Chaoyang Park) if possible, otherwise just the specific location name is fine.'
             },
             'user_mark_address': {
               'type': 'string',

--- a/lib/agent/skills/manage_timeline_card/timeline_templates.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_templates.dart
@@ -525,7 +525,7 @@ final List<Map<String, dynamic>> timelineTemplates = [
     'use_case': 'Image collections, multi-image displays, albums, etc.',
     'data_structure': '''
 - `image_urls` (List<String>, required): Image link list.
-- `title` (String, optional): Title (defaults to card title).
+- `title` (String, optional): Title following the same concrete, non-generic rules as the card title. For photo albums, prefer reliable venue, place, action, or OCR clues over mood-only titles. Defaults to card title.
 '''
   },
   {

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -18,6 +18,7 @@ import 'package:memex/data/services/table_change_notifier.dart';
 import 'package:memex/data/services/card_attachment_service.dart';
 import 'package:memex/data/services/card_detail_notifier.dart';
 import 'package:memex/data/services/clarification_request_service.dart';
+import 'package:memex/data/services/agent_background_task_service.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/app_update_service.dart';
 import 'package:memex/data/services/user_notification_service.dart';
@@ -224,6 +225,7 @@ class MemexRouter {
       initCustomAgentHandler();
       registerBuiltInEventSerializers();
       await CustomAgentConfigService.instance.registerAll(userId);
+      await AgentBackgroundTaskService.instance.startMonitoring();
 
       // Register file change callback and FTS event subscriptions.
       // Also triggers a one-time full rebuild when FTS tables were just created
@@ -482,11 +484,17 @@ class MemexRouter {
     _logger.info('Resetting MemexRouter for logout');
     _targetUserIdForInit = null;
     _initFuture = null;
+    unawaited(AgentBackgroundTaskService.instance.stopMonitoring(
+      reason: 'logout',
+    ));
     LocalTaskExecutor.instance.stop();
     SearchService.instance.reset();
   }
 
   void dispose() {
+    unawaited(AgentBackgroundTaskService.instance.stopMonitoring(
+      reason: 'router_dispose',
+    ));
     LocalTaskExecutor.instance.stop();
   }
 

--- a/lib/data/services/agent_background_task_service.dart
+++ b/lib/data/services/agent_background_task_service.dart
@@ -1,0 +1,228 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/utils/logger.dart';
+
+/// Keeps iOS informed while Memex agent tasks are active.
+///
+/// This service intentionally does not initialize the database by itself.
+/// MemexRouter calls [startMonitoring] after the task handlers and database are
+/// ready, so native background launches can be buffered until Dart can safely
+/// resume the local queue.
+class AgentBackgroundTaskService {
+  AgentBackgroundTaskService._();
+
+  static final AgentBackgroundTaskService instance =
+      AgentBackgroundTaskService._();
+
+  static const MethodChannel _channel =
+      MethodChannel('com.memexlab.memex/agent_background_tasks');
+
+  final _logger = getLogger('AgentBackgroundTaskService');
+
+  StreamSubscription<TaskActivitySnapshot>? _taskSubscription;
+  Timer? _backgroundCompletionPoller;
+  bool _bridgeInitialized = false;
+  bool _executorReady = false;
+  bool _pendingNativeRun = false;
+  bool _nativeBackgroundRunOpen = false;
+
+  Future<void> initializeNativeBridge() async {
+    if (!Platform.isIOS || _bridgeInitialized) return;
+
+    _bridgeInitialized = true;
+    _channel.setMethodCallHandler(_handleNativeCall);
+
+    try {
+      final capabilities =
+          await _channel.invokeMapMethod<String, dynamic>('initialize');
+      _logger.info('iOS agent background bridge initialized: $capabilities');
+    } catch (e, stack) {
+      _logger.warning(
+        'Failed to initialize iOS agent background bridge',
+        e,
+        stack,
+      );
+    }
+  }
+
+  Future<void> startMonitoring() async {
+    if (!Platform.isIOS) return;
+    await initializeNativeBridge();
+
+    _executorReady = true;
+    await _taskSubscription?.cancel();
+    _taskSubscription =
+        LocalTaskExecutor.instance.taskActivitySnapshotStream.listen(
+      (snapshot) => unawaited(
+        _syncSnapshot(snapshot, reason: 'task_activity_changed'),
+      ),
+      onError: (Object error, StackTrace stackTrace) {
+        _logger.warning(
+          'Task activity stream failed',
+          error,
+          stackTrace,
+        );
+      },
+    );
+
+    final snapshot = await LocalTaskExecutor.instance.getTaskActivitySnapshot();
+    await _syncSnapshot(snapshot, reason: 'executor_ready');
+
+    if (_pendingNativeRun) {
+      _pendingNativeRun = false;
+      await _handleNativeRun(reason: 'pending_native_run');
+    }
+  }
+
+  Future<void> stopMonitoring({String reason = 'stopped'}) async {
+    if (!Platform.isIOS) return;
+
+    _executorReady = false;
+    _pendingNativeRun = false;
+    _backgroundCompletionPoller?.cancel();
+    _backgroundCompletionPoller = null;
+    await _taskSubscription?.cancel();
+    _taskSubscription = null;
+
+    try {
+      await _channel.invokeMethod<void>('setTaskActivity', {
+        'pending': 0,
+        'processing': 0,
+        'retrying': 0,
+        'total': 0,
+        'hasActiveTasks': false,
+        'reason': reason,
+      });
+      await _completeNativeBackgroundRun(success: false, reason: reason);
+    } catch (e, stack) {
+      _logger.warning('Failed to stop iOS background monitoring', e, stack);
+    }
+  }
+
+  Future<void> onAppPaused() async {
+    if (!Platform.isIOS || !_executorReady) return;
+
+    final snapshot = await LocalTaskExecutor.instance.getTaskActivitySnapshot();
+    await _syncSnapshot(snapshot, reason: 'app_lifecycle_paused');
+  }
+
+  Future<void> onAppResumed() async {
+    if (!Platform.isIOS || !_executorReady) return;
+
+    final snapshot = await LocalTaskExecutor.instance.getTaskActivitySnapshot();
+    await _syncSnapshot(snapshot, reason: 'app_lifecycle_resumed');
+  }
+
+  Future<dynamic> _handleNativeCall(MethodCall call) async {
+    switch (call.method) {
+      case 'runPendingAgentTasks':
+        final args = call.arguments as Map<Object?, Object?>?;
+        await _handleNativeRun(
+          reason: args?['reason']?.toString() ?? 'native_background_run',
+        );
+        return true;
+      case 'backgroundTaskExpired':
+        final args = call.arguments as Map<Object?, Object?>?;
+        final reason = args?['reason']?.toString() ?? 'native_expired';
+        await LocalTaskExecutor.instance
+            .recordGracefulShutdown(reason: 'ios_$reason');
+        await _completeNativeBackgroundRun(success: false, reason: reason);
+        return true;
+      default:
+        throw MissingPluginException('Unknown native method ${call.method}');
+    }
+  }
+
+  Future<void> _handleNativeRun({required String reason}) async {
+    _nativeBackgroundRunOpen = true;
+
+    if (!_executorReady) {
+      _pendingNativeRun = true;
+      _logger
+          .info('Buffered native iOS background run until executor is ready');
+      return;
+    }
+
+    await LocalTaskExecutor.instance.clearGracefulShutdownMarker();
+
+    final snapshot = await LocalTaskExecutor.instance.getTaskActivitySnapshot();
+    await _syncSnapshot(snapshot, reason: reason);
+
+    if (snapshot.hasActiveTasks) {
+      _startCompletionPoller();
+    } else {
+      await _completeNativeBackgroundRun(success: true, reason: 'no_tasks');
+    }
+  }
+
+  void _startCompletionPoller() {
+    _backgroundCompletionPoller?.cancel();
+    _backgroundCompletionPoller =
+        Timer.periodic(const Duration(seconds: 2), (_) async {
+      if (!_executorReady) return;
+
+      final snapshot =
+          await LocalTaskExecutor.instance.getTaskActivitySnapshot();
+      await _syncSnapshot(snapshot, reason: 'background_completion_poll');
+
+      if (!snapshot.hasActiveTasks) {
+        _backgroundCompletionPoller?.cancel();
+        _backgroundCompletionPoller = null;
+        await _completeNativeBackgroundRun(
+          success: true,
+          reason: 'tasks_completed',
+        );
+      }
+    });
+  }
+
+  Future<void> _syncSnapshot(
+    TaskActivitySnapshot snapshot, {
+    required String reason,
+  }) async {
+    if (!Platform.isIOS || !_bridgeInitialized) return;
+
+    try {
+      await _channel.invokeMethod<void>('setTaskActivity', {
+        'pending': snapshot.pending,
+        'processing': snapshot.processing,
+        'retrying': snapshot.retrying,
+        'total': snapshot.total,
+        'hasActiveTasks': snapshot.hasActiveTasks,
+        'reason': reason,
+      });
+
+      if (!snapshot.hasActiveTasks) {
+        await _completeNativeBackgroundRun(
+          success: true,
+          reason: 'snapshot_empty',
+        );
+      }
+    } catch (e, stack) {
+      _logger.warning('Failed to sync task activity to iOS', e, stack);
+    }
+  }
+
+  Future<void> _completeNativeBackgroundRun({
+    required bool success,
+    required String reason,
+  }) async {
+    if (!Platform.isIOS || !_bridgeInitialized || !_nativeBackgroundRunOpen) {
+      return;
+    }
+
+    _nativeBackgroundRunOpen = false;
+
+    try {
+      await _channel.invokeMethod<void>('completeBackgroundRun', {
+        'success': success,
+        'reason': reason,
+      });
+    } catch (e, stack) {
+      _logger.warning('Failed to complete native iOS background run', e, stack);
+    }
+  }
+}

--- a/lib/data/services/task_handlers/analyze_assets_handler.dart
+++ b/lib/data/services/task_handlers/analyze_assets_handler.dart
@@ -39,14 +39,21 @@ class ExifData {
   final DateTime? datetimeOriginal;
   final List<double>? gpsCoordinates;
   final String? address;
+  final String? userMarkedLocation;
 
-  ExifData({this.datetimeOriginal, this.gpsCoordinates, this.address});
+  ExifData({
+    this.datetimeOriginal,
+    this.gpsCoordinates,
+    this.address,
+    this.userMarkedLocation,
+  });
 
   Map<String, dynamic> toJson() {
     return {
       'datetime_original': datetimeOriginal?.toIso8601String(),
       'gps_coordinates': gpsCoordinates,
       'address': address,
+      'user_marked_location': userMarkedLocation,
     };
   }
 }
@@ -243,6 +250,7 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
       DateTime? datetimeOriginal;
       List<double>? gpsCoordinates;
       String? address;
+      String? userMarkedLocation;
 
       // Add image dimensions to EXIF info
       if (width > 0 && height > 0) {
@@ -295,8 +303,10 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
                 lng,
               );
               if (markAddress != null) {
+                userMarkedLocation = markAddress;
                 addressLine +=
                     ', very close to user marked location ($markAddress) (less than 50 meters)';
+                exif['user_marked_location'] = markAddress;
               }
 
               infoLines.add(addressLine);
@@ -316,6 +326,7 @@ Future<AssetAnalysisResult?> _analyzeSingleAsset({
         datetimeOriginal: datetimeOriginal,
         gpsCoordinates: gpsCoordinates,
         address: address,
+        userMarkedLocation: userMarkedLocation,
       );
     }
 

--- a/lib/data/services/task_handlers/card_agent_handler.dart
+++ b/lib/data/services/task_handlers/card_agent_handler.dart
@@ -71,9 +71,10 @@ Future<CardRunCompletionEvidence> processWithCardAgent({
 
     // 2. Prepare Fact Content (merge assets info if needed)
     var enhancedFactContent = contentText;
-    final locationReminder = _formatLocationContextReminder(
-      locationContextReminder,
-    );
+    final hasAssetCaptureLocation = _hasAssetCaptureLocation(assetAnalyses);
+    final locationReminder = hasAssetCaptureLocation
+        ? ''
+        : _formatLocationContextReminder(locationContextReminder);
     if (locationReminder.isNotEmpty) {
       enhancedFactContent = '$locationReminder$enhancedFactContent';
     }
@@ -119,6 +120,24 @@ String _formatLocationContextReminder(String? reminder) {
   final trimmed = reminder?.trim();
   if (trimmed == null || trimmed.isEmpty) return '';
   return '<system-reminder>\n$trimmed\n</system-reminder>\n\n';
+}
+
+bool _hasAssetCaptureLocation(List<Map<String, dynamic>>? assetAnalyses) {
+  if (assetAnalyses == null) return false;
+  for (final analysis in assetAnalyses) {
+    final exifData = analysis['exif_data'];
+    if (exifData is! Map) continue;
+    final address = exifData['address']?.toString().trim();
+    if (address != null && address.isNotEmpty) return true;
+    final userMarkedLocation =
+        exifData['user_marked_location']?.toString().trim();
+    if (userMarkedLocation != null && userMarkedLocation.isNotEmpty) {
+      return true;
+    }
+    final gpsCoords = exifData['gps_coordinates'];
+    if (gpsCoords is List && gpsCoords.length >= 2) return true;
+  }
+  return false;
 }
 
 /// Applies rule-based template matching and writes the card file.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter/material.dart';
@@ -36,6 +37,7 @@ import 'package:memex/ui/settings/widgets/ai_service_setup_page.dart';
 import 'package:memex/ui/settings/widgets/model_config_list_page.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/data/services/agent_background_task_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/data/services/publish_timestamp_service.dart';
@@ -65,6 +67,7 @@ import 'package:memex/ui/settings/widgets/backup_restore_confirm_dialog.dart';
 import 'package:quick_actions/quick_actions.dart';
 import 'package:memex/data/services/quick_action_service.dart';
 import 'package:memex/data/services/speech_transcription_service.dart';
+import 'package:memex/utils/wakelock_manager.dart';
 
 final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();
 final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
@@ -78,6 +81,10 @@ void main() async {
   AppFlavor.init(appFlavor);
 
   await setupLogger();
+
+  if (kDebugMode || AppFlavor.isDev) {
+    await WakelockManager.acquire('debug_session');
+  }
 
   // Initialize l10n
   await UserStorage.initL10n();
@@ -93,6 +100,7 @@ void main() async {
   if (Platform.isIOS) {
     await Workmanager().cancelAll();
   }
+  await AgentBackgroundTaskService.instance.initializeNativeBridge();
 
   // MemexRouter is provided via config/dependencies.dart and created on first read
 
@@ -320,10 +328,12 @@ class _MemexAppState extends State<MemexApp> with WidgetsBindingObserver {
     if (state == AppLifecycleState.paused) {
       unawaited(LocalTaskExecutor.instance
           .recordGracefulShutdown(reason: 'app_lifecycle_paused'));
+      unawaited(AgentBackgroundTaskService.instance.onAppPaused());
       _lastPausedTime = DateTime.now();
       _checkLockSettingsBeforeLocking();
     } else if (state == AppLifecycleState.resumed) {
       unawaited(LocalTaskExecutor.instance.clearGracefulShutdownMarker());
+      unawaited(AgentBackgroundTaskService.instance.onAppResumed());
       MemexRouter().scheduleAutoBackupCheck(trigger: 'foreground');
       _checkGracePeriod();
     } else if (state == AppLifecycleState.detached) {

--- a/lib/utils/wakelock_manager.dart
+++ b/lib/utils/wakelock_manager.dart
@@ -1,0 +1,38 @@
+import 'package:memex/utils/logger.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+
+final _log = getLogger('WakelockManager');
+
+class WakelockManager {
+  WakelockManager._();
+
+  static final Set<String> _reasons = <String>{};
+
+  static Future<void> acquire(String reason) async {
+    final normalized = reason.trim();
+    if (normalized.isEmpty) return;
+    final wasEmpty = _reasons.isEmpty;
+    _reasons.add(normalized);
+    if (!wasEmpty) return;
+
+    try {
+      await WakelockPlus.enable();
+      _log.fine('Wakelock enabled: $normalized');
+    } catch (e) {
+      _log.fine('Failed to enable wakelock: $e');
+    }
+  }
+
+  static Future<void> release(String reason) async {
+    final normalized = reason.trim();
+    if (normalized.isEmpty) return;
+    if (!_reasons.remove(normalized) || _reasons.isNotEmpty) return;
+
+    try {
+      await WakelockPlus.disable();
+      _log.fine('Wakelock disabled');
+    } catch (e) {
+      _log.fine('Failed to disable wakelock: $e');
+    }
+  }
+}

--- a/test/agent/agent_utils_test.dart
+++ b/test/agent/agent_utils_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/agent_utils.dart';
+
+void main() {
+  test('formatAssetAnalysis includes photo capture location context', () {
+    final formatted = formatAssetAnalysis(
+      [
+        {
+          'index': 0,
+          'name': 'photo.heic',
+          'analysis': 'A child sits near a CETC Dongxin entrance.',
+          'exif_data': {
+            'datetime_original': '2026-06-07T10:56:39.000',
+            'address': 'Hangzhou - Liuxia Street',
+            'user_marked_location': 'Dongxin Chorus Garden',
+            'gps_coordinates': [30.228316, 120.04158],
+          },
+        },
+      ],
+      includeExif: true,
+    );
+
+    expect(formatted, contains('Photo Capture Time: 2026-06-07T10:56:39.000'));
+    expect(
+      formatted,
+      contains('Photo Capture Location: Hangzhou - Liuxia Street'),
+    );
+    expect(
+      formatted,
+      contains(
+        'Nearby User-Marked Location: Dongxin Chorus Garden (within 50 meters)',
+      ),
+    );
+    expect(formatted, contains('GPS Coordinates: Latitude 30.228316'));
+  });
+
+  test('formatAssetAnalysis omits exif details when includeExif is false', () {
+    final formatted = formatAssetAnalysis(
+      [
+        {
+          'index': 0,
+          'name': 'photo.heic',
+          'analysis': 'A child sits near a CETC Dongxin entrance.',
+          'exif_data': {
+            'address': 'Hangzhou - Liuxia Street',
+            'gps_coordinates': [30.228316, 120.04158],
+          },
+        },
+      ],
+    );
+
+    expect(formatted, isNot(contains('Photo Capture Location')));
+    expect(formatted, isNot(contains('GPS Coordinates')));
+  });
+}


### PR DESCRIPTION
解决 iOS 侧后台 Agent 任务在锁屏或切到后台后容易被系统中断的问题，并顺手优化照片/卡片标题生成时的地点线索使用。

Changes:
- Add an iOS MethodChannel bridge for Agent background task activity.
- Register BGProcessingTask and iOS 26 BGContinuedProcessingTask handling for active LocalTaskExecutor work.
- Keep UIApplication background task assertions while Agent tasks are active, and report expiration back to Dart.
- Add a ref-counted wakelock manager for concurrent Agent activity.
- Surface photo capture time/location/user-marked location into asset analysis prompts.
- Tighten timeline card title guidance to prefer concrete place/action/object clues over generic titles.

Validation:
- User verified lock-screen/background Agent processing on iOS 26.5 device.
- flutter test test/agent/agent_utils_test.dart
- flutter analyze --no-pub lib/data/services/agent_background_task_service.dart lib/utils/wakelock_manager.dart test/agent/agent_utils_test.dart
- xcodebuild -workspace ios/Runner.xcworkspace -scheme global -configuration Debug -sdk iphoneos -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build