### PR TITLE
[codex] 修复 Schedule 完成状态按 itemId 匹配

### DIFF
--- a/lib/ui/schedule/models/schedule_item.dart
+++ b/lib/ui/schedule/models/schedule_item.dart
@@ -143,10 +143,7 @@ class ScheduleItem {
     for (final completedItem in data.completed) {
       final sourceFactId = completedItem.cardId;
       final completedItemId = completedItem.itemId ?? completedItem.cardId;
-      final existingEntry = itemsByItemId.entries.where((entry) {
-        return entry.value.sourceFactId == sourceFactId;
-      }).firstOrNull;
-      final existing = existingEntry?.value;
+      final existing = itemsByItemId[completedItemId];
       if (existing != null) {
         itemsByItemId[existing.itemId] = existing.copyWith(
           status: ScheduleItemStatus.completed,

--- a/test/ui/schedule/models/schedule_item_test.dart
+++ b/test/ui/schedule/models/schedule_item_test.dart
@@ -276,11 +276,57 @@ void main() {
 
       expect(items, hasLength(2));
       expect(items.map((item) => item.itemId), ['pi_milk', 'pi_dentist']);
-      expect(
-        items.map((item) => item.sourceFactId).toSet(),
-        {'2026/04/26.md#ts_1'},
-      );
+      expect(items.map((item) => item.sourceFactId).toSet(), {
+        '2026/04/26.md#ts_1',
+      });
     });
+
+    test(
+      'does not complete a different pending item from the same source fact',
+      () {
+        final aggregation = ScheduleViewData(
+          id: 'schedule_state',
+          generatedAt: DateTime.parse('2026-04-26T08:00:00+08:00'),
+          timeRange: ScheduleViewTimeRange(
+            from: DateTime(2026, 4, 25),
+            to: DateTime(2026, 4, 26),
+          ),
+          timeline: [
+            ScheduleViewTimelineDay(
+              dayLabel: 'Today',
+              dayDate: DateTime(2026, 4, 26),
+              items: const [
+                ScheduleViewPendingItem(
+                  itemId: 'pi_pending_followup',
+                  cardId: 'facts/demo.md#ts_1',
+                  title: 'Follow up on training plan',
+                  type: 'task',
+                ),
+              ],
+            ),
+          ],
+          completed: [
+            ScheduleViewCompletedItem(
+              itemId: 'pi_completed_event',
+              cardId: 'facts/demo.md#ts_1',
+              title: 'Completed calendar event',
+              completedAt: DateTime.parse('2026-04-25T11:00:00+08:00'),
+            ),
+          ],
+        );
+
+        final items = ScheduleItem.fromViewData(aggregation);
+
+        final followupTodo = items.singleWhere(
+          (item) => item.itemId == 'pi_pending_followup',
+        );
+        final completedEvent = items.singleWhere(
+          (item) => item.itemId == 'pi_completed_event',
+        );
+        expect(followupTodo.status, ScheduleItemStatus.pending);
+        expect(completedEvent.status, ScheduleItemStatus.completed);
+      },
+    );
 
     test('derives task status from subtask progress conservatively', () {
       final pending = ScheduleItem.deriveTodoStatus(const [


### PR DESCRIPTION
## Summary

Fixes #237.

修复一个 Schedule UI 模型扁平化 bug：当同一条原始输入同时生成 completed item 和 pending todo 时，pending todo 可能会在 UI 中被误显示为 completed。

## 根因

`ScheduleItem.fromViewData` 之前在把 completed 列表回填到扁平化 UI item 时，按 `sourceFactId` / `cardId` 查找已有 item。

这太宽了：`sourceFactId` 表示“来自哪条原始输入”，不是 schedule item 的唯一身份。一条原始输入可以合法地产生多个 schedule item。

脱敏后的问题形态：

- item A：同一 `sourceFactId` 下的 event，已进入 completed
- item B：同一 `sourceFactId` 下的独立 todo，仍应保持 pending

旧逻辑因为只看 source fact，把 item A 的完成状态误合并到了 item B。

## 改动

- completed entry 回填状态时改为按 schedule `itemId` 匹配。
- 保留 completed entry 不存在于 pending timeline 时的 fallback 创建逻辑。
- 增加同 source fact 下 completed event / pending todo 混合场景的脱敏回归测试。

## 验证

- `flutter analyze lib/ui/schedule/models/schedule_item.dart test/ui/schedule/models/schedule_item_test.dart`
- `flutter test test/ui/schedule/models/schedule_item_test.dart`

## 备注

问题发生在 UI 模型扁平化展示层；持久化的 schedule state 不需要迁移。
