### PR TITLE
Fix iOS background task progress and expiration handling

### DIFF
--- a/ios/Runner/AgentBackgroundTaskChannelHandler.swift
+++ b/ios/Runner/AgentBackgroundTaskChannelHandler.swift
@@ -20,8 +20,6 @@ class AgentBackgroundTaskChannelHandler: NSObject {
     private var foregroundBackgroundTaskId = UIBackgroundTaskIdentifier.invalid
     private var activeSnapshot: [String: Any] = [:]
     private var bgProcessingTask: BGProcessingTask?
-    private var progressPulseTimer: Timer?
-    private var syntheticProgress: Int64 = 1
     private var submittedContinuedIdentifier: String?
     private var processingTaskRegistered = false
     private var continuedProcessingRegistered = false
@@ -142,9 +140,9 @@ class AgentBackgroundTaskChannelHandler: NSObject {
             beginForegroundBackgroundTaskIfNeeded(reason: snapshot["reason"] as? String ?? "active_tasks")
             scheduleProcessingTask()
             submitContinuedProcessingIfSupported(snapshot: snapshot)
-            updateContinuedProgress(snapshot: snapshot, completed: nil)
+            updateContinuedProgress(snapshot: snapshot)
         } else {
-            updateContinuedProgress(snapshot: snapshot, completed: 100)
+            updateContinuedProgress(snapshot: snapshot)
             cancelScheduledProcessing()
             completeBackgroundRuns(success: true)
             endForegroundBackgroundTask()
@@ -218,7 +216,7 @@ class AgentBackgroundTaskChannelHandler: NSObject {
             self.channel.invokeMethod("backgroundTaskExpired", arguments: ["reason": reason])
 
             self.scheduleProcessingTask()
-            self.completeBackgroundRuns(success: false)
+            self.completeExpiredBackgroundRuns(reason: reason)
             self.endForegroundBackgroundTask()
         }
 
@@ -234,23 +232,15 @@ class AgentBackgroundTaskChannelHandler: NSObject {
         bgProcessingTask = nil
 
         completeContinuedProcessingIfSupported(success: success)
-        stopProgressPulse()
     }
 
-    private func startProgressPulse() {
-        guard progressPulseTimer == nil else { return }
-        syntheticProgress = max(1, syntheticProgress)
-        progressPulseTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
-            guard let self = self else { return }
-            self.syntheticProgress = min(95, self.syntheticProgress + 1)
-            self.updateContinuedProgress(snapshot: self.activeSnapshot, completed: self.syntheticProgress)
-        }
-    }
+    private func completeExpiredBackgroundRuns(reason: String) {
+        NSLog("Memex: iOS background task expired (%@); agent queue will resume later", reason)
 
-    private func stopProgressPulse() {
-        progressPulseTimer?.invalidate()
-        progressPulseTimer = nil
-        syntheticProgress = 1
+        bgProcessingTask?.setTaskCompleted(success: false)
+        bgProcessingTask = nil
+
+        completeContinuedProcessingAfterExpiration()
     }
 
     private func registerContinuedProcessingHandlerIfSupported() {
@@ -262,14 +252,12 @@ class AgentBackgroundTaskChannelHandler: NSObject {
     @available(iOS 26.0, *)
     private func handleContinuedProcessingTask(_ task: BGContinuedProcessingTask) {
         continuedProcessingTask = task
-        task.progress.totalUnitCount = 100
-        task.progress.completedUnitCount = max(1, syntheticProgress)
+        updateContinuedProgress(snapshot: activeSnapshot)
 
         task.expirationHandler = { [weak self] in
             self?.handleExpiration(reason: "continued_processing_expired")
         }
 
-        startProgressPulse()
         invokeRunPendingTasks(reason: "continued_processing_launch")
     }
 
@@ -293,7 +281,6 @@ class AgentBackgroundTaskChannelHandler: NSObject {
             do {
                 try BGTaskScheduler.shared.submit(request)
                 submittedContinuedIdentifier = identifier
-                startProgressPulse()
             } catch {
                 NSLog("Memex: BGContinuedProcessingTask submit failed: %@", String(describing: error))
             }
@@ -326,15 +313,13 @@ class AgentBackgroundTaskChannelHandler: NSObject {
         return registered
     }
 
-    private func updateContinuedProgress(snapshot: [String: Any], completed: Int64?) {
+    private func updateContinuedProgress(snapshot: [String: Any]) {
         if #available(iOS 26.0, *) {
             guard let task = continuedProcessingTask else { return }
-            task.progress.totalUnitCount = 100
-            if let completed = completed {
-                task.progress.completedUnitCount = min(100, max(task.progress.completedUnitCount, completed))
-            } else {
-                task.progress.completedUnitCount = min(95, max(task.progress.completedUnitCount, syntheticProgress))
-            }
+            let total = max(1, int64Value(snapshot["progressTotal"]) ?? 1)
+            let completed = min(total, max(0, int64Value(snapshot["progressCompleted"]) ?? 0))
+            task.progress.totalUnitCount = total
+            task.progress.completedUnitCount = completed
             task.updateTitle(task.title, subtitle: subtitle(for: snapshot))
         }
     }
@@ -350,11 +335,35 @@ class AgentBackgroundTaskChannelHandler: NSObject {
         }
     }
 
+    private func completeContinuedProcessingAfterExpiration() {
+        if #available(iOS 26.0, *) {
+            if let task = continuedProcessingTask {
+                task.updateTitle(task.title, subtitle: "Paused. Memex will continue later.")
+                task.setTaskCompleted(success: false)
+            }
+            continuedProcessingTask = nil
+            submittedContinuedIdentifier = nil
+        }
+    }
+
     private func subtitle(for snapshot: [String: Any]) -> String {
         let total = snapshot["total"] as? Int ?? 0
         if total <= 0 {
             return "Finishing current work"
         }
         return "Processing \(total) queued task\(total == 1 ? "" : "s")"
+    }
+
+    private func int64Value(_ value: Any?) -> Int64? {
+        if let value = value as? Int64 {
+            return value
+        }
+        if let value = value as? Int {
+            return Int64(value)
+        }
+        if let value = value as? NSNumber {
+            return value.int64Value
+        }
+        return nil
     }
 }

--- a/lib/data/services/agent_background_task_service.dart
+++ b/lib/data/services/agent_background_task_service.dart
@@ -28,6 +28,9 @@ class AgentBackgroundTaskService {
   bool _executorReady = false;
   bool _pendingNativeRun = false;
   bool _nativeBackgroundRunOpen = false;
+  Set<String>? _progressActiveTaskIds;
+  int _progressCompleted = 0;
+  int _progressTotal = 0;
 
   Future<void> initializeNativeBridge() async {
     if (!Platform.isIOS || _bridgeInitialized) return;
@@ -82,6 +85,7 @@ class AgentBackgroundTaskService {
 
     _executorReady = false;
     _pendingNativeRun = false;
+    _resetProgressSession();
     _backgroundCompletionPoller?.cancel();
     _backgroundCompletionPoller = null;
     await _taskSubscription?.cancel();
@@ -129,7 +133,13 @@ class AgentBackgroundTaskService {
         final reason = args?['reason']?.toString() ?? 'native_expired';
         await LocalTaskExecutor.instance
             .recordGracefulShutdown(reason: 'ios_$reason');
-        await _completeNativeBackgroundRun(success: false, reason: reason);
+        _backgroundCompletionPoller?.cancel();
+        _backgroundCompletionPoller = null;
+        _nativeBackgroundRunOpen = false;
+        _resetProgressSession();
+        _logger.info(
+          'iOS background task expired ($reason); agent queue will resume later',
+        );
         return true;
       default:
         throw MissingPluginException('Unknown native method ${call.method}');
@@ -185,12 +195,16 @@ class AgentBackgroundTaskService {
   }) async {
     if (!Platform.isIOS || !_bridgeInitialized) return;
 
+    final progress = _progressFor(snapshot);
+
     try {
       await _channel.invokeMethod<void>('setTaskActivity', {
         'pending': snapshot.pending,
         'processing': snapshot.processing,
         'retrying': snapshot.retrying,
         'total': snapshot.total,
+        'progressCompleted': progress.completed,
+        'progressTotal': progress.total,
         'hasActiveTasks': snapshot.hasActiveTasks,
         'reason': reason,
       });
@@ -200,6 +214,7 @@ class AgentBackgroundTaskService {
           success: true,
           reason: 'snapshot_empty',
         );
+        _resetProgressSession();
       }
     } catch (e, stack) {
       _logger.warning('Failed to sync task activity to iOS', e, stack);
@@ -221,8 +236,65 @@ class AgentBackgroundTaskService {
         'success': success,
         'reason': reason,
       });
+      _resetProgressSession();
     } catch (e, stack) {
       _logger.warning('Failed to complete native iOS background run', e, stack);
     }
   }
+
+  _TaskProgress _progressFor(TaskActivitySnapshot snapshot) {
+    final activeTaskIds = snapshot.activeTaskIds;
+    final previousTaskIds = _progressActiveTaskIds;
+
+    if (!snapshot.hasActiveTasks) {
+      if (previousTaskIds != null && previousTaskIds.isNotEmpty) {
+        _progressCompleted += previousTaskIds.length;
+      }
+      _progressTotal = _progressTotal < _progressCompleted
+          ? _progressCompleted
+          : _progressTotal;
+      _progressActiveTaskIds = const <String>{};
+      return _TaskProgress(
+        completed: _progressTotal,
+        total: _progressTotal,
+      );
+    }
+
+    if (previousTaskIds == null) {
+      _progressCompleted = 0;
+      _progressTotal = activeTaskIds.length;
+    } else {
+      final finishedTaskCount =
+          previousTaskIds.difference(activeTaskIds).length;
+      final newTaskCount = activeTaskIds.difference(previousTaskIds).length;
+      _progressCompleted += finishedTaskCount;
+      _progressTotal += newTaskCount;
+    }
+
+    _progressActiveTaskIds = Set.unmodifiable(activeTaskIds);
+    if (_progressTotal < activeTaskIds.length + _progressCompleted) {
+      _progressTotal = activeTaskIds.length + _progressCompleted;
+    }
+
+    return _TaskProgress(
+      completed: _progressCompleted,
+      total: _progressTotal,
+    );
+  }
+
+  void _resetProgressSession() {
+    _progressActiveTaskIds = null;
+    _progressCompleted = 0;
+    _progressTotal = 0;
+  }
+}
+
+class _TaskProgress {
+  final int completed;
+  final int total;
+
+  const _TaskProgress({
+    required this.completed,
+    required this.total,
+  });
 }

--- a/lib/data/services/local_task_executor.dart
+++ b/lib/data/services/local_task_executor.dart
@@ -27,17 +27,20 @@ class TaskActivitySnapshot {
   final int pending;
   final int processing;
   final int retrying;
+  final Set<String> activeTaskIds;
 
   const TaskActivitySnapshot({
     required this.pending,
     required this.processing,
     required this.retrying,
+    this.activeTaskIds = const <String>{},
   });
 
   const TaskActivitySnapshot.empty()
       : pending = 0,
         processing = 0,
-        retrying = 0;
+        retrying = 0,
+        activeTaskIds = const <String>{};
 
   int get total => pending + processing + retrying;
 
@@ -48,11 +51,17 @@ class TaskActivitySnapshot {
     return other is TaskActivitySnapshot &&
         other.pending == pending &&
         other.processing == processing &&
-        other.retrying == retrying;
+        other.retrying == retrying &&
+        setEquals(other.activeTaskIds, activeTaskIds);
   }
 
   @override
-  int get hashCode => Object.hash(pending, processing, retrying);
+  int get hashCode => Object.hash(
+        pending,
+        processing,
+        retrying,
+        Object.hashAllUnordered(activeTaskIds),
+      );
 }
 
 /// Handler function type
@@ -148,6 +157,7 @@ class LocalTaskExecutor {
       pending: pending,
       processing: processing,
       retrying: retrying,
+      activeTaskIds: tasks.map((task) => task.id).toSet(),
     );
   }
 

--- a/test/data/services/local_task_executor_test.dart
+++ b/test/data/services/local_task_executor_test.dart
@@ -190,6 +190,11 @@ void main() {
           pending: 1,
           processing: 1,
           retrying: 1,
+          activeTaskIds: {
+            'pending-task',
+            'processing-task',
+            'retrying-task',
+          },
         ),
       );
       expect(snapshot.total, 3);


### PR DESCRIPTION
## Summary
- report iOS continued background progress from real local task queue state instead of a synthetic timer
- keep iOS background expiration separate from local task failure so resumable tasks are not marked failed
- include active task IDs in task activity snapshots so progress updates when queue membership changes

## Verification
- flutter analyze --no-pub lib/data/services/agent_background_task_service.dart lib/data/services/local_task_executor.dart
- flutter build ios --release --no-codesign --flavor global --no-pub
- installed signed release build on local iPhone wujia for manual testing