### PR TITLE
修复主界面头像偶发加载失败

### DIFF
--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -79,6 +79,7 @@ import 'package:memex/data/repositories/get_knowledge_insight_detail.dart';
 import 'package:memex/data/repositories/chat.dart' as chat_endpoint;
 import 'package:memex/data/services/llm_call_record_service.dart';
 import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/avatar_media_service.dart';
 import 'package:memex/agent/state_util.dart';
 import 'package:memex/agent/skills/knowledge_insight/native_widgets.dart';
 import 'package:memex/utils/result.dart';
@@ -1609,18 +1610,10 @@ class MemexRouter {
       return null;
     }
 
-    final lower = avatar.toLowerCase();
-    final isRelativeImagePath =
-        !avatar.startsWith('/') &&
-        (lower.endsWith('.png') ||
-            lower.endsWith('.jpg') ||
-            lower.endsWith('.jpeg') ||
-            lower.endsWith('.webp'));
-
-    if (isRelativeImagePath) {
-      return fileSystemService.toAbsolutePath(avatar);
-    }
-    return avatar;
+    return AvatarMediaService.resolveAvatarPath(
+      avatar,
+      fileSystemService: fileSystemService,
+    );
   }
 
   Future<void> updateUserAvatar(String avatar) async {
@@ -1633,6 +1626,10 @@ class MemexRouter {
     final meta = await fileSystemService.readProfileMeta(userId);
     meta['avatar'] = avatar;
     await fileSystemService.writeProfileMeta(userId, meta);
+    AvatarMediaService.precacheDiceBearAvatar(avatar);
+    EventBusService.instance.emitEvent(
+      ProfileUpdatedMessage(userId: userId, avatar: avatar),
+    );
   }
 
   Future<void> saveLLMConfigs(List<LLMConfig> configs) async {

--- a/lib/data/services/avatar_media_service.dart
+++ b/lib/data/services/avatar_media_service.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:memex/data/services/asset_safety_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class AvatarMediaService {
+  AvatarMediaService._();
+
+  static const _diceBearTimeout = Duration(seconds: 10);
+
+  static bool isImageAvatar(String? avatar) {
+    final value = avatar?.trim();
+    if (value == null || value.isEmpty) return false;
+
+    return value.startsWith('fs://') ||
+        _isRemoteUri(value) ||
+        p.isAbsolute(value) ||
+        hasSupportedImageExtension(value) ||
+        value.contains('/');
+  }
+
+  static bool isDiceBearSeed(String? avatar) {
+    final value = avatar?.trim();
+    return value != null && value.isNotEmpty && !isImageAvatar(value);
+  }
+
+  static bool isRelativeImagePath(String avatar) {
+    final value = avatar.trim();
+    if (value.isEmpty || p.isAbsolute(value)) return false;
+    if (value.startsWith('fs://') || _isRemoteUri(value)) return false;
+    return hasSupportedImageExtension(value);
+  }
+
+  static bool hasSupportedImageExtension(String value) {
+    final ext = p.extension(_pathForExtension(value)).toLowerCase();
+    return AssetSafetyService.imageExtensions.contains(ext);
+  }
+
+  static String resolveAvatarPath(
+    String avatar, {
+    required FileSystemService fileSystemService,
+  }) {
+    if (isRelativeImagePath(avatar)) {
+      return fileSystemService.toAbsolutePath(avatar);
+    }
+    return avatar;
+  }
+
+  static void precacheDiceBearAvatar(String? avatar) {
+    if (!isDiceBearSeed(avatar)) return;
+    unawaited(cacheDiceBearSvg(avatar!.trim()));
+  }
+
+  static String diceBearUrl(String seed) {
+    final encoded = Uri.encodeComponent(seed);
+    return 'https://api.dicebear.com/7.x/notionists/svg?seed=$encoded';
+  }
+
+  static Future<File> diceBearCacheFile(String seed) async {
+    final dir = await getApplicationSupportDirectory();
+    final hash = md5.convert(utf8.encode(seed)).toString();
+    return File(p.join(dir.path, 'avatar_$hash.svg'));
+  }
+
+  static Future<File?> loadDiceBearSvg(String seed) async {
+    final file = await diceBearCacheFile(seed);
+    if (await file.exists() && await file.length() > 0) {
+      return file;
+    }
+
+    final cachedPath = await cacheDiceBearSvg(seed);
+    if (cachedPath == null) return null;
+    return File(cachedPath);
+  }
+
+  static Future<String?> cacheDiceBearSvg(
+    String seed, {
+    http.Client? client,
+    Duration timeout = _diceBearTimeout,
+  }) async {
+    final cleanSeed = seed.trim();
+    if (cleanSeed.isEmpty) return null;
+
+    final ownsClient = client == null;
+    final httpClient = client ?? http.Client();
+    try {
+      final response = await httpClient
+          .get(Uri.parse(diceBearUrl(cleanSeed)))
+          .timeout(timeout);
+      if (response.statusCode != 200 || response.body.trim().isEmpty) {
+        return null;
+      }
+
+      final file = await diceBearCacheFile(cleanSeed);
+      await file.parent.create(recursive: true);
+      await file.writeAsString(response.body);
+      return file.path;
+    } catch (_) {
+      return null;
+    } finally {
+      if (ownsClient) {
+        httpClient.close();
+      }
+    }
+  }
+
+  static String _pathForExtension(String value) {
+    final uri = Uri.tryParse(value);
+    if (uri != null && uri.hasScheme) {
+      return uri.path;
+    }
+    return value.split('?').first.split('#').first;
+  }
+
+  static bool _isRemoteUri(String value) {
+    final uri = Uri.tryParse(value);
+    return uri != null && (uri.scheme == 'http' || uri.scheme == 'https');
+  }
+}

--- a/lib/data/services/character_service.dart
+++ b/lib/data/services/character_service.dart
@@ -4,6 +4,8 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 import 'package:memex/domain/models/character_model.dart';
+import 'package:memex/data/services/avatar_media_service.dart';
+import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/utils/user_storage.dart';
 
@@ -45,11 +47,17 @@ class CharacterService {
     final bg = character.chatBackground;
     var resolved = character;
     if (avatar != null && avatar.isNotEmpty && isRelativeAvatarPath(avatar)) {
-      final absolute = _fileSystem.toAbsolutePath(avatar);
+      final absolute = AvatarMediaService.resolveAvatarPath(
+        avatar,
+        fileSystemService: _fileSystem,
+      );
       resolved = resolved.copyWith(avatar: absolute);
     }
     if (bg != null && bg.isNotEmpty && _isRelativeMediaPath(bg)) {
-      final absolute = _fileSystem.toAbsolutePath(bg);
+      final absolute = AvatarMediaService.resolveAvatarPath(
+        bg,
+        fileSystemService: _fileSystem,
+      );
       resolved = resolved.copyWith(chatBackground: absolute);
     }
     return resolved;
@@ -57,23 +65,13 @@ class CharacterService {
 
   /// Returns true if the path looks like a relative file path (image/media).
   static bool _isRelativeMediaPath(String path) {
-    if (path.startsWith('/')) return false;
-    final lower = path.toLowerCase();
-    return lower.endsWith('.png') ||
-        lower.endsWith('.jpg') ||
-        lower.endsWith('.jpeg') ||
-        lower.endsWith('.webp');
+    return AvatarMediaService.isRelativeImagePath(path);
   }
 
   /// Returns true if the avatar value looks like a relative file path
   /// (not a DiceBear seed, not already absolute).
   static bool isRelativeAvatarPath(String avatar) {
-    if (avatar.startsWith('/')) return false; // already absolute
-    final lower = avatar.toLowerCase();
-    return lower.endsWith('.png') ||
-        lower.endsWith('.jpg') ||
-        lower.endsWith('.jpeg') ||
-        lower.endsWith('.webp');
+    return AvatarMediaService.isRelativeImagePath(avatar);
   }
 
   /// Get the Characters directory path for a user
@@ -426,7 +424,11 @@ class CharacterService {
       _logger.info("Created character $newId for user $userId");
 
       charDict['id'] = newId;
-      return CharacterModel.fromJson(charDict);
+      AvatarMediaService.precacheDiceBearAvatar(charDict['avatar'] as String?);
+      EventBusService.instance.emitEvent(
+        CharacterUpdatedMessage(userId: userId, characterId: newId),
+      );
+      return _resolveMediaPaths(CharacterModel.fromJson(charDict));
     } catch (e) {
       _logger.severe("Failed to create character for user $userId: $e");
       rethrow;
@@ -523,7 +525,11 @@ class CharacterService {
 
       _logger.info("Updated character $characterId for user $userId");
       charData['id'] = characterId;
-      return CharacterModel.fromJson(charData);
+      AvatarMediaService.precacheDiceBearAvatar(charData['avatar'] as String?);
+      EventBusService.instance.emitEvent(
+        CharacterUpdatedMessage(userId: userId, characterId: characterId),
+      );
+      return _resolveMediaPaths(CharacterModel.fromJson(charData));
     } catch (e) {
       _logger.severe(
         "Failed to update character $characterId for user $userId: $e",

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -61,6 +61,8 @@ class FileSystemService {
   static DateTime? _lastServerCheckTime;
   static FileSystemService? _instance;
 
+  static bool get isInitialized => _instance != null;
+
   static FileSystemService get instance {
     if (_instance == null) {
       throw StateError('FileSystemService not initialized. Call init() first.');

--- a/lib/domain/models/event_bus_message.dart
+++ b/lib/domain/models/event_bus_message.dart
@@ -11,6 +11,8 @@ enum EventBusMessageType {
   attachmentsChanged('attachments_changed'),
   invalidModelConfig('invalid_model_config'),
   errorNotification('error_notification'),
+  profileUpdated('profile_updated'),
+  characterUpdated('character_updated'),
   personaChatMessageAdded('persona_chat_message_added'),
   unknown('unknown');
 
@@ -57,6 +59,10 @@ abstract class EventBusMessage {
         return InvalidModelConfigMessage.fromJson(json);
       case EventBusMessageType.errorNotification:
         return ErrorNotificationMessage.fromJson(json);
+      case EventBusMessageType.profileUpdated:
+        return ProfileUpdatedMessage.fromJson(json);
+      case EventBusMessageType.characterUpdated:
+        return CharacterUpdatedMessage.fromJson(json);
       case EventBusMessageType.personaChatMessageAdded:
         return PersonaChatMessageAddedMessage.fromJson(json);
       default:
@@ -363,6 +369,50 @@ class AttachmentsChangedMessage extends EventBusMessage {
     final data = json['data'] as Map<String, dynamic>? ?? {};
     return AttachmentsChangedMessage(
       factId: data['fact_id'] as String?,
+    );
+  }
+}
+
+class ProfileUpdatedMessage extends EventBusMessage {
+  final String userId;
+  final String? avatar;
+
+  ProfileUpdatedMessage({required this.userId, this.avatar})
+      : super(
+          type: EventBusMessageType.profileUpdated,
+          data: {
+            'user_id': userId,
+            if (avatar != null) 'avatar': avatar,
+          },
+        );
+
+  factory ProfileUpdatedMessage.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>? ?? {};
+    return ProfileUpdatedMessage(
+      userId: data['user_id'] as String? ?? '',
+      avatar: data['avatar'] as String?,
+    );
+  }
+}
+
+class CharacterUpdatedMessage extends EventBusMessage {
+  final String userId;
+  final String characterId;
+
+  CharacterUpdatedMessage({required this.userId, required this.characterId})
+      : super(
+          type: EventBusMessageType.characterUpdated,
+          data: {
+            'user_id': userId,
+            'character_id': characterId,
+          },
+        );
+
+  factory CharacterUpdatedMessage.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>? ?? {};
+    return CharacterUpdatedMessage(
+      userId: data['user_id'] as String? ?? '',
+      characterId: data['character_id'] as String? ?? '',
     );
   }
 }

--- a/lib/ui/character/widgets/persona_avatar_button.dart
+++ b/lib/ui/character/widgets/persona_avatar_button.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
+import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/data/services/character_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/domain/models/character_model.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/ui/character/widgets/persona_chat_screen.dart';
@@ -23,6 +25,7 @@ class PersonaAvatarButton extends StatefulWidget {
 class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
   CharacterModel? _character;
   StreamSubscription? _unreadSub;
+  Timer? _retryTimer;
   int _unreadCount = 0;
 
   final Logger _logger = Logger('PersonaAvatarButton');
@@ -30,9 +33,11 @@ class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      Future.delayed(const Duration(seconds: 2), _load);
-    });
+    EventBusService.instance.addHandler(
+      EventBusMessageType.characterUpdated,
+      _onCharacterUpdated,
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
   }
 
   Future<void> _load() async {
@@ -40,9 +45,14 @@ class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
       final userId = await UserStorage.getUserId();
       _logger.info('PersonaAvatarButton _load: userId=$userId');
       if (userId == null) return;
+      if (!FileSystemService.isInitialized) {
+        _scheduleRetry();
+        return;
+      }
 
-      final primary =
-          await CharacterService.instance.getPrimaryCompanion(userId);
+      final primary = await CharacterService.instance.getPrimaryCompanion(
+        userId,
+      );
       _logger.info('PersonaAvatarButton _load: primary=${primary?.name}');
       if (!mounted || primary == null) return;
 
@@ -50,20 +60,41 @@ class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
 
       if (AppDatabase.isInitialized) {
         _unreadSub?.cancel();
-        _unreadSub =
-            PersonaChatService.instance.watchTotalUnreadCount().listen((count) {
-          if (mounted) setState(() => _unreadCount = count);
-        });
+        _unreadSub = PersonaChatService.instance.watchTotalUnreadCount().listen(
+          (count) {
+            if (mounted) setState(() => _unreadCount = count);
+          },
+        );
       }
     } catch (e, stack) {
       _logger.warning('PersonaAvatarButton _load failed: $e', e, stack);
     }
   }
 
+  void _scheduleRetry() {
+    if (_retryTimer?.isActive ?? false) return;
+    _retryTimer = Timer(const Duration(milliseconds: 250), () {
+      if (mounted) {
+        _load();
+      }
+    });
+  }
+
   @override
   void dispose() {
+    EventBusService.instance.removeHandler(
+      EventBusMessageType.characterUpdated,
+      _onCharacterUpdated,
+    );
     _unreadSub?.cancel();
+    _retryTimer?.cancel();
     super.dispose();
+  }
+
+  void _onCharacterUpdated(EventBusMessage message) {
+    if (mounted) {
+      _load();
+    }
   }
 
   void _openChat() {
@@ -100,8 +131,10 @@ class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
                 right: 0,
                 child: Container(
                   padding: const EdgeInsets.symmetric(horizontal: 4),
-                  constraints:
-                      const BoxConstraints(minWidth: 16, minHeight: 16),
+                  constraints: const BoxConstraints(
+                    minWidth: 16,
+                    minHeight: 16,
+                  ),
                   decoration: BoxDecoration(
                     color: Colors.red,
                     borderRadius: BorderRadius.circular(8),

--- a/lib/ui/core/widgets/character_avatar.dart
+++ b/lib/ui/core/widgets/character_avatar.dart
@@ -1,17 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:memex/data/services/avatar_media_service.dart';
 import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
 import 'package:memex/ui/core/widgets/local_image.dart';
 
 /// Returns true if the avatar string represents a local image file path
 /// (as opposed to a DiceBear seed string).
 bool isImageAvatar(String? avatar) {
-  if (avatar == null || avatar.isEmpty) return false;
-  final lower = avatar.toLowerCase();
-  return lower.endsWith('.png') ||
-      lower.endsWith('.jpg') ||
-      lower.endsWith('.jpeg') ||
-      lower.endsWith('.webp') ||
-      lower.contains('/');
+  return AvatarMediaService.isImageAvatar(avatar);
 }
 
 /// A unified character avatar widget that handles both DiceBear seed avatars

--- a/lib/ui/core/widgets/dicebear_avatar.dart
+++ b/lib/ui/core/widgets/dicebear_avatar.dart
@@ -1,45 +1,21 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:http/http.dart' as http;
-import 'package:path_provider/path_provider.dart';
-import 'package:crypto/crypto.dart';
-import 'dart:convert';
+import 'package:memex/data/services/avatar_media_service.dart';
 
 /// Builds a DiceBear Notionists avatar URL from a seed string.
-String dicebearUrl(String seed) {
-  final encoded = Uri.encodeComponent(seed);
-  return 'https://api.dicebear.com/7.x/notionists/svg?seed=$encoded';
-}
+String dicebearUrl(String seed) => AvatarMediaService.diceBearUrl(seed);
 
 /// Downloads and caches the avatar SVG for a given seed.
 /// Returns the local file path, or null on failure.
-Future<String?> cacheAvatarSvg(String seed) async {
-  try {
-    final url = dicebearUrl(seed);
-    final response = await http.get(Uri.parse(url)).timeout(
-          const Duration(seconds: 10),
-        );
-    if (response.statusCode == 200) {
-      final file = await _cacheFile(seed);
-      await file.writeAsString(response.body);
-      return file.path;
-    }
-  } catch (_) {}
-  return null;
-}
-
-Future<File> _cacheFile(String seed) async {
-  final dir = await getApplicationSupportDirectory();
-  final hash = md5.convert(utf8.encode(seed)).toString();
-  return File('${dir.path}/avatar_$hash.svg');
-}
+Future<String?> cacheAvatarSvg(String seed) =>
+    AvatarMediaService.cacheDiceBearSvg(seed);
 
 /// Displays a DiceBear Notionists avatar as a circle.
 ///
 /// [seed] is used to generate the avatar. If null, shows a placeholder icon.
-/// Loads from local cache first, falls back to network.
-class DiceBearAvatar extends StatelessWidget {
+/// Loads from local cache first, then fetches and stores the SVG if needed.
+class DiceBearAvatar extends StatefulWidget {
   const DiceBearAvatar({
     super.key,
     required this.seed,
@@ -52,25 +28,56 @@ class DiceBearAvatar extends StatelessWidget {
   final Color? backgroundColor;
 
   @override
+  State<DiceBearAvatar> createState() => _DiceBearAvatarState();
+}
+
+class _DiceBearAvatarState extends State<DiceBearAvatar> {
+  Future<File?>? _avatarFileFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _avatarFileFuture = _futureForSeed(widget.seed);
+  }
+
+  @override
+  void didUpdateWidget(covariant DiceBearAvatar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.seed != widget.seed) {
+      _avatarFileFuture = _futureForSeed(widget.seed);
+    }
+  }
+
+  Future<File?>? _futureForSeed(String? seed) {
+    final cleanSeed = seed?.trim();
+    if (cleanSeed == null || cleanSeed.isEmpty) return null;
+    return AvatarMediaService.loadDiceBearSvg(cleanSeed);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (seed == null || seed!.isEmpty) {
+    if (widget.seed == null || widget.seed!.isEmpty) {
       return _placeholder();
     }
 
     return ClipOval(
       child: Container(
-        width: size,
-        height: size,
-        color: backgroundColor ?? const Color(0xFFEEF2FF),
-        child: FutureBuilder<File>(
-          future: _cacheFile(seed!),
+        width: widget.size,
+        height: widget.size,
+        color: widget.backgroundColor ?? const Color(0xFFEEF2FF),
+        child: FutureBuilder<File?>(
+          future: _avatarFileFuture,
           builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return _loadingIndicator();
+            }
+
             if (snapshot.hasData && snapshot.data!.existsSync()) {
               try {
                 return SvgPicture.file(
                   snapshot.data!,
-                  width: size,
-                  height: size,
+                  width: widget.size,
+                  height: widget.size,
                   fit: BoxFit.cover,
                   errorBuilder: (_, __, ___) => _placeholder(),
                 );
@@ -78,15 +85,7 @@ class DiceBearAvatar extends StatelessWidget {
                 return _placeholder();
               }
             }
-            // Fallback to network with error handling
-            return SvgPicture.network(
-              dicebearUrl(seed!),
-              width: size,
-              height: size,
-              fit: BoxFit.cover,
-              placeholderBuilder: (_) => _loadingIndicator(),
-              errorBuilder: (_, __, ___) => _placeholder(),
-            );
+            return _placeholder();
           },
         ),
       ),
@@ -95,15 +94,15 @@ class DiceBearAvatar extends StatelessWidget {
 
   Widget _placeholder() {
     return Container(
-      width: size,
-      height: size,
+      width: widget.size,
+      height: widget.size,
       decoration: BoxDecoration(
-        color: backgroundColor ?? const Color(0xFFEEF2FF),
+        color: widget.backgroundColor ?? const Color(0xFFEEF2FF),
         shape: BoxShape.circle,
       ),
       child: Icon(
         Icons.person,
-        size: size * 0.5,
+        size: widget.size * 0.5,
         color: const Color(0xFF5B6CFF),
       ),
     );
@@ -111,13 +110,13 @@ class DiceBearAvatar extends StatelessWidget {
 
   Widget _loadingIndicator() {
     return Container(
-      width: size,
-      height: size,
-      color: backgroundColor ?? const Color(0xFFEEF2FF),
+      width: widget.size,
+      height: widget.size,
+      color: widget.backgroundColor ?? const Color(0xFFEEF2FF),
       child: Center(
         child: SizedBox(
-          width: size * 0.3,
-          height: size * 0.3,
+          width: widget.size * 0.3,
+          height: widget.size * 0.3,
           child: const CircularProgressIndicator(
             strokeWidth: 2,
             color: Color(0xFF5B6CFF),

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -12,6 +12,7 @@ import 'package:memex/ui/main_screen/widgets/action_center_sheet.dart';
 import 'package:memex/domain/models/system_card_constants.dart';
 import 'package:memex/ui/core/cards/native_card_factory.dart';
 import 'package:memex/data/services/demo_service.dart';
+import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/ui/core/cards/card_action_notification.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
@@ -128,6 +129,10 @@ class TimelineScreenState extends State<TimelineScreen> {
     super.initState();
     _pageController = PageController();
     _scrollController.addListener(_onScroll);
+    EventBusService.instance.addHandler(
+      EventBusMessageType.profileUpdated,
+      _handleProfileUpdated,
+    );
     _checkPermissionBadge();
     _loadUserAvatar();
     _checkModelConfig();
@@ -198,13 +203,23 @@ class TimelineScreenState extends State<TimelineScreen> {
 
   Future<void> _loadUserAvatar() async {
     final avatar = await MemexRouter().getUserAvatar();
-    if (mounted && avatar != null) {
+    if (mounted) {
       setState(() => _userAvatar = avatar);
+    }
+  }
+
+  void _handleProfileUpdated(EventBusMessage message) {
+    if (mounted) {
+      _loadUserAvatar();
     }
   }
 
   @override
   void dispose() {
+    EventBusService.instance.removeHandler(
+      EventBusMessageType.profileUpdated,
+      _handleProfileUpdated,
+    );
     _pageController.dispose();
     _tagScrollController.dispose();
     _scrollController.dispose();

--- a/lib/utils/user_storage.dart
+++ b/lib/utils/user_storage.dart
@@ -19,7 +19,7 @@ import 'package:memex/data/services/gemini_auth_service.dart';
 import 'package:memex/domain/models/task_exceptions.dart';
 import 'package:memex/llm_client/codex_responses_client.dart';
 import 'package:memex/llm_client/gemini_oauth_client.dart';
-import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
+import 'package:memex/data/services/avatar_media_service.dart';
 
 /// Agent cache data structure
 class AgentCacheData {
@@ -734,7 +734,7 @@ class UserStorage {
         final seed =
             (userId != null && userId.isNotEmpty) ? userId : defaultAvatarSeed;
         await prefs.setString(_keyUserAvatar, seed);
-        cacheAvatarSvg(seed); // Cache in background after migration
+        AvatarMediaService.precacheDiceBearAvatar(seed);
         return seed;
       }
       return avatar;
@@ -755,8 +755,7 @@ class UserStorage {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_keyUserAvatar, avatar);
-      // Cache SVG in background — don't block save
-      cacheAvatarSvg(avatar);
+      AvatarMediaService.precacheDiceBearAvatar(avatar);
     } catch (e) {
       // ignore error
     }

--- a/test/data/services/avatar_media_service_test.dart
+++ b/test/data/services/avatar_media_service_test.dart
@@ -1,0 +1,140 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:memex/data/services/avatar_media_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('memex_avatar_media_');
+    _mockPathProviderChannel(tempDir.path);
+    await FileSystemService.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    _clearPathProviderChannelMock();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('recognizes all imported image extensions as avatar image paths', () {
+    for (final ext in const [
+      'png',
+      'jpg',
+      'jpeg',
+      'webp',
+      'gif',
+      'bmp',
+      'heic',
+      'heif',
+      'tiff',
+      'tif',
+    ]) {
+      final relative = 'workspace/_user/_System/media/avatar.$ext';
+
+      expect(AvatarMediaService.isImageAvatar(relative), isTrue, reason: ext);
+      expect(
+        AvatarMediaService.isRelativeImagePath(relative),
+        isTrue,
+        reason: ext,
+      );
+    }
+  });
+
+  test('resolves relative avatar media paths against current data root', () {
+    const relative = 'workspace/_user/_System/media/avatar.heic';
+
+    final resolved = AvatarMediaService.resolveAvatarPath(
+      relative,
+      fileSystemService: FileSystemService.instance,
+    );
+
+    expect(resolved, p.join(tempDir.path, relative));
+  });
+
+  test(
+    'keeps DiceBear seeds and remote images out of relative path resolution',
+    () {
+      expect(AvatarMediaService.isDiceBearSeed('Felix'), isTrue);
+      expect(AvatarMediaService.isImageAvatar('Felix'), isFalse);
+      expect(AvatarMediaService.isRelativeImagePath('Felix'), isFalse);
+
+      const remote = 'https://example.com/avatar.heic';
+      expect(AvatarMediaService.isImageAvatar(remote), isTrue);
+      expect(AvatarMediaService.isRelativeImagePath(remote), isFalse);
+    },
+  );
+
+  test('caches DiceBear SVGs to application support directory', () async {
+    final client = MockClient((request) async {
+      expect(request.url.toString(), contains('seed=Felix'));
+      return http.Response(_svgBody, 200);
+    });
+
+    final cachedPath = await AvatarMediaService.cacheDiceBearSvg(
+      'Felix',
+      client: client,
+    );
+
+    expect(cachedPath, isNotNull);
+    final cached = File(cachedPath!);
+    expect(await cached.exists(), isTrue);
+    expect(await cached.readAsString(), _svgBody);
+  });
+
+  test(
+    'returns null without creating a cache file on download failure',
+    () async {
+      final client = MockClient((request) async => http.Response('nope', 503));
+
+      final cachedPath = await AvatarMediaService.cacheDiceBearSvg(
+        'offline',
+        client: client,
+      );
+      final cacheFile = await AvatarMediaService.diceBearCacheFile('offline');
+
+      expect(cachedPath, isNull);
+      expect(await cacheFile.exists(), isFalse);
+    },
+  );
+}
+
+const _svgBody =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48">'
+    '<rect width="48" height="48" fill="#5B6CFF"/></svg>';
+
+void _mockPathProviderChannel(String rootPath) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (call) async {
+          switch (call.method) {
+            case 'getTemporaryDirectory':
+            case 'getApplicationDocumentsDirectory':
+            case 'getApplicationSupportDirectory':
+            case 'getExternalStorageDirectory':
+              return rootPath;
+            case 'getExternalStorageDirectories':
+              return <String>[rootPath];
+          }
+          return null;
+        },
+      );
+}
+
+void _clearPathProviderChannelMock() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        null,
+      );
+}

--- a/test/data/services/character_service_default_seed_test.dart
+++ b/test/data/services/character_service_default_seed_test.dart
@@ -73,6 +73,28 @@ enabled: true
     expect(character.postHistoryInstructions, isNotNull);
   });
 
+  test('resolves imported HEIC avatar paths when loading characters', () async {
+    final userId = 'heic_user_${DateTime.now().microsecondsSinceEpoch}';
+    final charsPath = CharacterService.instance.getCharactersPath(userId);
+    await Directory(charsPath).create(recursive: true);
+    const relativeAvatar = 'workspace/_heic_user/_System/media/avatar.heic';
+    await File(p.join(charsPath, 'custom.yaml')).writeAsString(
+      '''
+name: Custom
+tags: []
+persona: ""
+avatar: "$relativeAvatar"
+enabled: true
+''',
+    );
+
+    final character =
+        await CharacterService.instance.getCharacter(userId, 'custom');
+
+    expect(character, isNotNull);
+    expect(character!.avatar, p.join(tempRoot.path, relativeAvatar));
+  });
+
   test('multi-character routing nudges multiple voices without forcing fill',
       () async {
     final userId = 'selection_user_${DateTime.now().microsecondsSinceEpoch}';

--- a/test/domain/models/event_bus_message_test.dart
+++ b/test/domain/models/event_bus_message_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/event_bus_message.dart';
+
+void main() {
+  test('parses profile update messages from event payloads', () {
+    final parsed = EventBusMessage.fromJson({
+      'type': 'profile_updated',
+      'data': {
+        'user_id': 'user-1',
+        'avatar': 'workspace/_user/_System/media/avatar.heic',
+      },
+    });
+
+    expect(parsed, isA<ProfileUpdatedMessage>());
+    final message = parsed as ProfileUpdatedMessage;
+    expect(message.type, EventBusMessageType.profileUpdated);
+    expect(message.userId, 'user-1');
+    expect(message.avatar, 'workspace/_user/_System/media/avatar.heic');
+  });
+
+  test('parses character update messages from event payloads', () {
+    final parsed = EventBusMessage.fromJson({
+      'type': 'character_updated',
+      'data': {
+        'user_id': 'user-1',
+        'character_id': 'mentor',
+      },
+    });
+
+    expect(parsed, isA<CharacterUpdatedMessage>());
+    final message = parsed as CharacterUpdatedMessage;
+    expect(message.type, EventBusMessageType.characterUpdated);
+    expect(message.userId, 'user-1');
+    expect(message.characterId, 'mentor');
+  });
+}

--- a/test/ui/character/widgets/persona_avatar_button_test.dart
+++ b/test/ui/character/widgets/persona_avatar_button_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/character/widgets/persona_avatar_button.dart';
+import 'package:memex/ui/core/widgets/character_avatar.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('renders an empty slot before a user is available', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await tester.pumpWidget(
+      const MaterialApp(home: Center(child: PersonaAvatarButton())),
+    );
+    await tester.pump();
+
+    expect(find.byType(CharacterAvatar), findsNothing);
+  });
+}

--- a/test/ui/core/widgets/avatar_widgets_test.dart
+++ b/test/ui/core/widgets/avatar_widgets_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/core/widgets/character_avatar.dart';
+import 'package:memex/ui/core/widgets/dicebear_avatar.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('CharacterAvatar routes HEIC media paths through LocalImage', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: CharacterAvatar(
+          avatar: 'workspace/_user/_System/media/avatar.heic',
+          name: 'User',
+        ),
+      ),
+    );
+
+    expect(find.byType(LocalImage), findsOneWidget);
+    expect(find.byType(DiceBearAvatar), findsNothing);
+  });
+
+  testWidgets('DiceBearAvatar shows a stable placeholder for empty seeds', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: DiceBearAvatar(seed: null, size: 48)),
+    );
+
+    expect(find.byIcon(Icons.person), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 变更

- 新增 `AvatarMediaService`，集中处理头像类型识别、相对路径解析、DiceBear URL/cache/预热。
- 用户头像与角色头像链路改用统一服务，支持 HEIC/HEIF/GIF/BMP/TIFF 等导入头像扩展名。
- `DiceBearAvatar` 改为本地缓存优先，缓存缺失时再下载写入，失败时稳定显示 placeholder。
- 增加 `profileUpdated` / `characterUpdated` 事件，主界面用户头像和角色头像更新后即时刷新。
- `PersonaAvatarButton` 移除固定 2 秒延迟；`FileSystemService` 未就绪时短间隔重试，避免启动竞态导致永久空白。

## 验证

- `flutter test --no-pub --concurrency=1 test/data/services/avatar_media_service_test.dart test/ui/core/widgets/avatar_widgets_test.dart test/ui/character/widgets/persona_avatar_button_test.dart test/data/services/character_service_default_seed_test.dart test/domain/models/event_bus_message_test.dart`：14 passed。
- `flutter analyze --no-pub ...`（头像链路相关变更文件，排除 `timeline_screen.dart` 既有 baseline info）：No issues found。
- `flutter test --no-pub --concurrency=1`：457 passed, 7 skipped。
- Android `Medium_Phone_API_35`：`globalDev` debug APK 构建/安装/冷启动；日志确认 `PersonaAvatarButton` 从未就绪重试到 `primary=Mentor`，无 `FileSystemService not initialized` / FATAL。该 AVD 的 `screencap` / Flutter screenshot 因 gfxstream/ColorBuffer 图形问题为黑屏，已作为模拟器截图限制记录。
- iOS `iPhone 17 Pro`：`global` scheme + `MEMEX_IOS_SIMULATOR_MLKIT_STUBS=1` 构建/启动；完成新用户 setup 到主界面，日志确认 `PersonaAvatarButton primary=老领导`，主界面右上头像区域可见。

Closes #244
