### PR TITLE
Fix schedule aggregation tool schemas

### DIFF
--- a/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
+++ b/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
@@ -7,6 +7,52 @@ import 'package:memex/domain/models/schedule_state.dart';
 
 import '../../../utils/user_storage.dart';
 
+const Map<String, dynamic> _scheduleSubtaskParameterSchema = {
+  'type': 'object',
+  'properties': {
+    'title': {'type': 'string'},
+    'completed': {'type': 'boolean'},
+    'closed_by_fact_id': {'type': 'string'},
+  },
+};
+
+const Map<String, dynamic> _presentationHeroParameterSchema = {
+  'type': 'object',
+  'properties': {
+    'item_id': {'type': 'string'},
+    'title': {'type': 'string'},
+    'description': {'type': 'string'},
+  },
+};
+
+const Map<String, dynamic> _quoteBlockParameterSchema = {
+  'type': 'object',
+  'properties': {
+    'title': {'type': 'string'},
+    'content': {'type': 'string'},
+    'priority': {
+      'type': 'string',
+      'enum': ['low', 'normal', 'high'],
+    },
+    'item_id': {'type': 'string'},
+  },
+};
+
+const Map<String, dynamic> _timelineDayParameterSchema = {
+  'type': 'object',
+  'properties': {
+    'day_label': {'type': 'string'},
+    'day_date': {
+      'type': 'string',
+      'description': 'Calendar day in YYYY-MM-DD format.',
+    },
+    'item_ids': {
+      'type': 'array',
+      'items': {'type': 'string'},
+    },
+  },
+};
+
 class ScheduleAggregationSkill extends Skill {
   ScheduleAggregationSkill({
     super.forceActivate,
@@ -87,7 +133,8 @@ Tool buildAddPendingItemTool() {
         'priority': {'type': 'number'},
         'subtasks': {
           'type': 'array',
-          'description': 'Todo-only explicit subtasks.'
+          'description': 'Todo-only explicit subtasks.',
+          'items': _scheduleSubtaskParameterSchema,
         },
         'sync_device_action': {
           'type': 'boolean',
@@ -172,7 +219,8 @@ Tool buildUpdatePendingItemTool() {
         'priority': {'type': 'number'},
         'subtasks': {
           'type': 'array',
-          'description': 'Todo-only explicit subtasks.'
+          'description': 'Todo-only explicit subtasks.',
+          'items': _scheduleSubtaskParameterSchema,
         },
         'sync_device_action': {
           'type': 'boolean',
@@ -301,10 +349,16 @@ Tool buildSetPresentationTool({bool stopAfterSetPresentation = false}) {
     parameters: {
       'type': 'object',
       'properties': {
-        'hero': {'type': 'object'},
+        'hero': _presentationHeroParameterSchema,
         'editorial_intro': {'type': 'string'},
-        'quote_blocks': {'type': 'array'},
-        'timeline': {'type': 'array'},
+        'quote_blocks': {
+          'type': 'array',
+          'items': _quoteBlockParameterSchema,
+        },
+        'timeline': {
+          'type': 'array',
+          'items': _timelineDayParameterSchema,
+        },
       },
       'required': ['editorial_intro', 'timeline'],
     },

--- a/test/agent/schedule_aggregation_skill_test.dart
+++ b/test/agent/schedule_aggregation_skill_test.dart
@@ -1,0 +1,77 @@
+import 'package:memex/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ScheduleAggregationSkill tool schemas', () {
+    test('declare items for every array parameter', () {
+      final tools = [
+        buildAddPendingItemTool(),
+        buildUpdatePendingItemTool(),
+        buildSetPresentationTool(),
+      ];
+
+      for (final tool in tools) {
+        final missing = <String>[];
+        _collectArraySchemasMissingItems(
+          tool.parameters,
+          tool.name,
+          missing,
+        );
+
+        expect(missing, isEmpty, reason: missing.join('\n'));
+      }
+    });
+
+    test('uses object item schemas for schedule aggregation payloads', () {
+      final addPendingProperties = _properties(buildAddPendingItemTool());
+      final updatePendingProperties = _properties(buildUpdatePendingItemTool());
+      final presentationProperties = _properties(buildSetPresentationTool());
+
+      expect(
+        addPendingProperties['subtasks'],
+        containsPair('items', containsPair('type', 'object')),
+      );
+      expect(
+        updatePendingProperties['subtasks'],
+        containsPair('items', containsPair('type', 'object')),
+      );
+      expect(
+        presentationProperties['quote_blocks'],
+        containsPair('items', containsPair('type', 'object')),
+      );
+      expect(
+        presentationProperties['timeline'],
+        containsPair('items', containsPair('type', 'object')),
+      );
+    });
+  });
+}
+
+Map<String, dynamic> _properties(dynamic tool) {
+  final parameters = Map<String, dynamic>.from(tool.parameters as Map);
+  return Map<String, dynamic>.from(parameters['properties'] as Map);
+}
+
+void _collectArraySchemasMissingItems(
+  dynamic schema,
+  String path,
+  List<String> missing,
+) {
+  if (schema is Map) {
+    final typed = Map<String, dynamic>.from(schema);
+    if (typed['type'] == 'array' && !typed.containsKey('items')) {
+      missing.add('$path is an array schema without items');
+    }
+    typed.forEach((key, value) {
+      _collectArraySchemasMissingItems(value, '$path.$key', missing);
+    });
+  } else if (schema is List) {
+    for (final entry in schema.indexed) {
+      _collectArraySchemasMissingItems(
+        entry.$2,
+        '$path[${entry.$1}]',
+        missing,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add explicit item schemas for schedule aggregation array tool parameters
- align presentation tool schemas with prompt/model parsing for hero, quote blocks, timeline days, and nested item ids
- add regression coverage so array schemas cannot omit items again

## Tests
- flutter test test/data/services/task_handlers/schedule_aggregator_handler_test.dart test/agent/schedule_aggregation_skill_test.dart