### PR TITLE
[codex] 强化 AI 编码测试规范

### DIFF
--- a/.cursor/rules/memex.mdc
+++ b/.cursor/rules/memex.mdc
@@ -1,0 +1,20 @@
+---
+description: Memex coding and testing rules
+globs:
+  - "**/*"
+alwaysApply: true
+---
+
+`AGENTS.md` is the canonical instruction file for this repository. Read it
+before editing code and follow its architecture, data-access, localization,
+logging, and testing requirements.
+
+Behavior changes require test evidence in the same PR:
+
+- Unit tests for changed non-UI behavior.
+- Widget tests for changed UI rendering, state, navigation, dialogs/sheets,
+  buttons, gestures, error/empty/loading states, localization, or interactions.
+- Integration or full-chain tests for cross-layer golden-path changes.
+
+If tests are not added or not run, the PR test plan must explain the concrete
+reason.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,8 +36,13 @@ Closes #
 
 ## Test plan
 
-<!-- List the exact commands and manual checks you ran. -->
+<!-- List the exact commands and manual checks you ran. For behavior changes,
+unit/widget test evidence is expected in this PR. If a box is not applicable,
+write the concrete reason next to it. -->
 
+- [ ] Added/updated unit tests for changed non-UI behavior, or explained why not:
+- [ ] Added/updated widget tests for UI/user interaction changes, or explained why not:
+- [ ] Exact test files:
 - [ ] `flutter test`
 - [ ] `flutter analyze`
 - [ ] Manual iOS check
@@ -51,4 +56,3 @@ Closes #
 - [ ] I did not edit generated `*.g.dart` files manually.
 - [ ] I did not add telemetry, hidden network calls, secrets, or signing keys.
 - [ ] I updated docs or localization when needed.
-

--- a/.github/claude/pr-ai-review-prompt.md
+++ b/.github/claude/pr-ai-review-prompt.md
@@ -33,5 +33,8 @@ Your job:
 5. Cite evidence as concise file/path references or short diff references.
 6. If the diff is too incomplete to assess a relevant area, raise risk instead of
    pretending confidence is high.
+7. Apply the unit/widget/integration test expectations from `AGENTS.md` and
+   `docs/pr-ai-review.*.md`; missing test evidence for behavior changes must be
+   reported in `test_gaps`.
 
 Return the structured JSON only.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+# Memex Copilot Instructions
+
+`AGENTS.md` is the canonical instruction file for this repository. Read it
+before suggesting or editing code.
+
+Key testing rule: behavior changes require test evidence in the same PR. Add or
+update unit tests for non-UI behavior, widget tests for UI/user interaction
+changes, and integration or full-chain tests for cross-layer golden-path
+changes. If tests are not applicable, the PR test plan must explain why.

--- a/.windsurf/rules/memex.md
+++ b/.windsurf/rules/memex.md
@@ -1,0 +1,13 @@
+# Memex Windsurf Rules
+
+`AGENTS.md` is the canonical instruction file for this repository. Read it
+before editing code and follow its architecture and testing rules.
+
+Behavior changes require test evidence in the same PR:
+
+- Unit tests for changed non-UI behavior.
+- Widget tests for UI rendering, state, navigation, dialogs/sheets, buttons,
+  gestures, error/empty/loading states, localization, or interactions.
+- Integration or full-chain tests for cross-layer golden-path changes.
+
+If tests are not added or not run, the PR test plan must explain why.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,31 @@ cd ios && pod install && cd ..
 
 Never edit `*.g.dart` files — always regenerate.
 
+## Testing Requirements
+
+Behavior changes must include tests in the same PR. Documentation, comments, or
+pure repository configuration changes may skip app tests only when the PR test
+plan explains why.
+
+- Add or update **unit tests** for changed domain models, utilities,
+  repositories, services, task handlers, agents, routing decisions, database
+  behavior, or non-UI ViewModel logic. Mirror the `lib/` path under `test/`
+  whenever a clear home exists.
+- Add or update **widget tests** for any UI rendering, state, navigation,
+  dialog/sheet, button, gesture, error/empty/loading state, localization, or
+  user interaction change. The test should assert the visible behavior a user
+  relies on.
+- Add an integration or full-chain regression test when a change crosses
+  repository/service/router/event/task/agent boundaries or fixes a golden-path
+  flow such as capture, card generation, timeline refresh, backup/restore, or
+  LLM configuration.
+- Do not delete, weaken, or rewrite tests just to make a change pass. If a test
+  expectation changes, preserve the old behavior in a new assertion when it is
+  still supported, or explain the behavior change in the PR.
+- Run the smallest meaningful targeted tests while iterating, then run
+  `flutter test` and `flutter analyze` before publishing when feasible. If a
+  command is not run, the PR test plan must state the exact reason.
+
 ## Architecture
 
 **MVVM + Provider** following [Flutter app architecture guide](https://docs.flutter.dev/app-architecture/guide).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,21 @@
 # Memex — Project Context for Claude Code
 
+## Authoritative Agent Rules
+
+`AGENTS.md` is the canonical instruction file for coding agents in this repo.
+Read it before editing code, and follow its architecture, data-access,
+localization, logging, and testing requirements. If this file conflicts with
+`AGENTS.md`, `AGENTS.md` wins.
+
+For testing, behavior changes require tests in the same PR:
+
+- Unit tests for changed domain, utility, repository, service, task, agent,
+  routing, database, or non-UI ViewModel behavior.
+- Widget tests for changed UI rendering, state, navigation, dialogs/sheets,
+  buttons, gestures, error/empty/loading states, localization, or interactions.
+- Integration/full-chain tests for cross-layer golden-path changes such as
+  capture, card generation, timeline refresh, backup/restore, and LLM config.
+
 ## Product
 
 Memex is a local-first, AI-native personal knowledge management app built with Flutter. Users capture text, photos, and voice recordings. A multi-agent system automatically organizes records into structured timeline cards, extracts knowledge, and generates cross-record insights.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,10 +70,30 @@ Community demand matters, but maintainers also consider strategic fit, implement
    - `MemexRouter` as the central facade.
    - `Result<T>` and `Command` for explicit async state and errors.
    - No manual edits to generated `*.g.dart` files.
-4. Add or update tests when changing behavior.
+4. Add or update the required tests when changing behavior.
 5. Fill in the PR template, including screenshots or screen recordings for UI changes.
 
 Maintainers may close PRs that are out of scope, too broad, or conflict with the local-first product direction. We will try to say that early so contributors do not spend unnecessary time.
+
+## Testing Expectations
+
+Behavior changes should include test evidence in the same PR. A clear test plan
+is part of the change, not a follow-up.
+
+- Add or update unit tests for changed domain models, utilities, repositories,
+  services, task handlers, agents, routing decisions, database behavior, or
+  non-UI ViewModel logic.
+- Add or update widget tests for UI rendering, state, navigation, dialogs or
+  sheets, buttons, gestures, error/empty/loading states, localization, or user
+  interactions.
+- Add integration or full-chain regression coverage when a change crosses
+  repository, service, router, event, task, or agent boundaries, or when it
+  fixes a core flow such as capture, card generation, timeline refresh,
+  backup/restore, or LLM configuration.
+- Do not remove or weaken existing tests to make a PR pass. If behavior changes,
+  update the assertions and explain the new expectation in the PR.
+- If tests are not added or not run, explain why in the PR test plan. "Not run"
+  without a concrete reason is not enough for behavior changes.
 
 ## Development Setup
 
@@ -105,7 +125,14 @@ cd ios && pod install && cd ..
 
 ## Using Coding Agents
 
-If you use an AI coding agent (Cursor, Codex, Claude Code, Kiro, etc.) to work on this codebase, make sure the agent reads `AGENTS.md` before it starts writing code. Most agents already look for this file automatically, but if yours doesn't, include it in the agent's context or prompt it to read the file first. `AGENTS.md` contains architecture rules, layer boundaries, naming conventions, and data-access patterns that are easy to violate without context.
+If you use an AI coding agent (Cursor, Codex, Claude Code, GitHub Copilot,
+Gemini, Windsurf, Kiro, etc.) to work on this codebase, make sure the agent
+reads `AGENTS.md` before it starts writing code. Most agents already look for
+this file automatically, but if yours doesn't, include it in the agent's context
+or prompt it to read the file first. `AGENTS.md` contains the canonical
+architecture rules, layer boundaries, naming conventions, data-access patterns,
+and required unit/widget test expectations that are easy to violate without
+context.
 
 ## Security and Privacy
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,9 @@
+# Memex Gemini Instructions
+
+`AGENTS.md` is the canonical instruction file for coding agents in this
+repository. Read it before editing code.
+
+Behavior changes require tests in the same PR: unit tests for non-UI behavior,
+widget tests for UI/user interaction changes, and integration or full-chain
+tests for cross-layer golden-path changes. If tests are not applicable, explain
+the concrete reason in the PR test plan.

--- a/docs/pr-ai-review.en.md
+++ b/docs/pr-ai-review.en.md
@@ -131,6 +131,28 @@ AI must check whether:
 - Agents use explicit file permissions, correct LLM resource lookup, and state
   persistence.
 
+## Test Gap Checks
+
+AI must treat test evidence as part of semantic review, not only check whether
+CI ran:
+
+- Changes to `lib/data/**`, `lib/domain/**`, `lib/utils/**`, `lib/agent/**`,
+  `lib/db/**`, `lib/routing/**`, or non-UI ViewModel behavior should include
+  matching unit tests, or a concrete exemption in the PR test plan.
+- Changes to `lib/ui/**` rendering, state, navigation, dialogs/sheets, buttons,
+  gestures, error/empty/loading states, localization, or user interactions
+  should include widget tests for the visible behavior, or a concrete exemption
+  in the PR test plan.
+- Changes that cross repository, service, router, event, task, or agent
+  boundaries, or affect golden paths such as capture, card generation, timeline
+  refresh, backup/restore, or LLM configuration, should include integration,
+  full-chain, or explicit end-to-end validation evidence.
+- A PR that only says `Not run`, `未运行`, or generally claims "manual testing"
+  does not provide sufficient test evidence.
+- Missing test evidence for non-documentation behavior changes must be listed
+  in `test_gaps`; if the affected scope is meaningful or touches a golden path,
+  risk should usually rise to `high` or above.
+
 ## Output
 
 AI must return JSON matching `.github/claude/pr-ai-review.schema.json`. The

--- a/docs/pr-ai-review.zh.md
+++ b/docs/pr-ai-review.zh.md
@@ -111,6 +111,23 @@ AI 必须检查：
 - 短 UI 字符串是否走 ARB，中长文案是否走 `AppLocalizationsExt`。
 - agent 是否使用明确文件权限、正确 LLM resource 获取和状态持久化。
 
+## 测试缺口检查
+
+AI 必须把测试证据当作语义 review 的一部分，而不是只看 CI 是否跑过：
+
+- 改动 `lib/data/**`、`lib/domain/**`、`lib/utils/**`、`lib/agent/**`、
+  `lib/db/**`、`lib/routing/**` 或非 UI ViewModel 行为时，应有对应 unit
+  test，或者 PR test plan 给出具体豁免理由。
+- 改动 `lib/ui/**` 的渲染、状态、导航、弹窗/底 sheet、按钮、手势、错误/空态/加载态、
+  localization 或用户交互时，应有 widget test 覆盖可见行为，或者 PR test plan 给出
+  具体豁免理由。
+- 改动跨越 repository、service、router、event、task 或 agent 边界，或影响记录输入、
+  card 生成、timeline 刷新、备份恢复、LLM 配置等黄金链路时，应有 integration、
+  full-chain 或明确的端到端验证说明。
+- PR 只写 `Not run`、`未运行` 或泛泛说“手动测试过”，不能算充分测试证据。
+- 非文档行为改动缺少足够测试时，应写入 `test_gaps`；如果影响范围不小或触及黄金链路，
+  通常应提升到 `high` 或更高风险。
+
 ## 输出要求
 
 AI 必须输出符合 `.github/claude/pr-ai-review.schema.json` 的 JSON。输出应包含：


### PR DESCRIPTION
## 变更

- 在 `AGENTS.md` 增加权威测试规范，明确行为改动必须在同一个 PR 中提供测试证据。
- 在 `CLAUDE.md`、`CONTRIBUTING.md` 和各类 AI 工具入口中强调以 `AGENTS.md` 为准。
- 新增 Cursor、GitHub Copilot、Gemini、Windsurf 的轻量入口文件，降低不同 AI 工具漏读规范的概率。
- 更新 PR 模板，要求说明 unit test、widget test、具体测试文件和未覆盖原因。
- 更新 PR AI Review 文档和 prompt，让缺少 unit/widget/integration 测试证据进入 `test_gaps` 并影响风险判断。

## 验证

- [x] `git diff --cached --check`
- [ ] `flutter test`：未运行。本 PR 只修改文档、PR 模板和 AI 工具说明，不改变 Flutter/Dart 运行时代码。
- [ ] `flutter analyze`：未运行。原因同上。

## 备注

这次没有创建对应 issue；该 PR 直接补齐贡献和 AI 编码规范。
