### PR TITLE
修复 Android 后台 Agent 通知完成后残留

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -158,5 +158,6 @@ flutter {
 
 dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.work:work-runtime:2.10.2")
     implementation("com.google.mlkit:text-recognition-chinese:16.0.1")
 }

--- a/android/app/src/main/kotlin/com/memexlab/memex/AgentBackgroundService.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/AgentBackgroundService.kt
@@ -13,23 +13,46 @@ import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
 import androidx.core.app.NotificationCompat
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import com.memexlab.memex.channels.AgentBackgroundChannelHandler
 
 class AgentBackgroundService : Service() {
     companion object {
         const val ACTION_UPDATE = "com.memexlab.memex.agent_background.UPDATE"
         const val ACTION_STOP = "com.memexlab.memex.agent_background.STOP"
+        const val EXTRA_WATCH_BACKGROUND_WORK = "watchBackgroundWork"
 
         private const val CHANNEL_ID = "agent_background"
-        private const val CHANNEL_NAME = "Agent processing"
-        private const val NOTIFICATION_ID = 188
+        private const val CHANNEL_NAME = "Memex Agent"
+        private const val BACKGROUND_WORK_UNIQUE_NAME = "agent_queue_drain"
+        private const val WORK_MONITOR_DELAY_MS = 2_000L
+        private const val WORK_MONITOR_GRACE_MS = 10_000L
+        const val NOTIFICATION_ID = 188
+
+        fun clear(context: Context) {
+            val intent = Intent(context, AgentBackgroundService::class.java).apply {
+                action = ACTION_STOP
+            }
+            context.stopService(intent)
+            val manager =
+                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.cancel(NOTIFICATION_ID)
+        }
     }
 
     private val handler = Handler(Looper.getMainLooper())
     private val stopRunnable = Runnable {
-        stopForegroundCompat(removeNotification = true)
+        stopForegroundCompat(removeNotification = false)
         stopSelf()
     }
+    private val workMonitorRunnable = Runnable { checkBackgroundDrainWork() }
+    private var watchBackgroundWork = false
+    private var workMonitorStartedAtMs = 0L
+    private var workInfosLiveData: LiveData<List<WorkInfo>>? = null
+    private var workInfoObserver: Observer<List<WorkInfo>>? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -37,41 +60,58 @@ class AgentBackgroundService : Service() {
         createNotificationChannel()
 
         if (intent == null) {
-            stopSelf(startId)
+            clearAndStop(startId)
             return START_NOT_STICKY
         }
 
         if (intent.action == ACTION_STOP) {
-            stopForegroundCompat(removeNotification = true)
-            stopSelf(startId)
+            clearAndStop(startId)
             return START_NOT_STICKY
         }
 
         val state = intent.getStringExtra("state") ?: "active"
+        if (state == "completed" || state == "idle") {
+            clearAndStop(startId)
+            return START_NOT_STICKY
+        }
+
+        watchBackgroundWork =
+            state == "active" && intent.getBooleanExtra(EXTRA_WATCH_BACKGROUND_WORK, false)
+        if (watchBackgroundWork && workMonitorStartedAtMs == 0L) {
+            workMonitorStartedAtMs = System.currentTimeMillis()
+        }
+
         val notification = buildNotification(intent, state)
         startForegroundCompat(notification)
 
         handler.removeCallbacks(stopRunnable)
-        if (state == "completed" || state == "failed" || state == "idle") {
+        if (state == "failed") {
             handler.postDelayed(stopRunnable, 5000)
         }
+        scheduleOrCancelWorkMonitor()
 
         return START_NOT_STICKY
     }
 
     override fun onDestroy() {
         handler.removeCallbacks(stopRunnable)
+        handler.removeCallbacks(workMonitorRunnable)
+        removeWorkInfoObserver()
         super.onDestroy()
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        if (!watchBackgroundWork) {
+            clearAndStop()
+        }
+        super.onTaskRemoved(rootIntent)
+    }
+
     private fun buildNotification(intent: Intent?, state: String): Notification {
-        val title = intent?.getStringExtra("title") ?: "Memex is processing"
+        val title = intent?.getStringExtra("title") ?: "Memex Agent"
         val stage = intent?.getStringExtra("stage") ?: "Processing"
         val detail = intent?.getStringExtra("detail") ?: ""
         val remainingTasks = intent?.getIntExtra("remainingTasks", 0) ?: 0
-        val pending = intent?.getIntExtra("pending", 0) ?: 0
-        val processing = intent?.getIntExtra("processing", 0) ?: 0
-        val retrying = intent?.getIntExtra("retrying", 0) ?: 0
 
         val openIntent = Intent(this, MainActivity::class.java).apply {
             action = AgentBackgroundChannelHandler.ACTION_OPEN_AGENT_ACTIVITY
@@ -86,14 +126,19 @@ class AgentBackgroundService : Service() {
         )
 
         val subText = when (state) {
-            "completed" -> "All tasks finished"
-            "failed" -> "Tap to review"
-            else -> "$remainingTasks remaining"
+            "failed" -> "Needs attention"
+            else -> {
+                val taskLabel = if (remainingTasks == 1) "task" else "tasks"
+                if (remainingTasks > 0) {
+                    "Processing $remainingTasks queued $taskLabel"
+                } else {
+                    "Processing"
+                }
+            }
         }
         val body = listOf(
             stage,
             detail,
-            "running $processing - waiting $pending - retrying $retrying",
         ).filter { it.isNotBlank() }.joinToString("\n")
 
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
@@ -129,6 +174,75 @@ class AgentBackgroundService : Service() {
             setShowBadge(false)
         }
         manager.createNotificationChannel(channel)
+    }
+
+    private fun scheduleOrCancelWorkMonitor() {
+        handler.removeCallbacks(workMonitorRunnable)
+        if (watchBackgroundWork) {
+            handler.postDelayed(workMonitorRunnable, WORK_MONITOR_DELAY_MS)
+        } else {
+            workMonitorStartedAtMs = 0L
+        }
+    }
+
+    private fun checkBackgroundDrainWork() {
+        if (!watchBackgroundWork) return
+
+        removeWorkInfoObserver()
+        val liveData =
+            WorkManager.getInstance(applicationContext)
+                .getWorkInfosForUniqueWorkLiveData(BACKGROUND_WORK_UNIQUE_NAME)
+        val observer =
+            object : Observer<List<WorkInfo>> {
+                override fun onChanged(infos: List<WorkInfo>) {
+                    removeWorkInfoObserver()
+                    val hasLiveWork = infos.any { info ->
+                        info.state == WorkInfo.State.ENQUEUED ||
+                            info.state == WorkInfo.State.RUNNING ||
+                            info.state == WorkInfo.State.BLOCKED
+                    }
+                    if (hasLiveWork) {
+                        scheduleOrCancelWorkMonitor()
+                        return
+                    }
+
+                    val waitedLongEnough =
+                        System.currentTimeMillis() - workMonitorStartedAtMs >=
+                            WORK_MONITOR_GRACE_MS
+                    if (waitedLongEnough) {
+                        clearAndStop()
+                    } else {
+                        scheduleOrCancelWorkMonitor()
+                    }
+                }
+            }
+        workInfosLiveData = liveData
+        workInfoObserver = observer
+        liveData.observeForever(observer)
+    }
+
+    private fun clearAndStop(startId: Int? = null) {
+        watchBackgroundWork = false
+        workMonitorStartedAtMs = 0L
+        handler.removeCallbacks(stopRunnable)
+        handler.removeCallbacks(workMonitorRunnable)
+        removeWorkInfoObserver()
+        stopForegroundCompat(removeNotification = true)
+        val manager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.cancel(NOTIFICATION_ID)
+        if (startId == null) {
+            stopSelf()
+        } else {
+            stopSelf(startId)
+        }
+    }
+
+    private fun removeWorkInfoObserver() {
+        val observer = workInfoObserver ?: return
+        workInfosLiveData?.removeObserver(observer)
+        workInfoObserver = null
+        workInfosLiveData = null
     }
 
     private fun startForegroundCompat(notification: Notification) {

--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/AgentBackgroundChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/AgentBackgroundChannelHandler.kt
@@ -27,11 +27,11 @@ object AgentBackgroundChannelHandler {
                     result.success(null)
                 }
                 "finishAgentStatus" -> {
-                    startOrUpdateService(activity, call)
+                    finishService(activity, call)
                     result.success(null)
                 }
                 "stopAgentStatus" -> {
-                    stopService(activity)
+                    AgentBackgroundService.clear(activity)
                     result.success(null)
                 }
                 "consumeInitialAgentAction" -> {
@@ -67,21 +67,26 @@ object AgentBackgroundChannelHandler {
         val intent = Intent(context, AgentBackgroundService::class.java).apply {
             action = AgentBackgroundService.ACTION_UPDATE
             putExtra("state", args["state"] as? String ?: "active")
-            putExtra("title", args["title"] as? String ?: "Memex is processing")
+            putExtra("title", args["title"] as? String ?: "Memex Agent")
             putExtra("stage", args["stage"] as? String ?: "Processing")
             putExtra("detail", args["detail"] as? String ?: "")
             putExtra("remainingTasks", (args["remainingTasks"] as? Number)?.toInt() ?: 0)
             putExtra("pending", (args["pending"] as? Number)?.toInt() ?: 0)
             putExtra("processing", (args["processing"] as? Number)?.toInt() ?: 0)
             putExtra("retrying", (args["retrying"] as? Number)?.toInt() ?: 0)
+            putExtra(
+                AgentBackgroundService.EXTRA_WATCH_BACKGROUND_WORK,
+                args["isInBackground"] as? Boolean ?: false,
+            )
         }
         ContextCompat.startForegroundService(context, intent)
     }
 
-    private fun stopService(context: Context) {
-        val intent = Intent(context, AgentBackgroundService::class.java).apply {
-            action = AgentBackgroundService.ACTION_STOP
+    private fun finishService(context: Context, call: MethodCall) {
+        val args = call.arguments as? Map<*, *> ?: emptyMap<String, Any?>()
+        when (args["state"] as? String) {
+            "completed", "idle" -> AgentBackgroundService.clear(context)
+            else -> startOrUpdateService(context, call)
         }
-        context.stopService(intent)
     }
 }

--- a/lib/data/services/agent_background_coordinator.dart
+++ b/lib/data/services/agent_background_coordinator.dart
@@ -13,9 +13,9 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
     AgentBackgroundPlatform? platform,
     AgentQueueDrainScheduler? scheduler,
     AppLifecycleState? initialLifecycleState,
-  })  : _platform = platform ?? MethodChannelAgentBackgroundPlatform(),
-        _scheduler = scheduler ?? WorkmanagerAgentQueueDrainScheduler(),
-        _initialLifecycleState = initialLifecycleState;
+  }) : _platform = platform ?? MethodChannelAgentBackgroundPlatform(),
+       _scheduler = scheduler ?? WorkmanagerAgentQueueDrainScheduler(),
+       _initialLifecycleState = initialLifecycleState;
 
   static AgentBackgroundCoordinator? _instance;
   static AgentBackgroundCoordinator get instance {
@@ -32,12 +32,13 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
   StreamSubscription<String>? _actionSubscription;
   late final StreamController<void> _openActivityController =
       StreamController<void>.broadcast(
-    onListen: _flushPendingOpenActivityRequest,
-  );
+        onListen: _flushPendingOpenActivityRequest,
+      );
 
   TaskActivitySnapshot _taskSnapshot = const TaskActivitySnapshot.empty();
   AgentActivityMessageModel? _latestMessage;
   AgentBackgroundStatus? _lastPublishedStatus;
+  bool? _lastPublishedIsInBackground;
   Future<void> _publishChain = Future<void>.value();
   Timer? _terminalStopTimer;
   bool _started = false;
@@ -55,7 +56,8 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
   }) {
     if (_started || !_platform.isSupported) return;
     _started = true;
-    _lifecycleState = _initialLifecycleState ??
+    _lifecycleState =
+        _initialLifecycleState ??
         WidgetsBinding.instance.lifecycleState ??
         AppLifecycleState.resumed;
     WidgetsBinding.instance.addObserver(this);
@@ -86,6 +88,7 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
     _taskSnapshot = const TaskActivitySnapshot.empty();
     _latestMessage = null;
     _lastPublishedStatus = null;
+    _lastPublishedIsInBackground = null;
     _drainWorkScheduledForCurrentRun = false;
     _publishGeneration++;
     await _safeStopPlatform();
@@ -94,6 +97,7 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     _lifecycleState = state;
+    _queuePublishStatus();
     if (_started &&
         state != AppLifecycleState.resumed &&
         _taskSnapshot.hasActiveTasks) {
@@ -161,11 +165,17 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
       taskSnapshot: _taskSnapshot,
       latestMessage: _latestMessage,
     );
+    final isInBackground = _lifecycleState != AppLifecycleState.resumed;
 
     if (!_started || generation != _publishGeneration) return;
-    if (status == _lastPublishedStatus) return;
+    if (status == _lastPublishedStatus &&
+        isInBackground == _lastPublishedIsInBackground) {
+      return;
+    }
     final previousPublishedStatus = _lastPublishedStatus;
+    final previousPublishedIsInBackground = _lastPublishedIsInBackground;
     _lastPublishedStatus = status;
+    _lastPublishedIsInBackground = isInBackground;
 
     _terminalStopTimer?.cancel();
     _terminalStopTimer = null;
@@ -178,13 +188,19 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
       }
 
       if (status.state == AgentBackgroundRunState.active) {
-        await _platform.updateStatus(status);
+        await _platform.updateStatus(status, isInBackground: isInBackground);
         if (!_started || generation != _publishGeneration) return;
         await _scheduleDrainIfNeeded();
         return;
       }
 
-      await _platform.finishStatus(status);
+      if (status.state == AgentBackgroundRunState.completed) {
+        await _scheduler.cancel();
+        await _safeStopPlatform();
+        return;
+      }
+
+      await _platform.finishStatus(status, isInBackground: isInBackground);
       if (!_started || generation != _publishGeneration) return;
       await _scheduler.cancel();
       _terminalStopTimer = Timer(const Duration(seconds: 5), () {
@@ -192,6 +208,7 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
       });
     } catch (e, stackTrace) {
       _lastPublishedStatus = previousPublishedStatus;
+      _lastPublishedIsInBackground = previousPublishedIsInBackground;
       if (status.state == AgentBackgroundRunState.active) {
         _drainWorkScheduledForCurrentRun = false;
       }
@@ -223,11 +240,7 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
       await _scheduler.schedule(expedited: true);
     } catch (e, stackTrace) {
       _drainWorkScheduledForCurrentRun = false;
-      _logger.warning(
-        'Failed to schedule agent queue drain',
-        e,
-        stackTrace,
-      );
+      _logger.warning('Failed to schedule agent queue drain', e, stackTrace);
     }
   }
 }

--- a/lib/data/services/agent_background_platform.dart
+++ b/lib/data/services/agent_background_platform.dart
@@ -9,9 +9,15 @@ abstract class AgentBackgroundPlatform {
 
   Stream<String> get actionStream;
 
-  Future<void> updateStatus(AgentBackgroundStatus status);
+  Future<void> updateStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  });
 
-  Future<void> finishStatus(AgentBackgroundStatus status);
+  Future<void> finishStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  });
 
   Future<void> stopStatus();
 
@@ -36,20 +42,26 @@ class MethodChannelAgentBackgroundPlatform implements AgentBackgroundPlatform {
   Stream<String> get actionStream => _actionController.stream;
 
   @override
-  Future<void> updateStatus(AgentBackgroundStatus status) {
+  Future<void> updateStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  }) {
     if (!isSupported) return Future<void>.value();
     return _channel.invokeMethod<void>(
       'updateAgentStatus',
-      status.toPlatformMap(),
+      status.toPlatformMap(isInBackground: isInBackground),
     );
   }
 
   @override
-  Future<void> finishStatus(AgentBackgroundStatus status) {
+  Future<void> finishStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  }) {
     if (!isSupported) return Future<void>.value();
     return _channel.invokeMethod<void>(
       'finishAgentStatus',
-      status.toPlatformMap(),
+      status.toPlatformMap(isInBackground: isInBackground),
     );
   }
 

--- a/lib/data/services/agent_background_status.dart
+++ b/lib/data/services/agent_background_status.dart
@@ -41,10 +41,10 @@ class AgentBackgroundStatus {
     };
 
     final title = switch (state) {
-      AgentBackgroundRunState.failed => 'Memex task needs attention',
-      AgentBackgroundRunState.completed => 'Memex task complete',
-      AgentBackgroundRunState.active => 'Memex is processing',
-      AgentBackgroundRunState.idle => 'Memex is idle',
+      AgentBackgroundRunState.failed => 'Memex Agent needs attention',
+      AgentBackgroundRunState.completed => 'Memex Agent',
+      AgentBackgroundRunState.active => 'Memex Agent',
+      AgentBackgroundRunState.idle => 'Memex Agent',
     };
 
     final stage =
@@ -90,10 +90,9 @@ class AgentBackgroundStatus {
 
   bool get shouldShowSystemSurface =>
       state == AgentBackgroundRunState.active ||
-      state == AgentBackgroundRunState.completed ||
       state == AgentBackgroundRunState.failed;
 
-  Map<String, dynamic> toPlatformMap() {
+  Map<String, dynamic> toPlatformMap({bool isInBackground = false}) {
     return {
       'state': state.name,
       'pending': pending,
@@ -107,6 +106,7 @@ class AgentBackgroundStatus {
       'scene': scene,
       'sceneId': sceneId,
       'updatedAtMs': updatedAt.millisecondsSinceEpoch,
+      'isInBackground': isInBackground,
     };
   }
 
@@ -149,17 +149,8 @@ String _detailFor({
   if (messageContent != null) return messageContent;
 
   if (taskSnapshot.hasActiveTasks) {
-    final parts = <String>[];
-    if (taskSnapshot.processing > 0) {
-      parts.add('${taskSnapshot.processing} running');
-    }
-    if (taskSnapshot.pending > 0) {
-      parts.add('${taskSnapshot.pending} waiting');
-    }
-    if (taskSnapshot.retrying > 0) {
-      parts.add('${taskSnapshot.retrying} retrying');
-    }
-    return '${taskSnapshot.total} remaining: ${parts.join(', ')}';
+    final taskLabel = taskSnapshot.total == 1 ? 'task' : 'tasks';
+    return 'Processing ${taskSnapshot.total} queued $taskLabel';
   }
 
   return switch (state) {

--- a/lib/data/services/agent_queue_background_worker.dart
+++ b/lib/data/services/agent_queue_background_worker.dart
@@ -4,6 +4,8 @@ import 'dart:math';
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/agent_background_platform.dart';
+import 'package:memex/data/services/agent_background_status.dart';
 import 'package:memex/data/services/agent_queue_drain_scheduler.dart';
 import 'package:memex/data/services/file_logger_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
@@ -24,6 +26,7 @@ class AgentQueueBackgroundWorker {
     Future<void> Function(String userId)? initializeTaskQueue,
     LocalTaskExecutor? executor,
     AgentQueueDrainScheduler? scheduler,
+    AgentBackgroundPlatform? backgroundPlatform,
     Duration maxRunDuration = _maxRunDuration,
     Duration databaseRetryDelay = const Duration(milliseconds: 300),
   }) async {
@@ -34,8 +37,11 @@ class AgentQueueBackgroundWorker {
     try {
       await UserStorage.initL10n();
       final userId = await UserStorage.getUserId();
+      final surfacePlatform =
+          backgroundPlatform ?? MethodChannelAgentBackgroundPlatform();
       if (userId == null || userId.isEmpty) {
         logger.info('Skipping agent queue drain: no active user.');
+        await _stopBackgroundSurface(logger, surfacePlatform);
         return true;
       }
 
@@ -68,6 +74,11 @@ class AgentQueueBackgroundWorker {
           expedited: false,
         );
       }
+      await _syncBackgroundSurfaceAfterDrain(
+        logger,
+        surfacePlatform,
+        result.snapshot,
+      );
 
       logger.info(
         'Agent queue drain finished. '
@@ -87,6 +98,49 @@ class AgentQueueBackgroundWorker {
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final seconds = max(30, scheduledAtSeconds - now);
     return Duration(seconds: seconds);
+  }
+
+  static Future<void> _syncBackgroundSurfaceAfterDrain(
+    Logger logger,
+    AgentBackgroundPlatform platform,
+    TaskActivitySnapshot snapshot,
+  ) async {
+    if (!platform.isSupported) return;
+
+    if (!snapshot.hasActiveTasks) {
+      await _stopBackgroundSurface(logger, platform);
+      return;
+    }
+
+    try {
+      await platform.updateStatus(
+        AgentBackgroundStatus.fromActivity(taskSnapshot: snapshot),
+        isInBackground: true,
+      );
+    } catch (e, stackTrace) {
+      logger.warning(
+        'Failed to refresh Android agent background surface after drain',
+        e,
+        stackTrace,
+      );
+    }
+  }
+
+  static Future<void> _stopBackgroundSurface(
+    Logger logger,
+    AgentBackgroundPlatform platform,
+  ) async {
+    if (!platform.isSupported) return;
+
+    try {
+      await platform.stopStatus();
+    } catch (e, stackTrace) {
+      logger.warning(
+        'Failed to stop Android agent background surface after drain',
+        e,
+        stackTrace,
+      );
+    }
   }
 
   static Future<T> _withDatabaseLockRetry<T>(

--- a/test/data/services/agent_background_coordinator_test.dart
+++ b/test/data/services/agent_background_coordinator_test.dart
@@ -51,6 +51,7 @@ void main() {
 
     expect(platform.updates.single.state, AgentBackgroundRunState.active);
     expect(platform.updates.single.remainingTasks, 1);
+    expect(platform.updateBackgroundFlags.single, isTrue);
     expect(scheduler.scheduleCount, 1);
 
     activityService.emit(
@@ -83,20 +84,24 @@ void main() {
     await _waitUntil(() => platform.updates.isNotEmpty);
 
     expect(platform.updates.single.state, AgentBackgroundRunState.active);
+    expect(platform.updateBackgroundFlags.single, isFalse);
     expect(scheduler.scheduleCount, 0);
 
     coordinator.didChangeAppLifecycleState(AppLifecycleState.paused);
     await _waitUntil(() => scheduler.scheduleCount == 1);
+    await _waitUntil(() => platform.updates.length == 2);
 
+    expect(platform.updateBackgroundFlags.last, isTrue);
     expect(scheduler.events.last, 'schedule:true:0');
   });
 
   test(
-    'finishes terminal status and cancels drain when queue empties',
+    'clears completed status and cancels drain when queue empties',
     () async {
       coordinator.start(executor: executor, activityService: activityService);
       await _insertTask(db, id: 'pending-a', status: 'pending');
       await _waitUntil(() => platform.updates.isNotEmpty);
+      final stopCountBeforeCompletion = platform.stopCount;
 
       activityService.emit(
         AgentActivityMessageModel(
@@ -115,9 +120,9 @@ void main() {
         ),
       );
 
-      await _waitUntil(() => platform.finished.isNotEmpty);
+      await _waitUntil(() => platform.stopCount > stopCountBeforeCompletion);
 
-      expect(platform.finished.last.state, AgentBackgroundRunState.completed);
+      expect(platform.finished, isEmpty);
       expect(scheduler.cancelCount, greaterThanOrEqualTo(1));
     },
   );
@@ -212,6 +217,7 @@ void main() {
 
     await _insertTask(db, id: 'pending-a', status: 'pending');
     await _waitUntil(() => platform.updateAttempts == 1);
+    final stopCountBeforeTerminal = platform.stopCount;
     platform.events.clear();
     scheduler.events.clear();
 
@@ -234,18 +240,21 @@ void main() {
 
     await Future<void>.delayed(const Duration(milliseconds: 50));
     expect(platform.finished, isEmpty);
+    expect(platform.stopCount, stopCountBeforeTerminal);
 
     platform.updateGate!.complete();
-    await _waitUntil(() => platform.finished.isNotEmpty);
+    await _waitUntil(() => platform.stopCount > stopCountBeforeTerminal);
 
-    expect(platform.events, ['update:active', 'finish:completed']);
+    expect(platform.events, ['update:active:bg=true', 'stop']);
     expect(scheduler.events, ['cancel']);
   });
 }
 
 class _FakePlatform implements AgentBackgroundPlatform {
   final updates = <AgentBackgroundStatus>[];
+  final updateBackgroundFlags = <bool>[];
   final finished = <AgentBackgroundStatus>[];
+  final finishBackgroundFlags = <bool>[];
   final events = <String>[];
   final initialActionConsumed = Completer<void>();
   var stopCount = 0;
@@ -270,26 +279,35 @@ class _FakePlatform implements AgentBackgroundPlatform {
   }
 
   @override
-  Future<void> finishStatus(AgentBackgroundStatus status) async {
-    events.add('finish:${status.state.name}');
+  Future<void> finishStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  }) async {
+    events.add('finish:${status.state.name}:bg=$isInBackground');
     finished.add(status);
+    finishBackgroundFlags.add(isInBackground);
   }
 
   @override
   Future<void> stopStatus() async {
+    events.add('stop');
     stopCount++;
   }
 
   @override
-  Future<void> updateStatus(AgentBackgroundStatus status) async {
+  Future<void> updateStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  }) async {
     updateAttempts++;
     await updateGate?.future;
     if (failNextUpdate) {
       failNextUpdate = false;
       throw StateError('platform temporarily unavailable');
     }
-    events.add('update:${status.state.name}');
+    events.add('update:${status.state.name}:bg=$isInBackground');
     updates.add(status);
+    updateBackgroundFlags.add(isInBackground);
   }
 
   void emitAction(String action) {
@@ -373,9 +391,7 @@ Future<void> _insertTask(
   required String status,
 }) async {
   final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-  await db
-      .into(db.tasks)
-      .insert(
+  await db.into(db.tasks).insert(
         TasksCompanion.insert(
           id: id,
           type: 'agent_task',

--- a/test/data/services/agent_background_status_test.dart
+++ b/test/data/services/agent_background_status_test.dart
@@ -29,9 +29,16 @@ void main() {
 
       expect(status.state, AgentBackgroundRunState.active);
       expect(status.remainingTasks, 4);
-      expect(status.title, 'Memex is processing');
-      expect(status.detail, '4 remaining: 1 running, 2 waiting, 1 retrying');
-      expect(status.toPlatformMap()['remainingTasks'], 4);
+      expect(status.title, 'Memex Agent');
+      expect(status.detail, 'Processing 4 queued tasks');
+      expect(
+        status.toPlatformMap(isInBackground: true),
+        containsPair('remainingTasks', 4),
+      );
+      expect(
+        status.toPlatformMap(isInBackground: true),
+        containsPair('isInBackground', true),
+      );
     });
 
     test('keeps retryable error visible as active while tasks remain', () {
@@ -85,6 +92,7 @@ void main() {
 
       expect(stillRunning.state, AgentBackgroundRunState.active);
       expect(completed.state, AgentBackgroundRunState.completed);
+      expect(completed.shouldShowSystemSurface, isFalse);
       expect(completed.detail, 'All background tasks finished.');
     });
 

--- a/test/data/services/agent_queue_background_worker_test.dart
+++ b/test/data/services/agent_queue_background_worker_test.dart
@@ -2,6 +2,8 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/agent_background_platform.dart';
+import 'package:memex/data/services/agent_background_status.dart';
 import 'package:memex/data/services/agent_queue_background_worker.dart';
 import 'package:memex/data/services/agent_queue_drain_scheduler.dart';
 import 'package:memex/data/services/local_task_executor.dart';
@@ -75,6 +77,7 @@ void main() {
     test('does not initialize task queue when no user is active', () async {
       SharedPreferences.setMockInitialValues({});
       var initialized = false;
+      final platform = _FakeBackgroundPlatform();
 
       final completed = await AgentQueueBackgroundWorker.run(
         initializeTaskQueue: (_) async {
@@ -82,15 +85,18 @@ void main() {
         },
         executor: executor,
         scheduler: scheduler,
+        backgroundPlatform: platform,
       );
 
       expect(completed, isTrue);
       expect(initialized, isFalse);
       expect(scheduler.scheduleCalls, 0);
+      expect(platform.stopCalls, 1);
     });
 
     test('retries a transient database lock before draining queue', () async {
       var attempts = 0;
+      final platform = _FakeBackgroundPlatform();
 
       final completed = await AgentQueueBackgroundWorker.run(
         initializeTaskQueue: (_) async {
@@ -101,12 +107,14 @@ void main() {
         },
         executor: executor,
         scheduler: scheduler,
+        backgroundPlatform: platform,
         databaseRetryDelay: Duration.zero,
       );
 
       expect(completed, isTrue);
       expect(attempts, 2);
       expect(scheduler.scheduleCalls, 0);
+      expect(platform.stopCalls, 1);
     });
 
     test('does not retry non-database initialization failures', () async {
@@ -138,11 +146,13 @@ void main() {
               scheduledAt: Value(now + 600),
             ),
           );
+      final platform = _FakeBackgroundPlatform();
 
       final completed = await AgentQueueBackgroundWorker.run(
         initializeTaskQueue: (_) async {},
         executor: executor,
         scheduler: scheduler,
+        backgroundPlatform: platform,
         databaseRetryDelay: Duration.zero,
       );
 
@@ -153,11 +163,17 @@ void main() {
         scheduler.initialDelays.single!.inSeconds,
         inInclusiveRange(590, 600),
       );
+      expect(platform.updates.single.state, AgentBackgroundRunState.active);
+      expect(platform.updateBackgroundFlags.single, isTrue);
+      expect(platform.stopCalls, 0);
     });
 
     test('drains handlers that publish agent activity after init', () async {
-      executor.registerHandler('activity_task',
-          (userId, payload, context) async {
+      executor.registerHandler('activity_task', (
+        userId,
+        payload,
+        context,
+      ) async {
         await AgentActivityService.instance.pushMessage(
           type: AgentActivityType.info,
           title: 'Background activity',
@@ -177,6 +193,7 @@ void main() {
               createdAt: Value(now),
             ),
           );
+      final platform = _FakeBackgroundPlatform();
 
       final completed = await AgentQueueBackgroundWorker.run(
         initializeTaskQueue: (_) async {
@@ -184,11 +201,13 @@ void main() {
         },
         executor: executor,
         scheduler: scheduler,
+        backgroundPlatform: platform,
         databaseRetryDelay: Duration.zero,
       );
 
-      final task = await (db.select(db.tasks)
-            ..where((t) => t.id.equals('activity-task')))
+      final task = await (db.select(
+        db.tasks,
+      )..where((t) => t.id.equals('activity-task')))
           .getSingle();
       final messages = await LocalAgentActivityService.instance.getHistory(
         limit: 1,
@@ -198,8 +217,47 @@ void main() {
       expect(task.status, 'completed');
       expect(messages.single.title, 'Background activity');
       expect(scheduler.scheduleCalls, 0);
+      expect(platform.stopCalls, 1);
     });
   });
+}
+
+class _FakeBackgroundPlatform implements AgentBackgroundPlatform {
+  final updates = <AgentBackgroundStatus>[];
+  final updateBackgroundFlags = <bool>[];
+  var finishCalls = 0;
+  var stopCalls = 0;
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Stream<String> get actionStream => const Stream<String>.empty();
+
+  @override
+  Future<String?> consumeInitialAction() async => null;
+
+  @override
+  Future<void> finishStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  }) async {
+    finishCalls++;
+  }
+
+  @override
+  Future<void> stopStatus() async {
+    stopCalls++;
+  }
+
+  @override
+  Future<void> updateStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  }) async {
+    updates.add(status);
+    updateBackgroundFlags.add(isInBackground);
+  }
 }
 
 class _FakeDrainScheduler implements AgentQueueDrainScheduler {
@@ -215,8 +273,10 @@ class _FakeDrainScheduler implements AgentQueueDrainScheduler {
   }
 
   @override
-  Future<void> schedule(
-      {Duration? initialDelay, bool expedited = false}) async {
+  Future<void> schedule({
+    Duration? initialDelay,
+    bool expedited = false,
+  }) async {
     initialDelays.add(initialDelay);
     expeditedValues.add(expedited);
   }

--- a/test/ui/agent_activity/agent_activity_widget_test.dart
+++ b/test/ui/agent_activity/agent_activity_widget_test.dart
@@ -30,6 +30,7 @@ void main() {
     bool forceVisible = false,
     TaskActivitySnapshot initialTaskSnapshot =
         const TaskActivitySnapshot.empty(),
+    Stream<TaskActivitySnapshot>? taskActivitySnapshotStream,
   }) {
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -40,6 +41,7 @@ void main() {
             forceVisible: forceVisible,
             initialTaskSnapshot: initialTaskSnapshot,
             taskActivitySnapshotStream:
+                taskActivitySnapshotStream ??
                 const Stream<TaskActivitySnapshot>.empty(),
           ),
         ),
@@ -67,6 +69,47 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets('updates background task count while detail sheet is open', (
+    tester,
+  ) async {
+    final taskSnapshots = StreamController<TaskActivitySnapshot>.broadcast();
+    const initialSnapshot = TaskActivitySnapshot(
+      pending: 1,
+      processing: 0,
+      retrying: 0,
+    );
+
+    await tester.pumpWidget(
+      buildHost(
+        initialTaskSnapshot: initialSnapshot,
+        taskActivitySnapshotStream: taskSnapshots.stream,
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 350));
+
+    final oneTaskMessage = UserStorage.l10n.insightProcessingBacklogMessage(1);
+    final twoTaskMessage = UserStorage.l10n.insightProcessingBacklogMessage(2);
+    expect(find.text(oneTaskMessage), findsOneWidget);
+
+    await tester.tap(find.text('AI is processing...'));
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(find.text(oneTaskMessage), findsWidgets);
+
+    taskSnapshots.add(
+      const TaskActivitySnapshot(pending: 1, processing: 1, retrying: 0),
+    );
+    await tester.pump();
+
+    expect(find.text(twoTaskMessage), findsWidgets);
+
+    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    await taskSnapshots.close();
+  });
+
   testWidgets('shows background task count before agent tool messages', (
     tester,
   ) async {
@@ -86,10 +129,7 @@ void main() {
     await tester.tap(find.text('AI is processing...'));
     await tester.pump(const Duration(milliseconds: 350));
 
-    expect(
-      find.text('1 background tasks are still processing.'),
-      findsWidgets,
-    );
+    expect(find.text('1 background tasks are still processing.'), findsWidgets);
 
     Navigator.of(tester.element(find.text('Activity Detail'))).pop();
     await tester.pump(const Duration(milliseconds: 350));
@@ -136,13 +176,19 @@ class _FakePlatform implements AgentBackgroundPlatform {
   Future<String?> consumeInitialAction() async => initialAction;
 
   @override
-  Future<void> finishStatus(AgentBackgroundStatus status) async {}
+  Future<void> finishStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  }) async {}
 
   @override
   Future<void> stopStatus() async {}
 
   @override
-  Future<void> updateStatus(AgentBackgroundStatus status) async {}
+  Future<void> updateStatus(
+    AgentBackgroundStatus status, {
+    bool isInBackground = false,
+  }) async {}
 
   void dispose() {
     unawaited(_actions.close());


### PR DESCRIPTION
Closes #250

## 变更说明

这个 PR 修复 Android Agent 后台处理通知在任务完成后仍残留的问题，并顺手把通知状态文案对齐到更接近 iOS 的 Agent 活动表达。

核心链路现在是：

1. 前台输入一句话后，`LocalTaskExecutor` 出现 active task，`AgentBackgroundCoordinator` 发布 active 通知状态。
2. 用户切到后台时，coordinator 会重新发布同一个 active 状态，但带上 `isInBackground=true`，并调度 WorkManager drain。
3. Android foreground service 在后台 active 时开始观察 `agent_queue_drain` unique work，作为后台 isolate MethodChannel 不可靠时的原生兜底。
4. WorkManager drain 完成后，Dart worker 会尝试同步通知：队列为空就 stop，仍有 retry/future task 就刷新 active 状态。
5. Android completed/idle 不再作为可见通知展示，而是统一视作清理信号，避免“任务完成但通知还留着”。

## 通知展示调整

- active：标题统一为 `Memex Agent`，正文使用 `Processing N queued tasks` 这类用户可理解的状态。
- failed：保留 `Memex Agent needs attention`，提示用户回到 app 查看。
- completed/idle：不展示系统通知，直接清理。
- 移除 Android 通知里的 `running / waiting / retrying` 内部状态拼接，避免和 iOS 展示风格割裂。

## 覆盖场景

- 前台 active 状态能发布通知，并记录是否在后台。
- 前台 active 时不调度 WorkManager，切后台后重新发布通知并调度 drain。
- 队列清空后 completed 会清理通知，而不是发送完成通知。
- 后台 worker 没有 active user 时清理通知。
- 后台 worker drain 后若仍有 future retry，保持 active 通知并重新调度。
- 后台 worker drain 完所有任务后清理通知。
- 通知入口打开的 Agent Activity widget 能跟随任务快照更新任务数。

## 验证

- `flutter test --no-pub --concurrency=1 test/data/services/agent_background_status_test.dart test/data/services/agent_background_coordinator_test.dart test/data/services/agent_queue_background_worker_test.dart test/ui/agent_activity/agent_activity_widget_test.dart`
- `flutter analyze --no-pub lib/data/services/agent_background_status.dart lib/data/services/agent_background_platform.dart lib/data/services/agent_background_coordinator.dart lib/data/services/agent_queue_background_worker.dart test/data/services/agent_background_status_test.dart test/data/services/agent_background_coordinator_test.dart test/data/services/agent_queue_background_worker_test.dart test/ui/agent_activity/agent_activity_widget_test.dart`
- `flutter build apk --debug --flavor globalDev --no-pub`
