### PR TITLE
[codex] 添加剪贴板预览与快速粘贴入口

### DIFF
--- a/lib/data/services/clipboard_preview_service.dart
+++ b/lib/data/services/clipboard_preview_service.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/services.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ClipboardPreviewCandidate {
+  const ClipboardPreviewCandidate({required this.text, required this.hash});
+
+  final String text;
+  final String hash;
+
+  int get characterCount => text.runes.length;
+
+  String get previewText => text.replaceAll(RegExp(r'\s+'), ' ').trim();
+}
+
+class ClipboardPreviewService {
+  static final ClipboardPreviewService instance = ClipboardPreviewService._();
+
+  static const _maxHandledHashes = 80;
+  static const _handledHashesKeyPrefix = 'clipboard_preview_handled_hashes_';
+
+  final _logger = getLogger('ClipboardPreviewService');
+
+  ClipboardPreviewService._();
+
+  Future<ClipboardPreviewCandidate?> fetchUnhandledText({
+    String? currentText,
+  }) async {
+    try {
+      final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+      final text = clipboardData?.text?.trim();
+      if (text == null || text.isEmpty) return null;
+
+      final existingText = currentText?.trim();
+      if (existingText != null &&
+          existingText.isNotEmpty &&
+          (existingText == text || existingText.contains(text))) {
+        await markTextHandled(text);
+        return null;
+      }
+
+      final hash = _hashText(text);
+      final handledHashes = await _loadHandledHashes();
+      if (handledHashes.contains(hash)) return null;
+
+      return ClipboardPreviewCandidate(text: text, hash: hash);
+    } catch (e, st) {
+      _logger.warning('Failed to inspect clipboard: $e', e, st);
+      return null;
+    }
+  }
+
+  Future<void> markHandled(ClipboardPreviewCandidate candidate) {
+    return _markHashHandled(candidate.hash);
+  }
+
+  Future<void> markTextHandled(String text) {
+    return _markHashHandled(_hashText(text.trim()));
+  }
+
+  Future<List<String>> _loadHandledHashes() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(await _handledHashesKey()) ?? const [];
+  }
+
+  Future<void> _markHashHandled(String hash) async {
+    if (hash.isEmpty) return;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final key = await _handledHashesKey();
+      final hashes = prefs.getStringList(key) ?? <String>[];
+      hashes.remove(hash);
+      hashes.insert(0, hash);
+      if (hashes.length > _maxHandledHashes) {
+        hashes.removeRange(_maxHandledHashes, hashes.length);
+      }
+      await prefs.setStringList(key, hashes);
+    } catch (e, st) {
+      _logger.warning('Failed to mark clipboard as handled: $e', e, st);
+    }
+  }
+
+  Future<String> _handledHashesKey() async {
+    final userId = await UserStorage.getUserId();
+    return '$_handledHashesKeyPrefix${userId ?? 'anonymous'}';
+  }
+
+  String _hashText(String text) {
+    if (text.isEmpty) return '';
+    return sha256.convert(utf8.encode(text)).toString();
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -237,6 +237,9 @@
   "discardDraftTitle": "Discard this draft?",
   "discardDraftMessage": "The draft content will be cleared.",
   "discardDraftTooltip": "Discard draft",
+  "clipboardPreviewTitle": "New clipboard",
+  "clipboardPreviewUnprocessed": "Not pasted yet",
+  "clipboardPreviewPasteToInput": "Paste to input",
   "tellAiWhatHappened": "Tell AI what happened...",
   "@recordingWithDuration": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1064,6 +1064,24 @@ abstract class AppLocalizations {
   /// **'Discard draft'**
   String get discardDraftTooltip;
 
+  /// No description provided for @clipboardPreviewTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'New clipboard'**
+  String get clipboardPreviewTitle;
+
+  /// No description provided for @clipboardPreviewUnprocessed.
+  ///
+  /// In en, this message translates to:
+  /// **'Not pasted yet'**
+  String get clipboardPreviewUnprocessed;
+
+  /// No description provided for @clipboardPreviewPasteToInput.
+  ///
+  /// In en, this message translates to:
+  /// **'Paste to input'**
+  String get clipboardPreviewPasteToInput;
+
   /// No description provided for @tellAiWhatHappened.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -542,6 +542,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get discardDraftTooltip => 'Discard draft';
 
   @override
+  String get clipboardPreviewTitle => 'New clipboard';
+
+  @override
+  String get clipboardPreviewUnprocessed => 'Not pasted yet';
+
+  @override
+  String get clipboardPreviewPasteToInput => 'Paste to input';
+
+  @override
   String get tellAiWhatHappened => 'Tell AI what happened...';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -526,6 +526,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get discardDraftTooltip => '丢弃草稿';
 
   @override
+  String get clipboardPreviewTitle => '新剪贴板';
+
+  @override
+  String get clipboardPreviewUnprocessed => '未处理';
+
+  @override
+  String get clipboardPreviewPasteToInput => '粘贴到输入框';
+
+  @override
   String get tellAiWhatHappened => '告诉AI发生了什么...';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -237,6 +237,9 @@
   "discardDraftTitle": "丢弃这份草稿？",
   "discardDraftMessage": "草稿内容会被清空。",
   "discardDraftTooltip": "丢弃草稿",
+  "clipboardPreviewTitle": "新剪贴板",
+  "clipboardPreviewUnprocessed": "未处理",
+  "clipboardPreviewPasteToInput": "粘贴到输入框",
   "tellAiWhatHappened": "告诉AI发生了什么...",
   "@recordingWithDuration": {
     "placeholders": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,7 +30,6 @@ import 'package:memex/domain/models/shortcut_item.dart' as app_shortcut;
 import 'package:record/record.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'dart:ui';
 import 'package:memex/ui/main_screen/widgets/input_sheet.dart';
 import 'package:memex/ui/settings/widgets/ai_service_setup_page.dart';
 import 'package:memex/ui/settings/widgets/model_config_list_page.dart';
@@ -67,6 +66,8 @@ import 'package:quick_actions/quick_actions.dart';
 import 'package:memex/data/services/quick_action_service.dart';
 import 'package:memex/data/services/speech_transcription_service.dart';
 import 'package:memex/utils/wakelock_manager.dart';
+import 'package:memex/data/services/clipboard_preview_service.dart';
+import 'package:memex/ui/main_screen/widgets/clipboard_preview_card.dart';
 
 final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();
 final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
@@ -89,10 +90,7 @@ void main() async {
   await UserStorage.initL10n();
 
   // Initialize Workmanager (for background tasks)
-  await Workmanager().initialize(
-    callbackDispatcher,
-    isInDebugMode: false,
-  );
+  await Workmanager().initialize(callbackDispatcher);
 
   // Cancel legacy pedometer background tasks on iOS without wiping newer
   // background registrations such as agent queue processing.
@@ -120,8 +118,10 @@ void main() async {
     ),
   );
 
-  final appRouter =
-      createAppRouter(rootNavigatorKey, () => RootShell(key: rootShellKey));
+  final appRouter = createAppRouter(
+    rootNavigatorKey,
+    () => RootShell(key: rootShellKey),
+  );
 
   // Initialize quick actions (app icon long-press shortcuts).
   const QuickActions quickActions = QuickActions();
@@ -129,10 +129,12 @@ void main() async {
     QuickActionService.instance.handleAction(shortcutType);
   });
 
-  runApp(MultiProvider(
-    providers: dependencyProviders,
-    child: MemexApp(router: appRouter),
-  ));
+  runApp(
+    MultiProvider(
+      providers: dependencyProviders,
+      child: MemexApp(router: appRouter),
+    ),
+  );
 }
 
 /// Root route content: user check then loading / UserSetupScreen / MainScreen (Compass-style).
@@ -226,9 +228,7 @@ class RootShellState extends State<RootShell> {
   @override
   Widget build(BuildContext context) {
     if (_isChecking) {
-      return const Scaffold(
-        body: Center(child: AgentLogoLoading()),
-      );
+      return const Scaffold(body: Center(child: AgentLogoLoading()));
     }
     if (_isLoadingFromICloud) {
       return Scaffold(
@@ -266,8 +266,9 @@ class RootShellState extends State<RootShell> {
               InsightViewModel(router: c.read<MemexRouter>())..loadData(),
         ),
         ChangeNotifierProvider<KnowledgeBaseViewModel>(
-          create: (c) => KnowledgeBaseViewModel(router: c.read<MemexRouter>())
-            ..fetchData(),
+          create: (c) =>
+              KnowledgeBaseViewModel(router: c.read<MemexRouter>())
+                ..fetchData(),
         ),
       ],
       child: const MainScreen(),
@@ -321,8 +322,11 @@ class _MemexAppState extends State<MemexApp> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused) {
-      unawaited(LocalTaskExecutor.instance
-          .recordGracefulShutdown(reason: 'app_lifecycle_paused'));
+      unawaited(
+        LocalTaskExecutor.instance.recordGracefulShutdown(
+          reason: 'app_lifecycle_paused',
+        ),
+      );
       unawaited(AgentBackgroundTaskService.instance.onAppPaused());
       _lastPausedTime = DateTime.now();
       _checkLockSettingsBeforeLocking();
@@ -332,8 +336,11 @@ class _MemexAppState extends State<MemexApp> with WidgetsBindingObserver {
       MemexRouter().scheduleAutoBackupCheck(trigger: 'foreground');
       _checkGracePeriod();
     } else if (state == AppLifecycleState.detached) {
-      unawaited(LocalTaskExecutor.instance
-          .recordGracefulShutdown(reason: 'app_lifecycle_detached'));
+      unawaited(
+        LocalTaskExecutor.instance.recordGracefulShutdown(
+          reason: 'app_lifecycle_detached',
+        ),
+      );
     }
   }
 
@@ -442,6 +449,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       GlobalKey<KnowledgeBaseScreenState>();
   final MemexRouter _memexRouter = MemexRouter();
   final EventBusService _eventBus = EventBusService.instance;
+  final ClipboardPreviewService _clipboardPreviewService =
+      ClipboardPreviewService.instance;
   Timer? _memoryButtonTapTimer;
   int _memoryButtonTapCount = 0;
   bool _isRestoringExternalBackup = false;
@@ -451,7 +460,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
   // Radial Menu & Recording State
   bool _isRadialMenuOpen = false;
-  List<app_shortcut.ShortcutItem> _shortcuts = [];
+  final List<app_shortcut.ShortcutItem> _shortcuts = [];
   final AudioRecorder _audioRecorder = AudioRecorder();
   String? _recordingPath;
   StreamingTranscriber? _quickTranscriber;
@@ -470,6 +479,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
   bool _earlyUpdateCheckStarted = false;
   late final ShareIntentHandler _shareIntentHandler;
   InputData? _sharedDraft;
+  ClipboardPreviewCandidate? _homeClipboardCandidate;
+  bool _isCheckingHomeClipboard = false;
 
   // Agent Button Position - REMOVED (Moved to Main App)
 
@@ -496,16 +507,23 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     _logger.info('initState: Starting comprehensive health check...');
     _checkAndReportHealthData().catchError((error, stackTrace) {
       _logger.severe(
-          '❌ Error in _checkAndReportHealthData: $error', error, stackTrace);
+        '❌ Error in _checkAndReportHealthData: $error',
+        error,
+        stackTrace,
+      );
     });
 
     // Start auto input collection and quantity check
     _logger.info('initState: Starting Auto Input collection check...');
 
     _eventBus.addHandler(
-        EventBusMessageType.invalidModelConfig, _handleInvalidModelConfig);
+      EventBusMessageType.invalidModelConfig,
+      _handleInvalidModelConfig,
+    );
     _eventBus.addHandler(
-        EventBusMessageType.errorNotification, _handleErrorNotification);
+      EventBusMessageType.errorNotification,
+      _handleErrorNotification,
+    );
 
     _shareIntentHandler = ShareIntentHandler(
       logger: _logger,
@@ -513,6 +531,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       onSharedDraft: (data) {
         if (!mounted) return;
         setState(() {
+          _homeClipboardCandidate = null;
           _sharedDraft = data;
           _isInputOpen = true;
         });
@@ -524,6 +543,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     QuickActionService.instance.attach();
     _consumeQuickActionIfNeeded();
 
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(_checkHomeClipboardPreview());
+    });
     _scheduleEarlyUpdateCheck();
   }
 
@@ -587,11 +609,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
                     style: const TextStyle(fontWeight: FontWeight.w600),
                   ),
                   const SizedBox(height: 6),
-                  Text(
-                    notes,
-                    maxLines: 8,
-                    overflow: TextOverflow.ellipsis,
-                  ),
+                  Text(notes, maxLines: 8, overflow: TextOverflow.ellipsis),
                 ],
               ],
             ),
@@ -626,34 +644,31 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
     try {
       final download = await AppUpdateService.instance.downloadUpdate(update);
-      final install =
-          await AppUpdateService.instance.installUpdate(download.apkPath);
-      final currentContext = rootNavigatorKey.currentContext;
-      if (currentContext == null) return;
-
+      final install = await AppUpdateService.instance.installUpdate(
+        download.apkPath,
+      );
       switch (install.status) {
         case AppUpdateInstallStatus.started:
-          ToastHelper.showSuccess(
-            currentContext,
+          ToastHelper.showSuccessWithKey(
+            rootScaffoldMessengerKey,
             UserStorage.l10n.earlyUpdateInstallStarted,
           );
         case AppUpdateInstallStatus.permissionRequired:
-          ToastHelper.showInfo(
-            currentContext,
+          ToastHelper.showInfoWithKey(
+            rootScaffoldMessengerKey,
             UserStorage.l10n.earlyUpdateInstallPermissionRequired,
           );
         case AppUpdateInstallStatus.unsupported:
           break;
       }
     } catch (e) {
-      final currentContext = rootNavigatorKey.currentContext;
       if (e is AppUpdateWifiRequiredException) {
-        ToastHelper.showInfo(
-          currentContext,
+        ToastHelper.showInfoWithKey(
+          rootScaffoldMessengerKey,
           UserStorage.l10n.earlyUpdateSkippedMobile,
         );
       } else {
-        ToastHelper.showError(currentContext, e);
+        ToastHelper.showErrorWithKey(rootScaffoldMessengerKey, e);
       }
     }
   }
@@ -675,22 +690,28 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       barrierDismissible: false,
       builder: (context) => AlertDialog(
         title: Text(UserStorage.l10n.warning),
-        content: Text(UserStorage.l10n
-            .invalidModelConfigDetailed(message.agentId, message.configKey)),
+        content: Text(
+          UserStorage.l10n.invalidModelConfigDetailed(
+            message.agentId,
+            message.configKey,
+          ),
+        ),
         actions: [
           TextButton(
             onPressed: () {
               Navigator.of(context).pop();
-              if (mounted)
+              if (mounted) {
                 setState(() => _isInvalidConfigDialogShowing = false);
+              }
             },
             child: Text(UserStorage.l10n.cancel),
           ),
           ElevatedButton(
             onPressed: () {
               Navigator.of(context).pop();
-              if (mounted)
+              if (mounted) {
                 setState(() => _isInvalidConfigDialogShowing = false);
+              }
               Navigator.push(
                 context,
                 MaterialPageRoute(
@@ -705,7 +726,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         ],
       ),
     ).then((_) {
-      if (mounted) setState(() => _isInvalidConfigDialogShowing = false);
+      if (mounted) {
+        setState(() => _isInvalidConfigDialogShowing = false);
+      }
     });
   }
 
@@ -731,8 +754,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
           TextButton(
             onPressed: () {
               Navigator.of(context).pop();
-              if (mounted)
+              if (mounted) {
                 setState(() => _isErrorNotificationDialogShowing = false);
+              }
             },
             child: Text(UserStorage.l10n.cancel),
           ),
@@ -740,8 +764,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
             ElevatedButton(
               onPressed: () {
                 Navigator.of(context).pop();
-                if (mounted)
+                if (mounted) {
                   setState(() => _isErrorNotificationDialogShowing = false);
+                }
                 Navigator.push(
                   context,
                   MaterialPageRoute(
@@ -780,11 +805,15 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       // Prefill text during demo
       if (DemoService.instance.currentStep == DemoStep.tapSend) {
         setState(() {
+          _homeClipboardCandidate = null;
           _sharedDraft = InputData(text: DemoService.instance.prefillText);
           _isInputOpen = true;
         });
       } else {
-        setState(() => _isInputOpen = true);
+        setState(() {
+          _homeClipboardCandidate = null;
+          _isInputOpen = true;
+        });
       }
     }
   }
@@ -798,8 +827,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
     if (buttonBox != null && stackBox != null) {
       final buttonSize = buttonBox.size;
-      final buttonPosition =
-          stackBox.globalToLocal(buttonBox.localToGlobal(Offset.zero));
+      final buttonPosition = stackBox.globalToLocal(
+        buttonBox.localToGlobal(Offset.zero),
+      );
       _centerButtonCenter =
           buttonPosition + Offset(buttonSize.width / 2, buttonSize.height / 2);
     } else {
@@ -816,7 +846,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
   }
 
   void _handleAICoreButtonLongPressMoveUpdate(
-      LongPressMoveUpdateDetails details) {
+    LongPressMoveUpdateDetails details,
+  ) {
     if (_isRadialMenuOpen) {
       // coordinates in 'details' are local to the AICoreButton (64x64).
       // We need to transform them to be relative to the same space as _centerButtonCenter (the Stack).
@@ -848,7 +879,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       final prefs = await SharedPreferences.getInstance();
       if (prefs.getBool('pedometer_attempting') == true) {
         _logger.warning(
-            'Pedometer crash detected from previous launch, skipping this session');
+          'Pedometer crash detected from previous launch, skipping this session',
+        );
         await prefs.remove('pedometer_attempting');
         // Set in-memory flag only — will retry on next app launch
         PedometerFetcher.skipThisSession = true;
@@ -869,12 +901,14 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       _logger.info('Fitness permission status: $fitnessStatus');
       if (!fitnessStatus.isGranted && !fitnessStatus.isLimited) {
         _logger.info(
-            'Fitness permission not granted, skipping health data collection');
+          'Fitness permission not granted, skipping health data collection',
+        );
         return;
       }
 
-      _logger
-          .info('Types to check: ${typesToCheck.map((t) => t.name).toList()}');
+      _logger.info(
+        'Types to check: ${typesToCheck.map((t) => t.name).toList()}',
+      );
       Map<HealthDataType, dynamic> newlyFetchedData = {};
 
       for (var type in typesToCheck) {
@@ -911,8 +945,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
                   dailySummary[dateStr]!['blood_pressure'] ??= [];
                   List existing = dailySummary[dateStr]!['blood_pressure'];
                   for (var item in val) {
-                    var found =
-                        existing.where((e) => e['time'] == item['time']);
+                    var found = existing.where(
+                      (e) => e['time'] == item['time'],
+                    );
                     if (found.isNotEmpty) {
                       found.first.addAll(item);
                     } else {
@@ -939,7 +974,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       }
 
       _logger.info(
-          'Reporting health summary to server for ${dailySummary.length} days...');
+        'Reporting health summary to server for ${dailySummary.length} days...',
+      );
       final success = await _memexRouter.reportDailyHealthSummary(dailySummary);
 
       if (success) {
@@ -950,11 +986,15 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         }
       } else {
         _logger.warning(
-            '❌ Failed to report health summary to server, will retry next time');
+          '❌ Failed to report health summary to server, will retry next time',
+        );
       }
     } catch (e, stackTrace) {
       _logger.severe(
-          '❌ Failed to check and report health data: $e', e, stackTrace);
+        '❌ Failed to check and report health data: $e',
+        e,
+        stackTrace,
+      );
     }
   }
 
@@ -967,9 +1007,13 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     QuickActionService.instance.detach();
     _shareIntentHandler.dispose();
     _eventBus.removeHandler(
-        EventBusMessageType.invalidModelConfig, _handleInvalidModelConfig);
+      EventBusMessageType.invalidModelConfig,
+      _handleInvalidModelConfig,
+    );
     _eventBus.removeHandler(
-        EventBusMessageType.errorNotification, _handleErrorNotification);
+      EventBusMessageType.errorNotification,
+      _handleErrorNotification,
+    );
     // Note: do not disconnect event bus here; other screens may still use it
     super.dispose();
   }
@@ -992,8 +1036,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         _quickTranscribedText = '';
         _quickPcmBuffer.clear();
         if (await speechService.supportsStreamingTranscription()) {
-          _logger
-              .info('Initializing streaming transcriber for quick recording');
+          _logger.info(
+            'Initializing streaming transcriber for quick recording',
+          );
           _quickTranscriber = StreamingTranscriber(
             onTextChanged: (fullText) {
               _quickTranscribedText = fullText;
@@ -1220,8 +1265,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
       // Final calibration from accumulated PCM
       if (_quickPcmBuffer.isNotEmpty) {
-        final useLocal =
-            await SpeechTranscriptionService.instance.isUsingLocalModel();
+        final useLocal = await SpeechTranscriptionService.instance
+            .isUsingLocalModel();
         final aligned = Uint8List.fromList(_quickPcmBuffer);
         final int16Data = Int16List.view(aligned.buffer);
         final samples = Float32List(int16Data.length);
@@ -1240,8 +1285,10 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
           final directory = await getTemporaryDirectory();
           final timestamp = DateTime.now().millisecondsSinceEpoch;
           final wavPath = '${directory.path}/quick_audio_$timestamp.wav';
-          await SpeechTranscriptionService.instance
-              .savePcmAsWav(wavPath, Uint8List.fromList(_quickPcmBuffer));
+          await SpeechTranscriptionService.instance.savePcmAsWav(
+            wavPath,
+            Uint8List.fromList(_quickPcmBuffer),
+          );
           _quickAudioPath = wavPath;
         }
         _quickPcmBuffer.clear();
@@ -1278,8 +1325,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         if (await audioFile.exists()) {
           final length = await audioFile.length();
           final fileName = _quickAudioPath!.split(Platform.pathSeparator).last;
-          audioHash =
-              md5.convert(utf8.encode('audio_${fileName}_$length')).toString();
+          audioHash = md5
+              .convert(utf8.encode('audio_${fileName}_$length'))
+              .toString();
         }
         unawaited(
           _handleInputSubmit(
@@ -1312,6 +1360,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       if (action == 'quick_note') {
         _logger.info('Quick action: opening input sheet');
         setState(() {
+          _homeClipboardCandidate = null;
           _isInputOpen = true;
         });
       }
@@ -1436,11 +1485,53 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) {
             _logger.info('Quick action (resumed): opening input sheet');
-            setState(() => _isInputOpen = true);
+            setState(() {
+              _homeClipboardCandidate = null;
+              _isInputOpen = true;
+            });
           }
         });
+      } else {
+        unawaited(_checkHomeClipboardPreview());
       }
     }
+  }
+
+  Future<void> _checkHomeClipboardPreview() async {
+    if (_isCheckingHomeClipboard ||
+        _isInputOpen ||
+        DemoService.instance.isActive) {
+      return;
+    }
+
+    _isCheckingHomeClipboard = true;
+    final candidate = await _clipboardPreviewService.fetchUnhandledText();
+    _isCheckingHomeClipboard = false;
+
+    if (!mounted || _isInputOpen) return;
+    setState(() => _homeClipboardCandidate = candidate);
+  }
+
+  Future<void> _pasteHomeClipboardToInput() async {
+    final candidate = _homeClipboardCandidate;
+    if (candidate == null) return;
+
+    await _clipboardPreviewService.markHandled(candidate);
+    if (!mounted) return;
+    setState(() {
+      _homeClipboardCandidate = null;
+      _sharedDraft = InputData(text: candidate.text);
+      _isInputOpen = true;
+    });
+  }
+
+  Future<void> _dismissHomeClipboardPreview() async {
+    final candidate = _homeClipboardCandidate;
+    if (candidate == null) return;
+
+    await _clipboardPreviewService.markHandled(candidate);
+    if (!mounted) return;
+    setState(() => _homeClipboardCandidate = null);
   }
 
   Future<bool> _handleInputSubmit(InputData data) async {
@@ -1499,7 +1590,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       // Show success message
       if (mounted) {
         ToastHelper.showSuccess(
-            context, UserStorage.l10n.recordSubmittedAiProcessing);
+          context,
+          UserStorage.l10n.recordSubmittedAiProcessing,
+        );
       }
 
       // Refresh auto-input count after manual input
@@ -1518,100 +1611,129 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    final timelineViewModel = context.watch<TimelineViewModel>();
+
     return AnnotatedRegion<SystemUiOverlayStyle>(
-        value: const SystemUiOverlayStyle(
-          systemNavigationBarColor: Colors.transparent,
-          systemNavigationBarDividerColor: Colors.transparent,
-          systemNavigationBarIconBrightness: Brightness.dark,
-          systemNavigationBarContrastEnforced: false,
-          statusBarColor: Colors.transparent,
-          statusBarIconBrightness: Brightness.dark,
-        ),
-        child: Scaffold(
-          extendBody: true,
-          resizeToAvoidBottomInset: false,
-          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-          body: Stack(
-            key: _mainStackKey,
-            children: [
-              // Main content wrapped in SafeArea
-              SafeArea(
-                bottom: false,
-                child: Column(
-                  children: [
-                    Expanded(
-                      child: IndexedStack(
-                        index: _currentTab,
-                        children: [
-                          TimelineScreen(
-                            key: _timelineKey,
-                            viewModel: context.watch<TimelineViewModel>(),
-                            insightViewModel: context.watch<InsightViewModel>(),
-                            onInputTap: () {
-                              setState(() {
-                                _isInputOpen = true;
-                              });
-                            },
-                          ),
-                          KnowledgeBaseScreen(
-                            key: _knowledgeBaseKey,
-                            viewModel: context.watch<KnowledgeBaseViewModel>(),
-                          ),
-                        ],
-                      ),
+      value: const SystemUiOverlayStyle(
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarDividerColor: Colors.transparent,
+        systemNavigationBarIconBrightness: Brightness.dark,
+        systemNavigationBarContrastEnforced: false,
+        statusBarColor: Colors.transparent,
+        statusBarIconBrightness: Brightness.dark,
+      ),
+      child: Scaffold(
+        extendBody: true,
+        resizeToAvoidBottomInset: false,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        body: Stack(
+          key: _mainStackKey,
+          children: [
+            // Main content wrapped in SafeArea
+            SafeArea(
+              bottom: false,
+              child: Column(
+                children: [
+                  Expanded(
+                    child: IndexedStack(
+                      index: _currentTab,
+                      children: [
+                        TimelineScreen(
+                          key: _timelineKey,
+                          viewModel: timelineViewModel,
+                          insightViewModel: context.watch<InsightViewModel>(),
+                          onInputTap: () {
+                            setState(() {
+                              _homeClipboardCandidate = null;
+                              _isInputOpen = true;
+                            });
+                          },
+                        ),
+                        KnowledgeBaseScreen(
+                          key: _knowledgeBaseKey,
+                          viewModel: context.watch<KnowledgeBaseViewModel>(),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-              ),
-
-              // Floating bottom bar overlay
-              _buildBottomBar(),
-
-              Positioned(
-                bottom: 164,
-                left: 0,
-                right: 0,
-                child: Center(
-                  child: AgentActivityWidget(
-                    navigatorKey: null,
-                    forceVisible:
-                        context.watch<TimelineViewModel>().isSubmitting,
                   ),
+                ],
+              ),
+            ),
+
+            if (!_isInputOpen &&
+                _homeClipboardCandidate != null &&
+                !timelineViewModel.isSubmitting)
+              _buildHomeClipboardPreview(),
+
+            // Floating bottom bar overlay
+            _buildBottomBar(),
+
+            Positioned(
+              bottom: 164,
+              left: 0,
+              right: 0,
+              child: Center(
+                child: AgentActivityWidget(
+                  navigatorKey: null,
+                  forceVisible: timelineViewModel.isSubmitting,
                 ),
               ),
+            ),
 
-              // Input sheet
-              InputSheet(
-                isOpen: _isInputOpen,
-                initialData: _sharedDraft,
-                onClose: () {
-                  setState(() {
-                    _isInputOpen = false;
-                    _sharedDraft = null;
-                  });
-                },
-                onSubmit: _handleInputSubmit,
+            // Input sheet
+            InputSheet(
+              isOpen: _isInputOpen,
+              initialData: _sharedDraft,
+              onClose: () {
+                setState(() {
+                  _isInputOpen = false;
+                  _sharedDraft = null;
+                });
+                unawaited(_checkHomeClipboardPreview());
+              },
+              onSubmit: _handleInputSubmit,
+            ),
+
+            if (_isRadialMenuOpen)
+              RadialMenu(
+                key: _radialMenuKey,
+                items: _shortcuts,
+                center: _centerButtonCenter,
+                visible: _isRadialMenuOpen,
+                onItemSelected: _handleShortcutSelect,
+                onCancel: _handleRadialCancel,
+                transcriptText: _quickTranscribedText.isNotEmpty
+                    ? _quickTranscribedText
+                    : null,
+                isCalibrating: _isQuickCalibrating,
               ),
 
-              if (_isRadialMenuOpen)
-                RadialMenu(
-                  key: _radialMenuKey,
-                  items: _shortcuts,
-                  center: _centerButtonCenter,
-                  visible: _isRadialMenuOpen,
-                  onItemSelected: _handleShortcutSelect,
-                  onCancel: _handleRadialCancel,
-                  transcriptText: _quickTranscribedText.isNotEmpty
-                      ? _quickTranscribedText
-                      : null,
-                  isCalibrating: _isQuickCalibrating,
-                ),
+            // Onboarding demo overlay
+            const DemoOverlay(),
+          ],
+        ),
+      ),
+    );
+  }
 
-              // Onboarding demo overlay
-              const DemoOverlay(),
-            ],
-          ),
-        ));
+  Widget _buildHomeClipboardPreview() {
+    final candidate = _homeClipboardCandidate;
+    if (candidate == null) return const SizedBox.shrink();
+
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 128,
+      child: SafeArea(
+        top: false,
+        minimum: const EdgeInsets.only(bottom: 8),
+        child: ClipboardPreviewCard(
+          candidate: candidate,
+          onPaste: _pasteHomeClipboardToInput,
+          onDismiss: _dismissHomeClipboardPreview,
+        ),
+      ),
+    );
   }
 
   Widget _buildBottomBar() {
@@ -1637,9 +1759,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
                   // Painted Native Vector Overlay
                   // Completely removing dependencies on Figma PNG/SVG transparent paddings!
                   Positioned.fill(
-                    child: CustomPaint(
-                      painter: _NavBarPainter(),
-                    ),
+                    child: CustomPaint(painter: _NavBarPainter()),
                   ),
 
                   // Shadow occluder mask
@@ -1734,8 +1854,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
                       behavior: HitTestBehavior.opaque,
                       onTap: () {
                         _handleLibraryTabTap();
-                        DemoService.instance
-                            .tryAdvance(DemoStep.tapKnowledgeTab);
+                        DemoService.instance.tryAdvance(
+                          DemoStep.tapKnowledgeTab,
+                        );
                       },
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
@@ -1751,7 +1872,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
                               BlendMode.srcIn,
                             ),
                           ),
-                          SizedBox(height: 76.0 - 47.02 - 21.15),
+                          const SizedBox(height: 76.0 - 47.02 - 21.15),
                           Text(
                             UserStorage.l10n.bottomNavLibrary,
                             textAlign: TextAlign.center,
@@ -1800,10 +1921,12 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     if (_knowledgeBaseButtonTapCount == 1) {
       setState(() => _currentTab = 1);
       _knowledgeBaseButtonTapTimer?.cancel();
-      _knowledgeBaseButtonTapTimer =
-          Timer(const Duration(milliseconds: 300), () {
-        _knowledgeBaseButtonTapCount = 0;
-      });
+      _knowledgeBaseButtonTapTimer = Timer(
+        const Duration(milliseconds: 300),
+        () {
+          _knowledgeBaseButtonTapCount = 0;
+        },
+      );
     } else if (_knowledgeBaseButtonTapCount == 2) {
       _knowledgeBaseButtonTapTimer?.cancel();
       _knowledgeBaseButtonTapCount = 0;
@@ -1834,20 +1957,18 @@ class _NavBarPainter extends CustomPainter {
     // Custom drop shadow that doesn't bleed weirdly
     // We clip the bottom so the shadow never goes below the nav bar visually
     canvas.save();
-    canvas
-        .clipRect(Rect.fromLTWH(-50, -50, size.width + 100, size.height + 50));
+    canvas.clipRect(
+      Rect.fromLTWH(-50, -50, size.width + 100, size.height + 50),
+    );
     canvas.drawPath(
       path,
       Paint()
-        ..color = Colors.black.withOpacity(0.08)
+        ..color = Colors.black.withValues(alpha: 0.08)
         ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 10.0),
     );
     canvas.restore();
 
-    canvas.drawPath(
-      path,
-      Paint()..color = Colors.white,
-    );
+    canvas.drawPath(path, Paint()..color = Colors.white);
   }
 
   @override

--- a/lib/ui/main_screen/widgets/clipboard_preview_card.dart
+++ b/lib/ui/main_screen/widgets/clipboard_preview_card.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:memex/data/services/clipboard_preview_service.dart';
+import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/utils/user_storage.dart';
+
+class ClipboardPreviewCard extends StatelessWidget {
+  const ClipboardPreviewCard({
+    super.key,
+    required this.candidate,
+    required this.onPaste,
+    required this.onDismiss,
+    this.margin = const EdgeInsets.symmetric(horizontal: 20),
+  });
+
+  final ClipboardPreviewCandidate candidate;
+  final VoidCallback onPaste;
+  final VoidCallback onDismiss;
+  final EdgeInsetsGeometry margin;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: margin,
+      child: Material(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        elevation: 0,
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: AppColors.primary.withValues(alpha: 0.14),
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.08),
+                blurRadius: 24,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          padding: const EdgeInsets.fromLTRB(14, 12, 12, 12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    width: 28,
+                    height: 28,
+                    decoration: BoxDecoration(
+                      color: AppColors.primary.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                    child: const Icon(
+                      Icons.content_paste_rounded,
+                      size: 16,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      UserStorage.l10n.clipboardPreviewTitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: GoogleFonts.inter(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.textPrimary,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: AppColors.success.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(99),
+                    ),
+                    child: Text(
+                      UserStorage.l10n.clipboardPreviewUnprocessed,
+                      style: GoogleFonts.inter(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.success,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10),
+              Text(
+                candidate.previewText,
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  height: 1.45,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: FilledButton.icon(
+                      onPressed: onPaste,
+                      icon: const Icon(Icons.keyboard_tab_rounded, size: 17),
+                      label: Text(
+                        UserStorage.l10n.clipboardPreviewPasteToInput,
+                      ),
+                      style: FilledButton.styleFrom(
+                        backgroundColor: Colors.black,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 11),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(14),
+                        ),
+                        textStyle: GoogleFonts.inter(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  IconButton(
+                    tooltip: UserStorage.l10n.ignore,
+                    onPressed: onDismiss,
+                    icon: const Icon(Icons.close_rounded),
+                    color: AppColors.textTertiary,
+                    style: IconButton.styleFrom(
+                      backgroundColor: const Color(0xFFF7F8FA),
+                      fixedSize: const Size(42, 42),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/main_screen/widgets/input_sheet.dart
+++ b/lib/ui/main_screen/widgets/input_sheet.dart
@@ -19,10 +19,12 @@ import 'package:memex/data/services/whisper_service.dart';
 import 'package:memex/data/services/streaming_transcriber.dart';
 import 'package:memex/data/services/speech_transcription_service.dart';
 import 'package:memex/data/services/input_draft_service.dart';
+import 'package:memex/data/services/clipboard_preview_service.dart';
 import 'package:memex/config/app_flavor.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/ui/core/widgets/local_image.dart';
 import 'package:memex/data/services/demo_service.dart';
+import 'package:memex/ui/main_screen/widgets/clipboard_preview_card.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -79,6 +81,7 @@ class _InputSheetState extends State<InputSheet>
   late AnimationController _pulseController;
 
   final TextEditingController _textController = TextEditingController();
+  final FocusNode _textFocusNode = FocusNode();
   final ScrollController _textScrollController = ScrollController();
 
   void _scrollTextToBottom() {
@@ -97,6 +100,8 @@ class _InputSheetState extends State<InputSheet>
 
   final Logger _logger = getLogger('InputSheet');
   final InputDraftService _draftService = InputDraftService.instance;
+  final ClipboardPreviewService _clipboardPreviewService =
+      ClipboardPreviewService.instance;
 
   StreamingTranscriber? _streamingTranscriber;
   StreamSubscription<Uint8List>? _audioStreamSub;
@@ -120,6 +125,8 @@ class _InputSheetState extends State<InputSheet>
   bool _isApplyingDraft = false;
   bool _isRestoredDraft = false;
   bool _isSubmitting = false;
+  bool _isCheckingClipboard = false;
+  ClipboardPreviewCandidate? _clipboardCandidate;
   final Map<String, AssetEntity> _assetsMap = {}; // path -> AssetEntity
 
   @override
@@ -152,6 +159,7 @@ class _InputSheetState extends State<InputSheet>
     );
 
     _textController.addListener(_onTextChanged);
+    _textFocusNode.addListener(_onTextFocusChanged);
 
     _audioPlayer.onPlayerComplete.listen((event) {
       if (!mounted) return;
@@ -196,6 +204,8 @@ class _InputSheetState extends State<InputSheet>
         state == AppLifecycleState.paused ||
         state == AppLifecycleState.detached) {
       _flushDraft();
+    } else if (state == AppLifecycleState.resumed && widget.isOpen) {
+      unawaited(_checkClipboardPreview());
     }
   }
 
@@ -208,6 +218,7 @@ class _InputSheetState extends State<InputSheet>
       await _restoreDraft();
     }
     if (!mounted || !widget.isOpen) return;
+    unawaited(_checkClipboardPreview());
     _fetchAutoClusters();
   }
 
@@ -243,8 +254,11 @@ class _InputSheetState extends State<InputSheet>
     _audioPlayer.stop();
 
     final regex = RegExp(r'#([^\s#]+)');
-    final tags =
-        regex.allMatches(text).map((m) => m.group(1)!).toSet().toList();
+    final tags = regex
+        .allMatches(text)
+        .map((m) => m.group(1)!)
+        .toSet()
+        .toList();
 
     setState(() {
       _selectedImages = List<XFile>.from(data.images);
@@ -257,6 +271,7 @@ class _InputSheetState extends State<InputSheet>
       _detectedTags = tags;
       _autoClusters = null;
       _isLoadingAuto = false;
+      _clipboardCandidate = null;
     });
     _setRestoredDraft(false);
 
@@ -282,6 +297,7 @@ class _InputSheetState extends State<InputSheet>
       _isLoadingAuto = false;
       _isRestoredDraft = false;
       _isSubmitting = false;
+      _clipboardCandidate = null;
     });
   }
 
@@ -347,6 +363,67 @@ class _InputSheetState extends State<InputSheet>
     if (!_isApplyingDraft) {
       _scheduleDraftSave();
     }
+  }
+
+  void _onTextFocusChanged() {
+    if (_textFocusNode.hasFocus && widget.isOpen) {
+      unawaited(_checkClipboardPreview());
+    }
+  }
+
+  Future<void> _checkClipboardPreview() async {
+    if (_isCheckingClipboard || !widget.isOpen) return;
+
+    _isCheckingClipboard = true;
+    final candidate = await _clipboardPreviewService.fetchUnhandledText(
+      currentText: _textController.text,
+    );
+    _isCheckingClipboard = false;
+
+    if (!mounted || !widget.isOpen) return;
+    setState(() => _clipboardCandidate = candidate);
+  }
+
+  Future<void> _pasteClipboardCandidate() async {
+    final candidate = _clipboardCandidate;
+    if (candidate == null) return;
+
+    final currentText = _textController.text;
+    final selection = _textController.selection;
+    final start = selection.isValid
+        ? selection.start.clamp(0, currentText.length)
+        : currentText.length;
+    final end = selection.isValid
+        ? selection.end.clamp(0, currentText.length)
+        : currentText.length;
+    final normalizedStart = start <= end ? start : end;
+    final normalizedEnd = start <= end ? end : start;
+    final updatedText = currentText.replaceRange(
+      normalizedStart,
+      normalizedEnd,
+      candidate.text,
+    );
+    final cursorOffset = normalizedStart + candidate.text.length;
+
+    _textController.value = TextEditingValue(
+      text: updatedText,
+      selection: TextSelection.collapsed(offset: cursorOffset),
+    );
+
+    await _clipboardPreviewService.markHandled(candidate);
+    if (!mounted) return;
+    setState(() => _clipboardCandidate = null);
+    _textFocusNode.requestFocus();
+    _scrollTextToBottom();
+  }
+
+  Future<void> _dismissClipboardCandidate() async {
+    final candidate = _clipboardCandidate;
+    if (candidate == null) return;
+
+    await _clipboardPreviewService.markHandled(candidate);
+    if (!mounted) return;
+    setState(() => _clipboardCandidate = null);
   }
 
   void _updateDetectedTags(String text) {
@@ -439,6 +516,8 @@ class _InputSheetState extends State<InputSheet>
     _pcmBuffer.clear();
     _pulseController.dispose();
     _textScrollController.dispose();
+    _textFocusNode.removeListener(_onTextFocusChanged);
+    _textFocusNode.dispose();
     _controller.dispose();
     _textController.dispose();
     _audioRecorder.dispose();
@@ -532,8 +611,8 @@ class _InputSheetState extends State<InputSheet>
             if (mounted) {
               final separator =
                   _preRecordingText.isNotEmpty && fullText.isNotEmpty
-                      ? ' '
-                      : '';
+                  ? ' '
+                  : '';
               setState(() {
                 _textController.text = '$_preRecordingText$separator$fullText';
                 _textController.selection = TextSelection.collapsed(
@@ -608,8 +687,8 @@ class _InputSheetState extends State<InputSheet>
 
   Future<void> _stopRecording() async {
     try {
-      final useLocal =
-          await SpeechTranscriptionService.instance.isUsingLocalModel();
+      final useLocal = await SpeechTranscriptionService.instance
+          .isUsingLocalModel();
 
       await _audioStreamSub?.cancel();
       _audioStreamSub = null;
@@ -1282,7 +1361,8 @@ class _InputSheetState extends State<InputSheet>
     // Calculate available height excluding keyboard
     final availableHeight = screenHeight - viewInsets.bottom;
     // Account for AutoRow (~84px) and card margins
-    final cardMaxHeight = availableHeight - 110;
+    final clipboardPreviewHeight = _clipboardCandidate == null ? 0.0 : 142.0;
+    final cardMaxHeight = availableHeight - 110 - clipboardPreviewHeight;
 
     return Stack(
       children: [
@@ -1314,6 +1394,22 @@ class _InputSheetState extends State<InputSheet>
                   children: [
                     // AUTO row above input area, single row
                     _buildAutoRow(),
+                    AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 180),
+                      switchInCurve: Curves.easeOut,
+                      switchOutCurve: Curves.easeIn,
+                      child: _clipboardCandidate == null
+                          ? const SizedBox.shrink()
+                          : Padding(
+                              key: ValueKey(_clipboardCandidate!.hash),
+                              padding: const EdgeInsets.only(bottom: 12),
+                              child: ClipboardPreviewCard(
+                                candidate: _clipboardCandidate!,
+                                onPaste: _pasteClipboardCandidate,
+                                onDismiss: _dismissClipboardCandidate,
+                              ),
+                            ),
+                    ),
                     Flexible(
                       child: GestureDetector(
                         onTap: () {},
@@ -1361,13 +1457,15 @@ class _InputSheetState extends State<InputSheet>
                                       children: [
                                         TextField(
                                           controller: _textController,
+                                          focusNode: _textFocusNode,
                                           scrollController:
                                               _textScrollController,
                                           autofocus: false,
                                           maxLines: 5,
                                           decoration: InputDecoration(
                                             hintText: UserStorage
-                                                .l10n.tellAiWhatHappened,
+                                                .l10n
+                                                .tellAiWhatHappened,
                                             hintStyle: const TextStyle(
                                               color: AppColors.textTertiary,
                                               fontSize: 18,
@@ -1390,9 +1488,9 @@ class _InputSheetState extends State<InputSheet>
                                               return Container(
                                                 padding:
                                                     const EdgeInsets.symmetric(
-                                                  horizontal: 12,
-                                                  vertical: 6,
-                                                ),
+                                                      horizontal: 12,
+                                                      vertical: 6,
+                                                    ),
                                                 decoration: BoxDecoration(
                                                   color: AppColors.iconBgLight,
                                                   borderRadius:
@@ -1445,28 +1543,28 @@ class _InputSheetState extends State<InputSheet>
                                                 return Padding(
                                                   padding:
                                                       const EdgeInsets.only(
-                                                    right: 8,
-                                                  ),
+                                                        right: 8,
+                                                      ),
                                                   child: Stack(
                                                     children: [
                                                       ClipRRect(
                                                         borderRadius:
-                                                            BorderRadius
-                                                                .circular(
-                                                          12,
-                                                        ),
+                                                            BorderRadius.circular(
+                                                              12,
+                                                            ),
                                                         child: GestureDetector(
                                                           onTap: () =>
                                                               _showImagePreview(
-                                                            index,
-                                                          ),
+                                                                index,
+                                                              ),
                                                           child:
                                                               _buildSelectedImagePreview(
-                                                            index: index,
-                                                            width: 100,
-                                                            height: 100,
-                                                            fit: BoxFit.cover,
-                                                          ),
+                                                                index: index,
+                                                                width: 100,
+                                                                height: 100,
+                                                                fit: BoxFit
+                                                                    .cover,
+                                                              ),
                                                         ),
                                                       ),
                                                       Positioned(
@@ -1475,20 +1573,20 @@ class _InputSheetState extends State<InputSheet>
                                                         child: GestureDetector(
                                                           onTap: () =>
                                                               _removeImage(
-                                                                  index),
+                                                                index,
+                                                              ),
                                                           child: Container(
                                                             padding:
-                                                                const EdgeInsets
-                                                                    .all(
-                                                              4,
-                                                            ),
+                                                                const EdgeInsets.all(
+                                                                  4,
+                                                                ),
                                                             decoration:
                                                                 const BoxDecoration(
-                                                              color: Colors
-                                                                  .black54,
-                                                              shape: BoxShape
-                                                                  .circle,
-                                                            ),
+                                                                  color: Colors
+                                                                      .black54,
+                                                                  shape: BoxShape
+                                                                      .circle,
+                                                                ),
                                                             child: const Icon(
                                                               Icons.close,
                                                               size: 16,
@@ -1513,9 +1611,7 @@ class _InputSheetState extends State<InputSheet>
                                             decoration: BoxDecoration(
                                               color: const Color(0xFFF8FAFC),
                                               borderRadius:
-                                                  BorderRadius.circular(
-                                                12,
-                                              ),
+                                                  BorderRadius.circular(12),
                                             ),
                                             child: Row(
                                               children: [
@@ -1528,8 +1624,8 @@ class _InputSheetState extends State<InputSheet>
                                                       color: Colors.white,
                                                       borderRadius:
                                                           BorderRadius.circular(
-                                                        18,
-                                                      ),
+                                                            18,
+                                                          ),
                                                     ),
                                                     child: Icon(
                                                       _isPlaying
@@ -1550,7 +1646,8 @@ class _InputSheetState extends State<InputSheet>
                                                     children: [
                                                       Text(
                                                         UserStorage
-                                                            .l10n.recordedAudio,
+                                                            .l10n
+                                                            .recordedAudio,
                                                         style: const TextStyle(
                                                           fontSize: 14,
                                                           fontWeight:
@@ -1563,7 +1660,8 @@ class _InputSheetState extends State<InputSheet>
                                                       Text(
                                                         _isPlaying
                                                             ? UserStorage
-                                                                .l10n.playing
+                                                                  .l10n
+                                                                  .playing
                                                             : _formatDuration(
                                                                 _audioDuration,
                                                               ),
@@ -1580,14 +1678,13 @@ class _InputSheetState extends State<InputSheet>
                                                   onTap: _removeAudio,
                                                   child: Container(
                                                     padding:
-                                                        const EdgeInsets.all(
-                                                      4,
-                                                    ),
+                                                        const EdgeInsets.all(4),
                                                     decoration:
                                                         const BoxDecoration(
-                                                      color: Colors.white,
-                                                      shape: BoxShape.circle,
-                                                    ),
+                                                          color: Colors.white,
+                                                          shape:
+                                                              BoxShape.circle,
+                                                        ),
                                                     child: const Icon(
                                                       Icons.close,
                                                       size: 16,
@@ -1607,9 +1704,10 @@ class _InputSheetState extends State<InputSheet>
                                               onTap: _isTranscribing
                                                   ? null
                                                   : (_isRecording
-                                                      ? _stopRecording
-                                                      : _startRecording),
-                                              onLongPress: (_isRecording ||
+                                                        ? _stopRecording
+                                                        : _startRecording),
+                                              onLongPress:
+                                                  (_isRecording ||
                                                       _isTranscribing)
                                                   ? null
                                                   : _pickAudioFile,
@@ -1644,26 +1742,24 @@ class _InputSheetState extends State<InputSheet>
                                                         Container(
                                                           width: 48,
                                                           height: 48,
-                                                          decoration:
-                                                              BoxDecoration(
+                                                          decoration: BoxDecoration(
                                                             color: _isRecording
                                                                 ? AppColors
-                                                                    .primary
+                                                                      .primary
                                                                 : _isTranscribing
-                                                                    ? AppColors
-                                                                        .primary
-                                                                        .withValues(
+                                                                ? AppColors
+                                                                      .primary
+                                                                      .withValues(
                                                                         alpha:
                                                                             0.08,
                                                                       )
-                                                                    : const Color(
-                                                                        0xFFF7F8FA,
-                                                                      ),
+                                                                : const Color(
+                                                                    0xFFF7F8FA,
+                                                                  ),
                                                             borderRadius:
-                                                                BorderRadius
-                                                                    .circular(
-                                                              24,
-                                                            ),
+                                                                BorderRadius.circular(
+                                                                  24,
+                                                                ),
                                                           ),
                                                           child: Stack(
                                                             alignment: Alignment
@@ -1672,18 +1768,21 @@ class _InputSheetState extends State<InputSheet>
                                                               Icon(
                                                                 Icons.mic,
                                                                 size: 22,
-                                                                color: _isRecording
-                                                                    ? Colors.white
+                                                                color:
+                                                                    _isRecording
+                                                                    ? Colors
+                                                                          .white
                                                                     : _isTranscribing
-                                                                        ? AppColors.primary
-                                                                        : AppColors.textSecondary,
+                                                                    ? AppColors
+                                                                          .primary
+                                                                    : AppColors
+                                                                          .textSecondary,
                                                               ),
                                                               if (_isTranscribing)
                                                                 const SizedBox(
                                                                   width: 36,
                                                                   height: 36,
-                                                                  child:
-                                                                      CircularProgressIndicator(
+                                                                  child: CircularProgressIndicator(
                                                                     strokeWidth:
                                                                         2,
                                                                     color: AppColors
@@ -1708,8 +1807,9 @@ class _InputSheetState extends State<InputSheet>
                                                 width: 48,
                                                 height: 48,
                                                 decoration: BoxDecoration(
-                                                  color:
-                                                      const Color(0xFFF7F8FA),
+                                                  color: const Color(
+                                                    0xFFF7F8FA,
+                                                  ),
                                                   borderRadius:
                                                       BorderRadius.circular(24),
                                                 ),
@@ -1730,8 +1830,9 @@ class _InputSheetState extends State<InputSheet>
                                                 width: 48,
                                                 height: 48,
                                                 decoration: BoxDecoration(
-                                                  color:
-                                                      const Color(0xFFF7F8FA),
+                                                  color: const Color(
+                                                    0xFFF7F8FA,
+                                                  ),
                                                   borderRadius:
                                                       BorderRadius.circular(24),
                                                 ),
@@ -1747,7 +1848,8 @@ class _InputSheetState extends State<InputSheet>
                                             GestureDetector(
                                               key: DemoService.instance.isActive
                                                   ? DemoService
-                                                      .instance.sendButtonKey
+                                                        .instance
+                                                        .sendButtonKey
                                                   : const ValueKey(
                                                       'input_sheet_submit_button',
                                                     ),
@@ -1755,9 +1857,9 @@ class _InputSheetState extends State<InputSheet>
                                               child: Container(
                                                 padding:
                                                     const EdgeInsets.symmetric(
-                                                  horizontal: 24,
-                                                  vertical: 12,
-                                                ),
+                                                      horizontal: 24,
+                                                      vertical: 12,
+                                                    ),
                                                 decoration: BoxDecoration(
                                                   color: Colors.black,
                                                   borderRadius:
@@ -1767,7 +1869,8 @@ class _InputSheetState extends State<InputSheet>
                                                   children: [
                                                     Text(
                                                       UserStorage
-                                                          .l10n.recordLabel,
+                                                          .l10n
+                                                          .recordLabel,
                                                       style: const TextStyle(
                                                         color: Colors.white,
                                                         fontSize: 16,
@@ -1926,8 +2029,9 @@ class _InputSheetState extends State<InputSheet>
             Icon(
               isAllSelected ? Icons.check_circle : Icons.add_circle_outline,
               size: 20,
-              color:
-                  isAllSelected ? AppColors.primary : const Color(0xFFCBD5E1),
+              color: isAllSelected
+                  ? AppColors.primary
+                  : const Color(0xFFCBD5E1),
             ),
           ],
         ),

--- a/lib/utils/toast_helper.dart
+++ b/lib/utils/toast_helper.dart
@@ -7,43 +7,45 @@ class ToastHelper {
   static void showError(BuildContext? context, dynamic error) {
     if (context == null) return;
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      _buildErrorSnackBar(error),
-    );
+    ScaffoldMessenger.of(context).showSnackBar(_buildErrorSnackBar(error));
   }
 
   /// Show success toast
   static void showSuccess(BuildContext? context, String message) {
     if (context == null) return;
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      _buildSuccessSnackBar(message),
-    );
+    ScaffoldMessenger.of(context).showSnackBar(_buildSuccessSnackBar(message));
   }
 
   /// Show success toast using GlobalKey
   static void showSuccessWithKey(
-      GlobalKey<ScaffoldMessengerState> key, String message) {
-    key.currentState?.showSnackBar(
-      _buildSuccessSnackBar(message),
-    );
+    GlobalKey<ScaffoldMessengerState> key,
+    String message,
+  ) {
+    key.currentState?.showSnackBar(_buildSuccessSnackBar(message));
   }
 
   /// Show error toast using GlobalKey
   static void showErrorWithKey(
-      GlobalKey<ScaffoldMessengerState> key, dynamic error) {
-    key.currentState?.showSnackBar(
-      _buildErrorSnackBar(error),
-    );
+    GlobalKey<ScaffoldMessengerState> key,
+    dynamic error,
+  ) {
+    key.currentState?.showSnackBar(_buildErrorSnackBar(error));
   }
 
   /// Show info toast
   static void showInfo(BuildContext? context, String message) {
     if (context == null) return;
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      _buildInfoSnackBar(message),
-    );
+    ScaffoldMessenger.of(context).showSnackBar(_buildInfoSnackBar(message));
+  }
+
+  /// Show info toast using GlobalKey
+  static void showInfoWithKey(
+    GlobalKey<ScaffoldMessengerState> key,
+    String message,
+  ) {
+    key.currentState?.showSnackBar(_buildInfoSnackBar(message));
   }
 
   static SnackBar _buildInfoSnackBar(String message) {
@@ -53,9 +55,7 @@ class ToastHelper {
       backgroundColor: Colors.blue.shade600,
       behavior: SnackBarBehavior.floating,
       margin: const EdgeInsets.all(16),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
     );
   }
 
@@ -66,9 +66,7 @@ class ToastHelper {
       backgroundColor: Colors.green.shade600,
       behavior: SnackBarBehavior.floating,
       margin: const EdgeInsets.all(16),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
     );
   }
 
@@ -85,19 +83,12 @@ class ToastHelper {
     return SnackBar(
       content: Row(
         children: [
-          const Icon(
-            Icons.error_outline,
-            color: Colors.red,
-            size: 20,
-          ),
+          const Icon(Icons.error_outline, color: Colors.red, size: 20),
           const SizedBox(width: 12),
           Expanded(
             child: Text(
               errorMessage,
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 14,
-              ),
+              style: const TextStyle(color: Colors.white, fontSize: 14),
             ),
           ),
         ],
@@ -110,9 +101,7 @@ class ToastHelper {
         right: 16,
         bottom: 130, // above submit button to avoid overlap
       ),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
     );
   }
 }

--- a/test/data/services/clipboard_preview_service_test.dart
+++ b/test/data/services/clipboard_preview_service_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/clipboard_preview_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late String? clipboardText;
+  final service = ClipboardPreviewService.instance;
+
+  setUp(() {
+    clipboardText = 'Remember to discuss the clipboard preview.';
+    SharedPreferences.setMockInitialValues({'user_id': 'test_user'});
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.getData') {
+            return {'text': clipboardText};
+          }
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  group('ClipboardPreviewService', () {
+    test(
+      'returns text clipboard candidate when it has not been handled',
+      () async {
+        final candidate = await service.fetchUnhandledText();
+
+        expect(candidate, isNotNull);
+        expect(candidate!.text, clipboardText);
+        expect(candidate.hash, isNotEmpty);
+      },
+    );
+
+    test('trims clipboard text and collapses preview whitespace', () async {
+      clipboardText = '  line one\n\nline two\t line three  ';
+
+      final candidate = await service.fetchUnhandledText();
+
+      expect(candidate, isNotNull);
+      expect(candidate!.text, 'line one\n\nline two\t line three');
+      expect(candidate.previewText, 'line one line two line three');
+      expect(candidate.characterCount, candidate.text.runes.length);
+    });
+
+    test('ignores blank clipboard text', () async {
+      clipboardText = ' \n\t ';
+
+      expect(await service.fetchUnhandledText(), isNull);
+    });
+
+    test(
+      'does not return the same candidate after it is marked handled',
+      () async {
+        final candidate = await service.fetchUnhandledText();
+        expect(candidate, isNotNull);
+
+        await service.markHandled(candidate!);
+
+        expect(await service.fetchUnhandledText(), isNull);
+      },
+    );
+
+    test('handled clipboard hashes are scoped per user', () async {
+      final candidate = await service.fetchUnhandledText();
+      expect(candidate, isNotNull);
+
+      await service.markHandled(candidate!);
+      expect(await service.fetchUnhandledText(), isNull);
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('user_id', 'another_user');
+      expect(await service.fetchUnhandledText(), isNotNull);
+
+      await prefs.setString('user_id', 'test_user');
+      expect(await service.fetchUnhandledText(), isNull);
+    });
+
+    test('keeps only the most recent handled hashes', () async {
+      for (var i = 0; i < 81; i += 1) {
+        await service.markTextHandled('handled text $i');
+      }
+
+      clipboardText = 'handled text 80';
+      expect(await service.fetchUnhandledText(), isNull);
+
+      clipboardText = 'handled text 0';
+      final droppedCandidate = await service.fetchUnhandledText();
+      expect(droppedCandidate, isNotNull);
+      expect(droppedCandidate!.text, 'handled text 0');
+    });
+
+    test(
+      'marks clipboard handled when current input already contains it',
+      () async {
+        final first = await service.fetchUnhandledText(
+          currentText: 'Draft\n$clipboardText',
+        );
+
+        expect(first, isNull);
+        expect(await service.fetchUnhandledText(), isNull);
+      },
+    );
+  });
+}

--- a/test/ui/main_screen/widgets/clipboard_preview_card_test.dart
+++ b/test/ui/main_screen/widgets/clipboard_preview_card_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/clipboard_preview_service.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/main_screen/widgets/clipboard_preview_card.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({'user_id': 'preview-card-test'});
+    await UserStorage.initL10n();
+  });
+
+  testWidgets('renders compact preview and exposes paste and dismiss actions', (
+    tester,
+  ) async {
+    var pasteCount = 0;
+    var dismissCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ClipboardPreviewCard(
+            candidate: const ClipboardPreviewCandidate(
+              text: 'first line\n\nsecond line',
+              hash: 'hash',
+            ),
+            onPaste: () => pasteCount += 1,
+            onDismiss: () => dismissCount += 1,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(UserStorage.l10n.clipboardPreviewTitle), findsOneWidget);
+    expect(
+      find.text(UserStorage.l10n.clipboardPreviewUnprocessed),
+      findsOneWidget,
+    );
+    expect(find.text('first line second line'), findsOneWidget);
+
+    await tester.tap(find.text(UserStorage.l10n.clipboardPreviewPasteToInput));
+    await tester.pump();
+    await tester.tap(find.byTooltip(UserStorage.l10n.ignore));
+    await tester.pump();
+
+    expect(pasteCount, 1);
+    expect(dismissCount, 1);
+  });
+}

--- a/test/ui/main_screen/widgets/input_sheet_test.dart
+++ b/test/ui/main_screen/widgets/input_sheet_test.dart
@@ -5,10 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:memex/data/services/clipboard_preview_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/input_draft_service.dart';
 import 'package:memex/data/services/local_asset_server.dart';
 import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/main_screen/widgets/clipboard_preview_card.dart';
 import 'package:memex/ui/main_screen/widgets/input_sheet.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -17,6 +19,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory testDataRoot;
+  String? clipboardText;
 
   setUpAll(() async {
     const recordChannel = MethodChannel('com.llfbandit.record/messages');
@@ -66,7 +69,25 @@ void main() {
   });
 
   setUp(() async {
+    clipboardText = null;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('user_id', 'input-sheet-test');
+    await prefs.remove(
+      'clipboard_preview_handled_hashes_input-sheet-test',
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.getData') {
+        return {'text': clipboardText};
+      }
+      return null;
+    });
     await InputDraftService.instance.clearActiveDraft();
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
   });
 
   tearDownAll(() async {
@@ -76,7 +97,10 @@ void main() {
     }
   });
 
-  Widget buildHost({InputData? initialData}) {
+  Widget buildHost({
+    InputData? initialData,
+    Future<bool> Function(InputData data)? onSubmit,
+  }) {
     var isOpen = true;
     var closeCount = 0;
 
@@ -98,7 +122,7 @@ void main() {
                       closeCount += 1;
                     });
                   },
-                  onSubmit: (_) async => true,
+                  onSubmit: onSubmit ?? (_) async => true,
                 ),
                 Text('close count: $closeCount'),
               ],
@@ -130,77 +154,163 @@ void main() {
     expect(find.text('close count: 1'), findsOneWidget);
   });
 
-  testWidgets('unsafe selected image uses safety placeholder in preview strip',
-      (
+  testWidgets('clipboard preview pastes into the input without submitting', (
     tester,
   ) async {
-    final image = File('${testDataRoot.path}/unsafe_selected.png');
-    image.writeAsBytesSync(_pngHeader(width: 1000, height: 13000));
+    clipboardText = 'clipboard note';
+    var submitCount = 0;
+
+    final directCandidate =
+        await ClipboardPreviewService.instance.fetchUnhandledText();
+    expect(directCandidate?.text, 'clipboard note');
 
     await tester.pumpWidget(
       buildHost(
-        initialData: InputData(
-          text: 'long screenshot',
-          images: [XFile(image.path)],
-        ),
+        initialData: InputData(text: ''),
+        onSubmit: (_) async {
+          submitCount += 1;
+          return true;
+        },
       ),
     );
     await tester.pump(const Duration(milliseconds: 350));
-    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tap(find.byType(TextField));
+    await pumpUntilFound(tester, find.byType(ClipboardPreviewCard));
 
-    expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
-    expect(find.byType(Image), findsNothing);
+    expect(find.byType(ClipboardPreviewCard), findsOneWidget);
+    expect(
+      find.text(UserStorage.l10n.clipboardPreviewPasteToInput),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text(UserStorage.l10n.clipboardPreviewPasteToInput));
+    await tester.pump();
+    await pumpUntilGone(tester, find.byType(ClipboardPreviewCard));
+
+    expect(find.byType(ClipboardPreviewCard), findsNothing);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      'clipboard note',
+    );
+    expect(submitCount, 0);
   });
 
   testWidgets(
-    'successful submit clears draft and suppresses dispose saves',
+    'clipboard preview is suppressed when the input already contains the clipboard',
     (tester) async {
-      final submitCompleter = Completer<bool>();
-      InputData? submittedData;
+      clipboardText = 'already included';
 
       await tester.pumpWidget(
-        buildSubmitHost(
-          onSubmit: (data, closeSheet) {
-            submittedData = data;
-            closeSheet();
-            return submitCompleter.future;
-          },
+        buildHost(
+          initialData: InputData(text: 'draft with already included text'),
         ),
       );
       await tester.pump(const Duration(milliseconds: 350));
-
-      await tester.enterText(find.byType(TextField), 'sent note');
-      await tester.pump();
-      await saveActiveDraft(tester, 'sent note');
-      expect(await activeDraftText(tester), 'sent note');
-
-      final submitButton = find.byKey(
-        const ValueKey('input_sheet_submit_button'),
-      );
-      await tester.runAsync<void>(() async {
-        tester.widget<GestureDetector>(submitButton).onTap!();
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-      });
-      await tester.pump();
       await tester.pump(const Duration(milliseconds: 50));
 
-      expect(submittedData?.text, 'sent note');
-      expect(await activeDraftText(tester), isNull);
+      expect(find.byType(ClipboardPreviewCard), findsNothing);
 
-      await tester.pumpWidget(const SizedBox.shrink());
-      await tester.pump(const Duration(milliseconds: 50));
-      expect(await activeDraftText(tester), isNull);
-
-      await tester.runAsync<void>(() async {
-        submitCompleter.complete(true);
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-      });
-      await tester.pump();
+      await tester.tap(find.byType(TextField));
       await tester.pump(const Duration(milliseconds: 50));
 
-      expect(await activeDraftText(tester), isNull);
+      expect(find.byType(ClipboardPreviewCard), findsNothing);
     },
   );
+
+  testWidgets('dismissing clipboard preview hides it for the same clipboard', (
+    tester,
+  ) async {
+    clipboardText = 'dismiss me';
+
+    await tester.pumpWidget(buildHost(initialData: InputData(text: '')));
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.tap(find.byType(TextField));
+    await pumpUntilFound(tester, find.byType(ClipboardPreviewCard));
+
+    expect(find.byType(ClipboardPreviewCard), findsOneWidget);
+
+    await tester.tap(find.byTooltip(UserStorage.l10n.ignore));
+    await tester.pump();
+    await pumpUntilGone(tester, find.byType(ClipboardPreviewCard));
+
+    expect(find.byType(ClipboardPreviewCard), findsNothing);
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.byType(ClipboardPreviewCard), findsNothing);
+  });
+
+  testWidgets(
+    'unsafe selected image uses safety placeholder in preview strip',
+    (tester) async {
+      final image = File('${testDataRoot.path}/unsafe_selected.png');
+      image.writeAsBytesSync(_pngHeader(width: 1000, height: 13000));
+
+      await tester.pumpWidget(
+        buildHost(
+          initialData: InputData(
+            text: 'long screenshot',
+            images: [XFile(image.path)],
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+      expect(find.byType(Image), findsNothing);
+    },
+  );
+
+  testWidgets('successful submit clears draft and suppresses dispose saves', (
+    tester,
+  ) async {
+    final submitCompleter = Completer<bool>();
+    InputData? submittedData;
+
+    await tester.pumpWidget(
+      buildSubmitHost(
+        onSubmit: (data, closeSheet) {
+          submittedData = data;
+          closeSheet();
+          return submitCompleter.future;
+        },
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 350));
+
+    await tester.enterText(find.byType(TextField), 'sent note');
+    await tester.pump();
+    await saveActiveDraft(tester, 'sent note');
+    expect(await activeDraftText(tester), 'sent note');
+
+    final submitButton = find.byKey(
+      const ValueKey('input_sheet_submit_button'),
+    );
+    await tester.runAsync<void>(() async {
+      tester.widget<GestureDetector>(submitButton).onTap!();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(submittedData?.text, 'sent note');
+    expect(await activeDraftText(tester), isNull);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(await activeDraftText(tester), isNull);
+
+    await tester.runAsync<void>(() async {
+      submitCompleter.complete(true);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(await activeDraftText(tester), isNull);
+  });
 
   testWidgets('failed submit writes the submitted text back to draft', (
     tester,
@@ -244,9 +354,7 @@ void main() {
 }
 
 typedef SubmitHostCallback = Future<bool> Function(
-  InputData data,
-  VoidCallback closeSheet,
-);
+    InputData data, VoidCallback closeSheet);
 
 Widget buildSubmitHost({required SubmitHostCallback onSubmit}) {
   var isOpen = true;
@@ -289,6 +397,20 @@ Future<void> saveActiveDraft(WidgetTester tester, String text) {
   return tester.runAsync<void>(() {
     return InputDraftService.instance.saveTextDraft(text);
   });
+}
+
+Future<void> pumpUntilFound(WidgetTester tester, Finder finder) async {
+  for (var i = 0; i < 20; i += 1) {
+    await tester.pump(const Duration(milliseconds: 50));
+    if (finder.evaluate().isNotEmpty) return;
+  }
+}
+
+Future<void> pumpUntilGone(WidgetTester tester, Finder finder) async {
+  for (var i = 0; i < 20; i += 1) {
+    await tester.pump(const Duration(milliseconds: 50));
+    if (finder.evaluate().isEmpty) return;
+  }
 }
 
 List<int> _pngHeader({required int width, required int height}) {


### PR DESCRIPTION
## 背景

Closes #252

当前剪贴板里有新文字时，用户在回到首页或点开输入框后缺少一个低打扰、可预览、可一键粘贴的入口。这个 PR 按“先预览，直接粘到输入框里，由用户决定是否二次修改”的方案实现。

## 改动

- 新增 `ClipboardPreviewService`，统一判断剪贴板候选、空内容过滤、已处理记录、同用户哈希隔离和容量裁剪。
- 新增剪贴板预览卡片，在首页和输入框内展示剪贴板文字摘要，支持一键粘贴和忽略。
- 输入框打开、聚焦、应用回前台时会重新检查剪贴板；粘贴后只写入输入框，不自动提交。
- 当输入框已包含剪贴板内容、用户忽略过同一段内容，或正在提交时，避免重复打扰。
- 补齐中英文文案和相关 widget/unit 覆盖。

## 测试

- `flutter analyze lib/main.dart lib/ui/main_screen/widgets/input_sheet.dart lib/data/services/clipboard_preview_service.dart lib/ui/main_screen/widgets/clipboard_preview_card.dart lib/utils/toast_helper.dart test/data/services/clipboard_preview_service_test.dart test/ui/main_screen/widgets/input_sheet_test.dart test/ui/main_screen/widgets/clipboard_preview_card_test.dart`
- `flutter test test/data/services/clipboard_preview_service_test.dart test/ui/main_screen/widgets/input_sheet_test.dart test/ui/main_screen/widgets/clipboard_preview_card_test.dart`
- `flutter test --no-pub --concurrency=1`
- `flutter test --no-pub`

说明：本地测试环境需要清掉代理变量后运行 Flutter 测试，否则 `flutter_tester` 会遇到 WebSocket 连接问题。
