### PR TITLE
fix: avoid marking paused iOS agent work as failed

### DIFF
--- a/ios/Runner/AgentBackgroundTaskChannelHandler.swift
+++ b/ios/Runner/AgentBackgroundTaskChannelHandler.swift
@@ -339,7 +339,10 @@ class AgentBackgroundTaskChannelHandler: NSObject {
         if #available(iOS 26.0, *) {
             if let task = continuedProcessingTask {
                 task.updateTitle(task.title, subtitle: "Paused. Memex will continue later.")
-                task.setTaskCompleted(success: false)
+                // The agent queue is durable and will resume from LocalTaskExecutor.
+                // Expiration means the current iOS visibility window ended, not that
+                // the Memex task failed.
+                task.setTaskCompleted(success: true)
             }
             continuedProcessingTask = nil
             submittedContinuedIdentifier = nil


### PR DESCRIPTION
## Summary
- Treat iOS 26 continued-processing expiration as a paused visibility window instead of a failed agent task
- Keep the durable LocalTaskExecutor resume behavior unchanged

## Verification
- flutter analyze --no-pub lib/data/services/agent_background_task_service.dart
- flutter build ios --release --flavor global --no-pub