### PR TITLE
修复剪贴板图片预览乱码和卡顿风险

### DIFF
--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/ChannelRegistrar.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/ChannelRegistrar.kt
@@ -22,5 +22,6 @@ object ChannelRegistrar {
         BackupStorageChannelHandler.register(flutterEngine, activity)
         BackupImportChannelHandler.register(flutterEngine, activity)
         AgentBackgroundChannelHandler.register(flutterEngine, activity)
+        ClipboardPreviewChannelHandler.register(flutterEngine, activity)
     }
 }

--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/ClipboardPreviewChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/ClipboardPreviewChannelHandler.kt
@@ -1,0 +1,232 @@
+package com.memexlab.memex.channels
+
+import android.app.Activity
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.provider.OpenableColumns
+import android.webkit.MimeTypeMap
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+
+/**
+ * Handles `com.memexlab.memex/clipboard_preview` MethodChannel.
+ */
+class ClipboardPreviewChannelHandler(private val activity: Activity) {
+
+    companion object {
+        private const val CHANNEL = "com.memexlab.memex/clipboard_preview"
+
+        fun register(flutterEngine: FlutterEngine, activity: Activity) {
+            val handler = ClipboardPreviewChannelHandler(activity)
+            MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+                .setMethodCallHandler { call, result ->
+                    when (call.method) {
+                        "getClipboardSummary" -> handler.getClipboardSummary(result)
+                        "copyImageToCache" -> {
+                            val uri = call.argument<String>("uri")
+                            val fileName = call.argument<String>("fileName")
+                            val mimeType = call.argument<String>("mimeType")
+                            handler.copyImageToCache(uri, fileName, mimeType, result)
+                        }
+                        else -> result.notImplemented()
+                    }
+                }
+        }
+    }
+
+    private fun getClipboardSummary(result: MethodChannel.Result) {
+        Thread {
+            try {
+                val summary = buildClipboardSummary()
+                activity.runOnUiThread { result.success(summary) }
+            } catch (e: Exception) {
+                activity.runOnUiThread {
+                    result.error("CLIPBOARD_READ_FAILED", e.message, null)
+                }
+            }
+        }.start()
+    }
+
+    private fun buildClipboardSummary(): Map<String, Any?>? {
+        val clip = clipboardManager().primaryClip
+        if (clip == null || clip.itemCount == 0) {
+            return null
+        }
+
+        val description = clip.description
+        val item = clip.getItemAt(0)
+        val uri = item.uri
+        val sourcePrefix = "android:${clipboardTimestamp(description)}"
+        val imageMimeType = resolveImageMimeType(uri, description.mimeTypeCount) {
+            description.getMimeType(it)
+        }
+
+        if (imageMimeType != null && uri != null) {
+            return mapOf(
+                "type" to "image",
+                "uri" to uri.toString(),
+                "mimeType" to imageMimeType,
+                "fileName" to displayName(uri),
+                "sourceId" to "$sourcePrefix:$uri:$imageMimeType",
+            )
+        }
+
+        val text = item.text?.toString()
+            ?: item.htmlText
+            ?: item.coerceToText(activity)?.toString()
+        if (text.isNullOrBlank()) {
+            return null
+        }
+
+        val textImageUri = parseImageUri(text.trim())
+        if (textImageUri != null) {
+            val textImageMimeType = imageMimeTypeForUri(textImageUri) ?: "image/*"
+            return mapOf(
+                "type" to "image",
+                "uri" to textImageUri.toString(),
+                "mimeType" to textImageMimeType,
+                "fileName" to displayName(textImageUri),
+                "sourceId" to "$sourcePrefix:$textImageUri:$textImageMimeType",
+            )
+        }
+
+        return mapOf(
+            "type" to "text",
+            "text" to text.trim(),
+        )
+    }
+
+    private fun copyImageToCache(
+        uriString: String?,
+        fileName: String?,
+        mimeType: String?,
+        result: MethodChannel.Result,
+    ) {
+        Thread {
+            try {
+                val uri = uriString?.let(Uri::parse) ?: currentClipboardImageUri()
+                    ?: throw IllegalStateException("No clipboard image URI")
+                val resolvedMimeType = imageMimeTypeForUri(uri) ?: mimeType ?: "image/png"
+                val extension = extensionForMimeType(resolvedMimeType)
+                    ?: MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+                    ?: "png"
+                val safeName = safeFileName(
+                    fileName?.takeIf { it.isNotBlank() }
+                        ?: "clipboard_image_${System.currentTimeMillis()}.$extension"
+                )
+                val targetDir = File(activity.cacheDir, "clipboard_images").apply {
+                    mkdirs()
+                }
+                val targetFile = File(targetDir, ensureExtension(safeName, extension))
+
+                activity.contentResolver.openInputStream(uri).use { input ->
+                    if (input == null) throw IllegalStateException("Unable to open clipboard image")
+                    targetFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+
+                activity.runOnUiThread { result.success(targetFile.absolutePath) }
+            } catch (e: SecurityException) {
+                activity.runOnUiThread { result.error("PERMISSION_DENIED", e.message, null) }
+            } catch (e: Exception) {
+                activity.runOnUiThread { result.error("COPY_FAILED", e.message, null) }
+            }
+        }.start()
+    }
+
+    private fun clipboardTimestamp(description: ClipDescription): Long {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            description.timestamp
+        } else {
+            0L
+        }
+    }
+
+    private fun clipboardManager(): ClipboardManager {
+        return activity.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    }
+
+    private fun currentClipboardImageUri(): Uri? {
+        val clip = clipboardManager().primaryClip ?: return null
+        if (clip.itemCount == 0) return null
+        return clip.getItemAt(0).uri ?: parseImageUri(
+            clip.getItemAt(0).text?.toString()?.trim()
+        )
+    }
+
+    private fun resolveImageMimeType(
+        uri: Uri?,
+        mimeTypeCount: Int,
+        mimeTypeAt: (Int) -> String,
+    ): String? {
+        for (index in 0 until mimeTypeCount) {
+            val mimeType = mimeTypeAt(index)
+            if (mimeType.startsWith("image/")) return mimeType
+        }
+        return uri?.let(::imageMimeTypeForUri)
+    }
+
+    private fun parseImageUri(text: String?): Uri? {
+        if (text.isNullOrBlank()) return null
+        val uri = runCatching { Uri.parse(text) }.getOrNull() ?: return null
+        val scheme = uri.scheme ?: return null
+        if (scheme != "content" && scheme != "file") return null
+        return if (imageMimeTypeForUri(uri)?.startsWith("image/") == true) uri else null
+    }
+
+    private fun imageMimeTypeForUri(uri: Uri): String? {
+        val resolverType = runCatching { activity.contentResolver.getType(uri) }.getOrNull()
+        if (resolverType?.startsWith("image/") == true) return resolverType
+
+        val extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+        if (extension.isNullOrBlank()) return null
+        val mimeType = MimeTypeMap.getSingleton()
+            .getMimeTypeFromExtension(extension.lowercase())
+        return mimeType?.takeIf { it.startsWith("image/") }
+    }
+
+    private fun displayName(uri: Uri): String? {
+        val cursor = runCatching {
+            activity.contentResolver.query(
+                uri,
+                arrayOf(OpenableColumns.DISPLAY_NAME),
+                null,
+                null,
+                null,
+            )
+        }.getOrNull()
+        cursor?.use {
+            if (it.moveToFirst()) {
+                val index = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index >= 0) return it.getString(index)
+            }
+        }
+        return uri.lastPathSegment
+    }
+
+    private fun extensionForMimeType(mimeType: String): String? {
+        return when (mimeType) {
+            "image/jpeg" -> "jpg"
+            "image/png" -> "png"
+            "image/gif" -> "gif"
+            "image/webp" -> "webp"
+            "image/heic" -> "heic"
+            "image/heif" -> "heif"
+            "image/bmp" -> "bmp"
+            else -> null
+        }
+    }
+
+    private fun safeFileName(fileName: String): String {
+        return fileName.replace(Regex("""[^\w.\-]+"""), "_")
+    }
+
+    private fun ensureExtension(fileName: String, extension: String): String {
+        return if (fileName.contains(".")) fileName else "$fileName.$extension"
+    }
+}

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		AA0001071000000100000004 /* SystemActionsChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001081000000100000004 /* SystemActionsChannelHandler.swift */; };
 		AA0001091000000100000005 /* AudioConverterChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00010A1000000100000005 /* AudioConverterChannelHandler.swift */; };
 		AA00010B1000000100000006 /* AgentBackgroundTaskChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00010C1000000100000006 /* AgentBackgroundTaskChannelHandler.swift */; };
+		AA00010D1000000100000007 /* ClipboardPreviewChannelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00010E1000000100000007 /* ClipboardPreviewChannelHandler.swift */; };
 		94D8E68DFAF0E975A7B3AAC9 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD25ADB84447B9A4366F6055 /* Pods_RunnerTests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -93,6 +94,7 @@
 		AA0001081000000100000004 /* SystemActionsChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemActionsChannelHandler.swift; sourceTree = "<group>"; };
 		AA00010A1000000100000005 /* AudioConverterChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioConverterChannelHandler.swift; sourceTree = "<group>"; };
 		AA00010C1000000100000006 /* AgentBackgroundTaskChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBackgroundTaskChannelHandler.swift; sourceTree = "<group>"; };
+		AA00010E1000000100000007 /* ClipboardPreviewChannelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardPreviewChannelHandler.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		83F22F54729A29819701B85D /* Pods-ShareExtension.debug-cn.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShareExtension.debug-cn.xcconfig"; path = "Target Support Files/Pods-ShareExtension/Pods-ShareExtension.debug-cn.xcconfig"; sourceTree = "<group>"; };
 		8968E2D1ACE76EDC468CD1F2 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 				AA0001081000000100000004 /* SystemActionsChannelHandler.swift */,
 				AA00010A1000000100000005 /* AudioConverterChannelHandler.swift */,
 				AA00010C1000000100000006 /* AgentBackgroundTaskChannelHandler.swift */,
+				AA00010E1000000100000007 /* ClipboardPreviewChannelHandler.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -589,6 +592,7 @@
 				AA0001071000000100000004 /* SystemActionsChannelHandler.swift in Sources */,
 				AA0001091000000100000005 /* AudioConverterChannelHandler.swift in Sources */,
 				AA00010B1000000100000006 /* AgentBackgroundTaskChannelHandler.swift in Sources */,
+				AA00010D1000000100000007 /* ClipboardPreviewChannelHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/ChannelRegistrar.swift
+++ b/ios/Runner/ChannelRegistrar.swift
@@ -16,5 +16,6 @@ class ChannelRegistrar {
         SystemActionsChannelHandler.register(with: messenger)
         AudioConverterChannelHandler.register(with: messenger)
         AgentBackgroundTaskChannelHandler.register(with: messenger)
+        ClipboardPreviewChannelHandler.register(with: messenger)
     }
 }

--- a/ios/Runner/ClipboardPreviewChannelHandler.swift
+++ b/ios/Runner/ClipboardPreviewChannelHandler.swift
@@ -1,0 +1,80 @@
+import Flutter
+import UIKit
+
+/// Handles `com.memexlab.memex/clipboard_preview` MethodChannel.
+class ClipboardPreviewChannelHandler: NSObject {
+
+    static func register(with messenger: FlutterBinaryMessenger) {
+        let channel = FlutterMethodChannel(
+            name: "com.memexlab.memex/clipboard_preview",
+            binaryMessenger: messenger
+        )
+        let instance = ClipboardPreviewChannelHandler()
+        channel.setMethodCallHandler(instance.handle)
+    }
+
+    private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "getClipboardSummary":
+            getClipboardSummary(result: result)
+        case "copyImageToCache":
+            copyImageToCache(result: result)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func getClipboardSummary(result: @escaping FlutterResult) {
+        let pasteboard = UIPasteboard.general
+        if pasteboard.hasImages {
+            result([
+                "type": "image",
+                "mimeType": "image/png",
+                "fileName": "clipboard_image.png",
+                "sourceId": "ios:\(pasteboard.changeCount):image",
+            ])
+            return
+        }
+
+        guard let text = pasteboard.string?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty else {
+            result(nil)
+            return
+        }
+
+        result([
+            "type": "text",
+            "text": text,
+        ])
+    }
+
+    private func copyImageToCache(result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let image = UIPasteboard.general.image,
+                  let data = image.pngData() else {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "NO_IMAGE", message: "No clipboard image", details: nil))
+                }
+                return
+            }
+
+            do {
+                let directory = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("clipboard_images", isDirectory: true)
+                try FileManager.default.createDirectory(
+                    at: directory,
+                    withIntermediateDirectories: true
+                )
+                let fileURL = directory.appendingPathComponent(
+                    "clipboard_image_\(Int(Date().timeIntervalSince1970 * 1000)).png"
+                )
+                try data.write(to: fileURL, options: .atomic)
+                DispatchQueue.main.async { result(fileURL.path) }
+            } catch {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "COPY_FAILED", message: "\(error)", details: nil))
+                }
+            }
+        }
+    }
+}

--- a/lib/data/services/clipboard_preview_service.dart
+++ b/lib/data/services/clipboard_preview_service.dart
@@ -1,55 +1,150 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+enum ClipboardPreviewCandidateType { text, image }
+
 class ClipboardPreviewCandidate {
-  const ClipboardPreviewCandidate({required this.text, required this.hash});
+  const ClipboardPreviewCandidate({
+    required this.type,
+    required this.hash,
+    required this.previewText,
+    this.text,
+    this.imageUri,
+    this.localPath,
+    this.dataUri,
+    this.mimeType,
+    this.fileName,
+    this.characterCount = 0,
+  });
 
-  final String text;
+  final ClipboardPreviewCandidateType type;
   final String hash;
+  final String previewText;
+  final String? text;
+  final String? imageUri;
+  final String? localPath;
+  final String? dataUri;
+  final String? mimeType;
+  final String? fileName;
+  final int characterCount;
 
-  int get characterCount => text.runes.length;
-
-  String get previewText => text.replaceAll(RegExp(r'\s+'), ' ').trim();
+  bool get isText => type == ClipboardPreviewCandidateType.text;
+  bool get isImage => type == ClipboardPreviewCandidateType.image;
 }
 
 class ClipboardPreviewService {
   static final ClipboardPreviewService instance = ClipboardPreviewService._();
 
+  static const _channel = MethodChannel('com.memexlab.memex/clipboard_preview');
+  static const _maxPreviewCharacters = 240;
   static const _maxHandledHashes = 80;
   static const _handledHashesKeyPrefix = 'clipboard_preview_handled_hashes_';
+  static const _platformReadTimeout = Duration(milliseconds: 700);
+
+  @visibleForTesting
+  static bool debugUseBackgroundWorker = true;
 
   final _logger = getLogger('ClipboardPreviewService');
 
   ClipboardPreviewService._();
 
-  Future<ClipboardPreviewCandidate?> fetchUnhandledText({
+  Future<ClipboardPreviewCandidate?> fetchUnhandledCandidate({
     String? currentText,
   }) async {
     try {
-      final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
-      final text = clipboardData?.text?.trim();
-      if (text == null || text.isEmpty) return null;
+      final summary = await _readClipboardSummary();
+      if (summary == null) return null;
 
-      final existingText = currentText?.trim();
-      if (existingText != null &&
-          existingText.isNotEmpty &&
-          (existingText == text || existingText.contains(text))) {
-        await markTextHandled(text);
-        return null;
+      if (summary.type == ClipboardPreviewCandidateType.text) {
+        final text = summary.text?.trim();
+        if (text == null || text.isEmpty) return null;
+
+        final existingText = currentText?.trim();
+        if (existingText != null &&
+            existingText.isNotEmpty &&
+            (existingText == text || existingText.contains(text))) {
+          await markTextHandled(text);
+          return null;
+        }
       }
 
-      final hash = _hashText(text);
-      final handledHashes = await _loadHandledHashes();
-      if (handledHashes.contains(hash)) return null;
+      final candidate = await _buildCandidate(summary);
+      if (candidate == null) return null;
 
-      return ClipboardPreviewCandidate(text: text, hash: hash);
+      final handledHashes = await _loadHandledHashes();
+      if (handledHashes.contains(candidate.hash)) return null;
+
+      return candidate;
     } catch (e, st) {
       _logger.warning('Failed to inspect clipboard: $e', e, st);
+      return null;
+    }
+  }
+
+  Future<ClipboardPreviewCandidate?> fetchUnhandledText({String? currentText}) {
+    return fetchUnhandledCandidate(currentText: currentText);
+  }
+
+  Future<XFile?> materializeImage(ClipboardPreviewCandidate candidate) async {
+    if (!candidate.isImage) return null;
+
+    try {
+      final localPath = candidate.localPath;
+      if (localPath != null && await File(localPath).exists()) {
+        return XFile(
+          localPath,
+          name: candidate.fileName,
+          mimeType: candidate.mimeType,
+        );
+      }
+
+      final dataUri = candidate.dataUri;
+      if (dataUri != null) {
+        final path = await _writeDataUriImageToCache(
+          dataUri,
+          candidate.mimeType,
+        );
+        return XFile(
+          path,
+          name: candidate.fileName ?? path.split(Platform.pathSeparator).last,
+          mimeType: candidate.mimeType,
+        );
+      }
+
+      final filePath = _filePathFromUri(candidate.imageUri);
+      if (filePath != null && await File(filePath).exists()) {
+        return XFile(
+          filePath,
+          name: candidate.fileName,
+          mimeType: candidate.mimeType,
+        );
+      }
+
+      final path = await _channel.invokeMethod<String>('copyImageToCache', {
+        'uri': candidate.imageUri,
+        'fileName': candidate.fileName,
+        'mimeType': candidate.mimeType,
+      });
+      if (path == null || path.isEmpty) return null;
+      return XFile(
+        path,
+        name: candidate.fileName ?? path.split(Platform.pathSeparator).last,
+        mimeType: candidate.mimeType,
+      );
+    } on MissingPluginException {
+      return null;
+    } catch (e, st) {
+      _logger.warning('Failed to materialize clipboard image: $e', e, st);
       return null;
     }
   }
@@ -58,8 +153,83 @@ class ClipboardPreviewService {
     return _markHashHandled(candidate.hash);
   }
 
-  Future<void> markTextHandled(String text) {
-    return _markHashHandled(_hashText(text.trim()));
+  Future<void> markTextHandled(String text) async {
+    return _markHashHandled(await _hashText('text:${text.trim()}'));
+  }
+
+  Future<_ClipboardSummary?> _readClipboardSummary() async {
+    final platformSummary = await _readPlatformClipboardSummary();
+    if (platformSummary != null) return platformSummary;
+
+    final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+    final text = clipboardData?.text?.trim();
+    if (text == null || text.isEmpty) return null;
+    return _summaryFromPlainText(text);
+  }
+
+  Future<_ClipboardSummary?> _readPlatformClipboardSummary() async {
+    try {
+      final raw = await _channel
+          .invokeMapMethod<String, Object?>('getClipboardSummary')
+          .timeout(_platformReadTimeout);
+      if (raw == null) return null;
+      return _ClipboardSummary.fromMap(raw);
+    } on MissingPluginException {
+      return null;
+    } on TimeoutException catch (e, st) {
+      _logger.warning('Clipboard platform summary timed out: $e', e, st);
+      return null;
+    } catch (e, st) {
+      _logger.warning('Clipboard platform summary failed: $e', e, st);
+      return null;
+    }
+  }
+
+  _ClipboardSummary _summaryFromPlainText(String text) {
+    if (_isImageDataUri(text)) {
+      return _ClipboardSummary(
+        type: ClipboardPreviewCandidateType.image,
+        dataUri: text,
+        mimeType: _mimeTypeFromDataUri(text),
+        sourceId: 'data:${text.length}:${_boundedSourceSlice(text)}',
+      );
+    }
+
+    if (_looksLikeImageFileUri(text)) {
+      return _ClipboardSummary(
+        type: ClipboardPreviewCandidateType.image,
+        imageUri: text,
+        fileName: _fileNameFromUri(text),
+        mimeType: _mimeTypeFromImagePath(text),
+        sourceId: text,
+      );
+    }
+
+    return _ClipboardSummary(
+      type: ClipboardPreviewCandidateType.text,
+      text: text,
+    );
+  }
+
+  Future<ClipboardPreviewCandidate?> _buildCandidate(
+    _ClipboardSummary summary,
+  ) async {
+    final data = await _runInBackground(_buildCandidateData, summary.toMap());
+    if (data == null) return null;
+    return ClipboardPreviewCandidate(
+      type: data['type'] == 'image'
+          ? ClipboardPreviewCandidateType.image
+          : ClipboardPreviewCandidateType.text,
+      hash: data['hash'] as String,
+      previewText: data['previewText'] as String,
+      text: data['text'] as String?,
+      imageUri: data['imageUri'] as String?,
+      localPath: data['localPath'] as String?,
+      dataUri: data['dataUri'] as String?,
+      mimeType: data['mimeType'] as String?,
+      fileName: data['fileName'] as String?,
+      characterCount: data['characterCount'] as int? ?? 0,
+    );
   }
 
   Future<List<String>> _loadHandledHashes() async {
@@ -90,8 +260,228 @@ class ClipboardPreviewService {
     return '$_handledHashesKeyPrefix${userId ?? 'anonymous'}';
   }
 
-  String _hashText(String text) {
-    if (text.isEmpty) return '';
-    return sha256.convert(utf8.encode(text)).toString();
+  Future<String> _hashText(String text) {
+    return _runInBackground(_hashTextSync, text);
   }
+
+  Future<String> _writeDataUriImageToCache(
+    String dataUri,
+    String? mimeType,
+  ) async {
+    final directory = await getTemporaryDirectory();
+    final extension = _extensionForMime(mimeType) ?? 'png';
+    final outputPath =
+        '${directory.path}/clipboard_image_${DateTime.now().millisecondsSinceEpoch}.$extension';
+    return _runInBackground(_writeDataUriImageFile, {
+      'dataUri': dataUri,
+      'outputPath': outputPath,
+    });
+  }
+
+  String? _filePathFromUri(String? uriString) {
+    if (uriString == null || uriString.isEmpty) return null;
+    final uri = Uri.tryParse(uriString);
+    if (uri == null || !uri.hasScheme) return uriString;
+    if (uri.scheme == 'file') return uri.toFilePath();
+    return null;
+  }
+}
+
+Future<R> _runInBackground<M, R>(
+  ComputeCallback<M, R> callback,
+  M message,
+) {
+  if (!ClipboardPreviewService.debugUseBackgroundWorker) {
+    return Future.value(callback(message));
+  }
+  return compute(callback, message);
+}
+
+class _ClipboardSummary {
+  const _ClipboardSummary({
+    required this.type,
+    this.text,
+    this.imageUri,
+    this.localPath,
+    this.dataUri,
+    this.mimeType,
+    this.fileName,
+    this.sourceId,
+  });
+
+  final ClipboardPreviewCandidateType type;
+  final String? text;
+  final String? imageUri;
+  final String? localPath;
+  final String? dataUri;
+  final String? mimeType;
+  final String? fileName;
+  final String? sourceId;
+
+  factory _ClipboardSummary.fromMap(Map<String, Object?> map) {
+    final type = map['type'] == 'image'
+        ? ClipboardPreviewCandidateType.image
+        : ClipboardPreviewCandidateType.text;
+    return _ClipboardSummary(
+      type: type,
+      text: map['text'] as String?,
+      imageUri: map['uri'] as String?,
+      localPath: map['localPath'] as String?,
+      dataUri: map['dataUri'] as String?,
+      mimeType: map['mimeType'] as String?,
+      fileName: map['fileName'] as String?,
+      sourceId: map['sourceId'] as String?,
+    );
+  }
+
+  Map<String, Object?> toMap() {
+    return {
+      'type': type == ClipboardPreviewCandidateType.image ? 'image' : 'text',
+      'text': text,
+      'imageUri': imageUri,
+      'localPath': localPath,
+      'dataUri': dataUri,
+      'mimeType': mimeType,
+      'fileName': fileName,
+      'sourceId': sourceId,
+      'maxPreviewCharacters': ClipboardPreviewService._maxPreviewCharacters,
+    };
+  }
+}
+
+Map<String, Object?>? _buildCandidateData(Map<String, Object?> input) {
+  final type = input['type'] as String?;
+  if (type == 'image') {
+    final sourceId = input['sourceId'] as String? ??
+        input['imageUri'] as String? ??
+        input['localPath'] as String? ??
+        input['dataUri'] as String?;
+    if (sourceId == null || sourceId.trim().isEmpty) return null;
+    return {
+      'type': 'image',
+      'hash': _hashTextSync('image:$sourceId'),
+      'previewText': '',
+      'text': null,
+      'imageUri': input['imageUri'] as String?,
+      'localPath': input['localPath'] as String?,
+      'dataUri': input['dataUri'] as String?,
+      'mimeType': input['mimeType'] as String?,
+      'fileName': input['fileName'] as String?,
+      'characterCount': 0,
+    };
+  }
+
+  final text = (input['text'] as String?)?.trim();
+  if (text == null || text.isEmpty) return null;
+  final maxPreviewCharacters = input['maxPreviewCharacters'] as int? ?? 240;
+  return {
+    'type': 'text',
+    'hash': _hashTextSync('text:$text'),
+    'previewText': _previewForText(text, maxPreviewCharacters),
+    'text': text,
+    'imageUri': null,
+    'localPath': null,
+    'dataUri': null,
+    'mimeType': null,
+    'fileName': null,
+    'characterCount': text.runes.length,
+  };
+}
+
+String _hashTextSync(String text) {
+  if (text.isEmpty) return '';
+  return sha256.convert(utf8.encode(text)).toString();
+}
+
+String _previewForText(String text, int maxCharacters) {
+  final buffer = StringBuffer();
+  var count = 0;
+  var truncated = false;
+
+  for (final rune in text.runes) {
+    if (count >= maxCharacters) {
+      truncated = true;
+      break;
+    }
+    buffer.writeCharCode(rune);
+    count += 1;
+  }
+
+  final preview = buffer.toString().replaceAll(RegExp(r'\s+'), ' ').trim();
+  return truncated ? '$preview...' : preview;
+}
+
+Future<String> _writeDataUriImageFile(Map<String, Object?> input) async {
+  final dataUri = input['dataUri'] as String;
+  final outputPath = input['outputPath'] as String;
+  final commaIndex = dataUri.indexOf(',');
+  if (commaIndex < 0) {
+    throw const FormatException('Invalid image data URI');
+  }
+  final payload = dataUri.substring(commaIndex + 1);
+  final bytes = base64.decode(payload);
+  final file = File(outputPath);
+  await file.parent.create(recursive: true);
+  await file.writeAsBytes(bytes, flush: true);
+  return outputPath;
+}
+
+bool _isImageDataUri(String text) {
+  return text.startsWith(RegExp(r'data:image/[a-zA-Z0-9.+-]+;base64,'));
+}
+
+String? _mimeTypeFromDataUri(String text) {
+  final match = RegExp(r'^data:([^;,]+)').firstMatch(text);
+  return match?.group(1);
+}
+
+bool _looksLikeImageFileUri(String text) {
+  final uri = Uri.tryParse(text);
+  final path = uri?.path ?? text;
+  return _mimeTypeFromImagePath(path)?.startsWith('image/') ?? false;
+}
+
+String? _mimeTypeFromImagePath(String text) {
+  final lower = text.toLowerCase();
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  if (lower.endsWith('.gif')) return 'image/gif';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  if (lower.endsWith('.heic')) return 'image/heic';
+  if (lower.endsWith('.heif')) return 'image/heif';
+  if (lower.endsWith('.bmp')) return 'image/bmp';
+  return null;
+}
+
+String? _extensionForMime(String? mimeType) {
+  switch (mimeType) {
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/png':
+      return 'png';
+    case 'image/gif':
+      return 'gif';
+    case 'image/webp':
+      return 'webp';
+    case 'image/heic':
+      return 'heic';
+    case 'image/heif':
+      return 'heif';
+    case 'image/bmp':
+      return 'bmp';
+  }
+  return null;
+}
+
+String? _fileNameFromUri(String uriString) {
+  final uri = Uri.tryParse(uriString);
+  final path = uri?.path ?? uriString;
+  if (path.isEmpty) return null;
+  final segments = path.split('/');
+  return segments.isEmpty ? null : segments.last;
+}
+
+String _boundedSourceSlice(String text) {
+  if (text.length <= 256) return text;
+  return '${text.substring(0, 128)}:${text.substring(text.length - 128)}';
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -238,8 +238,12 @@
   "discardDraftMessage": "The draft content will be cleared.",
   "discardDraftTooltip": "Discard draft",
   "clipboardPreviewTitle": "New clipboard",
+  "clipboardPreviewImageTitle": "Clipboard image",
+  "clipboardPreviewImageDescription": "Image ready to add",
   "clipboardPreviewUnprocessed": "Not pasted yet",
   "clipboardPreviewPasteToInput": "Paste to input",
+  "clipboardPreviewAddImageToInput": "Add image",
+  "clipboardPreviewImageFailed": "Couldn't read clipboard image",
   "tellAiWhatHappened": "Tell AI what happened...",
   "@recordingWithDuration": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1070,6 +1070,18 @@ abstract class AppLocalizations {
   /// **'New clipboard'**
   String get clipboardPreviewTitle;
 
+  /// No description provided for @clipboardPreviewImageTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Clipboard image'**
+  String get clipboardPreviewImageTitle;
+
+  /// No description provided for @clipboardPreviewImageDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Image ready to add'**
+  String get clipboardPreviewImageDescription;
+
   /// No description provided for @clipboardPreviewUnprocessed.
   ///
   /// In en, this message translates to:
@@ -1081,6 +1093,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Paste to input'**
   String get clipboardPreviewPasteToInput;
+
+  /// No description provided for @clipboardPreviewAddImageToInput.
+  ///
+  /// In en, this message translates to:
+  /// **'Add image'**
+  String get clipboardPreviewAddImageToInput;
+
+  /// No description provided for @clipboardPreviewImageFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t read clipboard image'**
+  String get clipboardPreviewImageFailed;
 
   /// No description provided for @tellAiWhatHappened.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -545,10 +545,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get clipboardPreviewTitle => 'New clipboard';
 
   @override
+  String get clipboardPreviewImageTitle => 'Clipboard image';
+
+  @override
+  String get clipboardPreviewImageDescription => 'Image ready to add';
+
+  @override
   String get clipboardPreviewUnprocessed => 'Not pasted yet';
 
   @override
   String get clipboardPreviewPasteToInput => 'Paste to input';
+
+  @override
+  String get clipboardPreviewAddImageToInput => 'Add image';
+
+  @override
+  String get clipboardPreviewImageFailed => 'Couldn\'t read clipboard image';
 
   @override
   String get tellAiWhatHappened => 'Tell AI what happened...';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -529,10 +529,22 @@ class AppLocalizationsZh extends AppLocalizations {
   String get clipboardPreviewTitle => '新剪贴板';
 
   @override
+  String get clipboardPreviewImageTitle => '剪贴板图片';
+
+  @override
+  String get clipboardPreviewImageDescription => '可添加到输入框';
+
+  @override
   String get clipboardPreviewUnprocessed => '未处理';
 
   @override
   String get clipboardPreviewPasteToInput => '粘贴到输入框';
+
+  @override
+  String get clipboardPreviewAddImageToInput => '添加图片';
+
+  @override
+  String get clipboardPreviewImageFailed => '无法读取剪贴板图片';
 
   @override
   String get tellAiWhatHappened => '告诉AI发生了什么...';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -238,8 +238,12 @@
   "discardDraftMessage": "草稿内容会被清空。",
   "discardDraftTooltip": "丢弃草稿",
   "clipboardPreviewTitle": "新剪贴板",
+  "clipboardPreviewImageTitle": "剪贴板图片",
+  "clipboardPreviewImageDescription": "可添加到输入框",
   "clipboardPreviewUnprocessed": "未处理",
   "clipboardPreviewPasteToInput": "粘贴到输入框",
+  "clipboardPreviewAddImageToInput": "添加图片",
+  "clipboardPreviewImageFailed": "无法读取剪贴板图片",
   "tellAiWhatHappened": "告诉AI发生了什么...",
   "@recordingWithDuration": {
     "placeholders": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1505,7 +1505,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     }
 
     _isCheckingHomeClipboard = true;
-    final candidate = await _clipboardPreviewService.fetchUnhandledText();
+    final candidate = await _clipboardPreviewService.fetchUnhandledCandidate();
     _isCheckingHomeClipboard = false;
 
     if (!mounted || _isInputOpen) return;
@@ -1516,11 +1516,33 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     final candidate = _homeClipboardCandidate;
     if (candidate == null) return;
 
+    if (candidate.isImage) {
+      final image = await _clipboardPreviewService.materializeImage(candidate);
+      if (image == null) {
+        ToastHelper.showInfoWithKey(
+          rootScaffoldMessengerKey,
+          UserStorage.l10n.clipboardPreviewImageFailed,
+        );
+        return;
+      }
+      await _clipboardPreviewService.markHandled(candidate);
+      if (!mounted) return;
+      setState(() {
+        _homeClipboardCandidate = null;
+        _sharedDraft = InputData(images: [image]);
+        _isInputOpen = true;
+      });
+      return;
+    }
+
+    final text = candidate.text;
+    if (text == null || text.isEmpty) return;
+
     await _clipboardPreviewService.markHandled(candidate);
     if (!mounted) return;
     setState(() {
       _homeClipboardCandidate = null;
-      _sharedDraft = InputData(text: candidate.text);
+      _sharedDraft = InputData(text: text);
       _isInputOpen = true;
     });
   }

--- a/lib/ui/main_screen/widgets/clipboard_preview_card.dart
+++ b/lib/ui/main_screen/widgets/clipboard_preview_card.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:memex/data/services/clipboard_preview_service.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -20,6 +19,17 @@ class ClipboardPreviewCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isImage = candidate.isImage;
+    final title = isImage
+        ? UserStorage.l10n.clipboardPreviewImageTitle
+        : UserStorage.l10n.clipboardPreviewTitle;
+    final previewText = isImage
+        ? UserStorage.l10n.clipboardPreviewImageDescription
+        : candidate.previewText;
+    final buttonLabel = isImage
+        ? UserStorage.l10n.clipboardPreviewAddImageToInput
+        : UserStorage.l10n.clipboardPreviewPasteToInput;
+
     return Padding(
       padding: margin,
       child: Material(
@@ -55,8 +65,10 @@ class ClipboardPreviewCard extends StatelessWidget {
                       color: AppColors.primary.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(14),
                     ),
-                    child: const Icon(
-                      Icons.content_paste_rounded,
+                    child: Icon(
+                      isImage
+                          ? Icons.image_outlined
+                          : Icons.content_paste_rounded,
                       size: 16,
                       color: AppColors.primary,
                     ),
@@ -64,10 +76,10 @@ class ClipboardPreviewCard extends StatelessWidget {
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      UserStorage.l10n.clipboardPreviewTitle,
+                      title,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: GoogleFonts.inter(
+                      style: const TextStyle(
                         fontSize: 14,
                         fontWeight: FontWeight.w700,
                         color: AppColors.textPrimary,
@@ -85,7 +97,7 @@ class ClipboardPreviewCard extends StatelessWidget {
                     ),
                     child: Text(
                       UserStorage.l10n.clipboardPreviewUnprocessed,
-                      style: GoogleFonts.inter(
+                      style: const TextStyle(
                         fontSize: 11,
                         fontWeight: FontWeight.w700,
                         color: AppColors.success,
@@ -96,10 +108,10 @@ class ClipboardPreviewCard extends StatelessWidget {
               ),
               const SizedBox(height: 10),
               Text(
-                candidate.previewText,
+                previewText,
                 maxLines: 3,
                 overflow: TextOverflow.ellipsis,
-                style: GoogleFonts.inter(
+                style: const TextStyle(
                   fontSize: 13,
                   height: 1.45,
                   fontWeight: FontWeight.w500,
@@ -112,10 +124,13 @@ class ClipboardPreviewCard extends StatelessWidget {
                   Expanded(
                     child: FilledButton.icon(
                       onPressed: onPaste,
-                      icon: const Icon(Icons.keyboard_tab_rounded, size: 17),
-                      label: Text(
-                        UserStorage.l10n.clipboardPreviewPasteToInput,
+                      icon: Icon(
+                        isImage
+                            ? Icons.add_photo_alternate_outlined
+                            : Icons.keyboard_tab_rounded,
+                        size: 17,
                       ),
+                      label: Text(buttonLabel),
                       style: FilledButton.styleFrom(
                         backgroundColor: Colors.black,
                         foregroundColor: Colors.white,
@@ -123,7 +138,7 @@ class ClipboardPreviewCard extends StatelessWidget {
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(14),
                         ),
-                        textStyle: GoogleFonts.inter(
+                        textStyle: const TextStyle(
                           fontSize: 13,
                           fontWeight: FontWeight.w700,
                         ),

--- a/lib/ui/main_screen/widgets/input_sheet.dart
+++ b/lib/ui/main_screen/widgets/input_sheet.dart
@@ -375,7 +375,7 @@ class _InputSheetState extends State<InputSheet>
     if (_isCheckingClipboard || !widget.isOpen) return;
 
     _isCheckingClipboard = true;
-    final candidate = await _clipboardPreviewService.fetchUnhandledText(
+    final candidate = await _clipboardPreviewService.fetchUnhandledCandidate(
       currentText: _textController.text,
     );
     _isCheckingClipboard = false;
@@ -384,10 +384,33 @@ class _InputSheetState extends State<InputSheet>
     setState(() => _clipboardCandidate = candidate);
   }
 
-  Future<void> _pasteClipboardCandidate() async {
-    final candidate = _clipboardCandidate;
-    if (candidate == null) return;
+  Future<void> _pasteClipboardCandidate(
+      ClipboardPreviewCandidate candidate) async {
+    if (candidate.isImage) {
+      final image = await _clipboardPreviewService.materializeImage(candidate);
+      if (!mounted) return;
+      if (image == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(UserStorage.l10n.clipboardPreviewImageFailed)),
+        );
+        return;
+      }
 
+      await _clipboardPreviewService.markHandled(candidate);
+      if (!mounted) return;
+      setState(() {
+        _selectedImages.add(image);
+        final fileName = candidate.fileName;
+        if (fileName != null && fileName.isNotEmpty) {
+          _originalFilenames[image.path] = fileName;
+        }
+        _clipboardCandidate = null;
+      });
+      return;
+    }
+
+    final candidateText = candidate.text;
+    if (candidateText == null || candidateText.isEmpty) return;
     final currentText = _textController.text;
     final selection = _textController.selection;
     final start = selection.isValid
@@ -401,9 +424,9 @@ class _InputSheetState extends State<InputSheet>
     final updatedText = currentText.replaceRange(
       normalizedStart,
       normalizedEnd,
-      candidate.text,
+      candidateText,
     );
-    final cursorOffset = normalizedStart + candidate.text.length;
+    final cursorOffset = normalizedStart + candidateText.length;
 
     _textController.value = TextEditingValue(
       text: updatedText,
@@ -417,10 +440,9 @@ class _InputSheetState extends State<InputSheet>
     _scrollTextToBottom();
   }
 
-  Future<void> _dismissClipboardCandidate() async {
-    final candidate = _clipboardCandidate;
-    if (candidate == null) return;
-
+  Future<void> _dismissClipboardCandidate(
+    ClipboardPreviewCandidate candidate,
+  ) async {
     await _clipboardPreviewService.markHandled(candidate);
     if (!mounted) return;
     setState(() => _clipboardCandidate = null);
@@ -1400,14 +1422,21 @@ class _InputSheetState extends State<InputSheet>
                       switchOutCurve: Curves.easeIn,
                       child: _clipboardCandidate == null
                           ? const SizedBox.shrink()
-                          : Padding(
-                              key: ValueKey(_clipboardCandidate!.hash),
-                              padding: const EdgeInsets.only(bottom: 12),
-                              child: ClipboardPreviewCard(
-                                candidate: _clipboardCandidate!,
-                                onPaste: _pasteClipboardCandidate,
-                                onDismiss: _dismissClipboardCandidate,
-                              ),
+                          : Builder(
+                              builder: (context) {
+                                final candidate = _clipboardCandidate!;
+                                return Padding(
+                                  key: ValueKey(candidate.hash),
+                                  padding: const EdgeInsets.only(bottom: 12),
+                                  child: ClipboardPreviewCard(
+                                    candidate: candidate,
+                                    onPaste: () =>
+                                        _pasteClipboardCandidate(candidate),
+                                    onDismiss: () =>
+                                        _dismissClipboardCandidate(candidate),
+                                  ),
+                                );
+                              },
                             ),
                     ),
                     Flexible(

--- a/test/data/services/clipboard_preview_service_test.dart
+++ b/test/data/services/clipboard_preview_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/clipboard_preview_service.dart';
@@ -7,23 +9,57 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late String? clipboardText;
+  late Directory tempDir;
   final service = ClipboardPreviewService.instance;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('clipboard_preview_test_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async {
+        if (call.method == 'getTemporaryDirectory') return tempDir.path;
+        return null;
+      },
+    );
+  });
 
   setUp(() {
     clipboardText = 'Remember to discuss the clipboard preview.';
     SharedPreferences.setMockInitialValues({'user_id': 'test_user'});
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (call) async {
-          if (call.method == 'Clipboard.getData') {
-            return {'text': clipboardText};
-          }
-          return null;
-        });
+      if (call.method == 'Clipboard.getData') {
+        return {'text': clipboardText};
+      }
+      return null;
+    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('com.memexlab.memex/clipboard_preview'),
+      (_) async => null,
+    );
   });
 
   tearDown(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('com.memexlab.memex/clipboard_preview'),
+      null,
+    );
+  });
+
+  tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
   });
 
   group('ClipboardPreviewService', () {
@@ -34,6 +70,7 @@ void main() {
 
         expect(candidate, isNotNull);
         expect(candidate!.text, clipboardText);
+        expect(candidate.isText, isTrue);
         expect(candidate.hash, isNotEmpty);
       },
     );
@@ -46,7 +83,61 @@ void main() {
       expect(candidate, isNotNull);
       expect(candidate!.text, 'line one\n\nline two\t line three');
       expect(candidate.previewText, 'line one line two line three');
-      expect(candidate.characterCount, candidate.text.runes.length);
+      expect(candidate.characterCount, candidate.text!.runes.length);
+    });
+
+    test('keeps full plain text while bounding the preview text', () async {
+      clipboardText = List.filled(1000, 'plain text').join(' ');
+
+      final candidate = await service.fetchUnhandledText();
+
+      expect(candidate, isNotNull);
+      expect(candidate!.isText, isTrue);
+      expect(candidate.text, clipboardText);
+      expect(candidate.characterCount, clipboardText!.runes.length);
+      expect(candidate.previewText.length, lessThanOrEqualTo(243));
+      expect(candidate.previewText.endsWith('...'), isTrue);
+    });
+
+    test('treats image data URI as an image candidate', () async {
+      clipboardText =
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ';
+
+      final candidate = await service.fetchUnhandledText();
+
+      expect(candidate, isNotNull);
+      expect(candidate!.isImage, isTrue);
+      expect(candidate.text, isNull);
+      expect(candidate.mimeType, 'image/png');
+      expect(candidate.previewText, isEmpty);
+      expect(candidate.dataUri, clipboardText);
+    });
+
+    test('materializes image data URI into a temporary image file', () async {
+      clipboardText = 'data:image/png;base64,'
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ'
+          'AAAADUlEQVR42mP8z8BQDwAFgwJ/l6WPOwAAAABJRU5ErkJggg==';
+      final candidate = await service.fetchUnhandledText();
+      expect(candidate, isNotNull);
+      expect(candidate!.isImage, isTrue);
+
+      final image = await service.materializeImage(candidate);
+
+      expect(image, isNotNull);
+      expect(await image!.length(), greaterThan(0));
+      expect(image.path.endsWith('.png'), isTrue);
+    });
+
+    test('treats image file URI as an image candidate', () async {
+      clipboardText = 'file:///tmp/memex_clipboard_image.jpg';
+
+      final candidate = await service.fetchUnhandledText();
+
+      expect(candidate, isNotNull);
+      expect(candidate!.isImage, isTrue);
+      expect(candidate.imageUri, clipboardText);
+      expect(candidate.mimeType, 'image/jpeg');
+      expect(candidate.fileName, 'memex_clipboard_image.jpg');
     });
 
     test('ignores blank clipboard text', () async {

--- a/test/ui/main_screen/widgets/clipboard_preview_card_test.dart
+++ b/test/ui/main_screen/widgets/clipboard_preview_card_test.dart
@@ -27,8 +27,11 @@ void main() {
         home: Scaffold(
           body: ClipboardPreviewCard(
             candidate: const ClipboardPreviewCandidate(
+              type: ClipboardPreviewCandidateType.text,
               text: 'first line\n\nsecond line',
+              previewText: 'first line second line',
               hash: 'hash',
+              characterCount: 24,
             ),
             onPaste: () => pasteCount += 1,
             onDismiss: () => dismissCount += 1,
@@ -45,6 +48,57 @@ void main() {
     expect(find.text('first line second line'), findsOneWidget);
 
     await tester.tap(find.text(UserStorage.l10n.clipboardPreviewPasteToInput));
+    await tester.pump();
+    await tester.tap(find.byTooltip(UserStorage.l10n.ignore));
+    await tester.pump();
+
+    expect(pasteCount, 1);
+    expect(dismissCount, 1);
+  });
+
+  testWidgets('renders image clipboard candidate with add image action', (
+    tester,
+  ) async {
+    var pasteCount = 0;
+    var dismissCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ClipboardPreviewCard(
+            candidate: const ClipboardPreviewCandidate(
+              type: ClipboardPreviewCandidateType.image,
+              hash: 'image-hash',
+              previewText: '',
+              imageUri: 'file:///tmp/clipboard.png',
+              mimeType: 'image/png',
+              fileName: 'clipboard.png',
+            ),
+            onPaste: () => pasteCount += 1,
+            onDismiss: () => dismissCount += 1,
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.text(UserStorage.l10n.clipboardPreviewImageTitle),
+      findsOneWidget,
+    );
+    expect(
+      find.text(UserStorage.l10n.clipboardPreviewImageDescription),
+      findsOneWidget,
+    );
+    expect(
+      find.text(UserStorage.l10n.clipboardPreviewAddImageToInput),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.text(UserStorage.l10n.clipboardPreviewAddImageToInput),
+    );
     await tester.pump();
     await tester.tap(find.byTooltip(UserStorage.l10n.ignore));
     await tester.pump();

--- a/test/ui/main_screen/widgets/input_sheet_test.dart
+++ b/test/ui/main_screen/widgets/input_sheet_test.dart
@@ -10,6 +10,7 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/input_draft_service.dart';
 import 'package:memex/data/services/local_asset_server.dart';
 import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
 import 'package:memex/ui/main_screen/widgets/clipboard_preview_card.dart';
 import 'package:memex/ui/main_screen/widgets/input_sheet.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -65,16 +66,24 @@ void main() {
     await UserStorage.initL10n();
 
     testDataRoot = await Directory.systemTemp.createTemp('memex_input_sheet_');
+    messenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async {
+        if (call.method == 'getTemporaryDirectory') {
+          return testDataRoot.path;
+        }
+        return null;
+      },
+    );
     await FileSystemService.init(testDataRoot.path);
   });
 
   setUp(() async {
     clipboardText = null;
+    ClipboardPreviewService.debugUseBackgroundWorker = false;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('user_id', 'input-sheet-test');
-    await prefs.remove(
-      'clipboard_preview_handled_hashes_input-sheet-test',
-    );
+    await prefs.remove('clipboard_preview_handled_hashes_input-sheet-test');
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (call) async {
       if (call.method == 'Clipboard.getData') {
@@ -82,15 +91,31 @@ void main() {
       }
       return null;
     });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('com.memexlab.memex/clipboard_preview'),
+      (_) async => null,
+    );
     await InputDraftService.instance.clearActiveDraft();
   });
 
   tearDown(() {
+    ClipboardPreviewService.debugUseBackgroundWorker = true;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('com.memexlab.memex/clipboard_preview'),
+      null,
+    );
   });
 
   tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
     await LocalAssetServer.stopServer();
     if (await testDataRoot.exists()) {
       await testDataRoot.delete(recursive: true);
@@ -239,6 +264,52 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
 
     expect(find.byType(ClipboardPreviewCard), findsNothing);
+  });
+
+  testWidgets('clipboard image preview adds image without submitting text', (
+    tester,
+  ) async {
+    final clipboardImage = File('${testDataRoot.path}/clipboard_preview.png');
+    clipboardImage.writeAsBytesSync(_pngHeader(width: 12, height: 12));
+    clipboardText = clipboardImage.uri.toString();
+
+    await tester.pumpWidget(
+      buildHost(
+        initialData: InputData(text: ''),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.tap(find.byType(TextField));
+    await pumpUntilFound(tester, find.byType(ClipboardPreviewCard));
+
+    expect(
+      find.text(UserStorage.l10n.clipboardPreviewImageTitle),
+      findsOneWidget,
+    );
+    expect(
+      find.text(UserStorage.l10n.clipboardPreviewAddImageToInput),
+      findsOneWidget,
+    );
+
+    final addImageButton = tester.widget<FilledButton>(
+      find.widgetWithText(
+        FilledButton,
+        UserStorage.l10n.clipboardPreviewAddImageToInput,
+      ),
+    );
+    addImageButton.onPressed!();
+    await tester.runAsync<void>(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    });
+    await tester.pump(const Duration(milliseconds: 250));
+    await pumpUntilGone(tester, find.byType(ClipboardPreviewCard));
+
+    expect(find.byType(ClipboardPreviewCard), findsNothing);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      isEmpty,
+    );
+    expect(find.byType(LocalImage), findsOneWidget);
   });
 
   testWidgets(


### PR DESCRIPTION
## 背景

关联 #258，跟进 #253 的评论反馈：截图后打开输入面板会显示一串乱码，并且页面会卡顿。

根因是剪贴板预览之前基本按纯文本链路处理。图片剪贴板在平台侧可能被暴露成 `content://`、`file://` 或 `data:image/...;base64,...`，Flutter 侧再把它当普通文本展示，就会出现长串“乱码”。同时，长文本/base64 的预览构造和 hash 如果都在主 isolate 同步做，也会增加打开输入面板时的卡顿风险。

## 改动

- 将剪贴板候选从纯文本扩展为 `text/image` 两类。
- 纯文本粘贴仍保留完整内容，只把卡片展示摘要限制在 240 个字符内。
- 对图片剪贴板做单独识别和展示，不再把图片 URI/base64 当文本渲染。
- 图片候选确认后物化为本地缓存图片，并复用现有输入面板图片列表链路。
- Dart 侧把候选构造、hash、data URI 写文件等重活放到 `compute` isolate。
- Android 新增 `ClipboardPreviewChannelHandler`：后台线程读取轻量摘要、后台线程复制图片到 cache，并兼容低版本 `ClipDescription.timestamp`。
- iOS 新增 `ClipboardPreviewChannelHandler`：用 `UIPasteboard` 先返回轻量图片摘要，确认后后台队列写入临时图片文件。
- 补齐中英文 l10n 文案和服务/widget 测试。

## 验证

- `flutter analyze lib/data/services/clipboard_preview_service.dart lib/ui/main_screen/widgets/clipboard_preview_card.dart lib/ui/main_screen/widgets/input_sheet.dart lib/main.dart test/data/services/clipboard_preview_service_test.dart test/ui/main_screen/widgets/clipboard_preview_card_test.dart test/ui/main_screen/widgets/input_sheet_test.dart` 通过。
- `flutter test --concurrency=1 test/data/services/clipboard_preview_service_test.dart test/ui/main_screen/widgets/clipboard_preview_card_test.dart test/ui/main_screen/widgets/input_sheet_test.dart` 通过，21 个测试通过。
- `flutter test` 通过，507 个测试通过，7 个 live/外部 key 相关测试跳过。
- `flutter build apk --flavor globalDev --debug` 通过。
- `flutter analyze` 全仓运行过，因仓库既有 info 级 lint 返回非 0，本次触达文件的定向 analyze 已确认无问题。
- `cd ios && pod install` 成功；随后尝试 `xcodebuild -project Runner.xcodeproj -target Runner -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO build`，本机在 ShareExtension storyboard 阶段报 `iOS 26.5 Platform Not Installed`，未能完成 iOS 编译验证。

## Preflight

- 已按 Memex PR preflight 检查 `upstream/main...HEAD` diff 范围。
- 无 build/cache 产物入提交。
- 新增用户可见文案均走 ARB/localization。

Closes #258