### PR TITLE
修复备份恢复解压阻塞和刷新

### DIFF
--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -7,6 +7,7 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/config/app_flavor.dart';
+import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/utils/logger.dart';
@@ -113,12 +114,14 @@ class BackupManifest {
         ? appVersion.split('+')
         : const <String>[];
     return BackupManifest(
-      format: json['format'] as String? ??
+      format:
+          json['format'] as String? ??
           (formatVersion == null ? '' : _backupFormat),
       formatVersion: formatVersion ?? 1,
       backupSchemaVersion:
           (json['backupSchemaVersion'] as num?)?.toInt() ?? formatVersion ?? 0,
-      createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ??
+      createdAt:
+          DateTime.tryParse(json['createdAt'] as String? ?? '') ??
           DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
       userId: json['userId'] as String?,
       appVersion: splitVersion.isEmpty ? appVersion : splitVersion.first,
@@ -128,25 +131,25 @@ class BackupManifest {
       platform: json['platform'] as String? ?? '',
       entries: rawEntries is List
           ? rawEntries
-              .whereType<Map>()
-              .map((entry) => entry.cast<String, dynamic>())
-              .toList()
+                .whereType<Map>()
+                .map((entry) => entry.cast<String, dynamic>())
+                .toList()
           : const [],
     );
   }
 
   Map<String, dynamic> toJson() => {
-        'format': format,
-        'formatVersion': formatVersion,
-        'backupSchemaVersion': backupSchemaVersion,
-        'createdAt': createdAt.toUtc().toIso8601String(),
-        if (userId != null) 'userId': userId,
-        'appVersion': appVersion,
-        'buildNumber': buildNumber,
-        'flavor': flavor,
-        'platform': platform,
-        'entries': entries,
-      };
+    'format': format,
+    'formatVersion': formatVersion,
+    'backupSchemaVersion': backupSchemaVersion,
+    'createdAt': createdAt.toUtc().toIso8601String(),
+    if (userId != null) 'userId': userId,
+    'appVersion': appVersion,
+    'buildNumber': buildNumber,
+    'flavor': flavor,
+    'platform': platform,
+    'entries': entries,
+  };
 }
 
 class BackupFileInfo {
@@ -227,7 +230,8 @@ class BackupService {
     final workspacePath = fs.getWorkspacePath(userId);
     final appDir = await getApplicationDocumentsDirectory();
     final createdAt = DateTime.now();
-    final fileName = '${filePrefix}_${_timestampForFile(createdAt)}'
+    final fileName =
+        '${filePrefix}_${_timestampForFile(createdAt)}'
         '$_backupExtension';
 
     final targetDir = outputDirectory == null
@@ -323,99 +327,62 @@ class BackupService {
     final currentUserId = await UserStorage.getUserId();
     if (currentUserId == null) throw Exception('No user logged in');
     var databaseClosedForRestore = false;
+    Directory? stagingRoot;
 
     try {
-      await inspectBackup(backupFilePath);
+      onProgress?.call('Inspecting backup...');
+      final backupInfo = await inspectBackup(backupFilePath);
+      final normalizedPath = backupInfo.path;
 
-      onProgress?.call('Reading backup...');
-      final bytes = await File(
-        _normalizeFilePath(backupFilePath),
-      ).readAsBytes();
-      final archive = ZipDecoder().decodeBytes(bytes);
-      _validateManifest(archive);
+      onProgress?.call('Preparing restore...');
+      stagingRoot = await _createRestoreStagingDirectory();
+      final stagingWorkspacePath = path.join(stagingRoot.path, 'workspace');
+      final stagingDbPath = path.join(stagingRoot.path, 'db');
+      final stagedRestore = await Isolate.run(
+        () => _stageBackupRestoreArchive(
+          backupFilePath: normalizedPath,
+          stagingWorkspacePath: stagingWorkspacePath,
+          stagingDbPath: stagingDbPath,
+        ),
+      );
+      _logger.info(
+        'Staged restore from $normalizedPath '
+        '(${stagedRestore.workspaceFileCount} workspace files, '
+        '${stagedRestore.dbFileCount} DB files)',
+      );
 
-      // 1. Restore settings FIRST to get the correct userId from backup
+      // 1. Restore settings FIRST to get the correct userId and data root.
       onProgress?.call('Restoring settings...');
-      for (final file in archive) {
-        if (file.name == 'settings.json' && file.isFile) {
-          final jsonStr = utf8.decode(_archiveFileBytes(file));
-          final settings = jsonDecode(jsonStr) as Map<String, dynamic>;
-          final prefs = await SharedPreferences.getInstance();
-          for (final entry in settings.entries) {
-            final value = entry.value;
-            if (value is String) {
-              await prefs.setString(entry.key, value);
-            } else if (value is int) {
-              await prefs.setInt(entry.key, value);
-            } else if (value is double) {
-              await prefs.setDouble(entry.key, value);
-            } else if (value is bool) {
-              await prefs.setBool(entry.key, value);
-            } else if (value is List && value.every((item) => item is String)) {
-              await prefs.setStringList(entry.key, value.cast<String>());
-            }
-          }
-          _logger.info('Restored ${settings.length} settings');
-        }
-      }
+      await _restoreSettings(stagedRestore.settings);
+      _logger.info('Restored ${stagedRestore.settings.length} settings');
 
       // Use the restored userId (from backup settings) for workspace and DB paths
       final restoredUserId = await UserStorage.getUserId() ?? currentUserId;
+      final dataRoot = await UserStorage.resolveDataRoot(restoredUserId);
+      await FileSystemService.init(dataRoot);
       final fs = FileSystemService.instance;
       final workspacePath = fs.getWorkspacePath(restoredUserId);
       final appDir = await getApplicationDocumentsDirectory();
+      final supportDir = await getApplicationSupportDirectory();
 
-      // 2. Restore workspace files
-      onProgress?.call('Restoring workspace...');
-      for (final file in archive) {
-        if (!file.isFile || !file.name.startsWith('workspace/')) continue;
-
-        final relativePath = file.name.substring('workspace/'.length);
-        if (relativePath.isEmpty) continue;
-
-        final targetPath = path.normalize(
-          path.join(workspacePath, relativePath),
-        );
-        if (!_isPathWithin(workspacePath, targetPath)) {
-          throw Exception('Unsafe backup entry path: ${file.name}');
-        }
-
-        final targetDir = Directory(path.dirname(targetPath));
-        if (!await targetDir.exists()) {
-          await targetDir.create(recursive: true);
-        }
-        await File(targetPath).writeAsBytes(_archiveFileBytes(file));
-      }
-
-      // 3. Restore DB
+      // 2. Close current DB before replacing DB files.
       onProgress?.call('Restoring database...');
-      // Close current DB first
       if (AppDatabase.isInitialized) {
         databaseClosedForRestore = true;
         await AppDatabase.instance.close();
       }
 
-      for (final file in archive) {
-        if (file.name.startsWith('db/') && file.isFile) {
-          final dbFileName = path.basename(file.name);
-          // Try both possible locations
-          final supportDir = await getApplicationSupportDirectory();
-          final possibleTargets = [
-            path.join(appDir.path, dbFileName),
-            path.join(supportDir.path, dbFileName),
-          ];
-          // Write to whichever location already has the file, or support dir
-          String targetPath = possibleTargets.last;
-          for (final p in possibleTargets) {
-            if (await File(p).exists()) {
-              targetPath = p;
-              break;
-            }
-          }
-          await File(targetPath).writeAsBytes(_archiveFileBytes(file));
-          _logger.info('Restored DB to: $targetPath');
-        }
-      }
+      // 3. Apply staged workspace and DB files in a background isolate.
+      onProgress?.call('Restoring workspace...');
+      await Isolate.run(
+        () => _applyStagedBackupRestore(
+          stagingWorkspacePath: stagingWorkspacePath,
+          stagingDbPath: stagingDbPath,
+          workspacePath: workspacePath,
+          appDocumentsPath: appDir.path,
+          appSupportPath: supportDir.path,
+        ),
+      );
 
       // Re-init DB
       await AppDatabase.init(restoredUserId);
@@ -426,6 +393,12 @@ class BackupService {
       await fs.rebuildCardCache(restoredUserId);
 
       _logger.info('Backup restored successfully');
+      EventBusService.instance.emitEvent(
+        BackupRestoredMessage(
+          userId: restoredUserId,
+          sourcePath: normalizedPath,
+        ),
+      );
       return true;
     } catch (e, stack) {
       _logger.severe('Restore failed: $e', e, stack);
@@ -437,6 +410,15 @@ class BackupService {
         } catch (_) {}
       }
       rethrow;
+    } finally {
+      final dir = stagingRoot;
+      if (dir != null && await dir.exists()) {
+        try {
+          await dir.delete(recursive: true);
+        } catch (e) {
+          _logger.warning('Failed to delete restore staging dir: $e');
+        }
+      }
     }
   }
 
@@ -489,8 +471,9 @@ class BackupService {
     required String reason,
     void Function(String status)? onProgress,
   }) {
-    final sanitizedReason =
-        reason.replaceAll(RegExp(r'[^a-zA-Z0-9_-]+'), '_').toLowerCase();
+    final sanitizedReason = reason
+        .replaceAll(RegExp(r'[^a-zA-Z0-9_-]+'), '_')
+        .toLowerCase();
     return createStoredBackup(
       filePrefix: '${_safetyBackupPrefix}_$sanitizedReason',
       onProgress: onProgress,
@@ -527,6 +510,7 @@ class BackupService {
           if (pruneAutoBackups) {
             await _pruneAndroidTreeBackups(treeUri);
           }
+          _emitBackupSnapshotsChanged('created', snapshotId: snapshot.id);
           return snapshot;
         } finally {
           final tempFile = File(tempPath);
@@ -555,6 +539,7 @@ class BackupService {
     if (pruneAutoBackups) {
       await _pruneFileBackups(backupDir);
     }
+    _emitBackupSnapshotsChanged('created', snapshotId: snapshot.id);
     return snapshot;
   }
 
@@ -595,6 +580,7 @@ class BackupService {
   static Future<void> deleteStoredBackup(BackupSnapshot snapshot) async {
     if (snapshot.isAndroidDocument) {
       await _deleteAndroidDocument(snapshot.documentUri!);
+      _emitBackupSnapshotsChanged('deleted', snapshotId: snapshot.id);
       return;
     }
 
@@ -614,6 +600,7 @@ class BackupService {
     if (await file.exists()) {
       await file.delete();
     }
+    _emitBackupSnapshotsChanged('deleted', snapshotId: snapshot.id);
   }
 
   /// List automatic/safety backups from both the platform default directory and
@@ -732,10 +719,12 @@ class BackupService {
     String rootPath;
 
     if (Platform.isIOS) {
-      rootPath = await UserStorage.resolveICloudDocumentsPath() ??
+      rootPath =
+          await UserStorage.resolveICloudDocumentsPath() ??
           (await getApplicationDocumentsDirectory()).path;
     } else if (Platform.isAndroid) {
-      rootPath = (await getExternalStorageDirectory())?.path ??
+      rootPath =
+          (await getExternalStorageDirectory())?.path ??
           (await getApplicationDocumentsDirectory()).path;
     } else {
       rootPath = (await getApplicationDocumentsDirectory()).path;
@@ -752,6 +741,43 @@ class BackupService {
     return dir;
   }
 
+  static Future<Directory> _createRestoreStagingDirectory() async {
+    final tempDir = await getTemporaryDirectory();
+    final dir = Directory(
+      path.join(
+        tempDir.path,
+        'memex_restore_${DateTime.now().microsecondsSinceEpoch}',
+      ),
+    );
+    return dir.create(recursive: true);
+  }
+
+  static Future<void> _restoreSettings(Map<String, dynamic> settings) async {
+    if (settings.isEmpty) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    for (final entry in settings.entries) {
+      final value = entry.value;
+      if (value is String) {
+        await prefs.setString(entry.key, value);
+      } else if (value is int) {
+        await prefs.setInt(entry.key, value);
+      } else if (value is double) {
+        await prefs.setDouble(entry.key, value);
+      } else if (value is bool) {
+        await prefs.setBool(entry.key, value);
+      } else if (value is List && value.every((item) => item is String)) {
+        await prefs.setStringList(entry.key, value.cast<String>());
+      }
+    }
+  }
+
+  static void _emitBackupSnapshotsChanged(String reason, {String? snapshotId}) {
+    EventBusService.instance.emitEvent(
+      BackupSnapshotsChangedMessage(reason: reason, snapshotId: snapshotId),
+    );
+  }
+
   /// Get estimated backup size (workspace + DB).
   static Future<int> estimateBackupSize() async {
     final userId = await UserStorage.getUserId();
@@ -759,35 +785,6 @@ class BackupService {
 
     final stats = await _collectSourceStats(userId);
     return stats.totalSize;
-  }
-
-  static void _validateManifest(Archive archive) {
-    final manifestFile = _findArchiveFile(archive, _backupManifestFileName);
-    if (manifestFile == null) {
-      _logger.warning('Backup has no manifest.json; treating as legacy backup');
-      return;
-    }
-
-    final manifestJson = utf8.decode(_archiveFileBytes(manifestFile));
-    final manifest = jsonDecode(manifestJson) as Map<String, dynamic>;
-    final entries = manifest['entries'];
-    if (entries is! List) return;
-
-    for (final entry in entries) {
-      if (entry is! Map) continue;
-      final entryPath = entry['path'] as String?;
-      final expectedSha = entry['sha256'] as String?;
-      if (entryPath == null || expectedSha == null) continue;
-
-      final file = _findArchiveFile(archive, entryPath);
-      if (file == null || !file.isFile) {
-        throw Exception('Backup is missing manifest entry: $entryPath');
-      }
-      final actualSha = sha256.convert(_archiveFileBytes(file)).toString();
-      if (actualSha != expectedSha) {
-        throw Exception('Backup checksum mismatch: $entryPath');
-      }
-    }
   }
 
   static ArchiveFile? _findArchiveFile(Archive archive, String name) {
@@ -798,7 +795,7 @@ class BackupService {
   }
 
   static List<int> _archiveFileBytes(ArchiveFile file) {
-    return List<int>.from(file.content as List);
+    return file.readBytes() ?? const <int>[];
   }
 
   static String _timestampForFile(DateTime time) {
@@ -831,8 +828,8 @@ class BackupService {
             fileCount += 1;
             latestModifiedMs =
                 latestModifiedMs > stat.modified.millisecondsSinceEpoch
-                    ? latestModifiedMs
-                    : stat.modified.millisecondsSinceEpoch;
+                ? latestModifiedMs
+                : stat.modified.millisecondsSinceEpoch;
           } catch (_) {}
         }
       }
@@ -852,8 +849,8 @@ class BackupService {
         fileCount += 1;
         latestModifiedMs =
             latestModifiedMs > stat.modified.millisecondsSinceEpoch
-                ? latestModifiedMs
-                : stat.modified.millisecondsSinceEpoch;
+            ? latestModifiedMs
+            : stat.modified.millisecondsSinceEpoch;
         break;
       }
     }
@@ -962,15 +959,17 @@ class BackupService {
   }
 
   static Future<void> _pruneFileBackups(Directory dir) async {
-    final snapshots = (await _listFileBackups(dir))
-        .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
-        .toList()
-      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final snapshots =
+        (await _listFileBackups(dir))
+            .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
+            .toList()
+          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
     var kept = 0;
     var keptBytes = 0;
     for (final snapshot in snapshots) {
-      final shouldKeep = kept < _autoBackupKeepRecent &&
+      final shouldKeep =
+          kept < _autoBackupKeepRecent &&
           keptBytes + snapshot.sizeBytes <= _autoBackupMaxBytes;
       if (shouldKeep) {
         kept += 1;
@@ -992,15 +991,17 @@ class BackupService {
   }
 
   static Future<void> _pruneAndroidTreeBackups(String treeUri) async {
-    final snapshots = (await _listAndroidTreeBackups(treeUri))
-        .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
-        .toList()
-      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final snapshots =
+        (await _listAndroidTreeBackups(treeUri))
+            .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
+            .toList()
+          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
     var kept = 0;
     var keptBytes = 0;
     for (final snapshot in snapshots) {
-      final shouldKeep = kept < _autoBackupKeepRecent &&
+      final shouldKeep =
+          kept < _autoBackupKeepRecent &&
           keptBytes + snapshot.sizeBytes <= _autoBackupMaxBytes;
       if (shouldKeep) {
         kept += 1;
@@ -1039,47 +1040,63 @@ class BackupService {
       );
     }
 
-    final bytes = await file.readAsBytes();
-    final archive = _decodeBackup(bytes);
-    ArchiveFile? manifestFile;
-    for (final file in archive.files) {
-      if (file.isFile && file.name == _backupManifestFileName) {
-        manifestFile = file;
-        break;
-      }
-    }
+    final stat = await file.stat();
+    return Isolate.run(
+      () => _inspectBackupFile(
+        backupFilePath: normalizedPath,
+        sizeBytes: stat.size,
+      ),
+    );
+  }
 
-    if (manifestFile == null) {
-      if (!_looksLikeLegacyBackup(archive)) {
-        throw const InvalidBackupFileException(
-          'Invalid backup file. Please select a .memex file.',
+  static BackupFileInfo _inspectBackupFile({
+    required String backupFilePath,
+    required int sizeBytes,
+  }) {
+    final archive = _decodeBackupFile(backupFilePath);
+    ArchiveFile? manifestFile;
+    try {
+      for (final file in archive.files) {
+        if (file.isFile && file.name == _backupManifestFileName) {
+          manifestFile = file;
+          break;
+        }
+      }
+
+      if (manifestFile == null) {
+        if (!_looksLikeLegacyBackup(archive)) {
+          throw const InvalidBackupFileException(
+            'Invalid backup file. Please select a .memex file.',
+          );
+        }
+        return BackupFileInfo(
+          path: backupFilePath,
+          sizeBytes: sizeBytes,
+          manifest: null,
         );
       }
+
+      final manifest = _readManifest(manifestFile);
+      if (manifest.format != _backupFormat) {
+        throw InvalidBackupFileException(
+          'Unsupported backup format: ${manifest.format}',
+        );
+      }
+      if (manifest.backupSchemaVersion > _currentBackupSchemaVersion) {
+        throw UnsupportedBackupVersionException(
+          backupSchemaVersion: manifest.backupSchemaVersion,
+          supportedSchemaVersion: _currentBackupSchemaVersion,
+        );
+      }
+
       return BackupFileInfo(
-        path: normalizedPath,
-        sizeBytes: bytes.length,
-        manifest: null,
+        path: backupFilePath,
+        sizeBytes: sizeBytes,
+        manifest: manifest,
       );
+    } finally {
+      archive.clearSync();
     }
-
-    final manifest = _readManifest(manifestFile);
-    if (manifest.format != _backupFormat) {
-      throw InvalidBackupFileException(
-        'Unsupported backup format: ${manifest.format}',
-      );
-    }
-    if (manifest.backupSchemaVersion > _currentBackupSchemaVersion) {
-      throw UnsupportedBackupVersionException(
-        backupSchemaVersion: manifest.backupSchemaVersion,
-        supportedSchemaVersion: _currentBackupSchemaVersion,
-      );
-    }
-
-    return BackupFileInfo(
-      path: normalizedPath,
-      sizeBytes: bytes.length,
-      manifest: manifest,
-    );
   }
 
   static bool _looksLikeLegacyBackup(Archive archive) {
@@ -1091,9 +1108,9 @@ class BackupService {
     );
   }
 
-  static Archive _decodeBackup(List<int> bytes) {
+  static Archive _decodeBackupFile(String backupFilePath) {
     try {
-      return ZipDecoder().decodeBytes(bytes);
+      return ZipDecoder().decodeStream(InputFileStream(backupFilePath));
     } catch (_) {
       throw const InvalidBackupFileException(
         'Invalid backup file. Please select a .memex file.',
@@ -1120,6 +1137,268 @@ class BackupService {
       }
     }
     return filePath;
+  }
+}
+
+Future<_StagedRestoreResult> _stageBackupRestoreArchive({
+  required String backupFilePath,
+  required String stagingWorkspacePath,
+  required String stagingDbPath,
+}) async {
+  final archive = BackupService._decodeBackupFile(backupFilePath);
+
+  try {
+    final manifestFile = BackupService._findArchiveFile(
+      archive,
+      _backupManifestFileName,
+    );
+    final manifest = manifestFile == null
+        ? null
+        : BackupService._readManifest(manifestFile);
+    if (manifest != null) {
+      _validateBackupManifestHeader(manifest);
+    }
+
+    final expectedShas = _manifestEntryShas(manifest);
+    final verifiedEntries = <String>{};
+    var looksLikeBackup = false;
+    var workspaceFileCount = 0;
+    var dbFileCount = 0;
+    var settings = <String, dynamic>{};
+
+    for (final file in archive) {
+      if (!file.isFile) continue;
+
+      if (file.name == 'settings.json') {
+        looksLikeBackup = true;
+        final bytes = BackupService._archiveFileBytes(file);
+        _verifyEntrySha(
+          file.name,
+          sha256.convert(bytes).toString(),
+          expectedShas,
+          verifiedEntries,
+        );
+        final decoded = jsonDecode(utf8.decode(bytes));
+        if (decoded is Map) {
+          settings = decoded.cast<String, dynamic>();
+        } else {
+          throw const InvalidBackupFileException('Invalid backup settings.');
+        }
+        continue;
+      }
+
+      if (file.name.startsWith('workspace/')) {
+        looksLikeBackup = true;
+        final relativePath = file.name.substring('workspace/'.length);
+        if (relativePath.isEmpty) continue;
+
+        final targetPath = path.normalize(
+          path.join(stagingWorkspacePath, relativePath),
+        );
+        if (!BackupService._isPathWithin(stagingWorkspacePath, targetPath)) {
+          throw Exception('Unsafe backup entry path: ${file.name}');
+        }
+
+        await _extractArchiveFile(file, targetPath);
+        await _verifyExtractedFileSha(
+          file.name,
+          targetPath,
+          expectedShas,
+          verifiedEntries,
+        );
+        workspaceFileCount += 1;
+        continue;
+      }
+
+      if (file.name.startsWith('db/')) {
+        looksLikeBackup = true;
+        final relativePath = file.name.substring('db/'.length);
+        if (relativePath.isEmpty ||
+            path.basename(relativePath) != relativePath) {
+          throw Exception('Unsafe backup entry path: ${file.name}');
+        }
+
+        final targetPath = path.normalize(
+          path.join(stagingDbPath, relativePath),
+        );
+        if (!BackupService._isPathWithin(stagingDbPath, targetPath)) {
+          throw Exception('Unsafe backup entry path: ${file.name}');
+        }
+
+        await _extractArchiveFile(file, targetPath);
+        await _verifyExtractedFileSha(
+          file.name,
+          targetPath,
+          expectedShas,
+          verifiedEntries,
+        );
+        dbFileCount += 1;
+      }
+    }
+
+    if (manifest == null && !looksLikeBackup) {
+      throw const InvalidBackupFileException(
+        'Invalid backup file. Please select a .memex file.',
+      );
+    }
+
+    for (final entryPath in expectedShas.keys) {
+      if (!verifiedEntries.contains(entryPath)) {
+        throw Exception('Backup is missing manifest entry: $entryPath');
+      }
+    }
+
+    return _StagedRestoreResult(
+      settings: settings,
+      workspaceFileCount: workspaceFileCount,
+      dbFileCount: dbFileCount,
+    );
+  } finally {
+    archive.clearSync();
+  }
+}
+
+Future<void> _applyStagedBackupRestore({
+  required String stagingWorkspacePath,
+  required String stagingDbPath,
+  required String workspacePath,
+  required String appDocumentsPath,
+  required String appSupportPath,
+}) async {
+  final stagingWorkspace = Directory(stagingWorkspacePath);
+  if (await stagingWorkspace.exists()) {
+    await for (final entity in stagingWorkspace.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is! File) continue;
+
+      final relativePath = path.relative(
+        entity.path,
+        from: stagingWorkspacePath,
+      );
+      final targetPath = path.normalize(path.join(workspacePath, relativePath));
+      if (!BackupService._isPathWithin(workspacePath, targetPath)) {
+        throw Exception('Unsafe staged workspace path: $relativePath');
+      }
+      await _moveFileReplacing(entity, targetPath);
+    }
+  }
+
+  final stagingDb = Directory(stagingDbPath);
+  if (await stagingDb.exists()) {
+    await for (final entity in stagingDb.list(followLinks: false)) {
+      if (entity is! File) continue;
+
+      final dbFileName = path.basename(entity.path);
+      final possibleTargets = [
+        path.join(appDocumentsPath, dbFileName),
+        path.join(appSupportPath, dbFileName),
+      ];
+      var targetPath = possibleTargets.last;
+      for (final candidate in possibleTargets) {
+        if (await File(candidate).exists()) {
+          targetPath = candidate;
+          break;
+        }
+      }
+      await _moveFileReplacing(entity, targetPath);
+    }
+  }
+}
+
+void _validateBackupManifestHeader(BackupManifest manifest) {
+  if (manifest.format != _backupFormat) {
+    throw InvalidBackupFileException(
+      'Unsupported backup format: ${manifest.format}',
+    );
+  }
+  if (manifest.backupSchemaVersion > _currentBackupSchemaVersion) {
+    throw UnsupportedBackupVersionException(
+      backupSchemaVersion: manifest.backupSchemaVersion,
+      supportedSchemaVersion: _currentBackupSchemaVersion,
+    );
+  }
+}
+
+Map<String, String> _manifestEntryShas(BackupManifest? manifest) {
+  if (manifest == null) return const {};
+
+  final result = <String, String>{};
+  for (final entry in manifest.entries) {
+    final entryPath = entry['path'] as String?;
+    final expectedSha = entry['sha256'] as String?;
+    if (entryPath == null || expectedSha == null) continue;
+    result[entryPath] = expectedSha;
+  }
+  return result;
+}
+
+Future<void> _extractArchiveFile(ArchiveFile file, String targetPath) async {
+  final targetDir = Directory(path.dirname(targetPath));
+  if (!await targetDir.exists()) {
+    await targetDir.create(recursive: true);
+  }
+
+  final output = OutputFileStream(targetPath);
+  try {
+    file.writeContent(output);
+  } finally {
+    output.closeSync();
+  }
+}
+
+Future<void> _verifyExtractedFileSha(
+  String entryPath,
+  String targetPath,
+  Map<String, String> expectedShas,
+  Set<String> verifiedEntries,
+) async {
+  final expectedSha = expectedShas[entryPath];
+  if (expectedSha == null) return;
+
+  final actualSha = await _sha256FilePath(targetPath);
+  _verifyEntrySha(entryPath, actualSha, expectedShas, verifiedEntries);
+}
+
+void _verifyEntrySha(
+  String entryPath,
+  String actualSha,
+  Map<String, String> expectedShas,
+  Set<String> verifiedEntries,
+) {
+  final expectedSha = expectedShas[entryPath];
+  if (expectedSha == null) return;
+
+  verifiedEntries.add(entryPath);
+  if (actualSha != expectedSha) {
+    throw Exception('Backup checksum mismatch: $entryPath');
+  }
+}
+
+Future<String> _sha256FilePath(String filePath) async {
+  final digest = await sha256.bind(File(filePath).openRead()).first;
+  return digest.toString();
+}
+
+Future<void> _moveFileReplacing(File source, String targetPath) async {
+  final targetDir = Directory(path.dirname(targetPath));
+  if (!await targetDir.exists()) {
+    await targetDir.create(recursive: true);
+  }
+
+  final targetFile = File(targetPath);
+  if (await targetFile.exists()) {
+    await targetFile.delete();
+  }
+
+  try {
+    await source.rename(targetPath);
+  } catch (_) {
+    await source.openRead().pipe(targetFile.openWrite());
+    if (await source.exists()) {
+      await source.delete();
+    }
   }
 }
 
@@ -1251,13 +1530,14 @@ Future<void> _addFileToBackupArchive(
   String archivePath,
   List<Map<String, dynamic>> manifestEntries,
 ) async {
-  final bytes = await file.readAsBytes();
-  _addBytesToBackupArchive(
-    encoder,
-    archivePath,
-    bytes,
-    manifestEntries: manifestEntries,
-  );
+  final stat = await file.stat();
+  final digest = await _sha256FilePath(file.path);
+  await encoder.addFile(file, archivePath, ZipFileEncoder.gzip);
+  manifestEntries.add({
+    'path': archivePath,
+    'size': stat.size,
+    'sha256': digest,
+  });
 }
 
 void _addBytesToBackupArchive(
@@ -1293,5 +1573,17 @@ class _BackupArchiveResult {
   const _BackupArchiveResult({
     required this.sizeBytes,
     required this.fileCount,
+  });
+}
+
+class _StagedRestoreResult {
+  final Map<String, dynamic> settings;
+  final int workspaceFileCount;
+  final int dbFileCount;
+
+  const _StagedRestoreResult({
+    required this.settings,
+    required this.workspaceFileCount,
+    required this.dbFileCount,
   });
 }

--- a/lib/domain/models/event_bus_message.dart
+++ b/lib/domain/models/event_bus_message.dart
@@ -14,6 +14,8 @@ enum EventBusMessageType {
   profileUpdated('profile_updated'),
   characterUpdated('character_updated'),
   personaChatMessageAdded('persona_chat_message_added'),
+  backupSnapshotsChanged('backup_snapshots_changed'),
+  backupRestored('backup_restored'),
   unknown('unknown');
 
   final String value;
@@ -32,10 +34,7 @@ abstract class EventBusMessage {
   final EventBusMessageType type;
   final Map<String, dynamic> data;
 
-  EventBusMessage({
-    required this.type,
-    required this.data,
-  });
+  EventBusMessage({required this.type, required this.data});
 
   factory EventBusMessage.fromJson(Map<String, dynamic> json) {
     final type = EventBusMessageType.fromString(json['type'] as String? ?? '');
@@ -65,6 +64,10 @@ abstract class EventBusMessage {
         return CharacterUpdatedMessage.fromJson(json);
       case EventBusMessageType.personaChatMessageAdded:
         return PersonaChatMessageAddedMessage.fromJson(json);
+      case EventBusMessageType.backupSnapshotsChanged:
+        return BackupSnapshotsChangedMessage.fromJson(json);
+      case EventBusMessageType.backupRestored:
+        return BackupRestoredMessage.fromJson(json);
       default:
         return UnknownMessage.fromJson(json);
     }
@@ -98,21 +101,21 @@ class CardUpdatedMessage extends EventBusMessage {
     this.address,
     this.failureReason,
   }) : super(
-          type: EventBusMessageType.cardUpdated,
-          data: {
-            'id': id,
-            'html': html,
-            'timestamp': timestamp,
-            'tags': tags,
-            'status': status,
-            if (title != null) 'title': title,
-            'ui_configs': uiConfigs.map((e) => e.toJson()).toList(),
-            if (assets != null && assets.isNotEmpty) 'assets': assets,
-            if (rawText != null) 'raw_text': rawText,
-            if (address != null) 'address': address,
-            if (failureReason != null) 'failure_reason': failureReason,
-          },
-        );
+         type: EventBusMessageType.cardUpdated,
+         data: {
+           'id': id,
+           'html': html,
+           'timestamp': timestamp,
+           'tags': tags,
+           'status': status,
+           if (title != null) 'title': title,
+           'ui_configs': uiConfigs.map((e) => e.toJson()).toList(),
+           if (assets != null && assets.isNotEmpty) 'assets': assets,
+           if (rawText != null) 'raw_text': rawText,
+           if (address != null) 'address': address,
+           if (failureReason != null) 'failure_reason': failureReason,
+         },
+       );
 
   factory CardUpdatedMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>;
@@ -130,7 +133,7 @@ class CardUpdatedMessage extends EventBusMessage {
       timestamp: data['timestamp'] as int,
       tags:
           (data['tags'] as List<dynamic>?)?.map((e) => e.toString()).toList() ??
-              [],
+          [],
       status: data['status'] as String? ?? 'processing',
       title: data['title'] as String?,
       uiConfigs: configs,
@@ -169,20 +172,20 @@ class CardAddedMessage extends EventBusMessage {
     this.rawText,
     this.address,
   }) : super(
-          type: EventBusMessageType.cardAdded,
-          data: {
-            'id': id,
-            'html': html,
-            'timestamp': timestamp,
-            'tags': tags,
-            'status': status,
-            if (title != null) 'title': title,
-            'ui_configs': uiConfigs.map((e) => e.toJson()).toList(),
-            if (assets != null && assets.isNotEmpty) 'assets': assets,
-            if (rawText != null) 'raw_text': rawText,
-            if (address != null) 'address': address,
-          },
-        );
+         type: EventBusMessageType.cardAdded,
+         data: {
+           'id': id,
+           'html': html,
+           'timestamp': timestamp,
+           'tags': tags,
+           'status': status,
+           if (title != null) 'title': title,
+           'ui_configs': uiConfigs.map((e) => e.toJson()).toList(),
+           if (assets != null && assets.isNotEmpty) 'assets': assets,
+           if (rawText != null) 'raw_text': rawText,
+           if (address != null) 'address': address,
+         },
+       );
 
   factory CardAddedMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>;
@@ -200,7 +203,7 @@ class CardAddedMessage extends EventBusMessage {
       timestamp: data['timestamp'] as int,
       tags:
           (data['tags'] as List<dynamic>?)?.map((e) => e.toString()).toList() ??
-              [],
+          [],
       status: data['status'] as String? ?? 'processing',
       title: data['title'] as String?,
       uiConfigs: configs,
@@ -217,20 +220,15 @@ class CardAddedMessage extends EventBusMessage {
 class CardDetailUpdatedMessage extends EventBusMessage {
   final String cardId;
 
-  CardDetailUpdatedMessage({
-    required this.cardId,
-  }) : super(
-          type: EventBusMessageType.cardDetailUpdated,
-          data: {
-            'card_id': cardId,
-          },
-        );
+  CardDetailUpdatedMessage({required this.cardId})
+    : super(
+        type: EventBusMessageType.cardDetailUpdated,
+        data: {'card_id': cardId},
+      );
 
   factory CardDetailUpdatedMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>;
-    return CardDetailUpdatedMessage(
-      cardId: data['card_id'] as String,
-    );
+    return CardDetailUpdatedMessage(cardId: data['card_id'] as String);
   }
 }
 
@@ -238,16 +236,11 @@ class NewInsightMessage extends EventBusMessage {
   final String insightId;
   final String html;
 
-  NewInsightMessage({
-    required this.insightId,
-    required this.html,
-  }) : super(
-          type: EventBusMessageType.newInsight,
-          data: {
-            'insight_id': insightId,
-            'html': html,
-          },
-        );
+  NewInsightMessage({required this.insightId, required this.html})
+    : super(
+        type: EventBusMessageType.newInsight,
+        data: {'insight_id': insightId, 'html': html},
+      );
 
   factory NewInsightMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>;
@@ -262,15 +255,15 @@ class NewInsightMessage extends EventBusMessage {
 class ScheduleAggregationUpdatedMessage extends EventBusMessage {
   final String aggregationId;
 
-  ScheduleAggregationUpdatedMessage({
-    required this.aggregationId,
-  }) : super(
-          type: EventBusMessageType.scheduleAggregationUpdated,
-          data: {'aggregation_id': aggregationId},
-        );
+  ScheduleAggregationUpdatedMessage({required this.aggregationId})
+    : super(
+        type: EventBusMessageType.scheduleAggregationUpdated,
+        data: {'aggregation_id': aggregationId},
+      );
 
   factory ScheduleAggregationUpdatedMessage.fromJson(
-      Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+  ) {
     final data = json['data'] as Map<String, dynamic>;
     return ScheduleAggregationUpdatedMessage(
       aggregationId: data['aggregation_id'] as String,
@@ -281,7 +274,7 @@ class ScheduleAggregationUpdatedMessage extends EventBusMessage {
 /// Unknown message type
 class UnknownMessage extends EventBusMessage {
   UnknownMessage({required super.data})
-      : super(type: EventBusMessageType.unknown);
+    : super(type: EventBusMessageType.unknown);
 
   factory UnknownMessage.fromJson(Map<String, dynamic> json) {
     return UnknownMessage(data: json['data'] as Map<String, dynamic>? ?? {});
@@ -291,10 +284,7 @@ class UnknownMessage extends EventBusMessage {
 /// New System Action Message (Trigger sync)
 class NewSystemActionMessage extends EventBusMessage {
   NewSystemActionMessage()
-      : super(
-          type: EventBusMessageType.newSystemAction,
-          data: {},
-        );
+    : super(type: EventBusMessageType.newSystemAction, data: {});
 
   factory NewSystemActionMessage.fromJson(Map<String, dynamic> json) {
     return NewSystemActionMessage();
@@ -307,13 +297,10 @@ class InvalidModelConfigMessage extends EventBusMessage {
   final String configKey;
 
   InvalidModelConfigMessage({required this.agentId, required this.configKey})
-      : super(
-          type: EventBusMessageType.invalidModelConfig,
-          data: {
-            'agent_id': agentId,
-            'config_key': configKey,
-          },
-        );
+    : super(
+        type: EventBusMessageType.invalidModelConfig,
+        data: {'agent_id': agentId, 'config_key': configKey},
+      );
 
   factory InvalidModelConfigMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>;
@@ -335,13 +322,13 @@ class ErrorNotificationMessage extends EventBusMessage {
     required this.errorMessage,
     this.cardId,
   }) : super(
-          type: EventBusMessageType.errorNotification,
-          data: {
-            'error_category': errorCategory,
-            'error_message': errorMessage,
-            if (cardId != null) 'card_id': cardId,
-          },
-        );
+         type: EventBusMessageType.errorNotification,
+         data: {
+           'error_category': errorCategory,
+           'error_message': errorMessage,
+           if (cardId != null) 'card_id': cardId,
+         },
+       );
 
   factory ErrorNotificationMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>;
@@ -358,18 +345,14 @@ class AttachmentsChangedMessage extends EventBusMessage {
   final String? factId;
 
   AttachmentsChangedMessage({this.factId})
-      : super(
-          type: EventBusMessageType.attachmentsChanged,
-          data: {
-            if (factId != null) 'fact_id': factId,
-          },
-        );
+    : super(
+        type: EventBusMessageType.attachmentsChanged,
+        data: {if (factId != null) 'fact_id': factId},
+      );
 
   factory AttachmentsChangedMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>? ?? {};
-    return AttachmentsChangedMessage(
-      factId: data['fact_id'] as String?,
-    );
+    return AttachmentsChangedMessage(factId: data['fact_id'] as String?);
   }
 }
 
@@ -378,13 +361,10 @@ class ProfileUpdatedMessage extends EventBusMessage {
   final String? avatar;
 
   ProfileUpdatedMessage({required this.userId, this.avatar})
-      : super(
-          type: EventBusMessageType.profileUpdated,
-          data: {
-            'user_id': userId,
-            if (avatar != null) 'avatar': avatar,
-          },
-        );
+    : super(
+        type: EventBusMessageType.profileUpdated,
+        data: {'user_id': userId, if (avatar != null) 'avatar': avatar},
+      );
 
   factory ProfileUpdatedMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>? ?? {};
@@ -400,13 +380,10 @@ class CharacterUpdatedMessage extends EventBusMessage {
   final String characterId;
 
   CharacterUpdatedMessage({required this.userId, required this.characterId})
-      : super(
-          type: EventBusMessageType.characterUpdated,
-          data: {
-            'user_id': userId,
-            'character_id': characterId,
-          },
-        );
+    : super(
+        type: EventBusMessageType.characterUpdated,
+        data: {'user_id': userId, 'character_id': characterId},
+      );
 
   factory CharacterUpdatedMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>? ?? {};
@@ -423,15 +400,56 @@ class PersonaChatMessageAddedMessage extends EventBusMessage {
   final String characterId;
 
   PersonaChatMessageAddedMessage({required this.characterId})
-      : super(
-          type: EventBusMessageType.personaChatMessageAdded,
-          data: {'character_id': characterId},
-        );
+    : super(
+        type: EventBusMessageType.personaChatMessageAdded,
+        data: {'character_id': characterId},
+      );
 
   factory PersonaChatMessageAddedMessage.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>? ?? {};
     return PersonaChatMessageAddedMessage(
       characterId: data['character_id'] as String? ?? '',
+    );
+  }
+}
+
+class BackupSnapshotsChangedMessage extends EventBusMessage {
+  final String reason;
+  final String? snapshotId;
+
+  BackupSnapshotsChangedMessage({this.reason = 'updated', this.snapshotId})
+    : super(
+        type: EventBusMessageType.backupSnapshotsChanged,
+        data: {
+          'reason': reason,
+          if (snapshotId != null) 'snapshot_id': snapshotId,
+        },
+      );
+
+  factory BackupSnapshotsChangedMessage.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>? ?? {};
+    return BackupSnapshotsChangedMessage(
+      reason: data['reason'] as String? ?? 'updated',
+      snapshotId: data['snapshot_id'] as String?,
+    );
+  }
+}
+
+class BackupRestoredMessage extends EventBusMessage {
+  final String userId;
+  final String sourcePath;
+
+  BackupRestoredMessage({required this.userId, required this.sourcePath})
+    : super(
+        type: EventBusMessageType.backupRestored,
+        data: {'user_id': userId, 'source_path': sourcePath},
+      );
+
+  factory BackupRestoredMessage.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>? ?? {};
+    return BackupRestoredMessage(
+      userId: data['user_id'] as String? ?? '',
+      sourcePath: data['source_path'] as String? ?? '',
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -266,9 +266,8 @@ class RootShellState extends State<RootShell> {
               InsightViewModel(router: c.read<MemexRouter>())..loadData(),
         ),
         ChangeNotifierProvider<KnowledgeBaseViewModel>(
-          create: (c) =>
-              KnowledgeBaseViewModel(router: c.read<MemexRouter>())
-                ..fetchData(),
+          create: (c) => KnowledgeBaseViewModel(router: c.read<MemexRouter>())
+            ..fetchData(),
         ),
       ],
       child: const MainScreen(),
@@ -481,6 +480,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
   InputData? _sharedDraft;
   ClipboardPreviewCandidate? _homeClipboardCandidate;
   bool _isCheckingHomeClipboard = false;
+  bool _isRefreshingAfterRestore = false;
 
   // Agent Button Position - REMOVED (Moved to Main App)
 
@@ -523,6 +523,10 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     _eventBus.addHandler(
       EventBusMessageType.errorNotification,
       _handleErrorNotification,
+    );
+    _eventBus.addHandler(
+      EventBusMessageType.backupRestored,
+      _handleBackupRestored,
     );
 
     _shareIntentHandler = ShareIntentHandler(
@@ -1014,8 +1018,42 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       EventBusMessageType.errorNotification,
       _handleErrorNotification,
     );
+    _eventBus.removeHandler(
+      EventBusMessageType.backupRestored,
+      _handleBackupRestored,
+    );
     // Note: do not disconnect event bus here; other screens may still use it
     super.dispose();
+  }
+
+  void _handleBackupRestored(EventBusMessage message) {
+    if (message is! BackupRestoredMessage) return;
+    unawaited(_refreshAfterBackupRestore(message.userId));
+  }
+
+  Future<void> _refreshAfterBackupRestore(String restoredUserId) async {
+    if (_isRefreshingAfterRestore) return;
+    _isRefreshingAfterRestore = true;
+    try {
+      var userId = restoredUserId;
+      if (userId.isEmpty) {
+        userId = await UserStorage.getUserId() ?? '';
+      }
+      if (userId.isNotEmpty) {
+        await _memexRouter.switchUser(userId);
+      }
+      if (!mounted) return;
+      await Future.wait<void>([
+        context.read<TimelineViewModel>().refresh(),
+        context.read<InsightViewModel>().loadData(),
+        context.read<KnowledgeBaseViewModel>().fetchData(),
+      ]);
+      if (mounted) setState(() {});
+    } catch (e, st) {
+      _logger.warning('Failed to refresh UI after backup restore: $e', e, st);
+    } finally {
+      _isRefreshingAfterRestore = false;
+    }
   }
 
   Future<void> _startRecording() async {
@@ -1265,8 +1303,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
 
       // Final calibration from accumulated PCM
       if (_quickPcmBuffer.isNotEmpty) {
-        final useLocal = await SpeechTranscriptionService.instance
-            .isUsingLocalModel();
+        final useLocal =
+            await SpeechTranscriptionService.instance.isUsingLocalModel();
         final aligned = Uint8List.fromList(_quickPcmBuffer);
         final int16Data = Int16List.view(aligned.buffer);
         final samples = Float32List(int16Data.length);
@@ -1325,9 +1363,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
         if (await audioFile.exists()) {
           final length = await audioFile.length();
           final fileName = _quickAudioPath!.split(Platform.pathSeparator).last;
-          audioHash = md5
-              .convert(utf8.encode('audio_${fileName}_$length'))
-              .toString();
+          audioHash =
+              md5.convert(utf8.encode('audio_${fileName}_$length')).toString();
         }
         unawaited(
           _handleInputSubmit(
@@ -1436,6 +1473,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
           });
         },
       );
+      await _refreshAfterBackupRestore(await UserStorage.getUserId() ?? '');
 
       if (!mounted || !rootNavigator.mounted) return;
       rootNavigator.pop();

--- a/lib/ui/settings/widgets/backup_restore_page.dart
+++ b/lib/ui/settings/widgets/backup_restore_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
@@ -7,17 +8,19 @@ import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:memex/data/services/backup_service.dart';
+import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/ui/settings/widgets/backup_restore_confirm_dialog.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/toast_helper.dart';
 import 'package:memex/utils/user_storage.dart';
 
-typedef AutoBackupCreator = Future<BackupSnapshot?> Function({
-  String trigger,
-  bool force,
-  void Function(String status)? onProgress,
-});
+typedef AutoBackupCreator =
+    Future<BackupSnapshot?> Function({
+      String trigger,
+      bool force,
+      void Function(String status)? onProgress,
+    });
 
 typedef StoredBackupDeleter = Future<void> Function(BackupSnapshot snapshot);
 
@@ -68,14 +71,47 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
   @override
   void initState() {
     super.initState();
+    EventBusService.instance.addHandler(
+      EventBusMessageType.backupSnapshotsChanged,
+      _handleBackupDataChanged,
+    );
+    EventBusService.instance.addHandler(
+      EventBusMessageType.backupRestored,
+      _handleBackupDataChanged,
+    );
     _loadPageData();
+  }
+
+  @override
+  void dispose() {
+    EventBusService.instance.removeHandler(
+      EventBusMessageType.backupSnapshotsChanged,
+      _handleBackupDataChanged,
+    );
+    EventBusService.instance.removeHandler(
+      EventBusMessageType.backupRestored,
+      _handleBackupDataChanged,
+    );
+    super.dispose();
+  }
+
+  bool get _isBusy =>
+      _isBackingUp ||
+      _isRestoring ||
+      _isCreatingSnapshot ||
+      _isPickingLocation ||
+      _deletingBackupId != null;
+
+  void _handleBackupDataChanged(EventBusMessage message) {
+    if (!mounted || _isBusy) return;
+    unawaited(_loadPageData(includeEstimatedSize: false));
   }
 
   Future<void> _loadPageData({bool includeEstimatedSize = true}) async {
     final userId = await UserStorage.getUserId();
     final size = includeEstimatedSize
         ? await (widget.estimateBackupSize ??
-            BackupService.estimateBackupSize)()
+              BackupService.estimateBackupSize)()
         : null;
     final location = await _resolveBackupLocationInfo();
     final snapshots =
@@ -560,6 +596,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
       await restore((status) {
         if (mounted) setState(() => _statusText = status);
       });
+      await _loadPageData(includeEstimatedSize: false);
 
       if (!mounted) return;
       setState(() {
@@ -606,11 +643,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
   @override
   Widget build(BuildContext context) {
-    final isBusy = _isBackingUp ||
-        _isRestoring ||
-        _isCreatingSnapshot ||
-        _isPickingLocation ||
-        _deletingBackupId != null;
+    final isBusy = _isBusy;
 
     return Scaffold(
       appBar: AppBar(

--- a/test/data/services/backup_service_test.dart
+++ b/test/data/services/backup_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -294,6 +295,87 @@ void main() {
     expect(await File(backupPath).exists(), isTrue);
   });
 
+  test('restore stages and applies workspace files from backup', () async {
+    final exportedDir = Directory(p.join(tempDir.path, 'ExportedBackups'));
+    final backupPath = await BackupService.createBackup(
+      outputDirectory: exportedDir.path,
+    );
+
+    final workspace = Directory(
+      FileSystemService.instance.getWorkspacePath('backup-service-user'),
+    );
+    final cardFile = File(p.join(workspace.path, 'Cards', 'card.md'));
+    await cardFile.writeAsString('local changes after backup');
+
+    try {
+      await BackupService.restoreBackup(backupPath);
+    } finally {
+      if (AppDatabase.isInitialized) {
+        await AppDatabase.instance.close();
+      }
+    }
+
+    expect(await cardFile.readAsString(), 'hello backup');
+  });
+
+  test(
+    'restore keeps the main isolate responsive while extracting a larger backup',
+    () async {
+      final workspace = Directory(
+        FileSystemService.instance.getWorkspacePath('backup-service-user'),
+      );
+      final largeFilesDir = Directory(p.join(workspace.path, 'Cards', 'Large'));
+      const largeFileCount = 32;
+      const largeFileSize = 768 * 1024;
+
+      for (var i = 0; i < largeFileCount; i += 1) {
+        await _writeDeterministicBinaryFile(
+          File(p.join(largeFilesDir.path, 'payload_$i.bin')),
+          sizeBytes: largeFileSize,
+          seed: i + 1,
+        );
+      }
+
+      final exportedDir = Directory(p.join(tempDir.path, 'ExportedBackups'));
+      final backupPath = await BackupService.createBackup(
+        outputDirectory: exportedDir.path,
+      );
+
+      final mutatedFile = File(p.join(largeFilesDir.path, 'payload_0.bin'));
+      await mutatedFile.writeAsString('local mutation after backup');
+
+      var mainIsolateTicks = 0;
+      final timer = Timer.periodic(const Duration(milliseconds: 10), (_) {
+        mainIsolateTicks += 1;
+      });
+      final stopwatch = Stopwatch()..start();
+      try {
+        await BackupService.restoreBackup(backupPath).timeout(
+          const Duration(seconds: 30),
+        );
+      } finally {
+        timer.cancel();
+        stopwatch.stop();
+        if (AppDatabase.isInitialized) {
+          await AppDatabase.instance.close();
+        }
+      }
+
+      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 20)));
+      expect(
+        mainIsolateTicks,
+        greaterThan(5),
+        reason: 'Restore should yield to the main isolate during extraction.',
+      );
+      expect(await mutatedFile.length(), largeFileSize);
+      expect(
+        await mutatedFile.openRead(0, 64).expand((bytes) => bytes).toList(),
+        _deterministicBytes(length: 64, seed: 1),
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
   group('inspectBackup', () {
     test('reads backup manifest metadata', () async {
       final file = await _writeBackup(
@@ -370,28 +452,28 @@ void main() {
 void _mockPathProviderChannel(String rootPath) {
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(
-        const MethodChannel('plugins.flutter.io/path_provider'),
-        (call) async {
-          switch (call.method) {
-            case 'getTemporaryDirectory':
-            case 'getApplicationDocumentsDirectory':
-            case 'getApplicationSupportDirectory':
-            case 'getExternalStorageDirectory':
-              return rootPath;
-            case 'getExternalStorageDirectories':
-              return <String>[rootPath];
-          }
-          return null;
-        },
-      );
+    const MethodChannel('plugins.flutter.io/path_provider'),
+    (call) async {
+      switch (call.method) {
+        case 'getTemporaryDirectory':
+        case 'getApplicationDocumentsDirectory':
+        case 'getApplicationSupportDirectory':
+        case 'getExternalStorageDirectory':
+          return rootPath;
+        case 'getExternalStorageDirectories':
+          return <String>[rootPath];
+      }
+      return null;
+    },
+  );
 }
 
 void _clearPathProviderChannelMock() {
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(
-        const MethodChannel('plugins.flutter.io/path_provider'),
-        null,
-      );
+    const MethodChannel('plugins.flutter.io/path_provider'),
+    null,
+  );
 }
 
 void _mockBackupStorageChannel(
@@ -399,17 +481,17 @@ void _mockBackupStorageChannel(
 ) {
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(
-        const MethodChannel('com.memexlab.memex/backup_storage'),
-        handler,
-      );
+    const MethodChannel('com.memexlab.memex/backup_storage'),
+    handler,
+  );
 }
 
 void _clearBackupStorageChannelMock() {
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(
-        const MethodChannel('com.memexlab.memex/backup_storage'),
-        null,
-      );
+    const MethodChannel('com.memexlab.memex/backup_storage'),
+    null,
+  );
 }
 
 class FakePathProviderPlatform extends PathProviderPlatform
@@ -451,4 +533,43 @@ Future<File> _writeBackup(
   final file = File('${tempDir.path}/$fileName');
   await file.writeAsBytes(ZipEncoder().encode(archive));
   return file;
+}
+
+Future<void> _writeDeterministicBinaryFile(
+  File file, {
+  required int sizeBytes,
+  required int seed,
+}) async {
+  await file.parent.create(recursive: true);
+  final sink = file.openWrite();
+  var remaining = sizeBytes;
+  var state = seed;
+
+  while (remaining > 0) {
+    final chunkLength = remaining < 64 * 1024 ? remaining : 64 * 1024;
+    final chunk = _deterministicBytes(
+      length: chunkLength,
+      seed: state,
+      nextState: (value) => state = value,
+    );
+    sink.add(chunk);
+    remaining -= chunkLength;
+  }
+
+  await sink.close();
+}
+
+List<int> _deterministicBytes({
+  required int length,
+  required int seed,
+  void Function(int value)? nextState,
+}) {
+  var state = seed;
+  final bytes = List<int>.filled(length, 0);
+  for (var i = 0; i < bytes.length; i += 1) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    bytes[i] = state & 0xff;
+  }
+  nextState?.call(state);
+  return bytes;
 }

--- a/test/domain/models/event_bus_message_test.dart
+++ b/test/domain/models/event_bus_message_test.dart
@@ -33,4 +33,36 @@ void main() {
     expect(message.userId, 'user-1');
     expect(message.characterId, 'mentor');
   });
+
+  test('parses backup snapshot change messages from event payloads', () {
+    final parsed = EventBusMessage.fromJson({
+      'type': 'backup_snapshots_changed',
+      'data': {
+        'reason': 'created',
+        'snapshot_id': 'memex_auto_2026.memex',
+      },
+    });
+
+    expect(parsed, isA<BackupSnapshotsChangedMessage>());
+    final message = parsed as BackupSnapshotsChangedMessage;
+    expect(message.type, EventBusMessageType.backupSnapshotsChanged);
+    expect(message.reason, 'created');
+    expect(message.snapshotId, 'memex_auto_2026.memex');
+  });
+
+  test('parses backup restored messages from event payloads', () {
+    final parsed = EventBusMessage.fromJson({
+      'type': 'backup_restored',
+      'data': {
+        'user_id': 'user-1',
+        'source_path': '/tmp/memex_backup.memex',
+      },
+    });
+
+    expect(parsed, isA<BackupRestoredMessage>());
+    final message = parsed as BackupRestoredMessage;
+    expect(message.type, EventBusMessageType.backupRestored);
+    expect(message.userId, 'user-1');
+    expect(message.sourcePath, '/tmp/memex_backup.memex');
+  });
 }

--- a/test/ui/settings/widgets/backup_restore_page_test.dart
+++ b/test/ui/settings/widgets/backup_restore_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/backup_service.dart';
+import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/l10n/app_localizations.dart';
 import 'package:memex/ui/settings/widgets/backup_restore_page.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -13,6 +14,8 @@ void main() {
     SharedPreferences.setMockInitialValues({'language': 'en'});
     await UserStorage.initL10n();
     await UserStorage.saveUser('backup-test-user');
+    EventBusService.instance.clearHandlers();
+    await EventBusService.instance.connect();
   });
 
   testWidgets('renders automatic backup settings and persists toggle', (
@@ -237,6 +240,39 @@ void main() {
     await _scrollUntilVisible(tester, find.text(snapshot.name));
 
     expect(estimateCalls, 1);
+  });
+
+  testWidgets('refreshes stored backup list when backup event is emitted', (
+    tester,
+  ) async {
+    final snapshots = <BackupSnapshot>[];
+    final snapshot = BackupSnapshot(
+      id: 'background-auto',
+      name: 'memex_auto_2026-05-15T12-00-00.memex',
+      createdAt: DateTime(2026, 5, 15, 12),
+      sizeBytes: 12,
+      filePath: '/tmp/memex_auto_2026-05-15T12-00-00.memex',
+    );
+
+    await _pumpBackupPage(
+      tester,
+      listStoredBackups: () async => List<BackupSnapshot>.of(snapshots),
+    );
+
+    expect(find.text(snapshot.name), findsNothing);
+
+    snapshots.add(snapshot);
+    EventBusService.instance.emitEvent(
+      BackupSnapshotsChangedMessage(reason: 'created', snapshotId: snapshot.id),
+    );
+
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pump();
+
+    await _scrollUntilVisible(tester, find.text(snapshot.name));
+    expect(find.text(snapshot.name), findsOneWidget);
   });
 
   testWidgets('shows Android backup location picker menu', (tester) async {


### PR DESCRIPTION
## 背景 / 根因

Fixes #260

用户在 DEV 包中通过文件管理器分享 `.memex` 备份并触发恢复时遇到一次 ANR。bugreport 显示不是 Java crash，而是 `com.memexlab.memex.dev` 在 `ACTION_SEND application/octet-stream` 分享恢复路径中出现 `Input dispatching timed out`。

原恢复路径会在主 isolate 上做备份检查、整包读取 zip、decode archive，并在恢复 workspace/db 时复制 entry bytes。较大的备份文件会造成 UI 卡住和内存峰值升高。

## 改动

- 将 `inspectBackup` 和恢复 staging/extract 移到后台 isolate。
- 恢复解压改为 `InputFileStream` + `ZipDecoder.decodeStream`，并用 `OutputFileStream` 流式写出，避免整包/整 entry 常驻主 isolate 内存。
- 恢复流程改为先 staging workspace/db，校验 manifest/hash 后再应用到真实 workspace 和 DB 目录。
- 恢复 settings 后重新按恢复用户的数据根目录初始化 `FileSystemService`，再关闭/恢复 DB。
- 备份创建、删除、恢复后通过 `EventBusService` 发出事件。
- 设置页监听备份事件刷新备份列表；恢复后主屏刷新 Timeline、Insight、KnowledgeBase，外部分享恢复路径也有直接刷新兜底。
- 备份创建侧同步改成流式计算文件 hash，并用 `ZipFileEncoder.addFile` 添加源文件，减少备份阶段的内存峰值。

## 测试

- `dart analyze lib/data/services/backup_service.dart lib/domain/models/event_bus_message.dart lib/ui/settings/widgets/backup_restore_page.dart lib/main.dart test/data/services/backup_service_test.dart test/ui/settings/widgets/backup_restore_page_test.dart test/domain/models/event_bus_message_test.dart`
  - 结果：No issues found
- `flutter test test/domain/models/event_bus_message_test.dart test/data/services/backup_service_test.dart test/ui/settings/widgets/backup_restore_page_test.dart test/ui/settings/widgets/backup_restore_confirm_dialog_test.dart`
  - 结果：33 passed
- `flutter test --concurrency=1`
  - 结果：506 passed, 7 skipped

## 性能 / 响应性回归覆盖

新增 `restore keeps the main isolate responsive while extracting a larger backup`：

- 构造 32 个 768 KiB 的确定性 payload，总计约 24 MiB 未压缩 workspace 内容。
- 走完整 `createBackup -> mutate local file -> restoreBackup` 链路。
- 恢复阶段用 10ms periodic timer 验证主 isolate 仍能响应。
- 恢复总耗时限制在 20s 预算内，并校验被修改文件恢复成备份内容。

这不是极限压测，但能防止恢复路径回退到明显阻塞主 isolate 的实现。