### PR TITLE
[codex] 降低备份创建大文件内存峰值

### DIFF
--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -27,9 +27,36 @@ const _safetyBackupPrefix = 'memex_safety';
 const _autoBackupInterval = Duration(hours: 24);
 const _autoBackupKeepRecent = 7;
 const _autoBackupMaxBytes = 2 * 1024 * 1024 * 1024; // 2 GB
+const _backupStoreWithoutCompressionThreshold = 16 * 1024 * 1024; // 16 MB
 const _backupManifestFileName = 'manifest.json';
 const _backupFormat = 'memex.backup';
 const _currentBackupSchemaVersion = 1;
+const _backupStoreWithoutCompressionExtensions = <String>{
+  '.7z',
+  '.aac',
+  '.avi',
+  '.bz2',
+  '.gif',
+  '.gz',
+  '.heic',
+  '.heif',
+  '.jpeg',
+  '.jpg',
+  '.m4a',
+  '.m4v',
+  '.mkv',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.ogg',
+  '.opus',
+  '.pdf',
+  '.png',
+  '.rar',
+  '.webm',
+  '.webp',
+  '.zip',
+};
 
 /// Android Storage Access Framework directory selected for backups.
 class AndroidBackupDirectory {
@@ -1532,12 +1559,49 @@ Future<void> _addFileToBackupArchive(
 ) async {
   final stat = await file.stat();
   final digest = await _sha256FilePath(file.path);
-  await encoder.addFile(file, archivePath, ZipFileEncoder.gzip);
+  await _addFileStreamToBackupArchive(
+    encoder,
+    file,
+    archivePath,
+    stat,
+    storeWithoutCompression: _shouldStoreFileWithoutCompression(
+      file.path,
+      stat.size,
+    ),
+  );
   manifestEntries.add({
     'path': archivePath,
     'size': stat.size,
     'sha256': digest,
   });
+}
+
+Future<void> _addFileStreamToBackupArchive(
+  ZipFileEncoder encoder,
+  File file,
+  String archivePath,
+  FileStat stat, {
+  required bool storeWithoutCompression,
+}) async {
+  final fileStream = InputFileStream(file.path);
+  final archiveFile = ArchiveFile.stream(archivePath, fileStream)
+    ..lastModTime = stat.modified.millisecondsSinceEpoch ~/ 1000
+    ..mode = stat.mode;
+  if (storeWithoutCompression) {
+    archiveFile.compression = CompressionType.none;
+  }
+
+  try {
+    encoder.addArchiveFile(archiveFile);
+  } finally {
+    await fileStream.close();
+  }
+}
+
+bool _shouldStoreFileWithoutCompression(String filePath, int fileSize) {
+  if (fileSize >= _backupStoreWithoutCompressionThreshold) return true;
+  final extension = path.extension(filePath).toLowerCase();
+  return _backupStoreWithoutCompressionExtensions.contains(extension);
 }
 
 void _addBytesToBackupArchive(

--- a/test/data/services/backup_service_test.dart
+++ b/test/data/services/backup_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:archive/archive.dart';
+import 'package:crypto/crypto.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/backup_service.dart';
@@ -80,6 +81,87 @@ void main() {
 
     expect(manifestJson['formatVersion'], 1);
     expect(manifestJson['entries'], isNotEmpty);
+  });
+
+  test('createBackup still compresses small text files', () async {
+    final outputDir = Directory(p.join(tempDir.path, 'Backups'));
+    final backupPath = await BackupService.createBackup(
+      outputDirectory: outputDir.path,
+    );
+
+    final archive = ZipDecoder().decodeBytes(
+      await File(backupPath).readAsBytes(),
+    );
+    final archivedCard = archive.files.firstWhere(
+      (file) => file.name == 'workspace/Cards/card.md',
+    );
+
+    expect(archivedCard.compression, CompressionType.deflate);
+    expect(utf8.decode(archivedCard.content), 'hello backup');
+  });
+
+  test('createBackup stores compressed media without recompressing', () async {
+    final workspace = Directory(
+      FileSystemService.instance.getWorkspacePath('backup-service-user'),
+    );
+    final mediaFile = File(p.join(workspace.path, 'Assets', 'clip.mp4'));
+    await mediaFile.create(recursive: true);
+    await mediaFile.writeAsBytes(List<int>.generate(1024, (index) => index));
+
+    final outputDir = Directory(p.join(tempDir.path, 'Backups'));
+    final backupPath = await BackupService.createBackup(
+      outputDirectory: outputDir.path,
+    );
+
+    final archive = ZipDecoder().decodeBytes(
+      await File(backupPath).readAsBytes(),
+    );
+    final archivedMedia = archive.files.firstWhere(
+      (file) => file.name == 'workspace/Assets/clip.mp4',
+    );
+
+    expect(archivedMedia.compression, CompressionType.none);
+    expect(archivedMedia.content, await mediaFile.readAsBytes());
+  });
+
+  test('createBackup stores large files without recompressing', () async {
+    final workspace = Directory(
+      FileSystemService.instance.getWorkspacePath('backup-service-user'),
+    );
+    final largeFile = File(p.join(workspace.path, 'Cards', 'large.bin'));
+    const largeFileSize = 16 * 1024 * 1024 + 1;
+    await _writeDeterministicBinaryFile(
+      largeFile,
+      sizeBytes: largeFileSize,
+      seed: 99,
+    );
+
+    final outputDir = Directory(p.join(tempDir.path, 'Backups'));
+    final backupPath = await BackupService.createBackup(
+      outputDirectory: outputDir.path,
+    );
+
+    final archive = ZipDecoder().decodeBytes(
+      await File(backupPath).readAsBytes(),
+    );
+    final archivedLargeFile = archive.files.firstWhere(
+      (file) => file.name == 'workspace/Cards/large.bin',
+    );
+    final manifest = archive.files.firstWhere(
+      (file) => file.name == 'manifest.json',
+    );
+    final manifestJson = jsonDecode(utf8.decode(manifest.content));
+    final entries = (manifestJson['entries'] as List)
+        .whereType<Map>()
+        .map((entry) => entry.cast<String, dynamic>());
+    final largeEntry = entries.firstWhere(
+      (entry) => entry['path'] == 'workspace/Cards/large.bin',
+    );
+
+    expect(archivedLargeFile.compression, CompressionType.none);
+    expect(archivedLargeFile.size, largeFileSize);
+    expect(largeEntry['size'], largeFileSize);
+    expect(largeEntry['sha256'], await _sha256File(largeFile));
   });
 
   test(
@@ -572,4 +654,9 @@ List<int> _deterministicBytes({
   }
   nextState?.call(state);
   return bytes;
+}
+
+Future<String> _sha256File(File file) async {
+  final digest = await sha256.bind(file.openRead()).first;
+  return digest.toString();
 }


### PR DESCRIPTION
## 背景 / 根因

Fixes #262

PR #261 已经把备份恢复路径里的整包读取、解压和 staging 移到后台 isolate，并降低了恢复时的 ANR / 内存峰值风险。继续检查创建备份链路时，创建流程本身已经在后台 isolate 中执行，文件 hash 也通过 `openRead()` 流式计算；但 `archive` 包在 deflate 单个 zip entry 时会先暂存该 entry 的压缩后内容。

这意味着普通备份不会卡主 isolate，但如果用户 workspace 中有超大附件，或视频、图片、压缩包这类已经压缩过的文件，创建备份仍可能出现不必要的单文件内存尖峰。

## 改动

- 对超过 16 MiB 的文件使用 zip store 模式，不再二次 deflate。
- 对常见已压缩媒体 / 压缩包扩展名使用 zip store 模式。
- 保留普通小文本、Markdown、JSON 等文件的 deflate 压缩。
- 保持 manifest 的 size / sha256 校验逻辑不变，恢复兼容性不变。
- 补充创建备份测试，覆盖普通小文本仍压缩、已压缩媒体不二次压缩、超过阈值大文件不二次压缩且 manifest hash 正确。

## 测试

- `dart analyze lib/data/services/backup_service.dart test/data/services/backup_service_test.dart`
  - 结果：No issues found
- `flutter test test/data/services/backup_service_test.dart`
  - 结果：18 passed
- `flutter test --concurrency=1`
  - 结果：515 passed, 7 skipped

## 说明

这不是完整自研 streaming zip writer；它是针对当前 `archive` encoder 行为的低风险内存保护。后续如果需要同时追求大文件压缩率和严格流式写 zip，可以单独实现 zip data descriptor 路径。