### PR TITLE
修复 Android 后台 Agent 通知实时活动更新

### DIFF
--- a/android/app/src/main/kotlin/com/memexlab/memex/AgentBackgroundService.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/AgentBackgroundService.kt
@@ -111,6 +111,7 @@ class AgentBackgroundService : Service() {
         val title = intent?.getStringExtra("title") ?: "Memex Agent"
         val stage = intent?.getStringExtra("stage") ?: "Processing"
         val detail = intent?.getStringExtra("detail") ?: ""
+        val summary = intent?.getStringExtra("summary") ?: ""
         val remainingTasks = intent?.getIntExtra("remainingTasks", 0) ?: 0
 
         val openIntent = Intent(this, MainActivity::class.java).apply {
@@ -125,7 +126,7 @@ class AgentBackgroundService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
 
-        val subText = when (state) {
+        val fallbackText = when (state) {
             "failed" -> "Needs attention"
             else -> {
                 val taskLabel = if (remainingTasks == 1) "task" else "tasks"
@@ -136,16 +137,18 @@ class AgentBackgroundService : Service() {
                 }
             }
         }
+        val contentText = summary.ifBlank { fallbackText }
         val body = listOf(
             stage,
             detail,
         ).filter { it.isNotBlank() }.joinToString("\n")
+        val bigText = body.ifBlank { contentText }
 
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_quick_note)
             .setContentTitle(title)
-            .setContentText(subText)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setContentText(contentText)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(bigText))
             .setContentIntent(pendingIntent)
             .setOngoing(state == "active")
             .setAutoCancel(state != "active")

--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/AgentBackgroundChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/AgentBackgroundChannelHandler.kt
@@ -70,6 +70,7 @@ object AgentBackgroundChannelHandler {
             putExtra("title", args["title"] as? String ?: "Memex Agent")
             putExtra("stage", args["stage"] as? String ?: "Processing")
             putExtra("detail", args["detail"] as? String ?: "")
+            putExtra("summary", args["summary"] as? String ?: "")
             putExtra("remainingTasks", (args["remainingTasks"] as? Number)?.toInt() ?: 0)
             putExtra("pending", (args["pending"] as? Number)?.toInt() ?: 0)
             putExtra("processing", (args["processing"] as? Number)?.toInt() ?: 0)

--- a/lib/data/services/agent_background_coordinator.dart
+++ b/lib/data/services/agent_background_coordinator.dart
@@ -7,15 +7,16 @@ import 'package:memex/data/services/agent_background_status.dart';
 import 'package:memex/data/services/agent_queue_drain_scheduler.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/user_storage.dart';
 
 class AgentBackgroundCoordinator with WidgetsBindingObserver {
   AgentBackgroundCoordinator({
     AgentBackgroundPlatform? platform,
     AgentQueueDrainScheduler? scheduler,
     AppLifecycleState? initialLifecycleState,
-  }) : _platform = platform ?? MethodChannelAgentBackgroundPlatform(),
-       _scheduler = scheduler ?? WorkmanagerAgentQueueDrainScheduler(),
-       _initialLifecycleState = initialLifecycleState;
+  })  : _platform = platform ?? MethodChannelAgentBackgroundPlatform(),
+        _scheduler = scheduler ?? WorkmanagerAgentQueueDrainScheduler(),
+        _initialLifecycleState = initialLifecycleState;
 
   static AgentBackgroundCoordinator? _instance;
   static AgentBackgroundCoordinator get instance {
@@ -32,8 +33,8 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
   StreamSubscription<String>? _actionSubscription;
   late final StreamController<void> _openActivityController =
       StreamController<void>.broadcast(
-        onListen: _flushPendingOpenActivityRequest,
-      );
+    onListen: _flushPendingOpenActivityRequest,
+  );
 
   TaskActivitySnapshot _taskSnapshot = const TaskActivitySnapshot.empty();
   AgentActivityMessageModel? _latestMessage;
@@ -56,8 +57,7 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
   }) {
     if (_started || !_platform.isSupported) return;
     _started = true;
-    _lifecycleState =
-        _initialLifecycleState ??
+    _lifecycleState = _initialLifecycleState ??
         WidgetsBinding.instance.lifecycleState ??
         AppLifecycleState.resumed;
     WidgetsBinding.instance.addObserver(this);
@@ -164,6 +164,7 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
     final status = AgentBackgroundStatus.fromActivity(
       taskSnapshot: _taskSnapshot,
       latestMessage: _latestMessage,
+      labels: _statusLabels(),
     );
     final isInBackground = _lifecycleState != AppLifecycleState.resumed;
 
@@ -241,6 +242,14 @@ class AgentBackgroundCoordinator with WidgetsBindingObserver {
     } catch (e, stackTrace) {
       _drainWorkScheduledForCurrentRun = false;
       _logger.warning('Failed to schedule agent queue drain', e, stackTrace);
+    }
+  }
+
+  AgentBackgroundStatusLabels _statusLabels() {
+    try {
+      return AgentBackgroundStatusLabels.fromL10n(UserStorage.l10n);
+    } catch (_) {
+      return const AgentBackgroundStatusLabels();
     }
   }
 }

--- a/lib/data/services/agent_background_status.dart
+++ b/lib/data/services/agent_background_status.dart
@@ -1,5 +1,6 @@
 import 'package:memex/data/services/agent_activity_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/l10n/app_localizations.dart';
 
 enum AgentBackgroundRunState { idle, active, completed, failed }
 
@@ -12,6 +13,7 @@ class AgentBackgroundStatus {
     required this.title,
     required this.stage,
     required this.detail,
+    required this.summary,
     required this.agentName,
     required this.updatedAt,
     this.scene,
@@ -22,6 +24,7 @@ class AgentBackgroundStatus {
     required TaskActivitySnapshot taskSnapshot,
     AgentActivityMessageModel? latestMessage,
     DateTime? now,
+    AgentBackgroundStatusLabels labels = const AgentBackgroundStatusLabels(),
   }) {
     final messageType = latestMessage?.type;
     final hasTasks = taskSnapshot.hasActiveTasks;
@@ -34,27 +37,35 @@ class AgentBackgroundStatus {
     };
 
     final fallbackStage = switch (state) {
-      AgentBackgroundRunState.failed => 'Needs attention',
-      AgentBackgroundRunState.completed => 'Completed',
-      AgentBackgroundRunState.active => 'Processing',
-      AgentBackgroundRunState.idle => 'Idle',
+      AgentBackgroundRunState.failed => labels.needsAttention,
+      AgentBackgroundRunState.completed => labels.completed,
+      AgentBackgroundRunState.active => labels.processing,
+      AgentBackgroundRunState.idle => labels.idle,
     };
 
     final title = switch (state) {
-      AgentBackgroundRunState.failed => 'Memex Agent needs attention',
-      AgentBackgroundRunState.completed => 'Memex Agent',
-      AgentBackgroundRunState.active => 'Memex Agent',
-      AgentBackgroundRunState.idle => 'Memex Agent',
+      AgentBackgroundRunState.failed => labels.needsAttentionTitle,
+      AgentBackgroundRunState.completed => labels.title,
+      AgentBackgroundRunState.active => labels.title,
+      AgentBackgroundRunState.idle => labels.title,
     };
 
     final stage =
         _firstNonBlank([latestMessage?.title, latestMessage?.agentName]) ??
-        fallbackStage;
+            fallbackStage;
 
     final detail = _detailFor(
       taskSnapshot: taskSnapshot,
       latestMessage: latestMessage,
       state: state,
+      labels: labels,
+    );
+    final summary = _summaryFor(
+      taskSnapshot: taskSnapshot,
+      latestMessage: latestMessage,
+      fallbackStage: fallbackStage,
+      detail: detail,
+      labels: labels,
     );
 
     return AgentBackgroundStatus(
@@ -65,6 +76,7 @@ class AgentBackgroundStatus {
       title: title,
       stage: stage,
       detail: detail,
+      summary: summary,
       agentName: latestMessage?.agentName ?? '',
       scene: latestMessage?.scene,
       sceneId: latestMessage?.sceneId,
@@ -79,6 +91,7 @@ class AgentBackgroundStatus {
   final String title;
   final String stage;
   final String detail;
+  final String summary;
   final String agentName;
   final String? scene;
   final String? sceneId;
@@ -102,6 +115,7 @@ class AgentBackgroundStatus {
       'title': title,
       'stage': stage,
       'detail': detail,
+      'summary': summary,
       'agentName': agentName,
       'scene': scene,
       'sceneId': sceneId,
@@ -120,6 +134,7 @@ class AgentBackgroundStatus {
         other.title == title &&
         other.stage == stage &&
         other.detail == detail &&
+        other.summary == summary &&
         other.agentName == agentName &&
         other.scene == scene &&
         other.sceneId == sceneId;
@@ -127,38 +142,106 @@ class AgentBackgroundStatus {
 
   @override
   int get hashCode => Object.hash(
-    state,
-    pending,
-    processing,
-    retrying,
-    title,
-    stage,
-    detail,
-    agentName,
-    scene,
-    sceneId,
-  );
+        state,
+        pending,
+        processing,
+        retrying,
+        title,
+        stage,
+        detail,
+        summary,
+        agentName,
+        scene,
+        sceneId,
+      );
+}
+
+class AgentBackgroundStatusLabels {
+  const AgentBackgroundStatusLabels({
+    this.title = 'Memex Agent',
+    this.needsAttentionTitle = 'Memex Agent needs attention',
+    this.processing = 'Processing',
+    this.needsAttention = 'Needs attention',
+    this.completed = 'Completed',
+    this.idle = 'Idle',
+    this.processingStarting = 'Processing is starting.',
+    this.processingStoppedWithError = 'Processing stopped with an error.',
+    this.allBackgroundTasksFinished = 'All background tasks finished.',
+    this.noBackgroundTasks = 'No background tasks.',
+    this.processingQueuedTasks = _defaultProcessingQueuedTasks,
+  });
+
+  factory AgentBackgroundStatusLabels.fromL10n(AppLocalizations l10n) {
+    return AgentBackgroundStatusLabels(
+      title: l10n.agentBackgroundTitle,
+      needsAttentionTitle: l10n.agentBackgroundNeedsAttentionTitle,
+      processing: l10n.agentBackgroundProcessing,
+      needsAttention: l10n.agentBackgroundNeedsAttention,
+      completed: l10n.agentBackgroundCompleted,
+      idle: l10n.agentBackgroundIdle,
+      processingStarting: l10n.agentBackgroundProcessingStarting,
+      processingStoppedWithError: l10n.agentBackgroundStoppedWithError,
+      allBackgroundTasksFinished: l10n.agentBackgroundAllTasksFinished,
+      noBackgroundTasks: l10n.agentBackgroundNoTasks,
+      processingQueuedTasks: l10n.agentBackgroundQueuedTasks,
+    );
+  }
+
+  final String title;
+  final String needsAttentionTitle;
+  final String processing;
+  final String needsAttention;
+  final String completed;
+  final String idle;
+  final String processingStarting;
+  final String processingStoppedWithError;
+  final String allBackgroundTasksFinished;
+  final String noBackgroundTasks;
+  final String Function(num count) processingQueuedTasks;
 }
 
 String _detailFor({
   required TaskActivitySnapshot taskSnapshot,
   required AgentActivityMessageModel? latestMessage,
   required AgentBackgroundRunState state,
+  required AgentBackgroundStatusLabels labels,
 }) {
   final messageContent = _trimToSingleLine(latestMessage?.content);
   if (messageContent != null) return messageContent;
 
   if (taskSnapshot.hasActiveTasks) {
-    final taskLabel = taskSnapshot.total == 1 ? 'task' : 'tasks';
-    return 'Processing ${taskSnapshot.total} queued $taskLabel';
+    return labels.processingQueuedTasks(taskSnapshot.total);
   }
 
   return switch (state) {
-    AgentBackgroundRunState.failed => 'Processing stopped with an error.',
-    AgentBackgroundRunState.completed => 'All background tasks finished.',
-    AgentBackgroundRunState.active => 'Processing is starting.',
-    AgentBackgroundRunState.idle => 'No background tasks.',
+    AgentBackgroundRunState.failed => labels.processingStoppedWithError,
+    AgentBackgroundRunState.completed => labels.allBackgroundTasksFinished,
+    AgentBackgroundRunState.active => labels.processingStarting,
+    AgentBackgroundRunState.idle => labels.noBackgroundTasks,
   };
+}
+
+String _summaryFor({
+  required TaskActivitySnapshot taskSnapshot,
+  required AgentActivityMessageModel? latestMessage,
+  required String fallbackStage,
+  required String detail,
+  required AgentBackgroundStatusLabels labels,
+}) {
+  final messageTitle = _firstNonBlank([
+    latestMessage?.title,
+    latestMessage?.agentName,
+  ]);
+  final messageContent = _trimToSingleLine(latestMessage?.content);
+  if (messageContent != null) {
+    return messageContent;
+  }
+  if (messageTitle != null) return messageTitle;
+  if (taskSnapshot.hasActiveTasks) {
+    return labels.processingQueuedTasks(taskSnapshot.total);
+  }
+  if (detail.isNotBlank) return detail;
+  return fallbackStage;
 }
 
 String? _firstNonBlank(Iterable<String?> values) {
@@ -175,4 +258,12 @@ String? _trimToSingleLine(String? value) {
   final compact = trimmed.replaceAll(RegExp(r'\s+'), ' ');
   if (compact.length <= 140) return compact;
   return '${compact.substring(0, 137)}...';
+}
+
+String _defaultProcessingQueuedTasks(num count) {
+  return 'Processing $count queued ${count == 1 ? 'task' : 'tasks'}';
+}
+
+extension on String {
+  bool get isNotBlank => trim().isNotEmpty;
 }

--- a/lib/data/services/agent_queue_background_worker.dart
+++ b/lib/data/services/agent_queue_background_worker.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/agent_activity_service.dart';
 import 'package:memex/data/services/agent_background_platform.dart';
 import 'package:memex/data/services/agent_background_status.dart';
 import 'package:memex/data/services/agent_queue_drain_scheduler.dart';
@@ -27,6 +28,7 @@ class AgentQueueBackgroundWorker {
     LocalTaskExecutor? executor,
     AgentQueueDrainScheduler? scheduler,
     AgentBackgroundPlatform? backgroundPlatform,
+    AgentActivityService? activityService,
     Duration maxRunDuration = _maxRunDuration,
     Duration databaseRetryDelay = const Duration(milliseconds: 300),
   }) async {
@@ -47,6 +49,13 @@ class AgentQueueBackgroundWorker {
 
       final taskExecutor = executor ?? LocalTaskExecutor.instance;
       final queueScheduler = scheduler ?? WorkmanagerAgentQueueDrainScheduler();
+      final labels = _statusLabels();
+      final liveSurface = _LiveBackgroundSurfacePublisher(
+        logger: logger,
+        platform: surfacePlatform,
+        executor: taskExecutor,
+        labels: labels,
+      );
       final result = await _withDatabaseLockRetry(
         logger,
         maxAttempts: _databaseMaxAttempts,
@@ -60,11 +69,20 @@ class AgentQueueBackgroundWorker {
               executor: taskExecutor,
             );
           }
-          return taskExecutor.drainAvailableTasks(
-            userId: userId,
-            maxDuration: maxRunDuration,
-            stopWhenDone: true,
-          );
+          final liveActivityService =
+              activityService ?? _tryGetActivityService(logger);
+          if (liveActivityService != null) {
+            await liveSurface.start(liveActivityService);
+          }
+          try {
+            return await taskExecutor.drainAvailableTasks(
+              userId: userId,
+              maxDuration: maxRunDuration,
+              stopWhenDone: true,
+            );
+          } finally {
+            await liveSurface.stop();
+          }
         },
       );
 
@@ -78,6 +96,8 @@ class AgentQueueBackgroundWorker {
         logger,
         surfacePlatform,
         result.snapshot,
+        latestMessage: liveSurface.latestMessage,
+        labels: labels,
       );
 
       logger.info(
@@ -103,8 +123,10 @@ class AgentQueueBackgroundWorker {
   static Future<void> _syncBackgroundSurfaceAfterDrain(
     Logger logger,
     AgentBackgroundPlatform platform,
-    TaskActivitySnapshot snapshot,
-  ) async {
+    TaskActivitySnapshot snapshot, {
+    AgentActivityMessageModel? latestMessage,
+    AgentBackgroundStatusLabels labels = const AgentBackgroundStatusLabels(),
+  }) async {
     if (!platform.isSupported) return;
 
     if (!snapshot.hasActiveTasks) {
@@ -114,7 +136,11 @@ class AgentQueueBackgroundWorker {
 
     try {
       await platform.updateStatus(
-        AgentBackgroundStatus.fromActivity(taskSnapshot: snapshot),
+        AgentBackgroundStatus.fromActivity(
+          taskSnapshot: snapshot,
+          latestMessage: latestMessage,
+          labels: labels,
+        ),
         isInBackground: true,
       );
     } catch (e, stackTrace) {
@@ -174,5 +200,97 @@ class AgentQueueBackgroundWorker {
     return message.contains('database is locked') ||
         message.contains('sqliteexception(5)') ||
         message.contains('code 5');
+  }
+
+  static AgentBackgroundStatusLabels _statusLabels() {
+    try {
+      return AgentBackgroundStatusLabels.fromL10n(UserStorage.l10n);
+    } catch (_) {
+      return const AgentBackgroundStatusLabels();
+    }
+  }
+
+  static AgentActivityService? _tryGetActivityService(Logger logger) {
+    try {
+      return AgentActivityService.instance;
+    } catch (e, stackTrace) {
+      logger.fine(
+        'Skipping live Android agent background surface updates: '
+        'agent activity service is unavailable',
+        e,
+        stackTrace,
+      );
+      return null;
+    }
+  }
+}
+
+class _LiveBackgroundSurfacePublisher {
+  _LiveBackgroundSurfacePublisher({
+    required this.logger,
+    required this.platform,
+    required this.executor,
+    required this.labels,
+  });
+
+  final Logger logger;
+  final AgentBackgroundPlatform platform;
+  final LocalTaskExecutor executor;
+  final AgentBackgroundStatusLabels labels;
+  StreamSubscription<AgentActivityMessageModel>? _subscription;
+  Future<void> _publishChain = Future<void>.value();
+
+  AgentActivityMessageModel? latestMessage;
+
+  Future<void> start(AgentActivityService activityService) async {
+    if (!platform.isSupported) return;
+    await _subscription?.cancel();
+    _subscription = activityService.messageStream.listen(
+      (message) {
+        latestMessage = message;
+        _publishChain =
+            _publishChain.then((_) => _publish(message)).catchError((
+          Object e,
+          StackTrace stackTrace,
+        ) {
+          logger.warning(
+            'Failed to refresh Android agent background surface from activity',
+            e,
+            stackTrace,
+          );
+        });
+        unawaited(_publishChain);
+      },
+      onError: (Object e, StackTrace stackTrace) {
+        logger.warning(
+          'Agent activity stream failed in background',
+          e,
+          stackTrace,
+        );
+      },
+    );
+  }
+
+  Future<void> stop() async {
+    await _subscription?.cancel();
+    _subscription = null;
+    await _publishChain;
+  }
+
+  Future<void> _publish(AgentActivityMessageModel message) async {
+    final snapshot = await executor.getTaskActivitySnapshot();
+    final status = AgentBackgroundStatus.fromActivity(
+      taskSnapshot: snapshot,
+      latestMessage: message,
+      labels: labels,
+    );
+    if (!status.shouldShowSystemSurface) return;
+
+    if (status.state == AgentBackgroundRunState.failed) {
+      await platform.finishStatus(status, isInBackground: true);
+      return;
+    }
+
+    await platform.updateStatus(status, isInBackground: true);
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1495,6 +1495,23 @@
   "earlyUpdateDialogTitle": "Early update available",
   "earlyUpdateReleaseNotes": "Release notes",
 
+  "agentBackgroundTitle": "Memex Agent",
+  "agentBackgroundNeedsAttentionTitle": "Memex Agent needs attention",
+  "agentBackgroundProcessing": "Processing",
+  "agentBackgroundNeedsAttention": "Needs attention",
+  "agentBackgroundCompleted": "Completed",
+  "agentBackgroundIdle": "Idle",
+  "agentBackgroundProcessingStarting": "Processing is starting.",
+  "agentBackgroundStoppedWithError": "Processing stopped with an error.",
+  "agentBackgroundAllTasksFinished": "All background tasks finished.",
+  "agentBackgroundNoTasks": "No background tasks.",
+  "agentBackgroundQueuedTasks": "{count, plural, =1{Processing 1 queued task} other{Processing {count} queued tasks}}",
+  "@agentBackgroundQueuedTasks": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+
   "dismissAllNotifications": "Clear all",
   "dismissByType": "Clear by type",
   "dismissTypeSystemAction": "Reminders & events",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5936,6 +5936,72 @@ abstract class AppLocalizations {
   /// **'Release notes'**
   String get earlyUpdateReleaseNotes;
 
+  /// No description provided for @agentBackgroundTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Memex Agent'**
+  String get agentBackgroundTitle;
+
+  /// No description provided for @agentBackgroundNeedsAttentionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Memex Agent needs attention'**
+  String get agentBackgroundNeedsAttentionTitle;
+
+  /// No description provided for @agentBackgroundProcessing.
+  ///
+  /// In en, this message translates to:
+  /// **'Processing'**
+  String get agentBackgroundProcessing;
+
+  /// No description provided for @agentBackgroundNeedsAttention.
+  ///
+  /// In en, this message translates to:
+  /// **'Needs attention'**
+  String get agentBackgroundNeedsAttention;
+
+  /// No description provided for @agentBackgroundCompleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Completed'**
+  String get agentBackgroundCompleted;
+
+  /// No description provided for @agentBackgroundIdle.
+  ///
+  /// In en, this message translates to:
+  /// **'Idle'**
+  String get agentBackgroundIdle;
+
+  /// No description provided for @agentBackgroundProcessingStarting.
+  ///
+  /// In en, this message translates to:
+  /// **'Processing is starting.'**
+  String get agentBackgroundProcessingStarting;
+
+  /// No description provided for @agentBackgroundStoppedWithError.
+  ///
+  /// In en, this message translates to:
+  /// **'Processing stopped with an error.'**
+  String get agentBackgroundStoppedWithError;
+
+  /// No description provided for @agentBackgroundAllTasksFinished.
+  ///
+  /// In en, this message translates to:
+  /// **'All background tasks finished.'**
+  String get agentBackgroundAllTasksFinished;
+
+  /// No description provided for @agentBackgroundNoTasks.
+  ///
+  /// In en, this message translates to:
+  /// **'No background tasks.'**
+  String get agentBackgroundNoTasks;
+
+  /// No description provided for @agentBackgroundQueuedTasks.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Processing 1 queued task} other{Processing {count} queued tasks}}'**
+  String agentBackgroundQueuedTasks(num count);
+
   /// No description provided for @dismissAllNotifications.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3295,6 +3295,50 @@ class AppLocalizationsEn extends AppLocalizations {
   String get earlyUpdateReleaseNotes => 'Release notes';
 
   @override
+  String get agentBackgroundTitle => 'Memex Agent';
+
+  @override
+  String get agentBackgroundNeedsAttentionTitle =>
+      'Memex Agent needs attention';
+
+  @override
+  String get agentBackgroundProcessing => 'Processing';
+
+  @override
+  String get agentBackgroundNeedsAttention => 'Needs attention';
+
+  @override
+  String get agentBackgroundCompleted => 'Completed';
+
+  @override
+  String get agentBackgroundIdle => 'Idle';
+
+  @override
+  String get agentBackgroundProcessingStarting => 'Processing is starting.';
+
+  @override
+  String get agentBackgroundStoppedWithError =>
+      'Processing stopped with an error.';
+
+  @override
+  String get agentBackgroundAllTasksFinished =>
+      'All background tasks finished.';
+
+  @override
+  String get agentBackgroundNoTasks => 'No background tasks.';
+
+  @override
+  String agentBackgroundQueuedTasks(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Processing $count queued tasks',
+      one: 'Processing 1 queued task',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get dismissAllNotifications => 'Clear all';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3166,6 +3166,46 @@ class AppLocalizationsZh extends AppLocalizations {
   String get earlyUpdateReleaseNotes => '更新说明';
 
   @override
+  String get agentBackgroundTitle => 'Memex Agent';
+
+  @override
+  String get agentBackgroundNeedsAttentionTitle => 'Memex Agent 需要处理';
+
+  @override
+  String get agentBackgroundProcessing => '处理中';
+
+  @override
+  String get agentBackgroundNeedsAttention => '需要处理';
+
+  @override
+  String get agentBackgroundCompleted => '已完成';
+
+  @override
+  String get agentBackgroundIdle => '空闲';
+
+  @override
+  String get agentBackgroundProcessingStarting => '正在开始处理。';
+
+  @override
+  String get agentBackgroundStoppedWithError => '处理因错误停止。';
+
+  @override
+  String get agentBackgroundAllTasksFinished => '所有后台任务已完成。';
+
+  @override
+  String get agentBackgroundNoTasks => '当前没有后台任务。';
+
+  @override
+  String agentBackgroundQueuedTasks(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '正在处理 $count 个后台任务',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get dismissAllNotifications => '清除全部';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1458,6 +1458,23 @@
   "earlyUpdateDialogTitle": "发现 Early 更新",
   "earlyUpdateReleaseNotes": "更新说明",
 
+  "agentBackgroundTitle": "Memex Agent",
+  "agentBackgroundNeedsAttentionTitle": "Memex Agent 需要处理",
+  "agentBackgroundProcessing": "处理中",
+  "agentBackgroundNeedsAttention": "需要处理",
+  "agentBackgroundCompleted": "已完成",
+  "agentBackgroundIdle": "空闲",
+  "agentBackgroundProcessingStarting": "正在开始处理。",
+  "agentBackgroundStoppedWithError": "处理因错误停止。",
+  "agentBackgroundAllTasksFinished": "所有后台任务已完成。",
+  "agentBackgroundNoTasks": "当前没有后台任务。",
+  "agentBackgroundQueuedTasks": "{count, plural, other{正在处理 {count} 个后台任务}}",
+  "@agentBackgroundQueuedTasks": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+
   "dismissAllNotifications": "清除全部",
   "dismissByType": "按类型清除",
   "dismissTypeSystemAction": "日程提醒",

--- a/test/data/services/agent_background_coordinator_test.dart
+++ b/test/data/services/agent_background_coordinator_test.dart
@@ -69,6 +69,8 @@ void main() {
 
     expect(platform.updates.last.stage, 'Updating PKM');
     expect(platform.updates.last.detail, 'Writing local notes');
+    expect(platform.updates.last.summary, 'Writing local notes');
+    expect(platform.updates.last.summary, isNot(contains('Updating PKM')));
     expect(scheduler.scheduleCount, 1);
   });
 
@@ -178,6 +180,7 @@ void main() {
 
       expect(platform.updates.last.state, AgentBackgroundRunState.active);
       expect(platform.updates.last.detail, 'Will retry automatically');
+      expect(platform.updates.last.summary, 'Will retry automatically');
       expect(platform.finished, isEmpty);
       expect(scheduler.cancelCount, cancelCountBeforeError);
     },

--- a/test/data/services/agent_background_platform_test.dart
+++ b/test/data/services/agent_background_platform_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/agent_background_platform.dart';
+import 'package:memex/data/services/agent_background_status.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channelName = 'com.memexlab.memex/agent_background';
+  const channel = MethodChannel(channelName);
+
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('passes summary through updateAgentStatus platform payload', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+    final platform = MethodChannelAgentBackgroundPlatform(channel: channel);
+
+    await platform.updateStatus(
+      AgentBackgroundStatus(
+        state: AgentBackgroundRunState.active,
+        pending: 1,
+        processing: 1,
+        retrying: 0,
+        title: 'Memex Agent',
+        stage: 'Calling Tool',
+        detail: 'Refreshing timeline',
+        summary: 'Refreshing timeline',
+        agentName: 'Timeline Agent',
+        scene: 'timeline',
+        sceneId: 'card-1',
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+      isInBackground: true,
+    );
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'updateAgentStatus');
+    final payload = calls.single.arguments as Map<Object?, Object?>;
+    expect(payload['title'], 'Memex Agent');
+    expect(payload['stage'], 'Calling Tool');
+    expect(payload['detail'], 'Refreshing timeline');
+    expect(payload['summary'], 'Refreshing timeline');
+    expect(payload['summary'], isNot(contains('Calling Tool')));
+    expect(payload['remainingTasks'], 2);
+    expect(payload['isInBackground'], isTrue);
+    expect(payload['scene'], 'timeline');
+    expect(payload['sceneId'], 'card-1');
+  });
+
+  test('passes summary through finishAgentStatus platform payload', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+    final platform = MethodChannelAgentBackgroundPlatform(channel: channel);
+
+    await platform.finishStatus(
+      AgentBackgroundStatus(
+        state: AgentBackgroundRunState.failed,
+        pending: 0,
+        processing: 0,
+        retrying: 0,
+        title: 'Memex Agent needs attention',
+        stage: 'Provider error',
+        detail: 'API key is missing',
+        summary: 'API key is missing',
+        agentName: 'Insight Agent',
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+      isInBackground: true,
+    );
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'finishAgentStatus');
+    final payload = calls.single.arguments as Map<Object?, Object?>;
+    expect(payload['state'], 'failed');
+    expect(payload['title'], 'Memex Agent needs attention');
+    expect(payload['detail'], 'API key is missing');
+    expect(payload['summary'], 'API key is missing');
+    expect(payload['isInBackground'], isTrue);
+  });
+
+  test('emits action event when Android asks Flutter to open agent activity',
+      () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final platform = MethodChannelAgentBackgroundPlatform(channel: channel);
+    final events = <String>[];
+    final subscription = platform.actionStream.listen(events.add);
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+      channelName,
+      const StandardMethodCodec().encodeMethodCall(
+        const MethodCall('openAgentActivity'),
+      ),
+      (_) {},
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, ['agent_activity']);
+    await subscription.cancel();
+  });
+}

--- a/test/data/services/agent_background_status_test.dart
+++ b/test/data/services/agent_background_status_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/agent_activity_service.dart';
 import 'package:memex/data/services/agent_background_status.dart';
 import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/l10n/app_localizations_zh.dart';
 
 void main() {
   group('AgentBackgroundStatus', () {
@@ -15,6 +16,7 @@ void main() {
       expect(status.shouldShowSystemSurface, isFalse);
       expect(status.remainingTasks, 0);
       expect(status.detail, 'No background tasks.');
+      expect(status.summary, 'No background tasks.');
     });
 
     test('uses task snapshot counts for active status', () {
@@ -31,6 +33,11 @@ void main() {
       expect(status.remainingTasks, 4);
       expect(status.title, 'Memex Agent');
       expect(status.detail, 'Processing 4 queued tasks');
+      expect(status.summary, 'Processing 4 queued tasks');
+      expect(
+        status.toPlatformMap(isInBackground: true),
+        containsPair('summary', 'Processing 4 queued tasks'),
+      );
       expect(
         status.toPlatformMap(isInBackground: true),
         containsPair('remainingTasks', 4),
@@ -63,6 +70,88 @@ void main() {
       expect(status.state, AgentBackgroundRunState.active);
       expect(status.stage, 'Provider timeout');
       expect(status.detail, 'Will retry automatically');
+      expect(status.summary, 'Will retry automatically');
+    });
+
+    test('uses activity content as notification summary without title prefix',
+        () {
+      final status = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot(
+          pending: 1,
+          processing: 1,
+          retrying: 0,
+        ),
+        latestMessage: AgentActivityMessageModel(
+          id: 4,
+          type: AgentActivityType.tool_call_response,
+          title: 'Tool called',
+          content: 'Updated the timeline card',
+          agentName: 'Timeline Agent',
+          agentId: 'timeline',
+          scene: 'timeline',
+          sceneId: 'card-123',
+          timestamp: DateTime(2026, 1, 1),
+        ),
+        now: DateTime(2026, 1, 1),
+      );
+
+      final platformMap = status.toPlatformMap(isInBackground: true);
+
+      expect(status.title, 'Memex Agent');
+      expect(status.stage, 'Tool called');
+      expect(status.detail, 'Updated the timeline card');
+      expect(status.summary, 'Updated the timeline card');
+      expect(status.summary, isNot(contains('Tool called')));
+      expect(platformMap, containsPair('summary', 'Updated the timeline card'));
+      expect(platformMap, containsPair('scene', 'timeline'));
+      expect(platformMap, containsPair('sceneId', 'card-123'));
+    });
+
+    test('falls back to activity title when content is blank', () {
+      final status = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot(
+          pending: 1,
+          processing: 0,
+          retrying: 0,
+        ),
+        latestMessage: AgentActivityMessageModel(
+          id: 5,
+          type: AgentActivityType.info,
+          title: 'Reading workspace',
+          content: ' \n\t ',
+          agentName: 'PKM Agent',
+          agentId: 'pkm',
+          timestamp: DateTime(2026, 1, 1),
+        ),
+        now: DateTime(2026, 1, 1),
+      );
+
+      expect(status.stage, 'Reading workspace');
+      expect(status.detail, 'Processing 1 queued task');
+      expect(status.summary, 'Reading workspace');
+    });
+
+    test('marks terminal error as failed when the queue is empty', () {
+      final status = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot.empty(),
+        latestMessage: AgentActivityMessageModel(
+          id: 6,
+          type: AgentActivityType.error,
+          title: 'Provider error',
+          content: 'API key is missing',
+          agentName: 'Insight Agent',
+          agentId: 'insight',
+          timestamp: DateTime(2026, 1, 1),
+        ),
+        now: DateTime(2026, 1, 1),
+      );
+
+      expect(status.state, AgentBackgroundRunState.failed);
+      expect(status.shouldShowSystemSurface, isTrue);
+      expect(status.title, 'Memex Agent needs attention');
+      expect(status.stage, 'Provider error');
+      expect(status.detail, 'API key is missing');
+      expect(status.summary, 'API key is missing');
     });
 
     test('marks terminal stop as completed only after queue is empty', () {
@@ -94,6 +183,7 @@ void main() {
       expect(completed.state, AgentBackgroundRunState.completed);
       expect(completed.shouldShowSystemSurface, isFalse);
       expect(completed.detail, 'All background tasks finished.');
+      expect(completed.summary, 'Done');
     });
 
     test('trims multi-line content before sending to platform', () {
@@ -118,6 +208,26 @@ void main() {
       expect(status.detail, hasLength(140));
       expect(status.detail, endsWith('...'));
       expect(status.detail.contains('\n'), isFalse);
+      expect(status.summary, hasLength(140));
+      expect(status.summary, status.detail);
+      expect(status.summary.contains('\n'), isFalse);
+    });
+
+    test('uses localized labels for platform-facing background copy', () {
+      final status = AgentBackgroundStatus.fromActivity(
+        taskSnapshot: const TaskActivitySnapshot(
+          pending: 2,
+          processing: 0,
+          retrying: 0,
+        ),
+        labels: AgentBackgroundStatusLabels.fromL10n(AppLocalizationsZh()),
+        now: DateTime(2026, 1, 1),
+      );
+
+      expect(status.title, 'Memex Agent');
+      expect(status.stage, '处理中');
+      expect(status.detail, '正在处理 2 个后台任务');
+      expect(status.summary, '正在处理 2 个后台任务');
     });
   });
 }

--- a/test/data/services/agent_queue_background_worker_test.dart
+++ b/test/data/services/agent_queue_background_worker_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -219,6 +221,197 @@ void main() {
       expect(scheduler.scheduleCalls, 0);
       expect(platform.stopCalls, 1);
     });
+
+    test(
+      'refreshes Android surface from live activity while task is processing',
+      () async {
+        final releaseHandler = Completer<void>();
+        executor.registerHandler('activity_task', (
+          userId,
+          payload,
+          context,
+        ) async {
+          await AgentActivityService.instance.pushMessage(
+            type: AgentActivityType.info,
+            title: 'Background activity',
+            content: 'worker drain',
+            agentName: 'Worker Agent',
+            agentId: 'worker-agent',
+            userId: userId,
+          );
+          await releaseHandler.future;
+        });
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        await db.into(db.tasks).insert(
+              TasksCompanion.insert(
+                id: 'live-activity-task',
+                type: 'activity_task',
+                payload: const Value('{}'),
+                status: 'pending',
+                createdAt: Value(now),
+              ),
+            );
+        final platform = _FakeBackgroundPlatform();
+
+        final runFuture = AgentQueueBackgroundWorker.run(
+          initializeTaskQueue: (_) async {
+            AgentActivityService.setInstance(
+              LocalAgentActivityService.instance,
+            );
+          },
+          executor: executor,
+          scheduler: scheduler,
+          backgroundPlatform: platform,
+          databaseRetryDelay: Duration.zero,
+        );
+
+        await _waitUntil(() => platform.updates.isNotEmpty);
+        expect(platform.updates.single.state, AgentBackgroundRunState.active);
+        expect(platform.updates.single.summary, 'worker drain');
+        expect(platform.updateBackgroundFlags.single, isTrue);
+        expect(platform.stopCalls, 0);
+
+        releaseHandler.complete();
+        final completed = await runFuture;
+
+        expect(completed, isTrue);
+        expect(platform.stopCalls, 1);
+      },
+    );
+
+    test(
+      'publishes each live activity update while task remains active',
+      () async {
+        final releaseHandler = Completer<void>();
+        executor.registerHandler('multi_activity_task', (
+          userId,
+          payload,
+          context,
+        ) async {
+          await AgentActivityService.instance.pushMessage(
+            type: AgentActivityType.info,
+            title: 'First step',
+            content: 'reading context',
+            agentName: 'Worker Agent',
+            agentId: 'worker-agent',
+            userId: userId,
+          );
+          await AgentActivityService.instance.pushMessage(
+            type: AgentActivityType.info,
+            title: 'Second step',
+            content: 'writing results',
+            agentName: 'Worker Agent',
+            agentId: 'worker-agent',
+            userId: userId,
+          );
+          await releaseHandler.future;
+        });
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        await db.into(db.tasks).insert(
+              TasksCompanion.insert(
+                id: 'multi-live-activity-task',
+                type: 'multi_activity_task',
+                payload: const Value('{}'),
+                status: 'pending',
+                createdAt: Value(now),
+              ),
+            );
+        final platform = _FakeBackgroundPlatform();
+
+        final runFuture = AgentQueueBackgroundWorker.run(
+          initializeTaskQueue: (_) async {
+            AgentActivityService.setInstance(
+              LocalAgentActivityService.instance,
+            );
+          },
+          executor: executor,
+          scheduler: scheduler,
+          backgroundPlatform: platform,
+          databaseRetryDelay: Duration.zero,
+        );
+
+        await _waitUntil(() => platform.updates.length >= 2);
+        expect(
+          platform.updates.map((status) => status.summary),
+          containsAllInOrder(['reading context', 'writing results']),
+        );
+        expect(
+          platform.updates.map((status) => status.stage),
+          containsAllInOrder(['First step', 'Second step']),
+        );
+        expect(platform.updateBackgroundFlags, everyElement(isTrue));
+        expect(platform.stopCalls, 0);
+
+        releaseHandler.complete();
+        final completed = await runFuture;
+
+        expect(completed, isTrue);
+        expect(platform.stopCalls, 1);
+      },
+    );
+
+    test(
+      'uses latest live activity in final status when retrying work remains',
+      () async {
+        executor.registerHandler('activity_task', (
+          userId,
+          payload,
+          context,
+        ) async {
+          await AgentActivityService.instance.pushMessage(
+            type: AgentActivityType.info,
+            title: 'Background activity',
+            content: 'last visible step',
+            agentName: 'Worker Agent',
+            agentId: 'worker-agent',
+            userId: userId,
+          );
+        });
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        await db.into(db.tasks).insert(
+              TasksCompanion.insert(
+                id: 'activity-before-retry',
+                type: 'activity_task',
+                payload: const Value('{}'),
+                status: 'pending',
+                createdAt: Value(now),
+              ),
+            );
+        await db.into(db.tasks).insert(
+              TasksCompanion.insert(
+                id: 'future-retry-after-activity',
+                type: 'unknown_task',
+                payload: const Value('{}'),
+                status: 'retrying',
+                createdAt: Value(now),
+                scheduledAt: Value(now + 600),
+              ),
+            );
+        final platform = _FakeBackgroundPlatform();
+
+        final completed = await AgentQueueBackgroundWorker.run(
+          initializeTaskQueue: (_) async {
+            AgentActivityService.setInstance(
+              LocalAgentActivityService.instance,
+            );
+          },
+          executor: executor,
+          scheduler: scheduler,
+          backgroundPlatform: platform,
+          databaseRetryDelay: Duration.zero,
+        );
+
+        expect(completed, isTrue);
+        expect(scheduler.scheduleCalls, 1);
+        expect(platform.stopCalls, 0);
+        expect(platform.updates, isNotEmpty);
+        expect(platform.updates.last.retrying, 1);
+        expect(platform.updates.last.remainingTasks, 1);
+        expect(platform.updates.last.summary, 'last visible step');
+        expect(platform.updates.last.stage, 'Background activity');
+        expect(platform.updateBackgroundFlags.last, isTrue);
+      },
+    );
   });
 }
 
@@ -279,5 +472,18 @@ class _FakeDrainScheduler implements AgentQueueDrainScheduler {
   }) async {
     initialDelays.add(initialDelay);
     expeditedValues.add(expedited);
+  }
+}
+
+Future<void> _waitUntil(
+  bool Function() predicate, {
+  Duration timeout = const Duration(seconds: 3),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!predicate()) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw TimeoutException('Condition was not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
   }
 }

--- a/test/ui/agent_activity/agent_activity_widget_test.dart
+++ b/test/ui/agent_activity/agent_activity_widget_test.dart
@@ -40,8 +40,7 @@ void main() {
           child: AgentActivityWidget(
             forceVisible: forceVisible,
             initialTaskSnapshot: initialTaskSnapshot,
-            taskActivitySnapshotStream:
-                taskActivitySnapshotStream ??
+            taskActivitySnapshotStream: taskActivitySnapshotStream ??
                 const Stream<TaskActivitySnapshot>.empty(),
           ),
         ),
@@ -160,6 +159,59 @@ void main() {
     await tester.pump();
     platform.dispose();
   });
+
+  testWidgets(
+    'notification action opens detail and renders live background activity',
+    (tester) async {
+      final platform = _FakePlatform();
+      final coordinator = AgentBackgroundCoordinator(
+        platform: platform,
+        scheduler: _NoopScheduler(),
+      );
+      setAgentBackgroundCoordinatorForTesting(coordinator);
+
+      await tester.pumpWidget(
+        buildHost(
+          initialTaskSnapshot: const TaskActivitySnapshot(
+            pending: 1,
+            processing: 1,
+            retrying: 0,
+          ),
+        ),
+      );
+      emitAgentBackgroundOpenActivityForTesting();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('Activity Detail'), findsOneWidget);
+      expect(
+        find.text('2 background tasks are still processing.'),
+        findsWidgets,
+      );
+
+      await AgentActivityService.instance.pushMessage(
+        type: AgentActivityType.info,
+        title: 'Background notification step',
+        content: 'Live notification body',
+        agentName: 'Worker Agent',
+        agentId: 'worker-agent',
+        userId: 'agent-activity-test',
+      );
+      await tester.pump();
+
+      expect(find.text('Live notification body'), findsOneWidget);
+      expect(find.textContaining('Worker Agent'), findsOneWidget);
+      expect(
+        find.text('2 background tasks are still processing.'),
+        findsWidgets,
+      );
+
+      Navigator.of(tester.element(find.text('Activity Detail'))).pop();
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      platform.dispose();
+    },
+  );
 }
 
 class _FakePlatform implements AgentBackgroundPlatform {


### PR DESCRIPTION
## What changed

- 让 Android background worker 在 WorkManager drain 期间订阅 Agent activity stream，并在任务仍 active 时把最新 activity 直接刷新到系统通知。
- 为 `AgentBackgroundStatus` 增加 `summary` 字段：通知标题保持稳定，最新 activity 内容进入小字；内容为空时再回退到 activity title 或队列状态。
- Android native 通知读取 `summary` 作为 collapsed `contentText`，expanded big text 仍保留 stage/detail 组合。
- 将后台通知固定文案接入 Flutter l10n，补齐 `app_en.arb` / `app_zh.arb` 及生成文件。
- 补充更详尽的 UT 和 widget test，覆盖 summary payload、连续 live activity、retrying 任务保留最后 activity、通知 action 打开 Activity Detail。

## Why

Android Agent 任务进入后台后，系统通知之前只展示队列级状态，不能及时反映 Agent 正在做什么。现在 activity 产生时会刷新通知小字，让用户在 App 后台也能看到最新运行进展。

Closes #264

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Enhancement
- [ ] Documentation
- [x] Localization
- [ ] Refactor
- [x] Tests

## Risk areas

- [ ] Database schema or migration
- [ ] Local file storage, backup, or restore
- [ ] App lock, security, or privacy boundary
- [x] Agent orchestration, skills, or background tasks
- [ ] LLM provider configuration or authentication
- [ ] iOS platform behavior
- [x] Android platform behavior
- [x] User-facing strings / localization
- [ ] None of the above

## Screenshots or recordings

不适用：本 PR 修改的是 Android 系统通知和现有 Agent Activity 入口链路，没有新增 Flutter 页面或视觉布局。

## Test plan

- [x] Added/updated unit tests for changed non-UI behavior, or explained why not: 新增/扩展 status、platform channel、coordinator、background worker 测试。
- [x] Added/updated widget tests for UI/user interaction changes, or explained why not: 扩展 Agent Activity widget 测试，覆盖通知 action 打开详情并显示 live activity。
- [x] Exact test files: `test/data/services/agent_background_status_test.dart`, `test/data/services/agent_background_platform_test.dart`, `test/data/services/agent_background_coordinator_test.dart`, `test/data/services/agent_queue_background_worker_test.dart`, `test/ui/agent_activity/agent_activity_widget_test.dart`。
- [x] `flutter test`: 523 passed, 7 skipped; live eval skipped because `OPENAI_BASE_URL` / `OPENAI_API_KEY` are not set.
- [x] `flutter analyze`: full repo analyze still exits with existing 287 info-level lints; focused analyze on touched Dart files reports `No issues found!`.
- [ ] Manual iOS check: 不适用，未改 iOS 平台链路。
- [x] Manual Android check: `flutter build apk --debug --flavor globalDev` passed, generated `build/app/outputs/flutter-apk/app-globaldev-debug.apk`.
- [ ] Not run; reason: Manual emulator notification visual verification was not run in this pass.

Additional validation:

```bash
dart analyze lib/data/services/agent_background_status.dart lib/data/services/agent_background_platform.dart lib/data/services/agent_background_coordinator.dart lib/data/services/agent_queue_background_worker.dart test/data/services/agent_background_status_test.dart test/data/services/agent_background_platform_test.dart test/data/services/agent_background_coordinator_test.dart test/data/services/agent_queue_background_worker_test.dart test/ui/agent_activity/agent_activity_widget_test.dart
flutter test test/data/services/agent_background_status_test.dart test/data/services/agent_background_platform_test.dart test/data/services/agent_background_coordinator_test.dart test/data/services/agent_queue_background_worker_test.dart test/ui/agent_activity/agent_activity_widget_test.dart
flutter test
flutter analyze
flutter build apk --debug --flavor globalDev
git diff --check
python3 scripts/pr_policy_check.py --repo-path . --base upstream/main --head HEAD --output /tmp/memex-policy-check-branch.json --markdown-output /tmp/memex-policy-check-branch.md --no-fail-on-decision
```

Policy preflight result: `LOW RISK`, no deterministic findings.

## Contributor checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I kept this PR focused on one change.
- [x] I did not edit generated `*.g.dart` files manually.
- [x] I did not add telemetry, hidden network calls, secrets, or signing keys.
- [x] I updated docs or localization when needed.
