### PR TITLE
feat: collect 9 more HealthKit metrics beyond steps

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -86,7 +86,7 @@
 		<key>NSRemindersFullAccessUsageDescription</key>
 		<string>Need reminders access to read, add and edit your todos</string>
 		<key>NSHealthShareUsageDescription</key>
-		<string>Memex reads your daily step count to generate personalized activity insights and trend analysis.</string>
+		<string>Memex reads your activity and health metrics — including steps, heart rate, resting heart rate, blood oxygen, blood pressure, blood glucose, sleep, active energy, body weight, and workouts — to generate personalized activity insights and trend analysis. Your health data stays on your device.</string>
 		<key>NSHealthUpdateUsageDescription</key>
 		<string>Memex does not write health data. This key is required by a third-party library.</string>
 		<key>NSFamilyControlsUsageDescription</key>

--- a/lib/data/services/health_service.dart
+++ b/lib/data/services/health_service.dart
@@ -54,14 +54,37 @@ class HealthService {
         reportIntervalMinutes: 1,
       );
     } else {
-      // iOS: Use HealthKit for accurate step count data.
-      // Pedometer fallback removed — CMPedometer can crash on some devices/debug modes.
+      // iOS: HealthKit. Steps are checked frequently; the richer Apple Watch
+      // metrics below share the same fetch/aggregate/report pipeline (their
+      // aggregation already exists in HealthKitFetcher and main.dart). Data is
+      // aggregated per day, so a 30-min check cadence is ample for them.
       _configs[HealthDataType.STEPS] = HealthStrategyConfig(
         type: HealthDataType.STEPS,
         prefKeySuffix: 'steps',
         primaryFetcher: HealthKitFetcher(),
         reportIntervalMinutes: 1,
       );
+
+      const healthKitTypes = <HealthDataType, String>{
+        HealthDataType.HEART_RATE: 'heart_rate',
+        HealthDataType.RESTING_HEART_RATE: 'resting_heart_rate',
+        HealthDataType.BLOOD_OXYGEN: 'blood_oxygen',
+        HealthDataType.BLOOD_PRESSURE_SYSTOLIC: 'bp_systolic',
+        HealthDataType.BLOOD_PRESSURE_DIASTOLIC: 'bp_diastolic',
+        HealthDataType.BLOOD_GLUCOSE: 'blood_glucose',
+        HealthDataType.SLEEP_ASLEEP: 'sleep',
+        HealthDataType.ACTIVE_ENERGY_BURNED: 'active_energy',
+        HealthDataType.WEIGHT: 'weight',
+        HealthDataType.WORKOUT: 'workout',
+      };
+      healthKitTypes.forEach((type, suffix) {
+        _configs[type] = HealthStrategyConfig(
+          type: type,
+          prefKeySuffix: suffix,
+          primaryFetcher: HealthKitFetcher(),
+          reportIntervalMinutes: 30,
+        );
+      });
     }
 
     // Initialize Background Task for Pedometer (Ensure it's registered on app start)

--- a/lib/ui/settings/widgets/system_authorization_page.dart
+++ b/lib/ui/settings/widgets/system_authorization_page.dart
@@ -98,16 +98,20 @@ class _SystemAuthorizationPageState extends State<SystemAuthorizationPage> {
       final permission =
           Platform.isIOS ? Permission.sensors : Permission.activityRecognition;
       final status = await permission.request();
+
+      // 2. Request HealthKit / Health Connect data-type authorization.
+      // This is INDEPENDENT of the Motion & Fitness permission: a user who
+      // already granted Motion (so step 1 no longer re-prompts) must still be
+      // able to authorize Health data types. Previously this was gated behind
+      // `status.isGranted` AND only reachable from the not-yet-granted tap
+      // path, so HealthKit authorization could never be triggered once Motion
+      // was granted — leaving every type at "Authorization not determined".
+      // iOS only surfaces the authorization sheet for not-yet-determined types.
+      await HealthService().requestAllPermissions();
+
       if (status.isPermanentlyDenied) {
         _showSettingsDialog();
-        return;
       }
-
-      // 2. Also request HealthKit/Health Connect data type authorization
-      if (status.isGranted) {
-        await HealthService().requestAllPermissions();
-      }
-
       _checkAllPermissions();
     } catch (e) {
       if (mounted) {
@@ -151,6 +155,7 @@ class _SystemAuthorizationPageState extends State<SystemAuthorizationPage> {
     required PermissionStatus? status,
     required VoidCallback onTap,
     bool showBadge = false,
+    bool reauthorizeWhenGranted = false,
   }) {
     Color statusColor;
     String statusText;
@@ -198,9 +203,15 @@ class _SystemAuthorizationPageState extends State<SystemAuthorizationPage> {
         ],
       ),
       onTap: () {
-        if (status != null && !status.isGranted && !status.isLimited) {
+        final granted =
+            status != null && (status.isGranted || status.isLimited);
+        if (status != null && !granted) {
           onTap();
-        } else if (status != null && (status.isGranted || status.isLimited)) {
+        } else if (granted && reauthorizeWhenGranted) {
+          // The Fitness item also drives HealthKit data-type authorization,
+          // which may still be undetermined even when Motion is granted.
+          onTap();
+        } else if (granted) {
           // show toast or open settings
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(content: Text(UserStorage.l10n.authorizedGoToSettings)),
@@ -293,6 +304,9 @@ class _SystemAuthorizationPageState extends State<SystemAuthorizationPage> {
                   showBadge: _fitnessStatus != null &&
                       !_fitnessStatus!.isGranted &&
                       !_fitnessStatus!.isLimited,
+                  // Tappable even when Motion is already granted, so HealthKit
+                  // data-type authorization can still be (re)triggered.
+                  reauthorizeWhenGranted: true,
                   onTap: () => _requestFitnessPermission(),
                 ),
                 const Divider(height: 1, indent: 56),

--- a/test/data/services/health_service_test.dart
+++ b/test/data/services/health_service_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health/health.dart';
+import 'package:memex/data/services/health_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('iOS registers rich HealthKit metrics, not just steps', () {
+    // The registry is platform-branched; this assertion is meaningful on the
+    // non-Android (iOS) branch that the test host resolves to.
+    if (Platform.isAndroid) return;
+
+    final types = HealthService().registeredTypes;
+    expect(
+      types,
+      containsAll(<HealthDataType>[
+        HealthDataType.STEPS,
+        HealthDataType.HEART_RATE,
+        HealthDataType.RESTING_HEART_RATE,
+        HealthDataType.BLOOD_OXYGEN,
+        HealthDataType.BLOOD_PRESSURE_SYSTOLIC,
+        HealthDataType.BLOOD_PRESSURE_DIASTOLIC,
+        HealthDataType.BLOOD_GLUCOSE,
+        HealthDataType.SLEEP_ASLEEP,
+        HealthDataType.ACTIVE_ENERGY_BURNED,
+        HealthDataType.WEIGHT,
+        HealthDataType.WORKOUT,
+      ]),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Two changes that together make Apple Health / Apple Watch data actually flow into Memex on iOS.

### 1. Enable 9 more HealthKit metrics (was steps-only)

The HealthKit fetch/aggregate/report pipeline already handled heart rate, resting heart rate, blood oxygen, blood pressure, blood glucose, sleep (with stages), active energy, weight, and workouts — but `_registerStrategies()` only registered `STEPS`, so all of it was dead code (never permission-prompted, never fetched). Register those 9 categories on iOS (30-min cadence, per-day aggregation) and widen `NSHealthShareUsageDescription` to match what is now read (required for App Store review). Android stays steps-only (Health Connect removed).

### 2. Fix HealthKit authorization being unreachable

HealthKit data-type authorization was gated behind requesting Motion & Fitness **and** that request granting in the same tap. Once Motion was already granted (true for anyone who ever enabled steps), tapping the Fitness row hit the "already granted → open settings" branch instead of the handler, so `requestAuthorization` never ran — every type stayed `Authorization not determined` and no health data could be read. Fix: decouple HealthKit authorization from Motion (always attempt `requestAllPermissions`), and make the Fitness row tappable when already granted so it can (re)trigger the HealthKit sheet.

## Verified on device

Real iPhone + Apple Watch: after authorizing, collection succeeded — steps, heart rate, resting HR, sleep (with stages), active energy, and workouts (biking / swimming) now write into the daily Facts `health:` field. Confirmed via device logs: `Authorization not determined` → `hasData=true`, `Reported health for 5 days`.

## Tests

- `test/data/services/health_service_test.dart`: registry now includes the 9 categories
- `flutter analyze` clean, `plutil -lint` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
