### PR TITLE
[codex] 增加自动备份保留策略

### DIFF
--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -25,8 +25,6 @@ const _backupExtension = '.memex';
 const _autoBackupPrefix = 'memex_auto';
 const _safetyBackupPrefix = 'memex_safety';
 const _autoBackupInterval = Duration(hours: 24);
-const _autoBackupMaxSnapshots = 30;
-const _autoBackupMaxBytes = 2 * 1024 * 1024 * 1024; // 2 GB
 const _backupStoreWithoutCompressionThreshold = 16 * 1024 * 1024; // 16 MB
 const _backupManifestFileName = 'manifest.json';
 const _backupFormat = 'memex.backup';
@@ -104,6 +102,7 @@ class BackupSnapshot {
   });
 
   bool get isAndroidDocument => documentUri != null;
+  bool get isAutoSnapshot => name.startsWith(_autoBackupPrefix);
   bool get isSafetySnapshot => name.startsWith(_safetyBackupPrefix);
 }
 
@@ -222,8 +221,6 @@ class BackupService {
   static final Lock _autoBackupLock = Lock();
   static const backupMimeType = 'application/x-memex-backup';
   static const currentBackupSchemaVersion = _currentBackupSchemaVersion;
-  static const autoBackupMaxSnapshots = _autoBackupMaxSnapshots;
-  static const autoBackupMaxBytes = _autoBackupMaxBytes;
 
   static const MethodChannel _backupStorageChannel = MethodChannel(
     'com.memexlab.memex/backup_storage',
@@ -582,6 +579,7 @@ class BackupService {
 
     final cleanupNow = now ?? DateTime.now();
     final retentionDays = await UserStorage.getAutoBackupRetentionDays(userId);
+    final maxBytes = await UserStorage.getAutoBackupMaxBytes(userId);
     var deleted = 0;
 
     try {
@@ -590,6 +588,7 @@ class BackupService {
         defaultDir,
         now: cleanupNow,
         retentionDays: retentionDays,
+        maxBytes: maxBytes,
       );
     } catch (e, st) {
       _logger.warning('Failed to prune default backups: $e', e, st);
@@ -603,6 +602,7 @@ class BackupService {
             treeUri,
             now: cleanupNow,
             retentionDays: retentionDays,
+            maxBytes: maxBytes,
           );
         } catch (e, st) {
           _logger.warning('Failed to prune Android backups: $e', e, st);
@@ -1033,6 +1033,7 @@ class BackupService {
     Directory dir, {
     required DateTime now,
     required int? retentionDays,
+    required int maxBytes,
   }) async {
     final snapshots = (await _listFileBackups(dir))
         .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
@@ -1047,6 +1048,7 @@ class BackupService {
         snapshot: snapshot,
         now: now,
         retentionDays: retentionDays,
+        maxBytes: maxBytes,
         keptCount: kept,
         keptBytes: keptBytes,
       );
@@ -1075,6 +1077,7 @@ class BackupService {
     String treeUri, {
     required DateTime now,
     required int? retentionDays,
+    required int maxBytes,
   }) async {
     final snapshots = (await _listAndroidTreeBackups(treeUri))
         .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
@@ -1089,6 +1092,7 @@ class BackupService {
         snapshot: snapshot,
         now: now,
         retentionDays: retentionDays,
+        maxBytes: maxBytes,
         keptCount: kept,
         keptBytes: keptBytes,
       );
@@ -1114,6 +1118,7 @@ class BackupService {
     required BackupSnapshot snapshot,
     required DateTime now,
     required int? retentionDays,
+    required int maxBytes,
     required int keptCount,
     required int keptBytes,
   }) {
@@ -1125,8 +1130,7 @@ class BackupService {
     final expiredByAge = cutoff != null && snapshot.createdAt.isBefore(cutoff);
     if (expiredByAge) return false;
 
-    if (keptCount >= _autoBackupMaxSnapshots) return false;
-    return keptBytes + snapshot.sizeBytes <= _autoBackupMaxBytes;
+    return keptBytes + snapshot.sizeBytes <= maxBytes;
   }
 
   static Future<void> _deleteAndroidDocument(String documentUri) async {

--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -25,7 +25,7 @@ const _backupExtension = '.memex';
 const _autoBackupPrefix = 'memex_auto';
 const _safetyBackupPrefix = 'memex_safety';
 const _autoBackupInterval = Duration(hours: 24);
-const _autoBackupKeepRecent = 7;
+const _autoBackupMaxSnapshots = 30;
 const _autoBackupMaxBytes = 2 * 1024 * 1024 * 1024; // 2 GB
 const _backupStoreWithoutCompressionThreshold = 16 * 1024 * 1024; // 16 MB
 const _backupManifestFileName = 'manifest.json';
@@ -141,14 +141,12 @@ class BackupManifest {
         ? appVersion.split('+')
         : const <String>[];
     return BackupManifest(
-      format:
-          json['format'] as String? ??
+      format: json['format'] as String? ??
           (formatVersion == null ? '' : _backupFormat),
       formatVersion: formatVersion ?? 1,
       backupSchemaVersion:
           (json['backupSchemaVersion'] as num?)?.toInt() ?? formatVersion ?? 0,
-      createdAt:
-          DateTime.tryParse(json['createdAt'] as String? ?? '') ??
+      createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ??
           DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
       userId: json['userId'] as String?,
       appVersion: splitVersion.isEmpty ? appVersion : splitVersion.first,
@@ -158,25 +156,25 @@ class BackupManifest {
       platform: json['platform'] as String? ?? '',
       entries: rawEntries is List
           ? rawEntries
-                .whereType<Map>()
-                .map((entry) => entry.cast<String, dynamic>())
-                .toList()
+              .whereType<Map>()
+              .map((entry) => entry.cast<String, dynamic>())
+              .toList()
           : const [],
     );
   }
 
   Map<String, dynamic> toJson() => {
-    'format': format,
-    'formatVersion': formatVersion,
-    'backupSchemaVersion': backupSchemaVersion,
-    'createdAt': createdAt.toUtc().toIso8601String(),
-    if (userId != null) 'userId': userId,
-    'appVersion': appVersion,
-    'buildNumber': buildNumber,
-    'flavor': flavor,
-    'platform': platform,
-    'entries': entries,
-  };
+        'format': format,
+        'formatVersion': formatVersion,
+        'backupSchemaVersion': backupSchemaVersion,
+        'createdAt': createdAt.toUtc().toIso8601String(),
+        if (userId != null) 'userId': userId,
+        'appVersion': appVersion,
+        'buildNumber': buildNumber,
+        'flavor': flavor,
+        'platform': platform,
+        'entries': entries,
+      };
 }
 
 class BackupFileInfo {
@@ -224,6 +222,8 @@ class BackupService {
   static final Lock _autoBackupLock = Lock();
   static const backupMimeType = 'application/x-memex-backup';
   static const currentBackupSchemaVersion = _currentBackupSchemaVersion;
+  static const autoBackupMaxSnapshots = _autoBackupMaxSnapshots;
+  static const autoBackupMaxBytes = _autoBackupMaxBytes;
 
   static const MethodChannel _backupStorageChannel = MethodChannel(
     'com.memexlab.memex/backup_storage',
@@ -257,8 +257,7 @@ class BackupService {
     final workspacePath = fs.getWorkspacePath(userId);
     final appDir = await getApplicationDocumentsDirectory();
     final createdAt = DateTime.now();
-    final fileName =
-        '${filePrefix}_${_timestampForFile(createdAt)}'
+    final fileName = '${filePrefix}_${_timestampForFile(createdAt)}'
         '$_backupExtension';
 
     final targetDir = outputDirectory == null
@@ -470,12 +469,13 @@ class BackupService {
         userId,
       );
 
-      if (!force &&
-          lastBackupAt != null &&
-          now.difference(lastBackupAt) < _autoBackupInterval) {
-        return null;
-      }
-      if (!force && lastFingerprint == fingerprint) {
+      final shouldSkip = !force &&
+          ((lastBackupAt != null &&
+                  now.difference(lastBackupAt) < _autoBackupInterval) ||
+              lastFingerprint == fingerprint);
+
+      if (shouldSkip) {
+        await pruneAutoBackups(now: now);
         return null;
       }
 
@@ -498,9 +498,8 @@ class BackupService {
     required String reason,
     void Function(String status)? onProgress,
   }) {
-    final sanitizedReason = reason
-        .replaceAll(RegExp(r'[^a-zA-Z0-9_-]+'), '_')
-        .toLowerCase();
+    final sanitizedReason =
+        reason.replaceAll(RegExp(r'[^a-zA-Z0-9_-]+'), '_').toLowerCase();
     return createStoredBackup(
       filePrefix: '${_safetyBackupPrefix}_$sanitizedReason',
       onProgress: onProgress,
@@ -535,7 +534,7 @@ class BackupService {
           );
           final snapshot = _snapshotFromAndroidInfo(info);
           if (pruneAutoBackups) {
-            await _pruneAndroidTreeBackups(treeUri);
+            await BackupService.pruneAutoBackups(emitEvent: false);
           }
           _emitBackupSnapshotsChanged('created', snapshotId: snapshot.id);
           return snapshot;
@@ -564,10 +563,57 @@ class BackupService {
       filePath: backupPath,
     );
     if (pruneAutoBackups) {
-      await _pruneFileBackups(backupDir);
+      await BackupService.pruneAutoBackups(emitEvent: false);
     }
     _emitBackupSnapshotsChanged('created', snapshotId: snapshot.id);
     return snapshot;
+  }
+
+  /// Apply the automatic backup retention policy without creating a new backup.
+  ///
+  /// Only snapshots created by the automatic system are removed. Safety
+  /// snapshots and manually exported files are intentionally left alone.
+  static Future<int> pruneAutoBackups({
+    DateTime? now,
+    bool emitEvent = true,
+  }) async {
+    final userId = await UserStorage.getUserId();
+    if (userId == null || userId.isEmpty) return 0;
+
+    final cleanupNow = now ?? DateTime.now();
+    final retentionDays = await UserStorage.getAutoBackupRetentionDays(userId);
+    var deleted = 0;
+
+    try {
+      final defaultDir = await resolveDefaultBackupDirectory();
+      deleted += await _pruneFileBackups(
+        defaultDir,
+        now: cleanupNow,
+        retentionDays: retentionDays,
+      );
+    } catch (e, st) {
+      _logger.warning('Failed to prune default backups: $e', e, st);
+    }
+
+    if (Platform.isAndroid) {
+      final treeUri = await UserStorage.getAndroidBackupTreeUri(userId);
+      if (treeUri != null && treeUri.isNotEmpty) {
+        try {
+          deleted += await _pruneAndroidTreeBackups(
+            treeUri,
+            now: cleanupNow,
+            retentionDays: retentionDays,
+          );
+        } catch (e, st) {
+          _logger.warning('Failed to prune Android backups: $e', e, st);
+        }
+      }
+    }
+
+    if (deleted > 0 && emitEvent) {
+      _emitBackupSnapshotsChanged('pruned');
+    }
+    return deleted;
   }
 
   /// Restore a stored snapshot. Android SAF snapshots are copied to a temp file
@@ -746,12 +792,10 @@ class BackupService {
     String rootPath;
 
     if (Platform.isIOS) {
-      rootPath =
-          await UserStorage.resolveICloudDocumentsPath() ??
+      rootPath = await UserStorage.resolveICloudDocumentsPath() ??
           (await getApplicationDocumentsDirectory()).path;
     } else if (Platform.isAndroid) {
-      rootPath =
-          (await getExternalStorageDirectory())?.path ??
+      rootPath = (await getExternalStorageDirectory())?.path ??
           (await getApplicationDocumentsDirectory()).path;
     } else {
       rootPath = (await getApplicationDocumentsDirectory()).path;
@@ -855,8 +899,8 @@ class BackupService {
             fileCount += 1;
             latestModifiedMs =
                 latestModifiedMs > stat.modified.millisecondsSinceEpoch
-                ? latestModifiedMs
-                : stat.modified.millisecondsSinceEpoch;
+                    ? latestModifiedMs
+                    : stat.modified.millisecondsSinceEpoch;
           } catch (_) {}
         }
       }
@@ -876,8 +920,8 @@ class BackupService {
         fileCount += 1;
         latestModifiedMs =
             latestModifiedMs > stat.modified.millisecondsSinceEpoch
-            ? latestModifiedMs
-            : stat.modified.millisecondsSinceEpoch;
+                ? latestModifiedMs
+                : stat.modified.millisecondsSinceEpoch;
         break;
       }
     }
@@ -985,19 +1029,27 @@ class BackupService {
     return result;
   }
 
-  static Future<void> _pruneFileBackups(Directory dir) async {
-    final snapshots =
-        (await _listFileBackups(dir))
-            .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
-            .toList()
-          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+  static Future<int> _pruneFileBackups(
+    Directory dir, {
+    required DateTime now,
+    required int? retentionDays,
+  }) async {
+    final snapshots = (await _listFileBackups(dir))
+        .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
+        .toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
     var kept = 0;
     var keptBytes = 0;
+    var deleted = 0;
     for (final snapshot in snapshots) {
-      final shouldKeep =
-          kept < _autoBackupKeepRecent &&
-          keptBytes + snapshot.sizeBytes <= _autoBackupMaxBytes;
+      final shouldKeep = _shouldKeepAutoBackup(
+        snapshot: snapshot,
+        now: now,
+        retentionDays: retentionDays,
+        keptCount: kept,
+        keptBytes: keptBytes,
+      );
       if (shouldKeep) {
         kept += 1;
         keptBytes += snapshot.sizeBytes;
@@ -1010,26 +1062,36 @@ class BackupService {
         final file = File(filePath);
         if (await file.exists()) {
           await file.delete();
+          deleted += 1;
         }
       } catch (e) {
         _logger.warning('Failed to delete old backup $filePath: $e');
       }
     }
+    return deleted;
   }
 
-  static Future<void> _pruneAndroidTreeBackups(String treeUri) async {
-    final snapshots =
-        (await _listAndroidTreeBackups(treeUri))
-            .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
-            .toList()
-          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+  static Future<int> _pruneAndroidTreeBackups(
+    String treeUri, {
+    required DateTime now,
+    required int? retentionDays,
+  }) async {
+    final snapshots = (await _listAndroidTreeBackups(treeUri))
+        .where((snapshot) => snapshot.name.startsWith(_autoBackupPrefix))
+        .toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
     var kept = 0;
     var keptBytes = 0;
+    var deleted = 0;
     for (final snapshot in snapshots) {
-      final shouldKeep =
-          kept < _autoBackupKeepRecent &&
-          keptBytes + snapshot.sizeBytes <= _autoBackupMaxBytes;
+      final shouldKeep = _shouldKeepAutoBackup(
+        snapshot: snapshot,
+        now: now,
+        retentionDays: retentionDays,
+        keptCount: kept,
+        keptBytes: keptBytes,
+      );
       if (shouldKeep) {
         kept += 1;
         keptBytes += snapshot.sizeBytes;
@@ -1040,10 +1102,31 @@ class BackupService {
       if (documentUri == null) continue;
       try {
         await _deleteAndroidDocument(documentUri);
+        deleted += 1;
       } catch (e) {
         _logger.warning('Failed to delete old Android backup $documentUri: $e');
       }
     }
+    return deleted;
+  }
+
+  static bool _shouldKeepAutoBackup({
+    required BackupSnapshot snapshot,
+    required DateTime now,
+    required int? retentionDays,
+    required int keptCount,
+    required int keptBytes,
+  }) {
+    if (keptCount == 0) return true;
+
+    final cutoff = retentionDays == null
+        ? null
+        : now.subtract(Duration(days: retentionDays));
+    final expiredByAge = cutoff != null && snapshot.createdAt.isBefore(cutoff);
+    if (expiredByAge) return false;
+
+    if (keptCount >= _autoBackupMaxSnapshots) return false;
+    return keptBytes + snapshot.sizeBytes <= _autoBackupMaxBytes;
   }
 
   static Future<void> _deleteAndroidDocument(String documentUri) async {
@@ -1179,9 +1262,8 @@ Future<_StagedRestoreResult> _stageBackupRestoreArchive({
       archive,
       _backupManifestFileName,
     );
-    final manifest = manifestFile == null
-        ? null
-        : BackupService._readManifest(manifestFile);
+    final manifest =
+        manifestFile == null ? null : BackupService._readManifest(manifestFile);
     if (manifest != null) {
       _validateBackupManifestHeader(manifest);
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1047,6 +1047,21 @@
     }
   },
   "lastBackupAt": "Last backup: {time}",
+  "autoBackupRetention": "Retention",
+  "@autoBackupRetentionDays": {
+    "placeholders": {
+      "days": {}
+    }
+  },
+  "autoBackupRetentionDays": "{days} days",
+  "autoBackupRetentionForever": "Keep forever",
+  "@autoBackupRetentionLimitHint": {
+    "placeholders": {
+      "count": {},
+      "size": {}
+    }
+  },
+  "autoBackupRetentionLimitHint": "Automatic cleanup keeps at most {count} snapshots and {size} total. Safety snapshots are kept separately.",
   "createSnapshotNow": "Back up now",
   "backupLocationMenu": "Change location",
   "defaultBackupLocation": "Default backup folder",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1055,13 +1055,13 @@
   },
   "autoBackupRetentionDays": "{days} days",
   "autoBackupRetentionForever": "Keep forever",
+  "autoBackupMaxSize": "Storage cap",
   "@autoBackupRetentionLimitHint": {
     "placeholders": {
-      "count": {},
       "size": {}
     }
   },
-  "autoBackupRetentionLimitHint": "Automatic cleanup keeps at most {count} snapshots and {size} total. Safety snapshots are kept separately.",
+  "autoBackupRetentionLimitHint": "Automatic cleanup keeps automatic snapshots under {size}. Safety snapshots and manual exports are kept separately.",
   "createSnapshotNow": "Back up now",
   "backupLocationMenu": "Change location",
   "defaultBackupLocation": "Default backup folder",
@@ -1070,6 +1070,9 @@
   "chooseBackupLocationAndroidDesc": "Pick a folder with Android's system picker and grant Memex persistent access.",
   "storedBackups": "Stored Backups",
   "noStoredBackups": "Automatic backups will appear here after the first snapshot.",
+  "backupTypeAutoSnapshot": "Automatic snapshot",
+  "backupTypeSafetySnapshot": "Safety snapshot",
+  "backupTypeManualBackup": "Manual backup",
   "refresh": "Refresh",
   "restoreThisBackup": "Restore this backup",
   "deleteThisBackup": "Delete this backup",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4209,6 +4209,30 @@ abstract class AppLocalizations {
   /// **'Last backup: {time}'**
   String lastBackupAt(Object time);
 
+  /// No description provided for @autoBackupRetention.
+  ///
+  /// In en, this message translates to:
+  /// **'Retention'**
+  String get autoBackupRetention;
+
+  /// No description provided for @autoBackupRetentionDays.
+  ///
+  /// In en, this message translates to:
+  /// **'{days} days'**
+  String autoBackupRetentionDays(Object days);
+
+  /// No description provided for @autoBackupRetentionForever.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep forever'**
+  String get autoBackupRetentionForever;
+
+  /// No description provided for @autoBackupRetentionLimitHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Automatic cleanup keeps at most {count} snapshots and {size} total. Safety snapshots are kept separately.'**
+  String autoBackupRetentionLimitHint(Object count, Object size);
+
   /// No description provided for @createSnapshotNow.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4227,11 +4227,17 @@ abstract class AppLocalizations {
   /// **'Keep forever'**
   String get autoBackupRetentionForever;
 
+  /// No description provided for @autoBackupMaxSize.
+  ///
+  /// In en, this message translates to:
+  /// **'Storage cap'**
+  String get autoBackupMaxSize;
+
   /// No description provided for @autoBackupRetentionLimitHint.
   ///
   /// In en, this message translates to:
-  /// **'Automatic cleanup keeps at most {count} snapshots and {size} total. Safety snapshots are kept separately.'**
-  String autoBackupRetentionLimitHint(Object count, Object size);
+  /// **'Automatic cleanup keeps automatic snapshots under {size}. Safety snapshots and manual exports are kept separately.'**
+  String autoBackupRetentionLimitHint(Object size);
 
   /// No description provided for @createSnapshotNow.
   ///
@@ -4280,6 +4286,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Automatic backups will appear here after the first snapshot.'**
   String get noStoredBackups;
+
+  /// No description provided for @backupTypeAutoSnapshot.
+  ///
+  /// In en, this message translates to:
+  /// **'Automatic snapshot'**
+  String get backupTypeAutoSnapshot;
+
+  /// No description provided for @backupTypeSafetySnapshot.
+  ///
+  /// In en, this message translates to:
+  /// **'Safety snapshot'**
+  String get backupTypeSafetySnapshot;
+
+  /// No description provided for @backupTypeManualBackup.
+  ///
+  /// In en, this message translates to:
+  /// **'Manual backup'**
+  String get backupTypeManualBackup;
 
   /// No description provided for @refresh.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2324,8 +2324,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoBackupRetentionForever => 'Keep forever';
 
   @override
-  String autoBackupRetentionLimitHint(Object count, Object size) {
-    return 'Automatic cleanup keeps at most $count snapshots and $size total. Safety snapshots are kept separately.';
+  String get autoBackupMaxSize => 'Storage cap';
+
+  @override
+  String autoBackupRetentionLimitHint(Object size) {
+    return 'Automatic cleanup keeps automatic snapshots under $size. Safety snapshots and manual exports are kept separately.';
   }
 
   @override
@@ -2354,6 +2357,15 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get noStoredBackups =>
       'Automatic backups will appear here after the first snapshot.';
+
+  @override
+  String get backupTypeAutoSnapshot => 'Automatic snapshot';
+
+  @override
+  String get backupTypeSafetySnapshot => 'Safety snapshot';
+
+  @override
+  String get backupTypeManualBackup => 'Manual backup';
 
   @override
   String get refresh => 'Refresh';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2313,6 +2313,22 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get autoBackupRetention => 'Retention';
+
+  @override
+  String autoBackupRetentionDays(Object days) {
+    return '$days days';
+  }
+
+  @override
+  String get autoBackupRetentionForever => 'Keep forever';
+
+  @override
+  String autoBackupRetentionLimitHint(Object count, Object size) {
+    return 'Automatic cleanup keeps at most $count snapshots and $size total. Safety snapshots are kept separately.';
+  }
+
+  @override
   String get createSnapshotNow => 'Back up now';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2238,8 +2238,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get autoBackupRetentionForever => '永久保留';
 
   @override
-  String autoBackupRetentionLimitHint(Object count, Object size) {
-    return '自动清理最多保留 $count 份快照，总大小不超过 $size。安全快照会单独保留。';
+  String get autoBackupMaxSize => '空间上限';
+
+  @override
+  String autoBackupRetentionLimitHint(Object size) {
+    return '自动清理会让自动快照总大小不超过 $size。安全快照和手动导出备份会单独保留。';
   }
 
   @override
@@ -2266,6 +2269,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get noStoredBackups => '创建第一个自动快照后会显示在这里。';
+
+  @override
+  String get backupTypeAutoSnapshot => '自动快照';
+
+  @override
+  String get backupTypeSafetySnapshot => '安全快照';
+
+  @override
+  String get backupTypeManualBackup => '手动备份';
 
   @override
   String get refresh => '刷新';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2227,6 +2227,22 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get autoBackupRetention => '保留';
+
+  @override
+  String autoBackupRetentionDays(Object days) {
+    return '$days 天';
+  }
+
+  @override
+  String get autoBackupRetentionForever => '永久保留';
+
+  @override
+  String autoBackupRetentionLimitHint(Object count, Object size) {
+    return '自动清理最多保留 $count 份快照，总大小不超过 $size。安全快照会单独保留。';
+  }
+
+  @override
   String get createSnapshotNow => '立即备份';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1032,6 +1032,21 @@
     }
   },
   "lastBackupAt": "上次备份：{time}",
+  "autoBackupRetention": "保留",
+  "@autoBackupRetentionDays": {
+    "placeholders": {
+      "days": {}
+    }
+  },
+  "autoBackupRetentionDays": "{days} 天",
+  "autoBackupRetentionForever": "永久保留",
+  "@autoBackupRetentionLimitHint": {
+    "placeholders": {
+      "count": {},
+      "size": {}
+    }
+  },
+  "autoBackupRetentionLimitHint": "自动清理最多保留 {count} 份快照，总大小不超过 {size}。安全快照会单独保留。",
   "createSnapshotNow": "立即备份",
   "backupLocationMenu": "更改位置",
   "defaultBackupLocation": "默认备份文件夹",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1040,13 +1040,13 @@
   },
   "autoBackupRetentionDays": "{days} 天",
   "autoBackupRetentionForever": "永久保留",
+  "autoBackupMaxSize": "空间上限",
   "@autoBackupRetentionLimitHint": {
     "placeholders": {
-      "count": {},
       "size": {}
     }
   },
-  "autoBackupRetentionLimitHint": "自动清理最多保留 {count} 份快照，总大小不超过 {size}。安全快照会单独保留。",
+  "autoBackupRetentionLimitHint": "自动清理会让自动快照总大小不超过 {size}。安全快照和手动导出备份会单独保留。",
   "createSnapshotNow": "立即备份",
   "backupLocationMenu": "更改位置",
   "defaultBackupLocation": "默认备份文件夹",
@@ -1055,6 +1055,9 @@
   "chooseBackupLocationAndroidDesc": "使用 Android 系统选择器选择文件夹，并授予 Memex 持久访问权限。",
   "storedBackups": "已保存备份",
   "noStoredBackups": "创建第一个自动快照后会显示在这里。",
+  "backupTypeAutoSnapshot": "自动快照",
+  "backupTypeSafetySnapshot": "安全快照",
+  "backupTypeManualBackup": "手动备份",
   "refresh": "刷新",
   "restoreThisBackup": "恢复此备份",
   "deleteThisBackup": "删除此备份",

--- a/lib/ui/settings/widgets/backup_restore_page.dart
+++ b/lib/ui/settings/widgets/backup_restore_page.dart
@@ -69,6 +69,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
   BackupLocationInfo? _backupLocationInfo;
   DateTime? _lastAutoBackupAt;
   int? _autoBackupRetentionDays = UserStorage.defaultAutoBackupRetentionDays;
+  int _autoBackupMaxBytes = UserStorage.defaultAutoBackupMaxBytes;
   List<BackupSnapshot> _storedBackups = const [];
 
   @override
@@ -129,6 +130,9 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     final retentionDays = userId != null && userId.isNotEmpty
         ? await UserStorage.getAutoBackupRetentionDays(userId)
         : UserStorage.defaultAutoBackupRetentionDays;
+    final maxBytes = userId != null && userId.isNotEmpty
+        ? await UserStorage.getAutoBackupMaxBytes(userId)
+        : UserStorage.defaultAutoBackupMaxBytes;
 
     if (mounted) {
       setState(() {
@@ -140,6 +144,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         _autoBackupEnabled = autoEnabled;
         _lastAutoBackupAt = lastAutoBackupAt;
         _autoBackupRetentionDays = retentionDays;
+        _autoBackupMaxBytes = maxBytes;
       });
     }
   }
@@ -166,6 +171,16 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     return days == null
         ? UserStorage.l10n.autoBackupRetentionForever
         : UserStorage.l10n.autoBackupRetentionDays(days);
+  }
+
+  String _backupTypeText(BackupSnapshot snapshot) {
+    if (snapshot.isSafetySnapshot) {
+      return UserStorage.l10n.backupTypeSafetySnapshot;
+    }
+    if (snapshot.isAutoSnapshot) {
+      return UserStorage.l10n.backupTypeAutoSnapshot;
+    }
+    return UserStorage.l10n.backupTypeManualBackup;
   }
 
   Future<BackupLocationInfo> _resolveBackupLocationInfo() async {
@@ -293,6 +308,32 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
       await _loadPageData(includeEstimatedSize: false);
     } catch (e, stack) {
       _logger.warning('Failed to update auto backup retention: $e', e, stack);
+      if (mounted) {
+        ToastHelper.showError(
+          context,
+          UserStorage.l10n.backupFailed(e.toString()),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isUpdatingRetention = false);
+      }
+    }
+  }
+
+  Future<void> _setAutoBackupMaxBytesValue(int bytes) async {
+    if (_isUpdatingRetention) return;
+    final userId = await UserStorage.getUserId();
+    if (userId == null || userId.isEmpty) return;
+
+    setState(() => _isUpdatingRetention = true);
+
+    try {
+      await UserStorage.setAutoBackupMaxBytes(userId, bytes);
+      await (widget.pruneAutoBackups ?? BackupService.pruneAutoBackups)();
+      await _loadPageData(includeEstimatedSize: false);
+    } catch (e, stack) {
+      _logger.warning('Failed to update auto backup max size: $e', e, stack);
       if (mounted) {
         ToastHelper.showError(
           context,
@@ -829,10 +870,11 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
           if (_estimatedSize.isNotEmpty) const SizedBox(height: 8),
           _retentionRow(isBusy),
           const SizedBox(height: 8),
+          _maxSizeRow(isBusy),
+          const SizedBox(height: 8),
           Text(
             UserStorage.l10n.autoBackupRetentionLimitHint(
-              BackupService.autoBackupMaxSnapshots,
-              _formatBytes(BackupService.autoBackupMaxBytes),
+              _formatBytes(_autoBackupMaxBytes),
             ),
             style: const TextStyle(
               fontSize: 12,
@@ -944,6 +986,67 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     );
   }
 
+  Widget _maxSizeRow(bool isBusy) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 96,
+          child: Text(
+            UserStorage.l10n.autoBackupMaxSize,
+            style: const TextStyle(
+              fontSize: 12,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: PopupMenuButton<int>(
+              key: const ValueKey('auto-backup-max-size-menu'),
+              enabled: !isBusy,
+              tooltip: UserStorage.l10n.autoBackupMaxSize,
+              initialValue: _autoBackupMaxBytes,
+              onSelected: _setAutoBackupMaxBytesValue,
+              itemBuilder: (context) => [
+                for (final bytes in UserStorage.autoBackupMaxBytesOptions)
+                  PopupMenuItem<int>(
+                    value: bytes,
+                    child: Text(_formatBytes(bytes)),
+                  ),
+              ],
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: Text(
+                      _formatBytes(_autoBackupMaxBytes),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: AppColors.textPrimary,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  _isUpdatingRetention
+                      ? const SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.expand_more, size: 16),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _buildStoredBackupsCard(bool isBusy) {
     return _settingsCard(
       child: Column(
@@ -988,6 +1091,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
             ..._storedBackups.map(
               (snapshot) => _StoredBackupTile(
                 snapshot: snapshot,
+                typeText: _backupTypeText(snapshot),
                 dateText: _formatDateTime(snapshot.createdAt),
                 sizeText: _formatBytes(snapshot.sizeBytes),
                 isDeleting: _deletingBackupId == snapshot.id,
@@ -1196,6 +1300,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
 class _StoredBackupTile extends StatelessWidget {
   final BackupSnapshot snapshot;
+  final String typeText;
   final String dateText;
   final String sizeText;
   final bool isDeleting;
@@ -1204,6 +1309,7 @@ class _StoredBackupTile extends StatelessWidget {
 
   const _StoredBackupTile({
     required this.snapshot,
+    required this.typeText,
     required this.dateText,
     required this.sizeText,
     required this.isDeleting,
@@ -1239,7 +1345,7 @@ class _StoredBackupTile extends StatelessWidget {
             style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
           ),
           subtitle: Text(
-            '$dateText - $sizeText',
+            '$typeText - $dateText - $sizeText',
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: const TextStyle(fontSize: 12),

--- a/lib/ui/settings/widgets/backup_restore_page.dart
+++ b/lib/ui/settings/widgets/backup_restore_page.dart
@@ -15,12 +15,11 @@ import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/toast_helper.dart';
 import 'package:memex/utils/user_storage.dart';
 
-typedef AutoBackupCreator =
-    Future<BackupSnapshot?> Function({
-      String trigger,
-      bool force,
-      void Function(String status)? onProgress,
-    });
+typedef AutoBackupCreator = Future<BackupSnapshot?> Function({
+  String trigger,
+  bool force,
+  void Function(String status)? onProgress,
+});
 
 typedef StoredBackupDeleter = Future<void> Function(BackupSnapshot snapshot);
 
@@ -32,6 +31,7 @@ class BackupRestorePage extends StatefulWidget {
   final Future<List<BackupSnapshot>> Function()? listStoredBackups;
   final AutoBackupCreator? createAutoBackup;
   final StoredBackupDeleter? deleteStoredBackup;
+  final Future<void> Function()? pruneAutoBackups;
   final Future<void> Function()? useDefaultBackupDirectory;
   final Future<AndroidBackupDirectory?> Function()? pickAndroidBackupDirectory;
 
@@ -44,6 +44,7 @@ class BackupRestorePage extends StatefulWidget {
     this.listStoredBackups,
     this.createAutoBackup,
     this.deleteStoredBackup,
+    this.pruneAutoBackups,
     this.useDefaultBackupDirectory,
     this.pickAndroidBackupDirectory,
   });
@@ -60,12 +61,14 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
   bool _isRestoring = false;
   bool _isCreatingSnapshot = false;
   bool _isPickingLocation = false;
+  bool _isUpdatingRetention = false;
   String? _deletingBackupId;
   bool _autoBackupEnabled = false;
   String _statusText = '';
   String _estimatedSize = '';
   BackupLocationInfo? _backupLocationInfo;
   DateTime? _lastAutoBackupAt;
+  int? _autoBackupRetentionDays = UserStorage.defaultAutoBackupRetentionDays;
   List<BackupSnapshot> _storedBackups = const [];
 
   @override
@@ -100,6 +103,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
       _isRestoring ||
       _isCreatingSnapshot ||
       _isPickingLocation ||
+      _isUpdatingRetention ||
       _deletingBackupId != null;
 
   void _handleBackupDataChanged(EventBusMessage message) {
@@ -111,7 +115,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     final userId = await UserStorage.getUserId();
     final size = includeEstimatedSize
         ? await (widget.estimateBackupSize ??
-              BackupService.estimateBackupSize)()
+            BackupService.estimateBackupSize)()
         : null;
     final location = await _resolveBackupLocationInfo();
     final snapshots =
@@ -122,6 +126,9 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     final lastAutoBackupAt = userId != null && userId.isNotEmpty
         ? await UserStorage.getLastAutoBackupAt(userId)
         : null;
+    final retentionDays = userId != null && userId.isNotEmpty
+        ? await UserStorage.getAutoBackupRetentionDays(userId)
+        : UserStorage.defaultAutoBackupRetentionDays;
 
     if (mounted) {
       setState(() {
@@ -132,6 +139,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
         _storedBackups = snapshots;
         _autoBackupEnabled = autoEnabled;
         _lastAutoBackupAt = lastAutoBackupAt;
+        _autoBackupRetentionDays = retentionDays;
       });
     }
   }
@@ -149,6 +157,15 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     return DateFormat.yMd(
       UserStorage.l10n.localeName,
     ).add_Hm().format(dateTime);
+  }
+
+  int get _autoBackupRetentionMenuValue =>
+      _autoBackupRetentionDays ?? UserStorage.autoBackupRetentionForever;
+
+  String _formatAutoBackupRetention(int? days) {
+    return days == null
+        ? UserStorage.l10n.autoBackupRetentionForever
+        : UserStorage.l10n.autoBackupRetentionDays(days);
   }
 
   Future<BackupLocationInfo> _resolveBackupLocationInfo() async {
@@ -259,6 +276,33 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
     await UserStorage.setAutoBackupEnabled(userId, enabled);
     if (mounted) {
       setState(() => _autoBackupEnabled = enabled);
+    }
+  }
+
+  Future<void> _setAutoBackupRetentionValue(int value) async {
+    if (_isUpdatingRetention) return;
+    final userId = await UserStorage.getUserId();
+    if (userId == null || userId.isEmpty) return;
+
+    final days = value == UserStorage.autoBackupRetentionForever ? null : value;
+    setState(() => _isUpdatingRetention = true);
+
+    try {
+      await UserStorage.setAutoBackupRetentionDays(userId, days);
+      await (widget.pruneAutoBackups ?? BackupService.pruneAutoBackups)();
+      await _loadPageData(includeEstimatedSize: false);
+    } catch (e, stack) {
+      _logger.warning('Failed to update auto backup retention: $e', e, stack);
+      if (mounted) {
+        ToastHelper.showError(
+          context,
+          UserStorage.l10n.backupFailed(e.toString()),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isUpdatingRetention = false);
+      }
     }
   }
 
@@ -779,6 +823,23 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
           _backupLocationRow(),
           const SizedBox(height: 8),
           _infoRow(UserStorage.l10n.autoBackupStatus, lastBackupText),
+          const SizedBox(height: 8),
+          if (_estimatedSize.isNotEmpty)
+            _infoRow(UserStorage.l10n.estimatedSize, _estimatedSize),
+          if (_estimatedSize.isNotEmpty) const SizedBox(height: 8),
+          _retentionRow(isBusy),
+          const SizedBox(height: 8),
+          Text(
+            UserStorage.l10n.autoBackupRetentionLimitHint(
+              BackupService.autoBackupMaxSnapshots,
+              _formatBytes(BackupService.autoBackupMaxBytes),
+            ),
+            style: const TextStyle(
+              fontSize: 12,
+              color: AppColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
           const SizedBox(height: 16),
           Row(
             children: [
@@ -815,6 +876,71 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _retentionRow(bool isBusy) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 96,
+          child: Text(
+            UserStorage.l10n.autoBackupRetention,
+            style: const TextStyle(
+              fontSize: 12,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: PopupMenuButton<int>(
+              key: const ValueKey('auto-backup-retention-menu'),
+              enabled: !isBusy,
+              tooltip: UserStorage.l10n.autoBackupRetention,
+              initialValue: _autoBackupRetentionMenuValue,
+              onSelected: _setAutoBackupRetentionValue,
+              itemBuilder: (context) => [
+                for (final days in UserStorage.autoBackupRetentionDayOptions)
+                  PopupMenuItem<int>(
+                    value: days,
+                    child: Text(UserStorage.l10n.autoBackupRetentionDays(days)),
+                  ),
+                PopupMenuItem<int>(
+                  value: UserStorage.autoBackupRetentionForever,
+                  child: Text(UserStorage.l10n.autoBackupRetentionForever),
+                ),
+              ],
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: Text(
+                      _formatAutoBackupRetention(_autoBackupRetentionDays),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: AppColors.textPrimary,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  _isUpdatingRetention
+                      ? const SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.expand_more, size: 16),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/utils/user_storage.dart
+++ b/lib/utils/user_storage.dart
@@ -75,6 +75,8 @@ class UserStorage {
       'memex_custom_data_root_path_';
   static const String _keyAutoBackupEnabledPrefix =
       'memex_auto_backup_enabled_';
+  static const String _keyAutoBackupRetentionDaysPrefix =
+      'memex_auto_backup_retention_days_';
   static const String _keyLastAutoBackupAtPrefix = 'memex_last_auto_backup_at_';
   static const String _keyLastAutoBackupFingerprintPrefix =
       'memex_last_auto_backup_fingerprint_';
@@ -82,6 +84,10 @@ class UserStorage {
       'memex_android_backup_tree_uri_';
   static const String _keyAndroidBackupTreeNamePrefix =
       'memex_android_backup_tree_name_';
+
+  static const int defaultAutoBackupRetentionDays = 30;
+  static const int autoBackupRetentionForever = -1;
+  static const List<int> autoBackupRetentionDayOptions = <int>[7, 14, 30, 90];
 
   static final Logger _logger = getLogger('UserStorage');
   static const MethodChannel _storageChannel =
@@ -886,6 +892,33 @@ class UserStorage {
   static Future<void> setAutoBackupEnabled(String userId, bool enabled) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_keyAutoBackupEnabledPrefix + userId, enabled);
+  }
+
+  /// Number of days to keep automatic backups for [userId].
+  ///
+  /// Returns `null` when the user explicitly chooses to keep automatic backups
+  /// forever. Missing or invalid values fall back to 30 days.
+  static Future<int?> getAutoBackupRetentionDays(String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getInt(_keyAutoBackupRetentionDaysPrefix + userId);
+    if (value == autoBackupRetentionForever) return null;
+    if (value == null || value <= 0) return defaultAutoBackupRetentionDays;
+    return value;
+  }
+
+  static Future<void> setAutoBackupRetentionDays(
+    String userId,
+    int? days,
+  ) async {
+    if (days != null && days <= 0) {
+      throw ArgumentError.value(days, 'days', 'must be positive or null');
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(
+      _keyAutoBackupRetentionDaysPrefix + userId,
+      days ?? autoBackupRetentionForever,
+    );
   }
 
   static Future<DateTime?> getLastAutoBackupAt(String userId) async {

--- a/lib/utils/user_storage.dart
+++ b/lib/utils/user_storage.dart
@@ -77,6 +77,8 @@ class UserStorage {
       'memex_auto_backup_enabled_';
   static const String _keyAutoBackupRetentionDaysPrefix =
       'memex_auto_backup_retention_days_';
+  static const String _keyAutoBackupMaxBytesPrefix =
+      'memex_auto_backup_max_bytes_';
   static const String _keyLastAutoBackupAtPrefix = 'memex_last_auto_backup_at_';
   static const String _keyLastAutoBackupFingerprintPrefix =
       'memex_last_auto_backup_fingerprint_';
@@ -88,6 +90,14 @@ class UserStorage {
   static const int defaultAutoBackupRetentionDays = 30;
   static const int autoBackupRetentionForever = -1;
   static const List<int> autoBackupRetentionDayOptions = <int>[7, 14, 30, 90];
+  static const int defaultAutoBackupMaxBytes = 2 * 1024 * 1024 * 1024;
+  static const List<int> autoBackupMaxBytesOptions = <int>[
+    512 * 1024 * 1024,
+    1024 * 1024 * 1024,
+    defaultAutoBackupMaxBytes,
+    5 * 1024 * 1024 * 1024,
+    10 * 1024 * 1024 * 1024,
+  ];
 
   static final Logger _logger = getLogger('UserStorage');
   static const MethodChannel _storageChannel =
@@ -919,6 +929,26 @@ class UserStorage {
       _keyAutoBackupRetentionDaysPrefix + userId,
       days ?? autoBackupRetentionForever,
     );
+  }
+
+  /// Total size cap for automatic backups. Invalid values fall back to 2 GB.
+  static Future<int> getAutoBackupMaxBytes(String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getInt(_keyAutoBackupMaxBytesPrefix + userId);
+    if (value == null || value <= 0) return defaultAutoBackupMaxBytes;
+    return value;
+  }
+
+  static Future<void> setAutoBackupMaxBytes(
+    String userId,
+    int bytes,
+  ) async {
+    if (bytes <= 0) {
+      throw ArgumentError.value(bytes, 'bytes', 'must be positive');
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_keyAutoBackupMaxBytesPrefix + userId, bytes);
   }
 
   static Future<DateTime?> getLastAutoBackupAt(String userId) async {

--- a/test/data/services/backup_service_test.dart
+++ b/test/data/services/backup_service_test.dart
@@ -239,6 +239,20 @@ void main() {
       () => UserStorage.setAutoBackupRetentionDays('backup-service-user', 0),
       throwsArgumentError,
     );
+
+    expect(
+      await UserStorage.getAutoBackupMaxBytes('backup-service-user'),
+      UserStorage.defaultAutoBackupMaxBytes,
+    );
+
+    await UserStorage.setAutoBackupMaxBytes('backup-service-user', 1024);
+    expect(
+        await UserStorage.getAutoBackupMaxBytes('backup-service-user'), 1024);
+
+    expect(
+      () => UserStorage.setAutoBackupMaxBytes('backup-service-user', 0),
+      throwsArgumentError,
+    );
   });
 
   test(
@@ -302,17 +316,19 @@ void main() {
     expect(await oldest.exists(), isFalse);
   });
 
-  test('automatic backup retention still caps forever history by count',
+  test('automatic backup retention still caps forever history by total size',
       () async {
     final backupDir = await BackupService.resolveDefaultBackupDirectory();
     final now = DateTime(2026, 5, 15, 12);
     await UserStorage.setAutoBackupRetentionDays('backup-service-user', null);
+    await UserStorage.setAutoBackupMaxBytes('backup-service-user', 3);
 
-    for (var i = 0; i < BackupService.autoBackupMaxSnapshots + 2; i += 1) {
+    for (var i = 0; i < 5; i += 1) {
       await _writeStoredBackupFile(
         backupDir,
         'memex_auto_${i.toString().padLeft(2, '0')}.memex',
         modified: now.subtract(Duration(minutes: i)),
+        sizeBytes: 1,
       );
     }
 
@@ -320,11 +336,11 @@ void main() {
     final remainingNames = await _storedBackupNames(backupDir);
 
     expect(deleted, 2);
-    expect(remainingNames.length, BackupService.autoBackupMaxSnapshots);
+    expect(remainingNames.length, 3);
     expect(remainingNames, contains('memex_auto_00.memex'));
-    expect(remainingNames, contains('memex_auto_29.memex'));
-    expect(remainingNames, isNot(contains('memex_auto_30.memex')));
-    expect(remainingNames, isNot(contains('memex_auto_31.memex')));
+    expect(remainingNames, contains('memex_auto_02.memex'));
+    expect(remainingNames, isNot(contains('memex_auto_03.memex')));
+    expect(remainingNames, isNot(contains('memex_auto_04.memex')));
   });
 
   test('automatic backup skip still prunes expired snapshots', () async {

--- a/test/data/services/backup_service_test.dart
+++ b/test/data/services/backup_service_test.dart
@@ -217,69 +217,144 @@ void main() {
     },
   );
 
+  test('automatic backup retention preference defaults and persists', () async {
+    expect(
+      await UserStorage.getAutoBackupRetentionDays('backup-service-user'),
+      UserStorage.defaultAutoBackupRetentionDays,
+    );
+
+    await UserStorage.setAutoBackupRetentionDays('backup-service-user', 14);
+    expect(
+      await UserStorage.getAutoBackupRetentionDays('backup-service-user'),
+      14,
+    );
+
+    await UserStorage.setAutoBackupRetentionDays('backup-service-user', null);
+    expect(
+      await UserStorage.getAutoBackupRetentionDays('backup-service-user'),
+      isNull,
+    );
+
+    expect(
+      () => UserStorage.setAutoBackupRetentionDays('backup-service-user', 0),
+      throwsArgumentError,
+    );
+  });
+
   test(
-    'automatic backup retention keeps the newest seven daily snapshots',
+    'automatic backup retention deletes only expired automatic snapshots',
     () async {
       final backupDir = await BackupService.resolveDefaultBackupDirectory();
       final now = DateTime(2026, 5, 15, 12);
+      await UserStorage.setAutoBackupRetentionDays('backup-service-user', 7);
 
-      for (var i = 0; i < 9; i += 1) {
-        final file = File(
-          p.join(
-            backupDir.path,
-            'memex_auto_2026-05-${(i + 1).toString().padLeft(2, '0')}T00-00-00.memex',
-          ),
-        );
-        await file.writeAsBytes([i]);
-        await file.setLastModified(now.subtract(Duration(days: 9 - i)));
-      }
+      final recent = await _writeStoredBackupFile(
+        backupDir,
+        'memex_auto_recent.memex',
+        modified: now.subtract(const Duration(days: 6)),
+      );
+      final boundary = await _writeStoredBackupFile(
+        backupDir,
+        'memex_auto_boundary.memex',
+        modified: now.subtract(const Duration(days: 7)),
+      );
+      final expired = await _writeStoredBackupFile(
+        backupDir,
+        'memex_auto_expired.memex',
+        modified: now.subtract(const Duration(days: 8)),
+      );
+      final safety = await _writeStoredBackupFile(
+        backupDir,
+        'memex_safety_before_restore.memex',
+        modified: now.subtract(const Duration(days: 60)),
+      );
 
-      await BackupService.createStoredBackup();
+      final deleted = await BackupService.pruneAutoBackups(now: now);
 
-      final files = await backupDir
-          .list()
-          .where(
-            (entity) =>
-                entity is File &&
-                p.basename(entity.path).startsWith('memex_auto'),
-          )
-          .toList();
-
-      expect(files.length, lessThanOrEqualTo(7));
+      expect(deleted, 1);
+      expect(await recent.exists(), isTrue);
+      expect(await boundary.exists(), isTrue);
+      expect(await expired.exists(), isFalse);
+      expect(await safety.exists(), isTrue);
     },
   );
 
-  test('safety snapshots are kept outside automatic retention', () async {
+  test('automatic backup pruning always keeps the newest snapshot', () async {
     final backupDir = await BackupService.resolveDefaultBackupDirectory();
+    final now = DateTime(2026, 5, 15, 12);
+    await UserStorage.setAutoBackupRetentionDays('backup-service-user', 7);
 
-    for (var i = 0; i < 9; i += 1) {
-      final file = File(
-        p.join(
-          backupDir.path,
-          'memex_auto_2026-05-${(i + 1).toString().padLeft(2, '0')}T00-00-00.memex',
-        ),
+    final oldest = await _writeStoredBackupFile(
+      backupDir,
+      'memex_auto_oldest.memex',
+      modified: now.subtract(const Duration(days: 30)),
+    );
+    final newest = await _writeStoredBackupFile(
+      backupDir,
+      'memex_auto_newest.memex',
+      modified: now.subtract(const Duration(days: 20)),
+    );
+
+    final deleted = await BackupService.pruneAutoBackups(now: now);
+
+    expect(deleted, 1);
+    expect(await newest.exists(), isTrue);
+    expect(await oldest.exists(), isFalse);
+  });
+
+  test('automatic backup retention still caps forever history by count',
+      () async {
+    final backupDir = await BackupService.resolveDefaultBackupDirectory();
+    final now = DateTime(2026, 5, 15, 12);
+    await UserStorage.setAutoBackupRetentionDays('backup-service-user', null);
+
+    for (var i = 0; i < BackupService.autoBackupMaxSnapshots + 2; i += 1) {
+      await _writeStoredBackupFile(
+        backupDir,
+        'memex_auto_${i.toString().padLeft(2, '0')}.memex',
+        modified: now.subtract(Duration(minutes: i)),
       );
-      await file.writeAsBytes([i]);
     }
 
-    final safety = await BackupService.createSafetySnapshot(
-      reason: 'before_storage_switch',
+    final deleted = await BackupService.pruneAutoBackups(now: now);
+    final remainingNames = await _storedBackupNames(backupDir);
+
+    expect(deleted, 2);
+    expect(remainingNames.length, BackupService.autoBackupMaxSnapshots);
+    expect(remainingNames, contains('memex_auto_00.memex'));
+    expect(remainingNames, contains('memex_auto_29.memex'));
+    expect(remainingNames, isNot(contains('memex_auto_30.memex')));
+    expect(remainingNames, isNot(contains('memex_auto_31.memex')));
+  });
+
+  test('automatic backup skip still prunes expired snapshots', () async {
+    await UserStorage.setAutoBackupEnabled('backup-service-user', true);
+    await UserStorage.setAutoBackupRetentionDays('backup-service-user', 7);
+    await UserStorage.setLastAutoBackupMetadata(
+      'backup-service-user',
+      createdAt: DateTime.now().subtract(const Duration(hours: 1)),
+      fingerprint: 'previous',
     );
-    await BackupService.createStoredBackup();
 
-    expect(await File(safety.filePath!).exists(), isTrue);
-    final safetyFiles = await backupDir
-        .list()
-        .where(
-          (entity) =>
-              entity is File &&
-              p
-                  .basename(entity.path)
-                  .startsWith('memex_safety_before_storage_switch'),
-        )
-        .toList();
+    final backupDir = await BackupService.resolveDefaultBackupDirectory();
+    final keep = await _writeStoredBackupFile(
+      backupDir,
+      'memex_auto_recent_skip.memex',
+      modified: DateTime.now().subtract(const Duration(days: 1)),
+    );
+    final expired = await _writeStoredBackupFile(
+      backupDir,
+      'memex_auto_expired_skip.memex',
+      modified: DateTime.now().subtract(const Duration(days: 8)),
+    );
 
-    expect(safetyFiles, isNotEmpty);
+    final snapshot = await BackupService.maybeCreateAutoBackup(
+      trigger: 'skip-prune-test',
+    );
+
+    expect(snapshot, isNull);
+    expect(await keep.exists(), isTrue);
+    expect(await expired.exists(), isFalse);
   });
 
   test('deleteStoredBackup removes only the selected local snapshot', () async {
@@ -615,6 +690,26 @@ Future<File> _writeBackup(
   final file = File('${tempDir.path}/$fileName');
   await file.writeAsBytes(ZipEncoder().encode(archive));
   return file;
+}
+
+Future<File> _writeStoredBackupFile(
+  Directory backupDir,
+  String fileName, {
+  required DateTime modified,
+  int sizeBytes = 1,
+}) async {
+  final file = File(p.join(backupDir.path, fileName));
+  await file.writeAsBytes(List<int>.filled(sizeBytes, 1));
+  await file.setLastModified(modified);
+  return file;
+}
+
+Future<Set<String>> _storedBackupNames(Directory backupDir) async {
+  return backupDir
+      .list()
+      .where((entity) => entity is File && entity.path.endsWith('.memex'))
+      .map((entity) => p.basename(entity.path))
+      .toSet();
 }
 
 Future<void> _writeDeterministicBinaryFile(

--- a/test/ui/settings/widgets/backup_restore_page_test.dart
+++ b/test/ui/settings/widgets/backup_restore_page_test.dart
@@ -33,6 +33,57 @@ void main() {
     expect(await UserStorage.isAutoBackupEnabled('backup-test-user'), isTrue);
   });
 
+  testWidgets('shows estimated backup size and persists retention policy', (
+    tester,
+  ) async {
+    var pruneCalls = 0;
+
+    await _pumpBackupPage(
+      tester,
+      estimateBackupSize: () async => 5 * 1024 * 1024,
+      pruneAutoBackups: () async {
+        pruneCalls += 1;
+      },
+    );
+
+    expect(find.text(UserStorage.l10n.estimatedSize), findsOneWidget);
+    expect(find.text('5.0 MB'), findsWidgets);
+    expect(
+      find.text(UserStorage.l10n.autoBackupRetentionDays(30)),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('auto-backup-retention-menu')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(UserStorage.l10n.autoBackupRetentionDays(14)));
+    await tester.pumpAndSettle();
+
+    expect(
+      await UserStorage.getAutoBackupRetentionDays('backup-test-user'),
+      14,
+    );
+    expect(pruneCalls, 1);
+    expect(
+      find.text(UserStorage.l10n.autoBackupRetentionDays(14)),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('auto-backup-retention-menu')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(UserStorage.l10n.autoBackupRetentionForever));
+    await tester.pumpAndSettle();
+
+    expect(
+      await UserStorage.getAutoBackupRetentionDays('backup-test-user'),
+      isNull,
+    );
+    expect(pruneCalls, 2);
+    expect(
+      find.text(UserStorage.l10n.autoBackupRetentionForever),
+      findsOneWidget,
+    );
+  });
+
   testWidgets(
     'shows stored automatic and safety snapshots with restore confirmation',
     (tester) async {
@@ -62,6 +113,7 @@ void main() {
 
       expect(find.text(autoName), findsOneWidget);
       expect(find.text(safetyName), findsOneWidget);
+      expect(find.textContaining('3 B'), findsWidgets);
       expect(find.byTooltip(UserStorage.l10n.restoreThisBackup), findsWidgets);
 
       await tester.ensureVisible(find.text(autoName));
@@ -175,18 +227,17 @@ void main() {
     await _pumpBackupPage(
       tester,
       listStoredBackups: () async => List<BackupSnapshot>.of(snapshots),
-      createAutoBackup:
-          ({
-            String trigger = 'automatic',
-            bool force = false,
-            void Function(String status)? onProgress,
-          }) async {
-            expect(trigger, 'manual');
-            expect(force, isTrue);
-            onProgress?.call('Compressing...');
-            snapshots.add(snapshot);
-            return snapshot;
-          },
+      createAutoBackup: ({
+        String trigger = 'automatic',
+        bool force = false,
+        void Function(String status)? onProgress,
+      }) async {
+        expect(trigger, 'manual');
+        expect(force, isTrue);
+        onProgress?.call('Compressing...');
+        snapshots.add(snapshot);
+        return snapshot;
+      },
     );
 
     await tester.tap(find.text(UserStorage.l10n.createSnapshotNow));
@@ -223,15 +274,14 @@ void main() {
         return 42;
       },
       listStoredBackups: () async => List<BackupSnapshot>.of(snapshots),
-      createAutoBackup:
-          ({
-            String trigger = 'automatic',
-            bool force = false,
-            void Function(String status)? onProgress,
-          }) async {
-            snapshots.add(snapshot);
-            return snapshot;
-          },
+      createAutoBackup: ({
+        String trigger = 'automatic',
+        bool force = false,
+        void Function(String status)? onProgress,
+      }) async {
+        snapshots.add(snapshot);
+        return snapshot;
+      },
     );
 
     expect(estimateCalls, 1);
@@ -343,8 +393,7 @@ void main() {
   });
 
   testWidgets('shows Android SAF folder name and URI details', (tester) async {
-    const treeUri =
-        'content://com.android.externalstorage.documents/tree/'
+    const treeUri = 'content://com.android.externalstorage.documents/tree/'
         'primary%3ADownload%2FMemexBackups';
 
     await _pumpBackupPage(
@@ -382,6 +431,7 @@ Future<void> _pumpBackupPage(
   Future<List<BackupSnapshot>> Function()? listStoredBackups,
   AutoBackupCreator? createAutoBackup,
   StoredBackupDeleter? deleteStoredBackup,
+  Future<void> Function()? pruneAutoBackups,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -395,6 +445,7 @@ Future<void> _pumpBackupPage(
         listStoredBackups: listStoredBackups ?? () async => const [],
         createAutoBackup: createAutoBackup,
         deleteStoredBackup: deleteStoredBackup,
+        pruneAutoBackups: pruneAutoBackups,
       ),
     ),
   );

--- a/test/ui/settings/widgets/backup_restore_page_test.dart
+++ b/test/ui/settings/widgets/backup_restore_page_test.dart
@@ -52,6 +52,8 @@ void main() {
       find.text(UserStorage.l10n.autoBackupRetentionDays(30)),
       findsOneWidget,
     );
+    expect(find.text(UserStorage.l10n.autoBackupMaxSize), findsOneWidget);
+    expect(find.text('2.0 GB'), findsOneWidget);
 
     await tester.tap(find.byKey(const ValueKey('auto-backup-retention-menu')));
     await tester.pumpAndSettle();
@@ -82,6 +84,18 @@ void main() {
       find.text(UserStorage.l10n.autoBackupRetentionForever),
       findsOneWidget,
     );
+
+    await tester.tap(find.byKey(const ValueKey('auto-backup-max-size-menu')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('1.0 GB'));
+    await tester.pumpAndSettle();
+
+    expect(
+      await UserStorage.getAutoBackupMaxBytes('backup-test-user'),
+      1024 * 1024 * 1024,
+    );
+    expect(pruneCalls, 3);
+    expect(find.text('1.0 GB'), findsOneWidget);
   });
 
   testWidgets(
@@ -90,6 +104,7 @@ void main() {
       const autoName = 'memex_auto_2026-05-15T10-00-00.memex';
       const safetyName =
           'memex_safety_before_restore_2026-05-15T10-05-00.memex';
+      const manualName = 'memex_backup_2026-05-15T09-00-00.memex';
       final autoSnapshot = BackupSnapshot(
         id: 'auto',
         name: autoName,
@@ -104,15 +119,31 @@ void main() {
         sizeBytes: 3,
         filePath: '/tmp/$safetyName',
       );
+      final manualSnapshot = BackupSnapshot(
+        id: 'manual',
+        name: manualName,
+        createdAt: DateTime(2026, 5, 15, 9),
+        sizeBytes: 4,
+        filePath: '/tmp/$manualName',
+      );
 
       await _pumpBackupPage(
         tester,
-        listStoredBackups: () async => [safetySnapshot, autoSnapshot],
+        listStoredBackups: () async =>
+            [safetySnapshot, autoSnapshot, manualSnapshot],
       );
       await _scrollUntilVisible(tester, find.text(autoName));
+      await _scrollUntilVisible(tester, find.text(manualName));
 
       expect(find.text(autoName), findsOneWidget);
       expect(find.text(safetyName), findsOneWidget);
+      expect(find.text(manualName), findsOneWidget);
+      expect(find.textContaining(UserStorage.l10n.backupTypeAutoSnapshot),
+          findsOneWidget);
+      expect(find.textContaining(UserStorage.l10n.backupTypeSafetySnapshot),
+          findsOneWidget);
+      expect(find.textContaining(UserStorage.l10n.backupTypeManualBackup),
+          findsOneWidget);
       expect(find.textContaining('3 B'), findsWidgets);
       expect(find.byTooltip(UserStorage.l10n.restoreThisBackup), findsWidgets);
 


### PR DESCRIPTION
## 背景

自动备份原本只有硬编码的清理规则，用户无法理解或调整保留周期；而且清理只在成功创建新自动备份之后执行，如果当天因为 24 小时间隔或数据指纹未变化而跳过创建，历史自动备份也不会单独清理。这个 PR 为 #272 增加可配置保留策略，并把备份大小和备份类型展示得更直观。

Closes #272

## 主要改动

- 新增自动备份保留设置：7 天、14 天、30 天、90 天、永久保留，默认 30 天。
- 新增自动备份空间上限设置：512MB、1GB、2GB、5GB、10GB，默认 2GB；不向用户暴露“最多份数”配置。
- 将自动备份裁剪提升为 `BackupService.pruneAutoBackups()`，在跳过新备份创建时也会清理过期自动快照。
- 自动清理只处理 `memex_auto*.memex`；安全快照和手动导出的备份不参与裁剪，并且至少保留最新一份自动快照。
- 在备份设置页展示预估备份大小、当前保留策略、空间上限和清理说明。
- 历史备份列表增加类型标记：自动快照 / 安全快照 / 手动备份，并继续展示每个备份文件大小。
- 补齐中英文 l10n 文案及生成文件。

## 测试

- ✅ `flutter pub get --offline`
- ✅ `flutter gen-l10n`
- ✅ `dart format lib/data/services/backup_service.dart lib/utils/user_storage.dart lib/ui/settings/widgets/backup_restore_page.dart test/data/services/backup_service_test.dart test/ui/settings/widgets/backup_restore_page_test.dart`
- ✅ `NO_PROXY=localhost,127.0.0.1,::1 flutter test test/data/services/backup_service_test.dart --no-pub --concurrency=1`（21 passed）
- ✅ `NO_PROXY=localhost,127.0.0.1,::1 flutter test test/ui/settings/widgets/backup_restore_page_test.dart --no-pub --concurrency=1`（11 passed）
- ✅ `NO_PROXY=localhost,127.0.0.1,::1 flutter analyze --no-pub lib/data/services/backup_service.dart lib/utils/user_storage.dart lib/ui/settings/widgets/backup_restore_page.dart test/data/services/backup_service_test.dart test/ui/settings/widgets/backup_restore_page_test.dart`（No issues found）
- ✅ `NO_PROXY=localhost,127.0.0.1,::1 flutter test --no-pub --concurrency=1`（556 passed, 7 skipped；skipped 为缺少 live/eval 环境变量的测试）
- ✅ `git diff --check`

## 说明

`flutter analyze --no-pub` 全量命令仍会因为仓库既有的 287 条 info 级 lint 返回非零；本 PR 对本次触达的 Dart 文件做了定向 analyze，结果无问题。
