### PR TITLE
fix: 收敛卡片生成失败状态

### DIFF
--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -1751,6 +1751,14 @@ class MemexRouter {
     return LocalTaskExecutor.instance.getTaskActivitySnapshot();
   }
 
+  Future<bool> hasActiveTaskForCard(String cardId) async {
+    await _ensureInitialized();
+    return LocalTaskExecutor.instance.hasActiveTaskForFactId(
+      cardId,
+      taskTypes: const {'handle_analyze_assets', 'card_agent_task'},
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Card-detail notification helpers
   // ---------------------------------------------------------------------------

--- a/lib/data/services/agent_run_service.dart
+++ b/lib/data/services/agent_run_service.dart
@@ -234,7 +234,7 @@ class AgentRunService {
     required String taskType,
   }) async {
     final run = await _getRun(runId);
-    if (run == null || run.state == _dbState(AgentRunState.failed)) return;
+    if (run == null) return;
     final stage = _stageForTask(taskType);
     final now = _nowSeconds();
     await (_db.update(_db.agentRuns)..where((r) => r.id.equals(runId))).write(
@@ -307,26 +307,37 @@ class AgentRunService {
     final failedTasks = tasks.where((task) => task.status == 'failed').toList();
     final now = _nowSeconds();
 
-    if (failedTasks.isNotEmpty) {
-      final failed = failedTasks.first;
-      await (_db.update(_db.agentRuns)..where((r) => r.id.equals(run.id)))
-          .write(
-        AgentRunsCompanion(
-          state: Value(_dbState(AgentRunState.failed)),
-          stage: const Value('Needs attention'),
-          message: Value(_trimNullable(failed.error) ?? 'Processing failed.'),
-          lastError: Value(_trimNullable(failed.error)),
-          currentTaskId: Value(failed.id),
-          currentTaskType: Value(failed.type),
-          remainingTasks: Value(activeTasks.length),
-          updatedAt: Value(now),
-          completedAt: Value(now),
-        ),
-      );
-      return;
-    }
-
     if (activeTasks.isEmpty) {
+      final latestFailed = _latestTask(failedTasks);
+      final latestCompleted = _latestTask(
+        tasks.where((task) => task.status == 'completed').toList(),
+      );
+      final latestFailedTs =
+          latestFailed == null ? -1 : _taskTerminalTimestamp(latestFailed);
+      final latestCompletedTs = latestCompleted == null
+          ? -1
+          : _taskTerminalTimestamp(latestCompleted);
+
+      if (latestFailed != null && latestFailedTs >= latestCompletedTs) {
+        await (_db.update(_db.agentRuns)..where((r) => r.id.equals(run.id)))
+            .write(
+          AgentRunsCompanion(
+            state: Value(_dbState(AgentRunState.failed)),
+            stage: const Value('Needs attention'),
+            message: Value(
+              _trimNullable(latestFailed.error) ?? 'Processing failed.',
+            ),
+            lastError: Value(_trimNullable(latestFailed.error)),
+            currentTaskId: Value(latestFailed.id),
+            currentTaskType: Value(latestFailed.type),
+            remainingTasks: const Value(0),
+            updatedAt: Value(now),
+            completedAt: Value(now),
+          ),
+        );
+        return;
+      }
+
       await (_db.update(_db.agentRuns)..where((r) => r.id.equals(run.id)))
           .write(
         AgentRunsCompanion(
@@ -337,6 +348,7 @@ class AgentRunService {
           remainingTasks: const Value(0),
           currentTaskId: const Value(null),
           currentTaskType: const Value(null),
+          lastError: const Value(null),
           updatedAt: Value(now),
           completedAt: Value(now),
         ),
@@ -495,6 +507,17 @@ bool _sameSnapshot(AgentRunSnapshot? a, AgentRunSnapshot? b) {
 int _nowSeconds() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
 int _maxUnit(int left, int right) => left > right ? left : right;
+
+Task? _latestTask(List<Task> tasks) {
+  if (tasks.isEmpty) return null;
+  return tasks.reduce((a, b) {
+    return _taskTerminalTimestamp(a) >= _taskTerminalTimestamp(b) ? a : b;
+  });
+}
+
+int _taskTerminalTimestamp(Task task) {
+  return task.completedAt ?? task.updatedAt ?? task.createdAt ?? 0;
+}
 
 String _trimError(Object error) {
   return _trimNullable(error.toString()) ?? 'Processing failed.';

--- a/lib/data/services/local_task_executor.dart
+++ b/lib/data/services/local_task_executor.dart
@@ -35,10 +35,10 @@ class TaskActivitySnapshot {
   });
 
   const TaskActivitySnapshot.empty()
-    : pending = 0,
-      processing = 0,
-      retrying = 0,
-      activeTaskIds = const <String>{};
+      : pending = 0,
+        processing = 0,
+        retrying = 0,
+        activeTaskIds = const <String>{};
 
   int get total => pending + processing + retrying;
 
@@ -55,11 +55,11 @@ class TaskActivitySnapshot {
 
   @override
   int get hashCode => Object.hash(
-    pending,
-    processing,
-    retrying,
-    Object.hashAllUnordered(activeTaskIds),
-  );
+        pending,
+        processing,
+        retrying,
+        Object.hashAllUnordered(activeTaskIds),
+      );
 }
 
 class TaskQueueDrainResult {
@@ -79,19 +79,17 @@ class TaskQueueDrainResult {
 enum TaskQueueOwnerKind { foreground, background }
 
 /// Handler function type
-typedef TaskHandler =
-    Future<void> Function(
-      String userId,
-      Map<String, dynamic> payload,
-      TaskContext context,
-    );
+typedef TaskHandler = Future<void> Function(
+  String userId,
+  Map<String, dynamic> payload,
+  TaskContext context,
+);
 
-typedef TaskConcurrencyKeyBuilder =
-    String Function(
-      String userId,
-      Map<String, dynamic> payload,
-      TaskContext context,
-    );
+typedef TaskConcurrencyKeyBuilder = String Function(
+  String userId,
+  Map<String, dynamic> payload,
+  TaskContext context,
+);
 
 /// Per-task-type concurrency policy. The executor prefixes the returned key
 /// with the task type, so [byUser] means "one task of this type per user".
@@ -121,14 +119,13 @@ class TaskConcurrencyPolicy {
 }
 
 /// Failure handler function type - called when all retries are exhausted
-typedef TaskFailureHandler =
-    Future<void> Function(
-      String userId,
-      Map<String, dynamic> payload,
-      TaskContext context,
-      Object error,
-      StackTrace? stackTrace,
-    );
+typedef TaskFailureHandler = Future<void> Function(
+  String userId,
+  Map<String, dynamic> payload,
+  TaskContext context,
+  Object error,
+  StackTrace? stackTrace,
+);
 
 class LocalTaskExecutor {
   static LocalTaskExecutor? _instance;
@@ -138,13 +135,13 @@ class LocalTaskExecutor {
   }
 
   LocalTaskExecutor._()
-    : _testDb = null,
-      _queueOwnerId = _newQueueOwnerId('foreground');
+      : _testDb = null,
+        _queueOwnerId = _newQueueOwnerId('foreground');
 
   @visibleForTesting
   LocalTaskExecutor.forTesting({AppDatabase? db, String? queueOwnerId})
-    : _testDb = db,
-      _queueOwnerId = queueOwnerId ?? _newQueueOwnerId('test');
+      : _testDb = db,
+        _queueOwnerId = queueOwnerId ?? _newQueueOwnerId('test');
 
   final Logger _logger = getLogger('LocalTaskExecutor');
   final AppDatabase? _testDb;
@@ -217,6 +214,31 @@ class LocalTaskExecutor {
     final query = _db.select(_db.tasks)
       ..where((t) => t.status.isIn(['pending', 'processing', 'retrying']));
     return _snapshotFromTasks(await query.get());
+  }
+
+  Future<bool> hasActiveTaskForFactId(
+    String factId, {
+    Set<String>? taskTypes,
+  }) async {
+    final query = _db.select(_db.tasks)
+      ..where((t) => t.status.isIn(['pending', 'processing', 'retrying']));
+    final tasks = await query.get();
+    for (final task in tasks) {
+      if (taskTypes != null && !taskTypes.contains(task.type)) {
+        continue;
+      }
+      if (task.runId == factId) return true;
+      try {
+        final payload = _decodePayload(task);
+        if (payload['run_id'] == factId || payload['fact_id'] == factId) {
+          return true;
+        }
+      } catch (_) {
+        // Ignore malformed payloads here. The executor's dependency and
+        // execution paths own validation/failure handling.
+      }
+    }
+    return false;
   }
 
   Future<TaskQueueDrainResult> drainAvailableTasks({
@@ -578,9 +600,7 @@ class LocalTaskExecutor {
       reason: reason,
     );
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    await _db
-        .into(_db.kvStore)
-        .insertOnConflictUpdate(
+    await _db.into(_db.kvStore).insertOnConflictUpdate(
           KvStoreCompanion.insert(
             key: _gracefulExitMarkerKey,
             value: Value(jsonEncode(marker.toJson())),
@@ -595,7 +615,8 @@ class LocalTaskExecutor {
 
     await (_db.delete(
       _db.kvStore,
-    )..where((kv) => kv.key.equals(_gracefulExitMarkerKey))).go();
+    )..where((kv) => kv.key.equals(_gracefulExitMarkerKey)))
+        .go();
   }
 
   // Max concurrent tasks
@@ -620,12 +641,10 @@ class LocalTaskExecutor {
     // We use a manual UUID or let Drift handle it?
     // Our schema defined ID as Text. Drift doesn't auto-generate Text IDs usually.
     // So we generate one.
-    final taskId = DateTime.now().microsecondsSinceEpoch
-        .toString(); // Simple ID for now
+    final taskId =
+        DateTime.now().microsecondsSinceEpoch.toString(); // Simple ID for now
 
-    await _db
-        .into(_db.tasks)
-        .insert(
+    await _db.into(_db.tasks).insert(
           TasksCompanion.insert(
             id: taskId,
             type: taskType,
@@ -1038,49 +1057,7 @@ class LocalTaskExecutor {
         }
         _logger.info('Task ${task.id} scheduled for retry at $nextRun');
       } else {
-        // Permanently failed
-        final failureHandler = _failureHandlers[task.type];
-        if (failureHandler != null) {
-          try {
-            final payloadMap = task.payload != null
-                ? jsonDecode(task.payload!) as Map<String, dynamic>
-                : <String, dynamic>{};
-            final currentUserId = _currentUserId;
-            if (currentUserId != null) {
-              await failureHandler(
-                currentUserId,
-                payloadMap,
-                TaskContext(
-                  taskId: task.id,
-                  taskType: task.type,
-                  bizId: task.bizId,
-                ),
-                e,
-                stack,
-              );
-            }
-          } catch (fhError, fhStack) {
-            _logger.severe('Failure handler error', fhError, fhStack);
-          }
-        }
-
-        await (_db.update(_db.tasks)..where((t) => t.id.equals(task.id))).write(
-          TasksCompanion(
-            status: const Value('failed'),
-            completedAt: Value(DateTime.now().millisecondsSinceEpoch ~/ 1000),
-            updatedAt: Value(now),
-            error: Value(e.toString()),
-          ),
-        );
-        final failedRunId = task.runId ?? _tryDecodeRunId(task);
-        if (failedRunId != null && failedRunId.isNotEmpty) {
-          await AgentRunService.instance.markTaskFailed(
-            runId: failedRunId,
-            taskId: task.id,
-            taskType: task.type,
-            error: e,
-          );
-        }
+        await _failTask(task, e, stack);
         _logger.severe('Task ${task.id} permanently failed');
       }
     } finally {
@@ -1187,7 +1164,8 @@ class LocalTaskExecutor {
   }) async {
     final task = await (_db.select(
       _db.tasks,
-    )..where((t) => t.id.equals(marker.taskId))).getSingleOrNull();
+    )..where((t) => t.id.equals(marker.taskId)))
+        .getSingleOrNull();
     if (task == null || task.status != 'processing') {
       await _deleteTaskExecutionMarker(marker.taskId);
       return;
@@ -1283,10 +1261,9 @@ class LocalTaskExecutor {
   }
 
   Future<_TaskExecutionMarker?> _loadTaskExecutionMarker(String taskId) async {
-    final row =
-        await (_db.select(_db.kvStore)
-              ..where((kv) => kv.key.equals(_taskExecutionMarkerKey(taskId))))
-            .getSingleOrNull();
+    final row = await (_db.select(_db.kvStore)
+          ..where((kv) => kv.key.equals(_taskExecutionMarkerKey(taskId))))
+        .getSingleOrNull();
     if (row?.value == null) return null;
 
     try {
@@ -1303,7 +1280,8 @@ class LocalTaskExecutor {
   Future<List<_TaskExecutionMarker>> _loadTaskExecutionMarkers() async {
     final rows = await (_db.select(
       _db.kvStore,
-    )..where((kv) => kv.key.like('$_activeTaskMarkerKeyPrefix%'))).get();
+    )..where((kv) => kv.key.like('$_activeTaskMarkerKeyPrefix%')))
+        .get();
     final markers = <_TaskExecutionMarker>[];
 
     for (final row in rows) {
@@ -1330,7 +1308,8 @@ class LocalTaskExecutor {
   Future<_GracefulExitMarker?> _loadGracefulExitMarker() async {
     final row = await (_db.select(
       _db.kvStore,
-    )..where((kv) => kv.key.equals(_gracefulExitMarkerKey))).getSingleOrNull();
+    )..where((kv) => kv.key.equals(_gracefulExitMarkerKey)))
+        .getSingleOrNull();
     if (row?.value == null) return null;
 
     try {
@@ -1350,7 +1329,8 @@ class LocalTaskExecutor {
       () async {
         await (_db.delete(
           _db.kvStore,
-        )..where((kv) => kv.key.equals(_gracefulExitMarkerKey))).go();
+        )..where((kv) => kv.key.equals(_gracefulExitMarkerKey)))
+            .go();
       },
     );
   }
@@ -1360,9 +1340,7 @@ class LocalTaskExecutor {
     await _runCrashGuardDatabaseOperation(
       'save task execution marker ${marker.taskId}',
       () async {
-        await _db
-            .into(_db.kvStore)
-            .insertOnConflictUpdate(
+        await _db.into(_db.kvStore).insertOnConflictUpdate(
               KvStoreCompanion.insert(
                 key: _taskExecutionMarkerKey(marker.taskId),
                 value: Value(jsonEncode(marker.toJson())),
@@ -1428,16 +1406,66 @@ class LocalTaskExecutor {
     return '$_activeTaskMarkerKeyPrefix$taskId';
   }
 
-  Future<void> _failTask(Task task, String error) async {
+  Future<void> _failTask(
+    Task task,
+    Object error, [
+    StackTrace? stackTrace,
+  ]) async {
+    final payloadMap = _safeDecodePayload(task);
+    final context = TaskContext(
+      taskId: task.id,
+      taskType: task.type,
+      bizId: task.bizId,
+    );
+    final failureHandler = _failureHandlers[task.type];
+    final currentUserId = _currentUserId;
+
+    if (failureHandler != null && currentUserId != null) {
+      try {
+        await failureHandler(
+          currentUserId,
+          payloadMap,
+          context,
+          error,
+          stackTrace,
+        );
+      } catch (fhError, fhStack) {
+        _logger.severe('Failure handler error', fhError, fhStack);
+      }
+    }
+
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     await (_db.update(_db.tasks)..where((t) => t.id.equals(task.id))).write(
       TasksCompanion(
         status: const Value('failed'),
         completedAt: Value(now),
         updatedAt: Value(now),
-        error: Value(error),
+        error: Value(error.toString()),
       ),
     );
+
+    final runId = task.runId ?? payloadMap['run_id'] as String?;
+    if (runId != null && runId.isNotEmpty) {
+      await AgentRunService.instance.markTaskFailed(
+        runId: runId,
+        taskId: task.id,
+        taskType: task.type,
+        error: error,
+      );
+    }
+  }
+
+  Map<String, dynamic> _safeDecodePayload(Task task) {
+    try {
+      return _decodePayload(task);
+    } catch (e, stackTrace) {
+      _logger.warning(
+        'Failed to decode payload for failed task ${task.id}',
+        e,
+        stackTrace,
+      );
+      return <String, dynamic>{};
+    }
   }
 
   @visibleForTesting
@@ -1462,14 +1490,16 @@ class LocalTaskExecutor {
   Future<List<KvStoreData>> getTaskExecutionMarkersForTesting() {
     return (_db.select(
       _db.kvStore,
-    )..where((kv) => kv.key.like('$_activeTaskMarkerKeyPrefix%'))).get();
+    )..where((kv) => kv.key.like('$_activeTaskMarkerKeyPrefix%')))
+        .get();
   }
 
   @visibleForTesting
   Future<KvStoreData?> getGracefulExitMarkerForTesting() {
     return (_db.select(
       _db.kvStore,
-    )..where((kv) => kv.key.equals(_gracefulExitMarkerKey))).getSingleOrNull();
+    )..where((kv) => kv.key.equals(_gracefulExitMarkerKey)))
+        .getSingleOrNull();
   }
 
   @visibleForTesting
@@ -1482,7 +1512,8 @@ class LocalTaskExecutor {
   Future<KvStoreData?> getQueueLeaseForTesting(String userId) {
     return (_db.select(
       _db.kvStore,
-    )..where((kv) => kv.key.equals(_queueLeaseKey(userId)))).getSingleOrNull();
+    )..where((kv) => kv.key.equals(_queueLeaseKey(userId))))
+        .getSingleOrNull();
   }
 
   /// Check if a task of [taskType] with [bizId] has failed.
@@ -1519,9 +1550,7 @@ class LocalTaskExecutor {
     final taskId = DateTime.now().microsecondsSinceEpoch.toString();
     final resultStr = jsonEncode(result);
 
-    await _db
-        .into(_db.tasks)
-        .insert(
+    await _db.into(_db.tasks).insert(
           TasksCompanion.insert(
             id: taskId,
             type: taskType,

--- a/lib/ui/timeline/widgets/failed_card_recovery_banner.dart
+++ b/lib/ui/timeline/widgets/failed_card_recovery_banner.dart
@@ -2,6 +2,43 @@ import 'package:flutter/material.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/utils/user_storage.dart';
 
+class CardProcessingStatusBanner extends StatelessWidget {
+  const CardProcessingStatusBanner({
+    super.key,
+    required this.status,
+    required this.failureReason,
+    required this.hasActiveTask,
+    required this.isRetrying,
+    required this.onRetry,
+    required this.onShowReason,
+  });
+
+  final String status;
+  final String? failureReason;
+  final bool hasActiveTask;
+  final bool isRetrying;
+  final VoidCallback? onRetry;
+  final VoidCallback? onShowReason;
+
+  @override
+  Widget build(BuildContext context) {
+    if (status == 'failed') {
+      return FailedCardRecoveryBanner(
+        failureReason: failureReason,
+        isRetrying: isRetrying,
+        onRetry: onRetry,
+        onShowReason: onShowReason,
+      );
+    }
+
+    if (status == 'processing' && hasActiveTask) {
+      return const CardRegeneratingBanner();
+    }
+
+    return const SizedBox.shrink();
+  }
+}
+
 class FailedCardRecoveryBanner extends StatelessWidget {
   const FailedCardRecoveryBanner({
     super.key,

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -57,6 +57,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   String? _replyToCommentId;
   String? _replyToCommentName;
   bool _isRetryingCard = false;
+  bool _hasActiveCardTask = false;
 
   @override
   void initState() {
@@ -144,10 +145,16 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     }
 
     try {
-      final detail = await _memexRouter.fetchCardDetail(widget.cardId);
+      final detailFuture = _memexRouter.fetchCardDetail(widget.cardId);
+      final activeTaskFuture = _memexRouter.hasActiveTaskForCard(
+        widget.cardId,
+      );
+      final detail = await detailFuture;
+      final hasActiveCardTask = await activeTaskFuture.catchError((_) => false);
       if (!mounted) return;
       setState(() {
         _detail = detail;
+        _hasActiveCardTask = hasActiveCardTask;
       });
       _resolveFirstImageAspectRatio(detail);
 
@@ -1124,16 +1131,17 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
                                   const SizedBox(height: 16),
-                                  if (detail.status == 'failed') ...[
-                                    FailedCardRecoveryBanner(
-                                      failureReason: detail.failureReason,
-                                      isRetrying: _isRetryingCard,
-                                      onRetry: _retryCardGeneration,
-                                      onShowReason: _showFailureReason,
-                                    ),
-                                    const SizedBox(height: 16),
-                                  ] else if (detail.status == 'processing') ...[
-                                    const CardRegeneratingBanner(),
+                                  CardProcessingStatusBanner(
+                                    status: detail.status,
+                                    failureReason: detail.failureReason,
+                                    hasActiveTask: _hasActiveCardTask,
+                                    isRetrying: _isRetryingCard,
+                                    onRetry: _retryCardGeneration,
+                                    onShowReason: _showFailureReason,
+                                  ),
+                                  if (detail.status == 'failed' ||
+                                      (detail.status == 'processing' &&
+                                          _hasActiveCardTask)) ...[
                                     const SizedBox(height: 16),
                                   ],
                                   // Title

--- a/test/data/services/agent_run_service_test.dart
+++ b/test/data/services/agent_run_service_test.dart
@@ -1,4 +1,4 @@
-import 'package:drift/drift.dart' hide isNotNull;
+import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/agent_run_service.dart';
@@ -141,6 +141,91 @@ void main() {
       expect(run.completedAt, isNotNull);
     });
 
+    test(
+      'new successful attempt resolves old failed activity for same fact',
+      () async {
+        await service.createForSubmittedInput(
+          userId: 'user-a',
+          factId: 'fact-retry',
+        );
+        await _insertTask(
+          db,
+          id: 'old-card-failed',
+          runId: 'fact-retry',
+          type: 'card_agent_task',
+          status: 'failed',
+        );
+        await service.markTaskFailed(
+          runId: 'fact-retry',
+          taskId: 'old-card-failed',
+          taskType: 'card_agent_task',
+          error: StateError('old provider crash'),
+        );
+        await _setTaskTerminalTimestamp(db, 'old-card-failed', 1);
+
+        await _insertTask(
+          db,
+          id: 'new-card-active',
+          runId: 'fact-retry',
+          type: 'card_agent_task',
+          status: 'processing',
+        );
+        await service.refreshRunFromTasks('fact-retry');
+
+        var run = await _getRun(db, 'fact-retry');
+        expect(run.state, 'running');
+        expect(run.stage, 'Generating card');
+        expect(run.currentTaskId, 'new-card-active');
+
+        await _setTaskStatus(db, 'new-card-active', 'completed');
+        await service.markTaskCompleted(
+          runId: 'fact-retry',
+          taskId: 'new-card-active',
+          taskType: 'card_agent_task',
+        );
+
+        run = await _getRun(db, 'fact-retry');
+        expect(run.state, 'completed');
+        expect(run.stage, 'Completed');
+        expect(run.currentTaskId, isNull);
+        expect(run.lastError, isNull);
+        expect(await service.getLatestVisibleRun(userId: 'user-a'), isNull);
+      },
+    );
+
+    test(
+      'latest failed attempt remains visible when it is newer than success',
+      () async {
+        await service.createForSubmittedInput(
+          userId: 'user-a',
+          factId: 'fact-latest-failed',
+        );
+        await _insertTask(
+          db,
+          id: 'old-completed-card',
+          runId: 'fact-latest-failed',
+          type: 'card_agent_task',
+          status: 'completed',
+        );
+        await _setTaskTerminalTimestamp(db, 'old-completed-card', 1);
+        await _insertTask(
+          db,
+          id: 'new-failed-card',
+          runId: 'fact-latest-failed',
+          type: 'card_agent_task',
+          status: 'failed',
+        );
+        await _setTaskTerminalTimestamp(db, 'new-failed-card', 2);
+
+        await service.refreshRunFromTasks('fact-latest-failed');
+
+        final run = await _getRun(db, 'fact-latest-failed');
+        expect(run.state, 'failed');
+        expect(run.stage, 'Needs attention');
+        expect(run.currentTaskId, 'new-failed-card');
+      },
+    );
+
     test('marks active runs paused when the OS background window closes',
         () async {
       await service.createForSubmittedInput(userId: 'user-a', factId: 'fact-4');
@@ -199,6 +284,19 @@ Future<void> _setTaskStatus(
     TasksCompanion(
       status: Value(status),
       updatedAt: Value(DateTime.now().millisecondsSinceEpoch ~/ 1000),
+    ),
+  );
+}
+
+Future<void> _setTaskTerminalTimestamp(
+  AppDatabase db,
+  String id,
+  int timestamp,
+) async {
+  await (db.update(db.tasks)..where((task) => task.id.equals(id))).write(
+    TasksCompanion(
+      updatedAt: Value(timestamp),
+      completedAt: Value(timestamp),
     ),
   );
 }

--- a/test/data/services/local_task_executor_test.dart
+++ b/test/data/services/local_task_executor_test.dart
@@ -1,12 +1,18 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/agent_run_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/data/services/task_handlers/card_agent_handler.dart';
 import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   late AppDatabase db;
@@ -34,9 +40,7 @@ void main() {
 
         final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
-        await db
-            .into(db.tasks)
-            .insert(
+        await db.into(db.tasks).insert(
               TasksCompanion.insert(
                 id: 'unresolved-dependency',
                 type: 'dependency_task',
@@ -48,9 +52,7 @@ void main() {
             );
 
         for (var i = 0; i < 50; i++) {
-          await db
-              .into(db.tasks)
-              .insert(
+          await db.into(db.tasks).insert(
                 TasksCompanion.insert(
                   id: 'blocked-$i',
                   type: 'blocked_task',
@@ -62,9 +64,7 @@ void main() {
               );
         }
 
-        await db
-            .into(db.tasks)
-            .insert(
+        await db.into(db.tasks).insert(
               TasksCompanion.insert(
                 id: 'runnable',
                 type: 'runnable_task',
@@ -96,9 +96,7 @@ void main() {
 
         final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
-        await db
-            .into(db.tasks)
-            .insert(
+        await db.into(db.tasks).insert(
               TasksCompanion.insert(
                 id: 'bad-dependency',
                 type: 'blocked_task',
@@ -110,9 +108,7 @@ void main() {
               ),
             );
 
-        await db
-            .into(db.tasks)
-            .insert(
+        await db.into(db.tasks).insert(
               TasksCompanion.insert(
                 id: 'runnable',
                 type: 'runnable_task',
@@ -133,6 +129,62 @@ void main() {
       },
     );
 
+    test('detects active tasks for a fact from run id or payload', () async {
+      await _insertTask(
+        db,
+        id: 'active-run-id',
+        type: 'card_agent_task',
+        status: 'pending',
+        payload: {'value': 1},
+        runId: '2026/06/13.md#ts_1',
+      );
+      await _insertTask(
+        db,
+        id: 'active-payload-fact',
+        type: 'legacy_card_agent_task',
+        status: 'retrying',
+        payload: {'fact_id': '2026/06/13.md#ts_2'},
+      );
+      await _insertTask(
+        db,
+        id: 'old-failed',
+        type: 'card_agent_task',
+        status: 'failed',
+        payload: {'fact_id': '2026/06/13.md#ts_3'},
+      );
+      await _insertTask(
+        db,
+        id: 'active-pkm-same-fact',
+        type: 'pkm_agent_task',
+        status: 'processing',
+        payload: {'fact_id': '2026/06/13.md#ts_4'},
+      );
+
+      expect(
+        await executor.hasActiveTaskForFactId('2026/06/13.md#ts_1'),
+        isTrue,
+      );
+      expect(
+        await executor.hasActiveTaskForFactId('2026/06/13.md#ts_2'),
+        isTrue,
+      );
+      expect(
+        await executor.hasActiveTaskForFactId('2026/06/13.md#ts_3'),
+        isFalse,
+      );
+      expect(
+        await executor.hasActiveTaskForFactId('2026/06/13.md#ts_4'),
+        isTrue,
+      );
+      expect(
+        await executor.hasActiveTaskForFactId(
+          '2026/06/13.md#ts_4',
+          taskTypes: const {'handle_analyze_assets', 'card_agent_task'},
+        ),
+        isFalse,
+      );
+    });
+
     test(
       'uses only available concurrency slots while backlog remains queued',
       () async {
@@ -147,9 +199,7 @@ void main() {
 
         await executor.start(userId: 'user-a');
         for (var i = 0; i < 4; i++) {
-          await db
-              .into(db.tasks)
-              .insert(
+          await db.into(db.tasks).insert(
                 TasksCompanion.insert(
                   id: 'active-$i',
                   type: 'already_processing',
@@ -161,9 +211,7 @@ void main() {
         }
 
         for (var i = 0; i < 3; i++) {
-          await db
-              .into(db.tasks)
-              .insert(
+          await db.into(db.tasks).insert(
                 TasksCompanion.insert(
                   id: 'runnable-$i',
                   type: 'runnable_task',
@@ -241,9 +289,7 @@ void main() {
     test('reports active task activity snapshot', () async {
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
-      await db
-          .into(db.tasks)
-          .insert(
+      await db.into(db.tasks).insert(
             TasksCompanion.insert(
               id: 'pending-task',
               type: 'task',
@@ -252,9 +298,7 @@ void main() {
               createdAt: Value(now),
             ),
           );
-      await db
-          .into(db.tasks)
-          .insert(
+      await db.into(db.tasks).insert(
             TasksCompanion.insert(
               id: 'processing-task',
               type: 'task',
@@ -263,9 +307,7 @@ void main() {
               createdAt: Value(now),
             ),
           );
-      await db
-          .into(db.tasks)
-          .insert(
+      await db.into(db.tasks).insert(
             TasksCompanion.insert(
               id: 'retrying-task',
               type: 'task',
@@ -274,9 +316,7 @@ void main() {
               createdAt: Value(now),
             ),
           );
-      await db
-          .into(db.tasks)
-          .insert(
+      await db.into(db.tasks).insert(
             TasksCompanion.insert(
               id: 'completed-task',
               type: 'task',
@@ -327,7 +367,8 @@ void main() {
         task = await _waitForTaskStatus(db, taskId, 'completed');
         final run = await (db.select(
           db.agentRuns,
-        )..where((row) => row.id.equals('fact-run'))).getSingle();
+        )..where((row) => row.id.equals('fact-run')))
+            .getSingle();
 
         expect(task.status, 'completed');
         expect(run.state, 'completed');
@@ -435,14 +476,14 @@ void main() {
 
         final drainFuture = executor
             .drainAvailableTasks(
-              userId: 'user-a',
-              maxDuration: const Duration(milliseconds: 100),
-              pollInterval: const Duration(milliseconds: 20),
-            )
+          userId: 'user-a',
+          maxDuration: const Duration(milliseconds: 100),
+          pollInterval: const Duration(milliseconds: 20),
+        )
             .then((result) {
-              drainCompleted = true;
-              return result;
-            });
+          drainCompleted = true;
+          return result;
+        });
 
         await started.future.timeout(const Duration(seconds: 3));
         await Future<void>.delayed(const Duration(milliseconds: 150));
@@ -758,9 +799,7 @@ void main() {
         completedTaskIds.add(context.taskId);
       });
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-      await db
-          .into(db.kvStore)
-          .insert(
+      await db.into(db.kvStore).insert(
             KvStoreCompanion.insert(
               key: 'agent_queue_lease:user-a',
               value: const Value('old-owner:background'),
@@ -1020,6 +1059,86 @@ void main() {
     });
 
     test(
+      'crash loop failure invokes card agent failure handler and marks card failed',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        await UserStorage.initL10n();
+        final tempDir = await Directory.systemTemp.createTemp(
+          'memex_card_agent_crash_failure_',
+        );
+        addTearDown(() async {
+          if (await tempDir.exists()) {
+            await tempDir.delete(recursive: true);
+          }
+        });
+        await FileSystemService.init(tempDir.path);
+
+        const userId = 'user-a';
+        const factId = '2026/06/13.md#ts_13';
+        await AgentRunService.instance.createForSubmittedInput(
+          userId: userId,
+          factId: factId,
+        );
+        await FileSystemService.instance.safeWriteCardFile(
+          userId,
+          factId,
+          CardData(
+            factId: factId,
+            timestamp: DateTime(2026, 6, 13, 9).millisecondsSinceEpoch ~/ 1000,
+            status: 'processing',
+            tags: const [],
+            uiConfigs: const [
+              UiConfig(
+                templateId: 'classic_card',
+                data: {'content': 'stale card'},
+              ),
+            ],
+          ),
+        );
+
+        executor.registerFailureHandler(
+          'card_agent_task',
+          handleCardAgentFailureImpl,
+        );
+        final task = await _insertTask(
+          db,
+          id: 'card-agent-crash-loop',
+          type: 'card_agent_task',
+          status: 'processing',
+          payload: {
+            'run_id': factId,
+            'fact_id': factId,
+            'combined_text': '原始记录内容',
+          },
+        );
+        await executor.markTaskExecutionStartedForTesting(task);
+        await _setMarkerCrashCount(db, executor, task.id, 1);
+
+        await executor.start(userId: userId);
+        await executor.stop();
+
+        final updatedTask = await _getTask(db, task.id);
+        final updatedCard = await FileSystemService.instance.readCardFile(
+          userId,
+          factId,
+        );
+        final run = await (db.select(
+          db.agentRuns,
+        )..where((r) => r.id.equals(factId)))
+            .getSingle();
+
+        expect(updatedTask.status, 'failed');
+        expect(updatedTask.error, contains('crash-like exits'));
+        expect(updatedCard?.status, 'failed');
+        expect(updatedCard?.failureReason, isNotNull);
+        expect(updatedCard?.failureReason, isNotEmpty);
+        expect(run.state, 'failed');
+        expect(run.stage, 'Needs attention');
+        expect(await executor.getTaskExecutionMarkerForTesting(), isNull);
+      },
+    );
+
+    test(
       'bad dependency JSON fails task instead of leaving it pending forever',
       () async {
         await _insertTask(
@@ -1048,17 +1167,17 @@ Future<Task> _insertTask(
   required String type,
   required String status,
   required Map<String, dynamic> payload,
+  String? runId,
   String? dependencies,
   int? scheduledAt,
 }) async {
   final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-  await db
-      .into(db.tasks)
-      .insert(
+  await db.into(db.tasks).insert(
         TasksCompanion.insert(
           id: id,
           type: type,
           payload: Value(jsonEncode(payload)),
+          runId: Value(runId),
           status: status,
           createdAt: Value(now),
           updatedAt: Value(now),

--- a/test/ui/timeline/widgets/failed_card_recovery_banner_test.dart
+++ b/test/ui/timeline/widgets/failed_card_recovery_banner_test.dart
@@ -68,4 +68,73 @@ void main() {
     expect(retryCount, 0);
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
   });
+
+  testWidgets('processing banner is hidden for stale processing card', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CardProcessingStatusBanner(
+            status: 'processing',
+            failureReason: null,
+            hasActiveTask: false,
+            isRetrying: false,
+            onRetry: null,
+            onShowReason: null,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(UserStorage.l10n.cardRegeneratingTitle), findsNothing);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('processing banner is shown while card has active task', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CardProcessingStatusBanner(
+            status: 'processing',
+            failureReason: null,
+            hasActiveTask: true,
+            isRetrying: false,
+            onRetry: null,
+            onShowReason: null,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(UserStorage.l10n.cardRegeneratingTitle), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('failed status still shows recovery even without active task', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CardProcessingStatusBanner(
+            status: 'failed',
+            failureReason: '模型服务超时',
+            hasActiveTask: false,
+            isRetrying: false,
+            onRetry: null,
+            onShowReason: null,
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.text(UserStorage.l10n.cardGenerationFailedTitle),
+      findsOneWidget,
+    );
+    expect(find.text(UserStorage.l10n.failureReason), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## 摘要
- 统一 LocalTaskExecutor 的永久失败处理，让失败处理器、task 状态和 agent_run 状态保持一致。
- 调整 AgentRunService 的状态收敛：后续成功完成的运行不再被旧失败覆盖，成功重跑会清理旧错误。
- 卡片详情页只在确实存在卡片生成相关活跃任务时展示再生成中状态，避免 pkm/comment 等任务误导用户。

## 验证
- flutter test --no-pub --concurrency=1 test/data/services/local_task_executor_test.dart test/data/services/agent_run_service_test.dart test/ui/timeline/widgets/failed_card_recovery_banner_test.dart
- flutter test --no-pub --concurrency=1
- dart analyze 变更文件：无 error/warning，仅保留既有 info lint
- Android 模拟器 Medium_Phone_API_35：构建 globalDev debug APK，安装并冷启动，进入 onboarding UI，无启动 crash 日志

Closes #277