### PR TITLE
fix: 保护 post card router 的空 tool_use 返回

### DIFF
--- a/lib/agent/post_card_router_agent/post_card_router_agent.dart
+++ b/lib/agent/post_card_router_agent/post_card_router_agent.dart
@@ -21,10 +21,7 @@ class PostCardRouterTargets {
   static const String scheduleAggregator = 'schedule_aggregator';
   static const String askClarification = 'ask_clarification';
 
-  static const Set<String> all = {
-    scheduleAggregator,
-    askClarification,
-  };
+  static const Set<String> all = {scheduleAggregator, askClarification};
 }
 
 class PostCardRouteResult {
@@ -37,6 +34,25 @@ class PostCardRouteResult {
   final List<String> activatedAgents;
   final String reason;
   final double? confidence;
+}
+
+/// Retryable protocol failure for router turns that stop for tool use without
+/// exposing a structured tool call to the agent runtime.
+class PostCardRouterProtocolException implements Exception {
+  PostCardRouterProtocolException({
+    required this.factId,
+    required this.stopReason,
+  });
+
+  final String factId;
+  final String stopReason;
+
+  @override
+  String toString() {
+    return 'PostCardRouterProtocolException: model stopped for tool use '
+        'without a structured select_downstream_agents call '
+        '(factId=$factId, stopReason=$stopReason)';
+  }
 }
 
 /// Lightweight selector agent. Decides which downstream agents should run
@@ -135,6 +151,18 @@ class PostCardRouterAgent {
       return decision;
     }
 
+    final malformedToolUse = _toolUseStopWithoutFunctionCalls(state);
+    if (malformedToolUse != null) {
+      _logger.warning(
+        'Router model stopped for tool use without structured function calls '
+        'for $factId; retrying. stopReason=${malformedToolUse.stopReason}',
+      );
+      throw PostCardRouterProtocolException(
+        factId: factId,
+        stopReason: malformedToolUse.stopReason!,
+      );
+    }
+
     _logger.warning(
       'Router did not call select_downstream_agents for $factId; treating '
       'as no-op.',
@@ -144,6 +172,28 @@ class PostCardRouterAgent {
       reason: 'router_no_decision',
     );
   }
+}
+
+ModelMessage? _toolUseStopWithoutFunctionCalls(AgentState state) {
+  for (final message in state.history.messages.reversed) {
+    if (message is! ModelMessage) continue;
+    final stopReason = message.stopReason;
+    if (stopReason == null || !_isToolUseStopReason(stopReason)) return null;
+    if (message.functionCalls.isNotEmpty) return null;
+    return message;
+  }
+  return null;
+}
+
+bool _isToolUseStopReason(String stopReason) {
+  final normalized = stopReason.toLowerCase().replaceAll(
+        RegExp(r'[^a-z0-9]+'),
+        '_',
+      );
+  return normalized == 'tool_use' ||
+      normalized == 'tool_calls' ||
+      normalized == 'function_call' ||
+      normalized == 'function_calls';
 }
 
 /// Build the structured context that the router LLM receives.
@@ -205,11 +255,7 @@ Tool _buildActivateTool({
       },
       'required': ['agents', 'reason'],
     },
-    executable: (
-      List<dynamic>? agents,
-      String reason,
-      num? confidence,
-    ) async {
+    executable: (List<dynamic>? agents, String reason, num? confidence) async {
       final normalized = _normalizeAgents(agents);
 
       // Enqueue the corresponding downstream tasks. Best-effort: a failure
@@ -247,10 +293,7 @@ Tool _buildActivateTool({
 
       // The routing decision is final once this tool returns. Stop the
       // agent immediately so the model does not produce a follow-up turn.
-      return AgentToolResult(
-        content: TextPart(summary),
-        stopFlag: true,
-      );
+      return AgentToolResult(content: TextPart(summary), stopFlag: true);
     },
   );
 }
@@ -371,7 +414,8 @@ String buildPostCardRouterInputMarkdown({
   buffer.writeln('### Raw Input Content');
   final trimmed = combinedText.trim();
   buffer.writeln(
-      trimmed.isEmpty ? '(No text content.)' : _truncate(trimmed, 4000));
+    trimmed.isEmpty ? '(No text content.)' : _truncate(trimmed, 4000),
+  );
   buffer.write(formatAssetAnalysis(assetAnalyses, includeExif: true));
   return buffer.toString().trimRight();
 }

--- a/lib/data/services/task_handlers/post_card_router_handler.dart
+++ b/lib/data/services/task_handlers/post_card_router_handler.dart
@@ -75,7 +75,7 @@ Future<void> handlePostCardRouter(
       'agents=${decision.activatedAgents}',
     );
   } catch (e, st) {
-    if (e is NonRetryableLlmException) {
+    if (e is NonRetryableLlmException || e is PostCardRouterProtocolException) {
       rethrow;
     }
     _logger.warning(

--- a/test/agent/post_card_router_agent_test.dart
+++ b/test/agent/post_card_router_agent_test.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/post_card_router_agent/post_card_router_agent.dart';
+import 'package:memex/data/services/agent_activity_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PostCardRouterAgent protocol guard', () {
+    late Directory tempRoot;
+    late String userId;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await UserStorage.initL10n();
+      AgentActivityService.setInstance(LocalAgentActivityService.instance);
+      userId = 'router_guard_${DateTime.now().microsecondsSinceEpoch}';
+      await UserStorage.saveUser(userId);
+
+      tempRoot = await Directory.systemTemp.createTemp('memex_router_guard_');
+      await FileSystemService.init(tempRoot.path);
+    });
+
+    tearDown(() async {
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test(
+      'throws retryable protocol error for tool_use without function calls',
+      () async {
+        await expectLater(
+          () => _routeWith(
+            userId: userId,
+            factId: 'fact_tool_use_without_calls',
+            response: ModelMessage(
+              model: 'test-model',
+              stopReason: 'tool_use',
+              textOutput:
+                  'select_downstream_agents({"agents":["schedule_aggregator"]})',
+            ),
+          ),
+          throwsA(
+            isA<PostCardRouterProtocolException>()
+                .having(
+                  (e) => e.factId,
+                  'factId',
+                  'fact_tool_use_without_calls',
+                )
+                .having((e) => e.stopReason, 'stopReason', 'tool_use'),
+          ),
+        );
+      },
+    );
+
+    test('executes structured schedule aggregator tool call', () async {
+      final result = await _routeWith(
+        userId: userId,
+        factId: 'fact_structured_schedule',
+        response: _toolCallResponse({
+          'agents': [PostCardRouterTargets.scheduleAggregator],
+          'reason': 'The input describes a dated schedule item.',
+          'confidence': 0.91,
+        }),
+      );
+
+      expect(result.activatedAgents, [
+        PostCardRouterTargets.scheduleAggregator,
+      ]);
+      expect(result.reason, 'The input describes a dated schedule item.');
+      expect(result.confidence, 0.91);
+    });
+
+    test('allows structured empty-agent no-op decision', () async {
+      final result = await _routeWith(
+        userId: userId,
+        factId: 'fact_structured_noop',
+        response: _toolCallResponse({
+          'agents': <String>[],
+          'reason': 'No downstream processing is needed.',
+        }),
+      );
+
+      expect(result.activatedAgents, isEmpty);
+      expect(result.reason, 'No downstream processing is needed.');
+    });
+
+    test(
+      'does not parse tool-shaped text when stop reason is not tool use',
+      () async {
+        final result = await _routeWith(
+          userId: userId,
+          factId: 'fact_text_only_no_decision',
+          response: ModelMessage(
+            model: 'test-model',
+            stopReason: 'stop',
+            textOutput:
+                'select_downstream_agents({"agents":["schedule_aggregator"]})',
+          ),
+        );
+
+        expect(result.activatedAgents, isEmpty);
+        expect(result.reason, 'router_no_decision');
+      },
+    );
+  });
+}
+
+Future<PostCardRouteResult> _routeWith({
+  required String userId,
+  required String factId,
+  required ModelMessage response,
+}) {
+  return PostCardRouterAgent.route(
+    client: _SingleResponseClient(response),
+    modelConfig: ModelConfig(model: 'test-model'),
+    userId: userId,
+    factId: factId,
+    combinedText: 'Meet Alex tomorrow at 10am.',
+    inputMarkdown: '- Raw Input ID (fact_id): $factId\n\n'
+        '### Raw Input Content\n'
+        'Meet Alex tomorrow at 10am.',
+    scheduleStateContext: const {'pending': <Map<String, dynamic>>[]},
+  );
+}
+
+ModelMessage _toolCallResponse(Map<String, dynamic> arguments) {
+  return ModelMessage(
+    model: 'test-model',
+    stopReason: 'tool_calls',
+    functionCalls: [
+      FunctionCall(
+        id: 'call_1',
+        name: 'select_downstream_agents',
+        arguments: jsonEncode(arguments),
+      ),
+    ],
+  );
+}
+
+class _SingleResponseClient extends LLMClient {
+  _SingleResponseClient(this.response);
+
+  final ModelMessage response;
+  var _callCount = 0;
+
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    _callCount += 1;
+    if (_callCount == 1) return response;
+    return ModelMessage(
+      model: modelConfig.model,
+      stopReason: 'stop',
+      textOutput: 'done',
+    );
+  }
+
+  @override
+  Future<Stream<StreamingMessage>> stream(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    throw UnsupportedError('Streaming is not used by this test client.');
+  }
+}


### PR DESCRIPTION
## 摘要
- 在 PostCardRouterAgent 中识别 provider 返回 tool_use/tool_calls stop reason 但没有 function call 的协议异常。
- 将这类异常从 router handler 透出为可重试失败，交给 LocalTaskExecutor 重试/最终失败，而不是静默写入 router_no_decision。
- 保留正常空结果和普通文本响应的原有语义，避免误伤无下游动作的合法场景。

## 验证
- flutter test --no-pub --concurrency=1 test/agent/post_card_router_agent_test.dart
- flutter test --no-pub --concurrency=1 test/data/services/local_task_executor_test.dart
- flutter test --no-pub --concurrency=1
- dart analyze 变更文件：无 issue
- Android 模拟器 Medium_Phone_API_35：arm64 globalDev debug APK 安装并冷启动，进入 onboarding UI，无启动 crash 日志

Closes #278