### PR TITLE
实现应用更新清单与关于页

### DIFF
--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/AppInfoChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/AppInfoChannelHandler.kt
@@ -1,0 +1,41 @@
+package com.memexlab.memex.channels
+
+import android.app.Activity
+import android.os.Build
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Handles `com.memexlab.memex/app_info` MethodChannel.
+ */
+class AppInfoChannelHandler(private val activity: Activity) {
+
+    companion object {
+        private const val CHANNEL = "com.memexlab.memex/app_info"
+
+        fun register(flutterEngine: FlutterEngine, activity: Activity) {
+            val handler = AppInfoChannelHandler(activity)
+            MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+                .setMethodCallHandler { call, result ->
+                    when (call.method) {
+                        "getInstallerSource" -> result.success(handler.getInstallerSource())
+                        else -> result.notImplemented()
+                    }
+                }
+        }
+    }
+
+    private fun getInstallerSource(): String? {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val sourceInfo = activity.packageManager.getInstallSourceInfo(activity.packageName)
+                sourceInfo.installingPackageName ?: sourceInfo.initiatingPackageName
+            } else {
+                @Suppress("DEPRECATION")
+                activity.packageManager.getInstallerPackageName(activity.packageName)
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/memexlab/memex/channels/ChannelRegistrar.kt
+++ b/android/app/src/main/kotlin/com/memexlab/memex/channels/ChannelRegistrar.kt
@@ -18,6 +18,7 @@ object ChannelRegistrar {
         WebViewChannelHandler.register(flutterEngine, activity)
         AudioConverterChannelHandler.register(flutterEngine, activity)
         SystemActionsChannelHandler.register(flutterEngine, activity)
+        AppInfoChannelHandler.register(flutterEngine, activity)
         AppUpdateChannelHandler.register(flutterEngine, activity)
         BackupStorageChannelHandler.register(flutterEngine, activity)
         BackupImportChannelHandler.register(flutterEngine, activity)

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -21,6 +21,8 @@ import 'package:memex/data/services/clarification_request_service.dart';
 import 'package:memex/data/services/agent_background_coordinator.dart';
 import 'package:memex/data/services/agent_background_task_service.dart';
 import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/data/services/app_info_service.dart';
+import 'package:memex/data/services/app_update_router.dart';
 import 'package:memex/data/services/app_update_service.dart';
 import 'package:memex/data/services/user_notification_service.dart';
 import 'package:path/path.dart' as path;
@@ -86,6 +88,7 @@ import 'package:memex/agent/skills/knowledge_insight/native_widgets.dart';
 import 'package:memex/utils/result.dart';
 import 'package:memex/domain/models/system_event.dart';
 import 'package:memex/domain/models/user_stats_model.dart';
+import 'package:memex/domain/models/app_build_info.dart';
 
 /// Local data service for Memex. Handles all data operations via local storage (FileSystemService, DB).
 class MemexRouter {
@@ -799,11 +802,43 @@ class MemexRouter {
   }
 
   Future<AppUpdateSettings> getAppUpdateSettings() {
-    return AppUpdateService.instance.loadSettings();
+    return AppUpdateRouter.instance.loadSettings();
   }
 
   Future<void> saveAppUpdateSettings(AppUpdateSettings settings) {
-    return AppUpdateService.instance.saveSettings(settings);
+    return AppUpdateRouter.instance.saveSettings(settings);
+  }
+
+  Future<Result<AppBuildInfo>> getAppBuildInfo() {
+    return runResult(() => AppInfoService.instance.loadBuildInfo());
+  }
+
+  Future<Result<UnifiedAppUpdateCheckResult>> checkAppUpdate({
+    bool manual = false,
+  }) {
+    return runResult(() {
+      return AppUpdateRouter.instance.checkForUpdate(manual: manual);
+    });
+  }
+
+  Future<Result<AppUpdateActionResult>> performAppUpdateAction(
+    UnifiedAppUpdateCheckResult check, {
+    void Function(int receivedBytes, int totalBytes)? onProgress,
+  }) {
+    return runResult(() {
+      return AppUpdateRouter.instance.performUpdateAction(
+        check,
+        onProgress: onProgress,
+      );
+    });
+  }
+
+  Future<AppUpdateCacheInfo> getAppUpdateCacheInfo() {
+    return AppUpdateRouter.instance.getDownloadedUpdateCacheInfo();
+  }
+
+  Future<Result<int>> clearAppUpdateCache() {
+    return runResult(() => AppUpdateRouter.instance.clearDownloadedUpdates());
   }
 
   Future<Result<AppUpdateCheckResult>> checkEarlyUpdate({

--- a/lib/data/services/app_info_service.dart
+++ b/lib/data/services/app_info_service.dart
@@ -1,0 +1,142 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:memex/config/app_flavor.dart';
+import 'package:memex/domain/models/app_build_info.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class AppPackageMetadata {
+  const AppPackageMetadata({
+    required this.appName,
+    required this.packageName,
+    required this.versionName,
+    required this.buildNumber,
+  });
+
+  final String appName;
+  final String packageName;
+  final String versionName;
+  final int buildNumber;
+}
+
+class AppInfoEnvironment {
+  const AppInfoEnvironment({
+    required this.isAndroid,
+    required this.isIOS,
+    required this.platformName,
+  });
+
+  factory AppInfoEnvironment.current() {
+    if (Platform.isAndroid) {
+      return const AppInfoEnvironment(
+        isAndroid: true,
+        isIOS: false,
+        platformName: 'android',
+      );
+    }
+    if (Platform.isIOS) {
+      return const AppInfoEnvironment(
+        isAndroid: false,
+        isIOS: true,
+        platformName: 'ios',
+      );
+    }
+    return const AppInfoEnvironment(
+      isAndroid: false,
+      isIOS: false,
+      platformName: 'unknown',
+    );
+  }
+
+  final bool isAndroid;
+  final bool isIOS;
+  final String platformName;
+}
+
+abstract class AppInfoPlatform {
+  Future<String?> getInstallerSource();
+}
+
+class MethodChannelAppInfoPlatform implements AppInfoPlatform {
+  const MethodChannelAppInfoPlatform();
+
+  static const MethodChannel _channel = MethodChannel(
+    'com.memexlab.memex/app_info',
+  );
+
+  @override
+  Future<String?> getInstallerSource() {
+    return _channel.invokeMethod<String>('getInstallerSource');
+  }
+}
+
+typedef AppPackageMetadataLoader = Future<AppPackageMetadata> Function();
+
+class AppInfoService {
+  AppInfoService({
+    AppInfoEnvironment? environment,
+    AppInfoPlatform? platform,
+    AppPackageMetadataLoader? packageLoader,
+  }) : _environment = environment ?? AppInfoEnvironment.current(),
+       _platform = platform ?? const MethodChannelAppInfoPlatform(),
+       _packageLoader = packageLoader ?? _loadPackageMetadata;
+
+  static final AppInfoService instance = AppInfoService();
+
+  final AppInfoEnvironment _environment;
+  final AppInfoPlatform _platform;
+  final AppPackageMetadataLoader _packageLoader;
+  final _logger = getLogger('AppInfoService');
+
+  Future<AppBuildInfo> loadBuildInfo() async {
+    final package = await _packageLoader();
+    return AppBuildInfo(
+      appName: package.appName,
+      packageName: package.packageName,
+      versionName: package.versionName,
+      buildNumber: package.buildNumber,
+      flavorName: AppFlavor.name,
+      regionName: _regionName,
+      channelName: _channelName,
+      platformName: _environment.platformName,
+      installerSource: await _loadInstallerSource(),
+    );
+  }
+
+  Future<String?> _loadInstallerSource() async {
+    if (!_environment.isAndroid) return null;
+    try {
+      final source = await _platform.getInstallerSource();
+      final trimmed = source?.trim();
+      return trimmed == null || trimmed.isEmpty ? null : trimmed;
+    } on MissingPluginException catch (e, st) {
+      _logger.fine('Installer source channel is unavailable', e, st);
+      return null;
+    } catch (e, st) {
+      _logger.warning('Failed to load Android installer source', e, st);
+      return null;
+    }
+  }
+
+  static Future<AppPackageMetadata> _loadPackageMetadata() async {
+    final info = await PackageInfo.fromPlatform();
+    return AppPackageMetadata(
+      appName: info.appName,
+      packageName: info.packageName,
+      versionName: info.version,
+      buildNumber: int.tryParse(info.buildNumber) ?? 0,
+    );
+  }
+
+  String get _regionName => switch (AppFlavor.current) {
+    AppFlavorType.cn => 'cn',
+    AppFlavorType.global => 'global',
+  };
+
+  String get _channelName => switch (AppFlavor.channel) {
+    AppChannelType.stable => 'stable',
+    AppChannelType.early => 'early',
+    AppChannelType.dev => 'dev',
+  };
+}

--- a/lib/data/services/app_update_router.dart
+++ b/lib/data/services/app_update_router.dart
@@ -1,0 +1,561 @@
+import 'package:memex/data/services/app_info_service.dart';
+import 'package:memex/data/services/app_update_service.dart';
+import 'package:memex/data/services/update_manifest_service.dart';
+import 'package:memex/domain/models/app_build_info.dart';
+import 'package:memex/domain/models/update_manifest.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+enum UnifiedAppUpdateStatus {
+  noUpdate,
+  updateAvailable,
+  unsupported,
+  checkFailed,
+}
+
+class UnifiedAppUpdateCheckResult {
+  const UnifiedAppUpdateCheckResult({
+    required this.status,
+    required this.buildInfo,
+    required this.providerKind,
+    required this.manifestSource,
+    required this.checkedAt,
+    this.channel,
+    this.apkUpdate,
+    this.actionUri,
+    this.error,
+    this.manifestGeneratedAt,
+    this.usedManifestFallback = false,
+    this.usedBuiltInFallback = false,
+  });
+
+  final UnifiedAppUpdateStatus status;
+  final AppBuildInfo buildInfo;
+  final UpdateProviderKind providerKind;
+  final UpdateManifestChannel? channel;
+  final AppUpdateInfo? apkUpdate;
+  final Uri? actionUri;
+  final String manifestSource;
+  final DateTime checkedAt;
+  final DateTime? manifestGeneratedAt;
+  final Object? error;
+  final bool usedManifestFallback;
+  final bool usedBuiltInFallback;
+
+  bool get hasUpdate => status == UnifiedAppUpdateStatus.updateAvailable;
+  bool get canDownloadApk => apkUpdate != null;
+  bool get canOpenExternalUpdate => actionUri != null && apkUpdate == null;
+  bool get requiresUpdate =>
+      channel?.requiresUpdateFor(buildInfo.buildNumber) ?? false;
+  int? get latestBuild => channel?.latestBuild ?? apkUpdate?.buildNumber;
+  String? get latestVersionName =>
+      channel?.versionName ?? apkUpdate?.versionName;
+}
+
+enum AppUpdateActionStatus {
+  openedExternal,
+  installStarted,
+  permissionRequired,
+  unsupported,
+}
+
+class AppUpdateActionResult {
+  const AppUpdateActionResult(this.status);
+
+  final AppUpdateActionStatus status;
+}
+
+abstract class UnifiedUpdateProvider {
+  const UnifiedUpdateProvider();
+
+  UpdateProviderKind get kind;
+
+  bool supports(AppBuildInfo buildInfo, UpdateManifestChannel channel);
+
+  UnifiedAppUpdateCheckResult buildResult({
+    required AppBuildInfo buildInfo,
+    required UpdateManifestChannel channel,
+    required UpdateManifestLoadResult manifestLoad,
+    required DateTime checkedAt,
+  });
+
+  bool packageMatches(AppBuildInfo buildInfo, UpdateManifestChannel channel) {
+    if (buildInfo.isAndroid) {
+      final expected = channel.packageName;
+      return expected == null || expected == buildInfo.packageName;
+    }
+    if (buildInfo.isIOS) {
+      final expected = channel.bundleId;
+      return expected == null || expected == buildInfo.packageName;
+    }
+    return false;
+  }
+
+  UnifiedAppUpdateCheckResult noUpdateResult({
+    required AppBuildInfo buildInfo,
+    required UpdateManifestChannel channel,
+    required UpdateManifestLoadResult manifestLoad,
+    required DateTime checkedAt,
+  }) {
+    return UnifiedAppUpdateCheckResult(
+      status: UnifiedAppUpdateStatus.noUpdate,
+      buildInfo: buildInfo,
+      providerKind: kind,
+      channel: channel,
+      manifestSource: manifestLoad.sourceUrl,
+      checkedAt: checkedAt,
+      manifestGeneratedAt: manifestLoad.manifest.generatedAt,
+      usedManifestFallback: manifestLoad.usedFallback,
+      usedBuiltInFallback: manifestLoad.usedBuiltInFallback,
+    );
+  }
+}
+
+class AppleAppStoreUpdateProvider extends UnifiedUpdateProvider {
+  const AppleAppStoreUpdateProvider();
+
+  @override
+  UpdateProviderKind get kind => UpdateProviderKind.appStore;
+
+  @override
+  bool supports(AppBuildInfo buildInfo, UpdateManifestChannel channel) {
+    return buildInfo.isIOS &&
+        channel.provider == kind &&
+        packageMatches(buildInfo, channel);
+  }
+
+  @override
+  UnifiedAppUpdateCheckResult buildResult({
+    required AppBuildInfo buildInfo,
+    required UpdateManifestChannel channel,
+    required UpdateManifestLoadResult manifestLoad,
+    required DateTime checkedAt,
+  }) {
+    if (!channel.isNewerThan(buildInfo.buildNumber)) {
+      return noUpdateResult(
+        buildInfo: buildInfo,
+        channel: channel,
+        manifestLoad: manifestLoad,
+        checkedAt: checkedAt,
+      );
+    }
+    return _externalResult(
+      kind: kind,
+      buildInfo: buildInfo,
+      channel: channel,
+      manifestLoad: manifestLoad,
+      checkedAt: checkedAt,
+    );
+  }
+}
+
+class AndroidStoreRedirectProvider extends UnifiedUpdateProvider {
+  const AndroidStoreRedirectProvider();
+
+  @override
+  UpdateProviderKind get kind => UpdateProviderKind.androidStore;
+
+  @override
+  bool supports(AppBuildInfo buildInfo, UpdateManifestChannel channel) {
+    return buildInfo.isAndroid &&
+        channel.provider == kind &&
+        packageMatches(buildInfo, channel);
+  }
+
+  @override
+  UnifiedAppUpdateCheckResult buildResult({
+    required AppBuildInfo buildInfo,
+    required UpdateManifestChannel channel,
+    required UpdateManifestLoadResult manifestLoad,
+    required DateTime checkedAt,
+  }) {
+    if (!channel.isNewerThan(buildInfo.buildNumber)) {
+      return noUpdateResult(
+        buildInfo: buildInfo,
+        channel: channel,
+        manifestLoad: manifestLoad,
+        checkedAt: checkedAt,
+      );
+    }
+    return _externalResult(
+      kind: kind,
+      buildInfo: buildInfo,
+      channel: channel,
+      manifestLoad: manifestLoad,
+      checkedAt: checkedAt,
+    );
+  }
+}
+
+class GooglePlayUpdateProvider extends UnifiedUpdateProvider {
+  const GooglePlayUpdateProvider();
+
+  @override
+  UpdateProviderKind get kind => UpdateProviderKind.googlePlay;
+
+  @override
+  bool supports(AppBuildInfo buildInfo, UpdateManifestChannel channel) {
+    return buildInfo.isAndroid &&
+        channel.provider == kind &&
+        packageMatches(buildInfo, channel);
+  }
+
+  @override
+  UnifiedAppUpdateCheckResult buildResult({
+    required AppBuildInfo buildInfo,
+    required UpdateManifestChannel channel,
+    required UpdateManifestLoadResult manifestLoad,
+    required DateTime checkedAt,
+  }) {
+    if (!channel.isNewerThan(buildInfo.buildNumber)) {
+      return noUpdateResult(
+        buildInfo: buildInfo,
+        channel: channel,
+        manifestLoad: manifestLoad,
+        checkedAt: checkedAt,
+      );
+    }
+    return _externalResult(
+      kind: kind,
+      buildInfo: buildInfo,
+      channel: channel,
+      manifestLoad: manifestLoad,
+      checkedAt: checkedAt,
+    );
+  }
+}
+
+class GithubApkUpdateProvider extends UnifiedUpdateProvider {
+  const GithubApkUpdateProvider();
+
+  @override
+  UpdateProviderKind get kind => UpdateProviderKind.githubApk;
+
+  @override
+  bool supports(AppBuildInfo buildInfo, UpdateManifestChannel channel) {
+    return buildInfo.isAndroid &&
+        channel.provider == kind &&
+        packageMatches(buildInfo, channel) &&
+        _allowsDirectApk(buildInfo, channel);
+  }
+
+  @override
+  UnifiedAppUpdateCheckResult buildResult({
+    required AppBuildInfo buildInfo,
+    required UpdateManifestChannel channel,
+    required UpdateManifestLoadResult manifestLoad,
+    required DateTime checkedAt,
+  }) {
+    if (!channel.isNewerThan(buildInfo.buildNumber)) {
+      return noUpdateResult(
+        buildInfo: buildInfo,
+        channel: channel,
+        manifestLoad: manifestLoad,
+        checkedAt: checkedAt,
+      );
+    }
+
+    final apkUrl = channel.apkUrl!;
+    final update = AppUpdateInfo(
+      releaseName: 'Memex ${channel.versionName}+${channel.latestBuild}',
+      tagName: channel.releaseNotesUrl ?? channel.versionName!,
+      versionName: channel.versionName!,
+      buildNumber: channel.latestBuild,
+      assetName: _assetNameFromUrl(apkUrl, buildInfo, channel),
+      sizeBytes: channel.sizeBytes!,
+      downloadUrl: apkUrl,
+      sha256: channel.sha256,
+      releaseNotes: channel.releaseNotes ?? channel.releaseNotesUrl ?? '',
+      publishedAt: manifestLoad.manifest.generatedAt,
+    );
+
+    return UnifiedAppUpdateCheckResult(
+      status: UnifiedAppUpdateStatus.updateAvailable,
+      buildInfo: buildInfo,
+      providerKind: kind,
+      channel: channel,
+      apkUpdate: update,
+      manifestSource: manifestLoad.sourceUrl,
+      checkedAt: checkedAt,
+      manifestGeneratedAt: manifestLoad.manifest.generatedAt,
+      usedManifestFallback: manifestLoad.usedFallback,
+      usedBuiltInFallback: manifestLoad.usedBuiltInFallback,
+    );
+  }
+
+  bool _allowsDirectApk(AppBuildInfo buildInfo, UpdateManifestChannel channel) {
+    if (buildInfo.isEarly || buildInfo.isDev || buildInfo.isDirectInstall) {
+      return true;
+    }
+    final packageName = buildInfo.packageName.toLowerCase();
+    return packageName.contains('.early') ||
+        packageName.contains('.dev') ||
+        channel.key.contains('_early') ||
+        channel.key.contains('_dev');
+  }
+
+  String _assetNameFromUrl(
+    String apkUrl,
+    AppBuildInfo buildInfo,
+    UpdateManifestChannel channel,
+  ) {
+    final uri = Uri.tryParse(apkUrl);
+    final pathSegments = uri?.pathSegments ?? const <String>[];
+    if (pathSegments.isNotEmpty) {
+      final candidate = Uri.decodeComponent(pathSegments.last);
+      if (candidate.toLowerCase().endsWith('.apk')) return candidate;
+    }
+    return 'memex_${buildInfo.flavorName}_${channel.versionName}_${channel.latestBuild}.apk';
+  }
+}
+
+class NoopUpdateProvider extends UnifiedUpdateProvider {
+  const NoopUpdateProvider();
+
+  @override
+  UpdateProviderKind get kind => UpdateProviderKind.noop;
+
+  @override
+  bool supports(AppBuildInfo buildInfo, UpdateManifestChannel channel) {
+    return channel.provider == kind;
+  }
+
+  @override
+  UnifiedAppUpdateCheckResult buildResult({
+    required AppBuildInfo buildInfo,
+    required UpdateManifestChannel channel,
+    required UpdateManifestLoadResult manifestLoad,
+    required DateTime checkedAt,
+  }) {
+    return noUpdateResult(
+      buildInfo: buildInfo,
+      channel: channel,
+      manifestLoad: manifestLoad,
+      checkedAt: checkedAt,
+    );
+  }
+}
+
+UnifiedAppUpdateCheckResult _externalResult({
+  required UpdateProviderKind kind,
+  required AppBuildInfo buildInfo,
+  required UpdateManifestChannel channel,
+  required UpdateManifestLoadResult manifestLoad,
+  required DateTime checkedAt,
+}) {
+  return UnifiedAppUpdateCheckResult(
+    status: UnifiedAppUpdateStatus.updateAvailable,
+    buildInfo: buildInfo,
+    providerKind: kind,
+    channel: channel,
+    actionUri: channel.primaryActionUri,
+    manifestSource: manifestLoad.sourceUrl,
+    checkedAt: checkedAt,
+    manifestGeneratedAt: manifestLoad.manifest.generatedAt,
+    usedManifestFallback: manifestLoad.usedFallback,
+    usedBuiltInFallback: manifestLoad.usedBuiltInFallback,
+  );
+}
+
+typedef AppUpdateRouterClock = DateTime Function();
+
+class AppUpdateRouter {
+  AppUpdateRouter({
+    AppInfoService? appInfoService,
+    UpdateManifestService? manifestService,
+    AppUpdateService? apkUpdateService,
+    List<UnifiedUpdateProvider>? providers,
+    AppUpdateRouterClock? clock,
+  }) : _appInfoService = appInfoService ?? AppInfoService.instance,
+       _manifestService = manifestService ?? UpdateManifestService.instance,
+       _apkUpdateService = apkUpdateService ?? AppUpdateService.instance,
+       _providers =
+           providers ??
+           const [
+             AppleAppStoreUpdateProvider(),
+             AndroidStoreRedirectProvider(),
+             GooglePlayUpdateProvider(),
+             GithubApkUpdateProvider(),
+             NoopUpdateProvider(),
+           ],
+       _clock = clock ?? DateTime.now;
+
+  static final AppUpdateRouter instance = AppUpdateRouter();
+
+  final AppInfoService _appInfoService;
+  final UpdateManifestService _manifestService;
+  final AppUpdateService _apkUpdateService;
+  final List<UnifiedUpdateProvider> _providers;
+  final AppUpdateRouterClock _clock;
+  final _logger = getLogger('AppUpdateRouter');
+
+  Future<bool> shouldRunAutoCheck() async {
+    final buildInfo = await _appInfoService.loadBuildInfo();
+    if (buildInfo.isDev) return false;
+    final settings = await _apkUpdateService.loadSettings();
+    return settings.shouldAutoCheck(now: _clock());
+  }
+
+  Future<AppUpdateSettings> loadSettings() {
+    return _apkUpdateService.loadSettings();
+  }
+
+  Future<void> saveSettings(AppUpdateSettings settings) {
+    return _apkUpdateService.saveSettings(settings);
+  }
+
+  Future<AppUpdateCacheInfo> getDownloadedUpdateCacheInfo() {
+    return _apkUpdateService.getDownloadedUpdateCacheInfo();
+  }
+
+  Future<int> clearDownloadedUpdates() {
+    return _apkUpdateService.clearDownloadedUpdates();
+  }
+
+  Future<UnifiedAppUpdateCheckResult> checkForUpdate({
+    bool manual = false,
+  }) async {
+    final buildInfo = await _appInfoService.loadBuildInfo();
+    final checkedAt = _clock();
+    if (!manual && buildInfo.isDev) {
+      return _checkFailed(
+        buildInfo: buildInfo,
+        checkedAt: checkedAt,
+        error: 'Dev builds do not run automatic update checks.',
+      );
+    }
+
+    try {
+      final manifestLoad = await _manifestService.loadManifest();
+      if (manifestLoad.usedBuiltInFallback) {
+        await _recordLastCheckAt();
+        return _checkFailed(
+          buildInfo: buildInfo,
+          checkedAt: checkedAt,
+          error: manifestLoad.error ?? 'No update manifest is available.',
+          manifestSource: manifestLoad.sourceUrl,
+          usedManifestFallback: true,
+          usedBuiltInFallback: true,
+        );
+      }
+
+      final channel = manifestLoad.manifest.channelFor(buildInfo);
+      if (channel == null) {
+        await _recordLastCheckAt();
+        return UnifiedAppUpdateCheckResult(
+          status: UnifiedAppUpdateStatus.noUpdate,
+          buildInfo: buildInfo,
+          providerKind: UpdateProviderKind.noop,
+          manifestSource: manifestLoad.sourceUrl,
+          checkedAt: checkedAt,
+          manifestGeneratedAt: manifestLoad.manifest.generatedAt,
+          usedManifestFallback: manifestLoad.usedFallback,
+        );
+      }
+
+      final provider = selectProvider(buildInfo, channel);
+      if (provider == null) {
+        await _recordLastCheckAt();
+        return UnifiedAppUpdateCheckResult(
+          status: UnifiedAppUpdateStatus.unsupported,
+          buildInfo: buildInfo,
+          providerKind: channel.provider,
+          channel: channel,
+          manifestSource: manifestLoad.sourceUrl,
+          checkedAt: checkedAt,
+          manifestGeneratedAt: manifestLoad.manifest.generatedAt,
+          usedManifestFallback: manifestLoad.usedFallback,
+        );
+      }
+
+      final result = provider.buildResult(
+        buildInfo: buildInfo,
+        channel: channel,
+        manifestLoad: manifestLoad,
+        checkedAt: checkedAt,
+      );
+      await _recordLastCheckAt();
+      return result;
+    } catch (e, st) {
+      _logger.warning('Unified app update check failed', e, st);
+      await _recordLastCheckAt();
+      return _checkFailed(buildInfo: buildInfo, checkedAt: checkedAt, error: e);
+    }
+  }
+
+  UnifiedUpdateProvider? selectProvider(
+    AppBuildInfo buildInfo,
+    UpdateManifestChannel channel,
+  ) {
+    for (final provider in _providers) {
+      if (provider.supports(buildInfo, channel)) return provider;
+    }
+    return null;
+  }
+
+  Future<AppUpdateActionResult> performUpdateAction(
+    UnifiedAppUpdateCheckResult check, {
+    void Function(int receivedBytes, int totalBytes)? onProgress,
+  }) async {
+    final apkUpdate = check.apkUpdate;
+    if (apkUpdate != null) {
+      final download = await _apkUpdateService.downloadUpdate(
+        apkUpdate,
+        onProgress: onProgress,
+      );
+      final install = await _apkUpdateService.installUpdate(download.apkPath);
+      return switch (install.status) {
+        AppUpdateInstallStatus.started => const AppUpdateActionResult(
+          AppUpdateActionStatus.installStarted,
+        ),
+        AppUpdateInstallStatus.permissionRequired =>
+          const AppUpdateActionResult(AppUpdateActionStatus.permissionRequired),
+        AppUpdateInstallStatus.unsupported => const AppUpdateActionResult(
+          AppUpdateActionStatus.unsupported,
+        ),
+      };
+    }
+
+    final actionUri = check.actionUri;
+    if (actionUri != null) {
+      final launched = await launchUrl(
+        actionUri,
+        mode: LaunchMode.externalApplication,
+      );
+      if (launched) {
+        return const AppUpdateActionResult(
+          AppUpdateActionStatus.openedExternal,
+        );
+      }
+    }
+
+    return const AppUpdateActionResult(AppUpdateActionStatus.unsupported);
+  }
+
+  Future<void> _recordLastCheckAt() async {
+    final settings = await _apkUpdateService.loadSettings();
+    await _apkUpdateService.saveSettings(
+      settings.copyWith(lastCheckAt: _clock()),
+    );
+  }
+
+  UnifiedAppUpdateCheckResult _checkFailed({
+    required AppBuildInfo buildInfo,
+    required DateTime checkedAt,
+    required Object error,
+    String manifestSource = 'unavailable',
+    bool usedManifestFallback = false,
+    bool usedBuiltInFallback = false,
+  }) {
+    return UnifiedAppUpdateCheckResult(
+      status: UnifiedAppUpdateStatus.checkFailed,
+      buildInfo: buildInfo,
+      providerKind: UpdateProviderKind.noop,
+      manifestSource: manifestSource,
+      checkedAt: checkedAt,
+      error: error,
+      usedManifestFallback: usedManifestFallback,
+      usedBuiltInFallback: usedBuiltInFallback,
+    );
+  }
+}

--- a/lib/data/services/app_update_service.dart
+++ b/lib/data/services/app_update_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path/path.dart' as path;
@@ -87,6 +88,7 @@ class AppUpdateInfo {
   final String assetName;
   final int sizeBytes;
   final String downloadUrl;
+  final String? sha256;
   final String releaseNotes;
   final DateTime? publishedAt;
 
@@ -98,6 +100,7 @@ class AppUpdateInfo {
     required this.assetName,
     required this.sizeBytes,
     required this.downloadUrl,
+    this.sha256,
     required this.releaseNotes,
     this.publishedAt,
   });
@@ -694,6 +697,17 @@ class AppUpdateService {
         );
         return false;
       }
+      final expectedSha256 = _normalizeSha256(update.sha256);
+      if (expectedSha256 != null) {
+        final actualSha256 = await _fileSha256(file);
+        if (actualSha256 != expectedSha256) {
+          _logger.info(
+            'Discarding cached APK with unexpected sha256 for '
+            '${update.displayVersion}',
+          );
+          return false;
+        }
+      }
       return true;
     } catch (e, st) {
       _logger.warning('Failed to inspect cached APK: ${file.path}', e, st);
@@ -720,6 +734,17 @@ class AppUpdateService {
         'Downloaded APK size mismatch for ${update.displayVersion}: '
         'expected $expectedBytes bytes, found ${stat.size}.',
       );
+    }
+
+    final expectedSha256 = _normalizeSha256(update.sha256);
+    if (expectedSha256 != null) {
+      final actualSha256 = await _fileSha256(file);
+      if (actualSha256 != expectedSha256) {
+        await _deleteIfExists(file);
+        throw AppUpdateInvalidPackageException(
+          'Downloaded APK sha256 mismatch for ${update.displayVersion}.',
+        );
+      }
     }
   }
 
@@ -829,11 +854,24 @@ class AppUpdateService {
     return fallback.replaceAll(RegExp(r'[^a-zA-Z0-9._-]'), '_');
   }
 
+  static String? _normalizeSha256(String? value) {
+    final normalized = value?.trim().toLowerCase();
+    if (normalized == null || normalized.isEmpty) return null;
+    return RegExp(r'^[a-f0-9]{64}$').hasMatch(normalized) ? normalized : null;
+  }
+
+  static Future<String> _fileSha256(File file) async {
+    final input = file.openRead();
+    final digest = await sha256.bind(input).first;
+    return digest.toString();
+  }
+
   static String _downloadKeyFor(AppUpdateInfo update) {
     return [
       _safeFileName(update.assetName),
       update.downloadUrl,
       update.sizeBytes,
+      update.sha256 ?? '',
     ].join('|');
   }
 }

--- a/lib/data/services/settings_registry.dart
+++ b/lib/data/services/settings_registry.dart
@@ -1,9 +1,6 @@
-import 'dart:io';
-
 import 'package:memex/config/app_config.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:memex/config/app_flavor.dart';
 import 'package:memex/domain/models/settings_item.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/ui/settings/widgets/ai_service_setup_page.dart';
@@ -13,6 +10,8 @@ import 'package:memex/ui/settings/widgets/settings_page.dart';
 import 'package:memex/ui/settings/widgets/debug_settings_page.dart';
 import 'package:memex/ui/settings/widgets/data_storage_page.dart';
 import 'package:memex/ui/settings/widgets/backup_restore_page.dart';
+import 'package:memex/ui/settings/view_models/about_memex_viewmodel.dart';
+import 'package:memex/ui/settings/widgets/about_memex_page.dart';
 import 'package:memex/ui/settings/widgets/location_context_settings_page.dart';
 import 'package:memex/ui/settings/widgets/experimental_lab_page.dart';
 import 'package:memex/ui/memory/view_models/memory_viewmodel.dart';
@@ -366,37 +365,45 @@ class SettingsRegistry {
         UserStorage.l10n.settings,
       ],
     ),
-    if (Platform.isAndroid && AppFlavor.isEarly)
-      SettingsItem(
-        id: 'settings.early_updates',
-        titleGetter: () => UserStorage.l10n.earlyUpdateSettingsTitle,
-        descriptionGetter: () => UserStorage.l10n.earlyUpdateSettingsDesc,
-        keywords: const [
-          '更新',
-          '自动更新',
-          'Early',
-          '预发布',
-          '内测',
-          'APK',
-          'GitHub',
-          'Wi-Fi',
-          'update',
-          'auto update',
-          'pre-release',
-          'prerelease',
-          'download',
-          'install',
-          'wifi',
-        ],
-        icon: Icons.system_update_alt,
-        navigationTarget: NavigationTarget(
-          pageBuilder: (_) => const SettingsPage(),
+    SettingsItem(
+      id: 'settings.about_memex',
+      titleGetter: () => UserStorage.l10n.aboutMemexTitle,
+      descriptionGetter: () => UserStorage.l10n.aboutMemexDesc,
+      keywords: const [
+        '关于',
+        '版本',
+        '构建',
+        '渠道',
+        '安装来源',
+        '更新',
+        '自动更新',
+        'APK',
+        'App Store',
+        'Google Play',
+        'GitHub',
+        'Wi-Fi',
+        'about',
+        'version',
+        'build',
+        'channel',
+        'installer',
+        'update',
+        'auto update',
+        'download',
+        'install',
+        'diagnostics',
+      ],
+      icon: Icons.info_outline,
+      navigationTarget: NavigationTarget(
+        pageBuilder: (context) => AboutMemexPage(
+          viewModel: AboutMemexViewModel(router: context.read<MemexRouter>()),
         ),
-        parentPathGetter: () => [
-          UserStorage.l10n.personalCenter,
-          UserStorage.l10n.settings,
-        ],
       ),
+      parentPathGetter: () => [
+        UserStorage.l10n.personalCenter,
+        UserStorage.l10n.settings,
+      ],
+    ),
     SettingsItem(
       id: 'settings.show_insight',
       titleGetter: () => UserStorage.l10n.showInsightTextTitle,

--- a/lib/data/services/update_manifest_service.dart
+++ b/lib/data/services/update_manifest_service.dart
@@ -1,0 +1,165 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:memex/domain/models/update_manifest.dart';
+import 'package:memex/utils/logger.dart';
+
+class UpdateManifestEndpoint {
+  const UpdateManifestEndpoint({required this.manifestUrl, this.sha256Url});
+
+  final String manifestUrl;
+  final String? sha256Url;
+}
+
+class UpdateManifestLoadResult {
+  const UpdateManifestLoadResult({
+    required this.manifest,
+    required this.sourceUrl,
+    required this.loadedAt,
+    this.error,
+    this.usedFallback = false,
+    this.usedBuiltInFallback = false,
+  });
+
+  final UpdateManifest manifest;
+  final String sourceUrl;
+  final DateTime loadedAt;
+  final Object? error;
+  final bool usedFallback;
+  final bool usedBuiltInFallback;
+
+  bool get hasError => error != null;
+}
+
+typedef UpdateManifestClock = DateTime Function();
+
+class UpdateManifestService {
+  UpdateManifestService({
+    http.Client? httpClient,
+    List<UpdateManifestEndpoint>? endpoints,
+    UpdateManifestClock? clock,
+    this.verifyManifestSha256 = true,
+    this.requestTimeout = const Duration(seconds: 5),
+  })  : _httpClient = httpClient ?? http.Client(),
+        _endpoints = endpoints ?? defaultEndpoints,
+        _clock = clock ?? DateTime.now;
+
+  static final UpdateManifestService instance = UpdateManifestService();
+
+  static const primaryManifestUrl =
+      'https://www.memexlab.ai/updates/v1/manifest.json';
+  static const primaryManifestSha256Url =
+      'https://www.memexlab.ai/updates/v1/manifest.sha256';
+  static const fallbackManifestUrl =
+      'https://github.com/memex-lab/memex/releases/latest/download/manifest.json';
+  static const fallbackManifestSha256Url =
+      'https://github.com/memex-lab/memex/releases/latest/download/manifest.sha256';
+
+  static const defaultEndpoints = [
+    UpdateManifestEndpoint(
+      manifestUrl: primaryManifestUrl,
+      sha256Url: primaryManifestSha256Url,
+    ),
+    UpdateManifestEndpoint(
+      manifestUrl: fallbackManifestUrl,
+      sha256Url: fallbackManifestSha256Url,
+    ),
+  ];
+
+  final http.Client _httpClient;
+  final List<UpdateManifestEndpoint> _endpoints;
+  final UpdateManifestClock _clock;
+  final bool verifyManifestSha256;
+  final Duration requestTimeout;
+  final _logger = getLogger('UpdateManifestService');
+
+  Future<UpdateManifestLoadResult> loadManifest() async {
+    Object? firstError;
+    for (var i = 0; i < _endpoints.length; i += 1) {
+      final endpoint = _endpoints[i];
+      try {
+        final manifest = await _fetchManifest(endpoint);
+        return UpdateManifestLoadResult(
+          manifest: manifest,
+          sourceUrl: endpoint.manifestUrl,
+          loadedAt: _clock(),
+          usedFallback: i > 0,
+        );
+      } catch (e, st) {
+        firstError ??= e;
+        _logger.warning(
+          'Failed to load update manifest from ${endpoint.manifestUrl}',
+          e,
+          st,
+        );
+      }
+    }
+
+    return UpdateManifestLoadResult(
+      manifest: UpdateManifest.empty(),
+      sourceUrl: 'built-in:no-op',
+      loadedAt: _clock(),
+      error: firstError,
+      usedFallback: true,
+      usedBuiltInFallback: true,
+    );
+  }
+
+  Future<UpdateManifest> _fetchManifest(UpdateManifestEndpoint endpoint) async {
+    final manifestUri = Uri.parse(endpoint.manifestUrl);
+    final response = await _httpClient
+        .get(manifestUri, headers: _headers)
+        .timeout(requestTimeout);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Manifest request failed: HTTP ${response.statusCode}',
+        uri: manifestUri,
+      );
+    }
+
+    final body = response.body;
+    if (verifyManifestSha256 && endpoint.sha256Url != null) {
+      await _verifyManifestSha256(body, endpoint.sha256Url!);
+    }
+
+    return UpdateManifest.fromJsonString(body);
+  }
+
+  Future<void> _verifyManifestSha256(String body, String sha256Url) async {
+    final uri = Uri.parse(sha256Url);
+    final response =
+        await _httpClient.get(uri, headers: _headers).timeout(requestTimeout);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      _logger.info(
+        'Skipping optional manifest sha256 check: HTTP '
+        '${response.statusCode} for $sha256Url',
+      );
+      return;
+    }
+
+    final expected = _extractSha256(response.body);
+    if (expected == null) {
+      _logger.info(
+        'Skipping optional manifest sha256 check: invalid hash file',
+      );
+      return;
+    }
+
+    final actual = sha256.convert(utf8.encode(body)).toString();
+    if (actual != expected) {
+      throw const FormatException('Manifest sha256 mismatch');
+    }
+  }
+
+  String? _extractSha256(String value) {
+    final match = RegExp(r'\b[a-fA-F0-9]{64}\b').firstMatch(value);
+    return match?.group(0)?.toLowerCase();
+  }
+
+  static const _headers = {
+    'Accept': 'application/json',
+    'User-Agent': 'Memex-Updater',
+  };
+}

--- a/lib/domain/models/app_build_info.dart
+++ b/lib/domain/models/app_build_info.dart
@@ -1,0 +1,86 @@
+class AppBuildInfo {
+  const AppBuildInfo({
+    required this.appName,
+    required this.packageName,
+    required this.versionName,
+    required this.buildNumber,
+    required this.flavorName,
+    required this.regionName,
+    required this.channelName,
+    required this.platformName,
+    this.installerSource,
+  });
+
+  final String appName;
+  final String packageName;
+  final String versionName;
+  final int buildNumber;
+  final String flavorName;
+  final String regionName;
+  final String channelName;
+  final String platformName;
+  final String? installerSource;
+
+  String get displayVersion => '$versionName+$buildNumber';
+
+  String get updateChannelKey =>
+      [platformName, regionName, channelName].join('_').toLowerCase();
+
+  bool get isAndroid => platformName == 'android';
+  bool get isIOS => platformName == 'ios';
+  bool get isDev => channelName == 'dev';
+  bool get isEarly => channelName == 'early';
+  bool get isStable => channelName == 'stable';
+
+  String get installerDisplayName {
+    final source = installerSource?.trim();
+    if (source == null || source.isEmpty) return 'Unknown';
+    return switch (source) {
+      'com.android.vending' => 'Google Play',
+      'com.huawei.appmarket' => 'Huawei AppGallery',
+      'com.tencent.android.qqdownloader' => 'Tencent App Store',
+      'com.xiaomi.market' => 'Xiaomi GetApps',
+      'com.oppo.market' => 'OPPO App Market',
+      'com.bbk.appstore' => 'vivo App Store',
+      'com.sec.android.app.samsungapps' => 'Samsung Galaxy Store',
+      'com.android.packageinstaller' ||
+      'com.google.android.packageinstaller' ||
+      'com.android.shell' =>
+        'Direct install',
+      _ => source,
+    };
+  }
+
+  bool get isDirectInstall {
+    final source = installerSource?.trim();
+    if (source == null || source.isEmpty) return false;
+    return source == 'com.android.packageinstaller' ||
+        source == 'com.google.android.packageinstaller' ||
+        source == 'com.android.shell';
+  }
+
+  String diagnostics({
+    String? updateProvider,
+    String? updateChannel,
+    String? manifestSource,
+    DateTime? manifestGeneratedAt,
+  }) {
+    final lines = <String>[
+      'appName=$appName',
+      'packageName=$packageName',
+      'version=$displayVersion',
+      'platform=$platformName',
+      'flavor=$flavorName',
+      'region=$regionName',
+      'channel=$channelName',
+      'installerSource=${installerSource ?? 'unknown'}',
+      'installerDisplayName=$installerDisplayName',
+      'updateChannel=${updateChannel ?? updateChannelKey}',
+      if (updateProvider != null) 'updateProvider=$updateProvider',
+      if (manifestSource != null) 'manifestSource=$manifestSource',
+      if (manifestGeneratedAt != null)
+        'manifestGeneratedAt=${manifestGeneratedAt.toIso8601String()}',
+    ];
+    return lines.join('\n');
+  }
+}

--- a/lib/domain/models/update_manifest.dart
+++ b/lib/domain/models/update_manifest.dart
@@ -1,0 +1,250 @@
+import 'dart:convert';
+
+import 'package:memex/domain/models/app_build_info.dart';
+
+enum UpdateProviderKind {
+  appStore('app_store'),
+  androidStore('android_store'),
+  googlePlay('google_play'),
+  githubApk('github_apk'),
+  noop('noop');
+
+  const UpdateProviderKind(this.wireName);
+
+  final String wireName;
+
+  static UpdateProviderKind parse(String value) {
+    for (final kind in values) {
+      if (kind.wireName == value) return kind;
+    }
+    throw FormatException('Unsupported update provider: $value');
+  }
+}
+
+class UpdateManifest {
+  const UpdateManifest({
+    required this.schemaVersion,
+    required this.channels,
+    this.generatedAt,
+    this.expiresAt,
+  });
+
+  static const supportedSchemaVersion = 1;
+
+  final int schemaVersion;
+  final DateTime? generatedAt;
+  final DateTime? expiresAt;
+  final Map<String, UpdateManifestChannel> channels;
+
+  factory UpdateManifest.empty() {
+    return const UpdateManifest(
+      schemaVersion: supportedSchemaVersion,
+      channels: {},
+    );
+  }
+
+  factory UpdateManifest.fromJsonString(String raw) {
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('Manifest root must be an object');
+    }
+    return UpdateManifest.fromJson(decoded);
+  }
+
+  factory UpdateManifest.fromJson(Map<String, dynamic> json) {
+    final schemaVersion = _requiredInt(json, 'schemaVersion');
+    if (schemaVersion != supportedSchemaVersion) {
+      throw FormatException(
+        'Unsupported manifest schemaVersion: $schemaVersion',
+      );
+    }
+
+    final rawChannels = json['channels'];
+    if (rawChannels is! Map) {
+      throw const FormatException('Manifest channels must be an object');
+    }
+
+    final channels = <String, UpdateManifestChannel>{};
+    for (final entry in rawChannels.entries) {
+      final key = entry.key.toString();
+      final value = entry.value;
+      if (value is! Map) {
+        throw FormatException('Manifest channel $key must be an object');
+      }
+      channels[key.toLowerCase()] = UpdateManifestChannel.fromJson(
+        key: key.toLowerCase(),
+        json: Map<String, dynamic>.from(value),
+      );
+    }
+
+    return UpdateManifest(
+      schemaVersion: schemaVersion,
+      generatedAt: _optionalDate(json['generatedAt']),
+      expiresAt: _optionalDate(json['expiresAt']),
+      channels: Map.unmodifiable(channels),
+    );
+  }
+
+  UpdateManifestChannel? channelFor(AppBuildInfo buildInfo) {
+    return channels[buildInfo.updateChannelKey];
+  }
+}
+
+class UpdateManifestChannel {
+  const UpdateManifestChannel({
+    required this.key,
+    required this.provider,
+    required this.latestBuild,
+    required this.minSupportedBuild,
+    this.packageName,
+    this.bundleId,
+    this.country,
+    this.versionName,
+    this.storeUrl,
+    this.fallbackStoreUrl,
+    this.apkUrl,
+    this.sha256,
+    this.sizeBytes,
+    this.releaseNotes,
+    this.releaseNotesUrl,
+  });
+
+  final String key;
+  final UpdateProviderKind provider;
+  final int latestBuild;
+  final int minSupportedBuild;
+  final String? packageName;
+  final String? bundleId;
+  final String? country;
+  final String? versionName;
+  final String? storeUrl;
+  final String? fallbackStoreUrl;
+  final String? apkUrl;
+  final String? sha256;
+  final int? sizeBytes;
+  final String? releaseNotes;
+  final String? releaseNotesUrl;
+
+  factory UpdateManifestChannel.fromJson({
+    required String key,
+    required Map<String, dynamic> json,
+  }) {
+    final provider = UpdateProviderKind.parse(
+      _requiredString(json, 'provider'),
+    );
+    final latestBuild = _requiredInt(json, 'latestBuild', channelKey: key);
+    final minSupportedBuild = _requiredInt(
+      json,
+      'minSupportedBuild',
+      channelKey: key,
+    );
+
+    final channel = UpdateManifestChannel(
+      key: key,
+      provider: provider,
+      latestBuild: latestBuild,
+      minSupportedBuild: minSupportedBuild,
+      packageName: _optionalString(json['packageName']),
+      bundleId: _optionalString(json['bundleId']),
+      country: _optionalString(json['country']),
+      versionName: _optionalString(json['versionName']),
+      storeUrl: _optionalString(json['storeUrl']),
+      fallbackStoreUrl: _optionalString(json['fallbackStoreUrl']),
+      apkUrl: _optionalString(json['apkUrl'] ?? json['downloadUrl']),
+      sha256: _optionalString(json['sha256'])?.toLowerCase(),
+      sizeBytes: _optionalInt(json['sizeBytes'], channelKey: key),
+      releaseNotes: _optionalString(json['releaseNotes']),
+      releaseNotesUrl: _optionalString(json['releaseNotesUrl']),
+    );
+    channel._validateProviderFields();
+    return channel;
+  }
+
+  Uri? get primaryActionUri {
+    final value = switch (provider) {
+      UpdateProviderKind.githubApk => apkUrl,
+      UpdateProviderKind.appStore => storeUrl ?? fallbackStoreUrl,
+      UpdateProviderKind.androidStore ||
+      UpdateProviderKind.googlePlay => storeUrl ?? fallbackStoreUrl,
+      UpdateProviderKind.noop => null,
+    };
+    return value == null ? null : Uri.tryParse(value);
+  }
+
+  bool isNewerThan(int currentBuildNumber) => latestBuild > currentBuildNumber;
+
+  bool requiresUpdateFor(int currentBuildNumber) {
+    return minSupportedBuild > 0 && currentBuildNumber < minSupportedBuild;
+  }
+
+  void _validateProviderFields() {
+    if (latestBuild < 0 || minSupportedBuild < 0) {
+      throw FormatException('Manifest channel $key build numbers must be >= 0');
+    }
+
+    switch (provider) {
+      case UpdateProviderKind.githubApk:
+        _requireNonEmpty(apkUrl, 'apkUrl');
+        _requireNonEmpty(versionName, 'versionName');
+        final size = sizeBytes;
+        if (size == null || size <= 0) {
+          throw FormatException(
+            'Manifest channel $key requires positive sizeBytes',
+          );
+        }
+        final hash = sha256;
+        if (hash == null || !RegExp(r'^[a-f0-9]{64}$').hasMatch(hash)) {
+          throw FormatException(
+            'Manifest channel $key requires a 64-character sha256',
+          );
+        }
+      case UpdateProviderKind.appStore:
+        _requireNonEmpty(storeUrl ?? fallbackStoreUrl, 'storeUrl');
+      case UpdateProviderKind.androidStore:
+      case UpdateProviderKind.googlePlay:
+        _requireNonEmpty(storeUrl ?? fallbackStoreUrl, 'fallbackStoreUrl');
+      case UpdateProviderKind.noop:
+        break;
+    }
+  }
+
+  void _requireNonEmpty(String? value, String fieldName) {
+    if (value == null || value.trim().isEmpty) {
+      throw FormatException('Manifest channel $key requires $fieldName');
+    }
+  }
+}
+
+int _requiredInt(Map<String, dynamic> json, String key, {String? channelKey}) {
+  final value = json[key];
+  if (value is int) return value;
+  final label = channelKey == null ? key : '$channelKey.$key';
+  throw FormatException('Manifest field $label must be an integer');
+}
+
+int? _optionalInt(Object? value, {String? channelKey}) {
+  if (value == null) return null;
+  if (value is int) return value;
+  final label = channelKey == null ? 'sizeBytes' : '$channelKey.sizeBytes';
+  throw FormatException('Manifest field $label must be an integer');
+}
+
+String _requiredString(Map<String, dynamic> json, String key) {
+  final value = _optionalString(json[key]);
+  if (value == null || value.isEmpty) {
+    throw FormatException('Manifest field $key must be a non-empty string');
+  }
+  return value;
+}
+
+String? _optionalString(Object? value) {
+  if (value == null) return null;
+  if (value is! String) return null;
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+DateTime? _optionalDate(Object? value) {
+  if (value is! String || value.trim().isEmpty) return null;
+  return DateTime.tryParse(value);
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1609,6 +1609,73 @@
   "earlyUpdateCheckFailed": "Update check failed: {error}",
   "earlyUpdateDialogTitle": "Early update available",
   "earlyUpdateReleaseNotes": "Release notes",
+  "aboutMemexTitle": "About Memex",
+  "aboutMemexDesc": "Version, channel, installer source, and update diagnostics.",
+  "appInfoUnknown": "Unknown",
+  "appInfoVersion": "Version",
+  "appInfoBuild": "Build",
+  "appInfoFlavor": "Flavor",
+  "appInfoChannel": "Channel",
+  "appInfoInstallerSource": "Installed from",
+  "appInfoPackage": "Package",
+  "appUpdateSectionTitle": "Updates",
+  "appUpdateAutoCheckTitle": "Auto check for updates",
+  "appUpdateAutoCheckDesc": "Check at startup at most once every 12 hours.",
+  "appUpdateWifiOnlyTitle": "Download on Wi-Fi only",
+  "appUpdateWifiOnlyDesc": "Skip direct package downloads while using mobile data.",
+  "appUpdateAutoInstallTitle": "Auto download and install",
+  "appUpdateAutoInstallDesc": "For direct packages, download and open the system installer automatically.",
+  "appUpdateCheckNow": "Check now",
+  "appUpdateChecking": "Checking update manifest...",
+  "appUpdateOpeningStore": "Opening update page...",
+  "appUpdateNoUpdate": "You are already on the latest build.",
+  "appUpdateUnsupportedProvider": "This update path is not available for the current install source.",
+  "@appUpdateApkFound": {
+    "placeholders": {
+      "version": {},
+      "build": {}
+    }
+  },
+  "appUpdateApkFound": "Build {version}+{build} is available for direct install.",
+  "@appUpdateStoreFound": {
+    "placeholders": {
+      "version": {},
+      "build": {}
+    }
+  },
+  "appUpdateStoreFound": "Build {version}+{build} is available from your app store.",
+  "appUpdateDownloadAndInstall": "Download and install",
+  "appUpdateOpenUpdatePage": "Open update page",
+  "appUpdateStoreOpened": "Update page opened.",
+  "@appUpdateDownloadingPercent": {
+    "placeholders": {
+      "percent": {}
+    }
+  },
+  "appUpdateDownloadingPercent": "Downloading update: {percent}%",
+  "appUpdateCopyDiagnostics": "Copy diagnostics",
+  "appUpdateDiagnosticsCopied": "Version diagnostics copied.",
+  "@appUpdateDiagnosticsCopyFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "appUpdateDiagnosticsCopyFailed": "Failed to copy diagnostics: {error}",
+  "appUpdateClearCache": "Clear downloaded package",
+  "appUpdateCacheCleared": "Downloaded update package cleared.",
+  "@appUpdateCacheInfo": {
+    "placeholders": {
+      "count": {},
+      "bytes": {}
+    }
+  },
+  "appUpdateCacheInfo": "{count} downloaded update file(s), {bytes} bytes.",
+  "@appUpdateCheckFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "appUpdateCheckFailed": "Update check failed: {error}",
   "dismissAllNotifications": "Clear all",
   "dismissByType": "Clear by type",
   "dismissTypeSystemAction": "Reminders & events",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6435,6 +6435,210 @@ abstract class AppLocalizations {
   /// **'Release notes'**
   String get earlyUpdateReleaseNotes;
 
+  /// No description provided for @aboutMemexTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'About Memex'**
+  String get aboutMemexTitle;
+
+  /// No description provided for @aboutMemexDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Version, channel, installer source, and update diagnostics.'**
+  String get aboutMemexDesc;
+
+  /// No description provided for @appInfoUnknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get appInfoUnknown;
+
+  /// No description provided for @appInfoVersion.
+  ///
+  /// In en, this message translates to:
+  /// **'Version'**
+  String get appInfoVersion;
+
+  /// No description provided for @appInfoBuild.
+  ///
+  /// In en, this message translates to:
+  /// **'Build'**
+  String get appInfoBuild;
+
+  /// No description provided for @appInfoFlavor.
+  ///
+  /// In en, this message translates to:
+  /// **'Flavor'**
+  String get appInfoFlavor;
+
+  /// No description provided for @appInfoChannel.
+  ///
+  /// In en, this message translates to:
+  /// **'Channel'**
+  String get appInfoChannel;
+
+  /// No description provided for @appInfoInstallerSource.
+  ///
+  /// In en, this message translates to:
+  /// **'Installed from'**
+  String get appInfoInstallerSource;
+
+  /// No description provided for @appInfoPackage.
+  ///
+  /// In en, this message translates to:
+  /// **'Package'**
+  String get appInfoPackage;
+
+  /// No description provided for @appUpdateSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Updates'**
+  String get appUpdateSectionTitle;
+
+  /// No description provided for @appUpdateAutoCheckTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto check for updates'**
+  String get appUpdateAutoCheckTitle;
+
+  /// No description provided for @appUpdateAutoCheckDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Check at startup at most once every 12 hours.'**
+  String get appUpdateAutoCheckDesc;
+
+  /// No description provided for @appUpdateWifiOnlyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Download on Wi-Fi only'**
+  String get appUpdateWifiOnlyTitle;
+
+  /// No description provided for @appUpdateWifiOnlyDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Skip direct package downloads while using mobile data.'**
+  String get appUpdateWifiOnlyDesc;
+
+  /// No description provided for @appUpdateAutoInstallTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto download and install'**
+  String get appUpdateAutoInstallTitle;
+
+  /// No description provided for @appUpdateAutoInstallDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'For direct packages, download and open the system installer automatically.'**
+  String get appUpdateAutoInstallDesc;
+
+  /// No description provided for @appUpdateCheckNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Check now'**
+  String get appUpdateCheckNow;
+
+  /// No description provided for @appUpdateChecking.
+  ///
+  /// In en, this message translates to:
+  /// **'Checking update manifest...'**
+  String get appUpdateChecking;
+
+  /// No description provided for @appUpdateOpeningStore.
+  ///
+  /// In en, this message translates to:
+  /// **'Opening update page...'**
+  String get appUpdateOpeningStore;
+
+  /// No description provided for @appUpdateNoUpdate.
+  ///
+  /// In en, this message translates to:
+  /// **'You are already on the latest build.'**
+  String get appUpdateNoUpdate;
+
+  /// No description provided for @appUpdateUnsupportedProvider.
+  ///
+  /// In en, this message translates to:
+  /// **'This update path is not available for the current install source.'**
+  String get appUpdateUnsupportedProvider;
+
+  /// No description provided for @appUpdateApkFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Build {version}+{build} is available for direct install.'**
+  String appUpdateApkFound(Object version, Object build);
+
+  /// No description provided for @appUpdateStoreFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Build {version}+{build} is available from your app store.'**
+  String appUpdateStoreFound(Object version, Object build);
+
+  /// No description provided for @appUpdateDownloadAndInstall.
+  ///
+  /// In en, this message translates to:
+  /// **'Download and install'**
+  String get appUpdateDownloadAndInstall;
+
+  /// No description provided for @appUpdateOpenUpdatePage.
+  ///
+  /// In en, this message translates to:
+  /// **'Open update page'**
+  String get appUpdateOpenUpdatePage;
+
+  /// No description provided for @appUpdateStoreOpened.
+  ///
+  /// In en, this message translates to:
+  /// **'Update page opened.'**
+  String get appUpdateStoreOpened;
+
+  /// No description provided for @appUpdateDownloadingPercent.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading update: {percent}%'**
+  String appUpdateDownloadingPercent(Object percent);
+
+  /// No description provided for @appUpdateCopyDiagnostics.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy diagnostics'**
+  String get appUpdateCopyDiagnostics;
+
+  /// No description provided for @appUpdateDiagnosticsCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'Version diagnostics copied.'**
+  String get appUpdateDiagnosticsCopied;
+
+  /// No description provided for @appUpdateDiagnosticsCopyFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to copy diagnostics: {error}'**
+  String appUpdateDiagnosticsCopyFailed(Object error);
+
+  /// No description provided for @appUpdateClearCache.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear downloaded package'**
+  String get appUpdateClearCache;
+
+  /// No description provided for @appUpdateCacheCleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloaded update package cleared.'**
+  String get appUpdateCacheCleared;
+
+  /// No description provided for @appUpdateCacheInfo.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} downloaded update file(s), {bytes} bytes.'**
+  String appUpdateCacheInfo(Object count, Object bytes);
+
+  /// No description provided for @appUpdateCheckFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Update check failed: {error}'**
+  String appUpdateCheckFailed(Object error);
+
   /// No description provided for @dismissAllNotifications.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3586,6 +3586,125 @@ class AppLocalizationsEn extends AppLocalizations {
   String get earlyUpdateReleaseNotes => 'Release notes';
 
   @override
+  String get aboutMemexTitle => 'About Memex';
+
+  @override
+  String get aboutMemexDesc =>
+      'Version, channel, installer source, and update diagnostics.';
+
+  @override
+  String get appInfoUnknown => 'Unknown';
+
+  @override
+  String get appInfoVersion => 'Version';
+
+  @override
+  String get appInfoBuild => 'Build';
+
+  @override
+  String get appInfoFlavor => 'Flavor';
+
+  @override
+  String get appInfoChannel => 'Channel';
+
+  @override
+  String get appInfoInstallerSource => 'Installed from';
+
+  @override
+  String get appInfoPackage => 'Package';
+
+  @override
+  String get appUpdateSectionTitle => 'Updates';
+
+  @override
+  String get appUpdateAutoCheckTitle => 'Auto check for updates';
+
+  @override
+  String get appUpdateAutoCheckDesc =>
+      'Check at startup at most once every 12 hours.';
+
+  @override
+  String get appUpdateWifiOnlyTitle => 'Download on Wi-Fi only';
+
+  @override
+  String get appUpdateWifiOnlyDesc =>
+      'Skip direct package downloads while using mobile data.';
+
+  @override
+  String get appUpdateAutoInstallTitle => 'Auto download and install';
+
+  @override
+  String get appUpdateAutoInstallDesc =>
+      'For direct packages, download and open the system installer automatically.';
+
+  @override
+  String get appUpdateCheckNow => 'Check now';
+
+  @override
+  String get appUpdateChecking => 'Checking update manifest...';
+
+  @override
+  String get appUpdateOpeningStore => 'Opening update page...';
+
+  @override
+  String get appUpdateNoUpdate => 'You are already on the latest build.';
+
+  @override
+  String get appUpdateUnsupportedProvider =>
+      'This update path is not available for the current install source.';
+
+  @override
+  String appUpdateApkFound(Object version, Object build) {
+    return 'Build $version+$build is available for direct install.';
+  }
+
+  @override
+  String appUpdateStoreFound(Object version, Object build) {
+    return 'Build $version+$build is available from your app store.';
+  }
+
+  @override
+  String get appUpdateDownloadAndInstall => 'Download and install';
+
+  @override
+  String get appUpdateOpenUpdatePage => 'Open update page';
+
+  @override
+  String get appUpdateStoreOpened => 'Update page opened.';
+
+  @override
+  String appUpdateDownloadingPercent(Object percent) {
+    return 'Downloading update: $percent%';
+  }
+
+  @override
+  String get appUpdateCopyDiagnostics => 'Copy diagnostics';
+
+  @override
+  String get appUpdateDiagnosticsCopied => 'Version diagnostics copied.';
+
+  @override
+  String appUpdateDiagnosticsCopyFailed(Object error) {
+    return 'Failed to copy diagnostics: $error';
+  }
+
+  @override
+  String get appUpdateClearCache => 'Clear downloaded package';
+
+  @override
+  String get appUpdateCacheCleared => 'Downloaded update package cleared.';
+
+  @override
+  String appUpdateCacheInfo(Object count, Object bytes) {
+    return '$count downloaded update file(s), $bytes bytes.';
+  }
+
+  @override
+  String appUpdateCheckFailed(Object error) {
+    return 'Update check failed: $error';
+  }
+
+  @override
   String get dismissAllNotifications => 'Clear all';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3443,6 +3443,120 @@ class AppLocalizationsZh extends AppLocalizations {
   String get earlyUpdateReleaseNotes => '更新说明';
 
   @override
+  String get aboutMemexTitle => '关于 Memex';
+
+  @override
+  String get aboutMemexDesc => '查看版本、渠道、安装来源和更新诊断信息。';
+
+  @override
+  String get appInfoUnknown => '未知';
+
+  @override
+  String get appInfoVersion => '版本';
+
+  @override
+  String get appInfoBuild => '构建号';
+
+  @override
+  String get appInfoFlavor => 'Flavor';
+
+  @override
+  String get appInfoChannel => '渠道';
+
+  @override
+  String get appInfoInstallerSource => '安装来源';
+
+  @override
+  String get appInfoPackage => '包名';
+
+  @override
+  String get appUpdateSectionTitle => '检查更新';
+
+  @override
+  String get appUpdateAutoCheckTitle => '自动检测更新';
+
+  @override
+  String get appUpdateAutoCheckDesc => '启动时检测，每 12 小时最多一次。';
+
+  @override
+  String get appUpdateWifiOnlyTitle => '仅在 Wi-Fi 下载';
+
+  @override
+  String get appUpdateWifiOnlyDesc => '使用移动数据时跳过直装包下载。';
+
+  @override
+  String get appUpdateAutoInstallTitle => '自动下载并安装';
+
+  @override
+  String get appUpdateAutoInstallDesc => '仅对直装包生效，发现新版本后下载并打开系统安装器。';
+
+  @override
+  String get appUpdateCheckNow => '立即检查';
+
+  @override
+  String get appUpdateChecking => '正在检查更新 Manifest...';
+
+  @override
+  String get appUpdateOpeningStore => '正在打开更新页面...';
+
+  @override
+  String get appUpdateNoUpdate => '当前已经是最新构建。';
+
+  @override
+  String get appUpdateUnsupportedProvider => '当前安装来源不支持这个更新方式。';
+
+  @override
+  String appUpdateApkFound(Object version, Object build) {
+    return '发现可直装版本 $version+$build。';
+  }
+
+  @override
+  String appUpdateStoreFound(Object version, Object build) {
+    return '应用商店中有新版本 $version+$build。';
+  }
+
+  @override
+  String get appUpdateDownloadAndInstall => '下载并安装';
+
+  @override
+  String get appUpdateOpenUpdatePage => '打开更新页面';
+
+  @override
+  String get appUpdateStoreOpened => '已打开更新页面。';
+
+  @override
+  String appUpdateDownloadingPercent(Object percent) {
+    return '正在下载更新：$percent%';
+  }
+
+  @override
+  String get appUpdateCopyDiagnostics => '复制诊断信息';
+
+  @override
+  String get appUpdateDiagnosticsCopied => '已复制版本诊断信息。';
+
+  @override
+  String appUpdateDiagnosticsCopyFailed(Object error) {
+    return '复制诊断信息失败：$error';
+  }
+
+  @override
+  String get appUpdateClearCache => '清除下载包';
+
+  @override
+  String get appUpdateCacheCleared => '已清除下载包。';
+
+  @override
+  String appUpdateCacheInfo(Object count, Object bytes) {
+    return '已下载 $count 个更新文件，共 $bytes 字节。';
+  }
+
+  @override
+  String appUpdateCheckFailed(Object error) {
+    return '检查更新失败：$error';
+  }
+
+  @override
   String get dismissAllNotifications => '清除全部';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1572,6 +1572,73 @@
   "earlyUpdateCheckFailed": "检查更新失败：{error}",
   "earlyUpdateDialogTitle": "发现 Early 更新",
   "earlyUpdateReleaseNotes": "更新说明",
+  "aboutMemexTitle": "关于 Memex",
+  "aboutMemexDesc": "查看版本、渠道、安装来源和更新诊断信息。",
+  "appInfoUnknown": "未知",
+  "appInfoVersion": "版本",
+  "appInfoBuild": "构建号",
+  "appInfoFlavor": "Flavor",
+  "appInfoChannel": "渠道",
+  "appInfoInstallerSource": "安装来源",
+  "appInfoPackage": "包名",
+  "appUpdateSectionTitle": "检查更新",
+  "appUpdateAutoCheckTitle": "自动检测更新",
+  "appUpdateAutoCheckDesc": "启动时检测，每 12 小时最多一次。",
+  "appUpdateWifiOnlyTitle": "仅在 Wi-Fi 下载",
+  "appUpdateWifiOnlyDesc": "使用移动数据时跳过直装包下载。",
+  "appUpdateAutoInstallTitle": "自动下载并安装",
+  "appUpdateAutoInstallDesc": "仅对直装包生效，发现新版本后下载并打开系统安装器。",
+  "appUpdateCheckNow": "立即检查",
+  "appUpdateChecking": "正在检查更新 Manifest...",
+  "appUpdateOpeningStore": "正在打开更新页面...",
+  "appUpdateNoUpdate": "当前已经是最新构建。",
+  "appUpdateUnsupportedProvider": "当前安装来源不支持这个更新方式。",
+  "@appUpdateApkFound": {
+    "placeholders": {
+      "version": {},
+      "build": {}
+    }
+  },
+  "appUpdateApkFound": "发现可直装版本 {version}+{build}。",
+  "@appUpdateStoreFound": {
+    "placeholders": {
+      "version": {},
+      "build": {}
+    }
+  },
+  "appUpdateStoreFound": "应用商店中有新版本 {version}+{build}。",
+  "appUpdateDownloadAndInstall": "下载并安装",
+  "appUpdateOpenUpdatePage": "打开更新页面",
+  "appUpdateStoreOpened": "已打开更新页面。",
+  "@appUpdateDownloadingPercent": {
+    "placeholders": {
+      "percent": {}
+    }
+  },
+  "appUpdateDownloadingPercent": "正在下载更新：{percent}%",
+  "appUpdateCopyDiagnostics": "复制诊断信息",
+  "appUpdateDiagnosticsCopied": "已复制版本诊断信息。",
+  "@appUpdateDiagnosticsCopyFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "appUpdateDiagnosticsCopyFailed": "复制诊断信息失败：{error}",
+  "appUpdateClearCache": "清除下载包",
+  "appUpdateCacheCleared": "已清除下载包。",
+  "@appUpdateCacheInfo": {
+    "placeholders": {
+      "count": {},
+      "bytes": {}
+    }
+  },
+  "appUpdateCacheInfo": "已下载 {count} 个更新文件，共 {bytes} 字节。",
+  "@appUpdateCheckFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "appUpdateCheckFailed": "检查更新失败：{error}",
   "dismissAllNotifications": "清除全部",
   "dismissByType": "按类型清除",
   "dismissTypeSystemAction": "日程提醒",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,6 +51,7 @@ import 'package:memex/ui/agent_activity/widgets/agent_activity_widget.dart';
 import 'package:memex/ui/main_screen/widgets/ai_core_button.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/data/services/local_server_service.dart';
+import 'package:memex/data/services/app_update_router.dart';
 import 'package:memex/data/services/app_update_service.dart';
 import 'package:memex/data/services/backup_service.dart';
 import 'package:go_router/go_router.dart';
@@ -474,7 +475,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
   final GlobalKey _mainStackKey = GlobalKey();
   bool _isInvalidConfigDialogShowing = false;
   bool _isErrorNotificationDialogShowing = false;
-  bool _earlyUpdateCheckStarted = false;
+  bool _appUpdateCheckStarted = false;
   late final ShareIntentHandler _shareIntentHandler;
   InputData? _sharedDraft;
   ClipboardPreviewCandidate? _homeClipboardCandidate;
@@ -549,44 +550,48 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) unawaited(_checkHomeClipboardPreview());
     });
-    _scheduleEarlyUpdateCheck();
+    _scheduleAppUpdateCheck();
   }
 
-  void _scheduleEarlyUpdateCheck() {
-    final service = AppUpdateService.instance;
-    if (!service.isSupported || _earlyUpdateCheckStarted) return;
-    _earlyUpdateCheckStarted = true;
+  void _scheduleAppUpdateCheck() {
+    if (_appUpdateCheckStarted) return;
+    _appUpdateCheckStarted = true;
     Future.delayed(const Duration(seconds: 3), () {
       if (!mounted) return;
-      unawaited(_checkEarlyUpdateInBackground());
+      unawaited(_checkAppUpdateInBackground());
     });
   }
 
-  Future<void> _checkEarlyUpdateInBackground() async {
-    final service = AppUpdateService.instance;
-    if (!await service.shouldRunAutoCheck()) return;
+  Future<void> _checkAppUpdateInBackground() async {
+    final updateRouter = AppUpdateRouter.instance;
 
     try {
-      final settings = await service.loadSettings();
-      final result = await service.checkForUpdate(manual: false);
-      if (!mounted || result.status != AppUpdateCheckStatus.updateAvailable) {
+      if (!await updateRouter.shouldRunAutoCheck()) return;
+      final settings = await updateRouter.loadSettings();
+      final result = await updateRouter.checkForUpdate(manual: false);
+      if (!mounted || !result.hasUpdate) {
         return;
       }
 
-      final update = result.update!;
-      if (settings.autoDownloadAndInstall) {
-        await _downloadAndInstallEarlyUpdate(update);
+      if (result.canDownloadApk) {
+        if (settings.autoDownloadAndInstall) {
+          await _performAppUpdateAction(result);
+        } else {
+          _showAppUpdateDialog(result);
+        }
       } else {
-        _showEarlyUpdateDialog(update);
+        _showStoreUpdateSnackBar(result);
       }
     } catch (e, st) {
-      _logger.warning('Early update check failed: $e', e, st);
+      _logger.warning('App update check failed: $e', e, st);
     }
   }
 
-  void _showEarlyUpdateDialog(AppUpdateInfo update) {
+  void _showAppUpdateDialog(UnifiedAppUpdateCheckResult check) {
     final context = rootNavigatorKey.currentContext;
     if (context == null) return;
+    final update = check.apkUpdate;
+    if (update == null) return;
 
     showDialog<void>(
       context: context,
@@ -625,10 +630,10 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
             FilledButton.icon(
               onPressed: () {
                 Navigator.of(context).pop();
-                unawaited(_downloadAndInstallEarlyUpdate(update));
+                unawaited(_performAppUpdateAction(check));
               },
               icon: const Icon(Icons.download, size: 18),
-              label: Text(UserStorage.l10n.earlyUpdateDownloadAndInstall),
+              label: Text(UserStorage.l10n.appUpdateDownloadAndInstall),
             ),
           ],
         );
@@ -636,32 +641,52 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     );
   }
 
-  Future<void> _downloadAndInstallEarlyUpdate(AppUpdateInfo update) async {
+  void _showStoreUpdateSnackBar(UnifiedAppUpdateCheckResult check) {
+    final latestVersion = check.latestVersionName ?? '-';
+    final latestBuild = check.latestBuild ?? 0;
+    rootScaffoldMessengerKey.currentState?.showSnackBar(
+      SnackBar(
+        content: Text(
+          UserStorage.l10n.appUpdateStoreFound(latestVersion, latestBuild),
+        ),
+        action: SnackBarAction(
+          label: UserStorage.l10n.appUpdateOpenUpdatePage,
+          onPressed: () => unawaited(_performAppUpdateAction(check)),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _performAppUpdateAction(
+    UnifiedAppUpdateCheckResult check,
+  ) async {
     final context = rootNavigatorKey.currentContext;
-    if (context != null) {
+    if (context != null && check.canDownloadApk) {
       ToastHelper.showInfo(
         context,
-        UserStorage.l10n.earlyUpdateDownloadingPercent(0),
+        UserStorage.l10n.appUpdateDownloadingPercent(0),
       );
     }
 
     try {
-      final download = await AppUpdateService.instance.downloadUpdate(update);
-      final install = await AppUpdateService.instance.installUpdate(
-        download.apkPath,
-      );
-      switch (install.status) {
-        case AppUpdateInstallStatus.started:
+      final action = await AppUpdateRouter.instance.performUpdateAction(check);
+      switch (action.status) {
+        case AppUpdateActionStatus.openedExternal:
+          ToastHelper.showSuccessWithKey(
+            rootScaffoldMessengerKey,
+            UserStorage.l10n.appUpdateStoreOpened,
+          );
+        case AppUpdateActionStatus.installStarted:
           ToastHelper.showSuccessWithKey(
             rootScaffoldMessengerKey,
             UserStorage.l10n.earlyUpdateInstallStarted,
           );
-        case AppUpdateInstallStatus.permissionRequired:
+        case AppUpdateActionStatus.permissionRequired:
           ToastHelper.showInfoWithKey(
             rootScaffoldMessengerKey,
             UserStorage.l10n.earlyUpdateInstallPermissionRequired,
           );
-        case AppUpdateInstallStatus.unsupported:
+        case AppUpdateActionStatus.unsupported:
           break;
       }
     } catch (e) {

--- a/lib/ui/settings/view_models/about_memex_viewmodel.dart
+++ b/lib/ui/settings/view_models/about_memex_viewmodel.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/app_update_router.dart';
+import 'package:memex/data/services/app_update_service.dart';
+import 'package:memex/domain/models/app_build_info.dart';
+import 'package:memex/utils/result.dart';
+import 'package:memex/utils/user_storage.dart';
+
+abstract class AboutMemexViewModelContract implements Listenable {
+  AppBuildInfo? get buildInfo;
+  AppUpdateSettings? get settings;
+  AppUpdateCacheInfo get cacheInfo;
+  UnifiedAppUpdateCheckResult? get updateCheck;
+  bool get loading;
+  bool get checking;
+  bool get performingUpdate;
+  bool get clearingCache;
+  int get downloadPercent;
+  String? get statusText;
+
+  Future<void> load();
+  Future<void> checkNow();
+  Future<void> performUpdateAction();
+  Future<void> clearUpdateCache();
+  Future<void> copyDiagnostics();
+  Future<void> updateAutoCheckEnabled(bool value);
+  Future<void> updateWifiOnlyDownloads(bool value);
+  Future<void> updateAutoDownloadAndInstall(bool value);
+}
+
+class AboutMemexViewModel extends ChangeNotifier
+    implements AboutMemexViewModelContract {
+  AboutMemexViewModel({required MemexRouter router}) : _router = router;
+
+  final MemexRouter _router;
+
+  @override
+  AppBuildInfo? buildInfo;
+
+  @override
+  AppUpdateSettings? settings;
+
+  @override
+  AppUpdateCacheInfo cacheInfo = AppUpdateCacheInfo.empty;
+
+  @override
+  UnifiedAppUpdateCheckResult? updateCheck;
+
+  @override
+  bool loading = false;
+
+  @override
+  bool checking = false;
+
+  @override
+  bool performingUpdate = false;
+
+  @override
+  bool clearingCache = false;
+
+  @override
+  int downloadPercent = 0;
+
+  @override
+  String? statusText;
+
+  bool get _busy => loading || checking || performingUpdate || clearingCache;
+
+  @override
+  Future<void> load() async {
+    if (loading) return;
+    loading = true;
+    notifyListeners();
+
+    final buildResult = await _router.getAppBuildInfo();
+    buildResult.when(
+      onOk: (value) => buildInfo = value,
+      onError: (error, _) =>
+          statusText = UserStorage.l10n.appUpdateCheckFailed(error),
+    );
+
+    try {
+      settings = await _router.getAppUpdateSettings();
+      cacheInfo = await _router.getAppUpdateCacheInfo();
+    } catch (e) {
+      statusText = UserStorage.l10n.appUpdateCheckFailed(e);
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  @override
+  Future<void> checkNow() async {
+    if (_busy) return;
+    checking = true;
+    statusText = UserStorage.l10n.appUpdateChecking;
+    notifyListeners();
+
+    final result = await _router.checkAppUpdate(manual: true);
+    result.when(
+      onOk: (value) {
+        updateCheck = value;
+        statusText = _statusTextForCheck(value);
+      },
+      onError: (error, _) =>
+          statusText = UserStorage.l10n.appUpdateCheckFailed(error),
+    );
+
+    try {
+      settings = await _router.getAppUpdateSettings();
+      cacheInfo = await _router.getAppUpdateCacheInfo();
+    } catch (_) {
+      // The check result is the user-facing state; cache refresh is best effort.
+    }
+
+    checking = false;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> performUpdateAction() async {
+    final check = updateCheck;
+    if (check == null || !check.hasUpdate || _busy) return;
+
+    performingUpdate = true;
+    downloadPercent = 0;
+    statusText = check.canDownloadApk
+        ? UserStorage.l10n.appUpdateDownloadingPercent(0)
+        : UserStorage.l10n.appUpdateOpeningStore;
+    notifyListeners();
+
+    final result = await _router.performAppUpdateAction(
+      check,
+      onProgress: (receivedBytes, totalBytes) {
+        if (totalBytes <= 0) return;
+        downloadPercent = ((receivedBytes / totalBytes) * 100)
+            .clamp(0, 100)
+            .round();
+        statusText = UserStorage.l10n.appUpdateDownloadingPercent(
+          downloadPercent,
+        );
+        notifyListeners();
+      },
+    );
+
+    result.when(
+      onOk: (value) {
+        statusText = switch (value.status) {
+          AppUpdateActionStatus.openedExternal =>
+            UserStorage.l10n.appUpdateStoreOpened,
+          AppUpdateActionStatus.installStarted =>
+            UserStorage.l10n.earlyUpdateInstallStarted,
+          AppUpdateActionStatus.permissionRequired =>
+            UserStorage.l10n.earlyUpdateInstallPermissionRequired,
+          AppUpdateActionStatus.unsupported =>
+            UserStorage.l10n.appUpdateUnsupportedProvider,
+        };
+      },
+      onError: (error, _) {
+        statusText = switch (error) {
+          AppUpdateWifiRequiredException() =>
+            UserStorage.l10n.earlyUpdateSkippedMobile,
+          AppUpdateDownloadInProgressException() =>
+            UserStorage.l10n.earlyUpdateDownloadInProgress,
+          _ => UserStorage.l10n.appUpdateCheckFailed(error),
+        };
+      },
+    );
+
+    try {
+      cacheInfo = await _router.getAppUpdateCacheInfo();
+    } catch (_) {
+      // Best effort.
+    }
+    performingUpdate = false;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> clearUpdateCache() async {
+    if (_busy) return;
+    clearingCache = true;
+    notifyListeners();
+
+    final result = await _router.clearAppUpdateCache();
+    result.when(
+      onOk: (_) {
+        cacheInfo = AppUpdateCacheInfo.empty;
+        statusText = UserStorage.l10n.appUpdateCacheCleared;
+      },
+      onError: (error, _) =>
+          statusText = UserStorage.l10n.appUpdateCheckFailed(error),
+    );
+
+    clearingCache = false;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> copyDiagnostics() async {
+    final info = buildInfo;
+    if (info == null) return;
+
+    try {
+      final check = updateCheck;
+      await Clipboard.setData(
+        ClipboardData(
+          text: info.diagnostics(
+            updateProvider: check?.providerKind.wireName,
+            updateChannel: check?.channel?.key,
+            manifestSource: check?.manifestSource,
+            manifestGeneratedAt: check?.manifestGeneratedAt,
+          ),
+        ),
+      );
+      statusText = UserStorage.l10n.appUpdateDiagnosticsCopied;
+    } catch (e) {
+      statusText = UserStorage.l10n.appUpdateDiagnosticsCopyFailed(e);
+    }
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateAutoCheckEnabled(bool value) async {
+    final current = settings;
+    if (current == null || _busy) return;
+    final updated = current.copyWith(autoCheckEnabled: value);
+    await _router.saveAppUpdateSettings(updated);
+    settings = updated;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateWifiOnlyDownloads(bool value) async {
+    final current = settings;
+    if (current == null || _busy) return;
+    final updated = current.copyWith(wifiOnlyDownloads: value);
+    await _router.saveAppUpdateSettings(updated);
+    settings = updated;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateAutoDownloadAndInstall(bool value) async {
+    final current = settings;
+    if (current == null || _busy) return;
+    final updated = current.copyWith(autoDownloadAndInstall: value);
+    await _router.saveAppUpdateSettings(updated);
+    settings = updated;
+    notifyListeners();
+  }
+
+  String _statusTextForCheck(UnifiedAppUpdateCheckResult check) {
+    return switch (check.status) {
+      UnifiedAppUpdateStatus.noUpdate => UserStorage.l10n.appUpdateNoUpdate,
+      UnifiedAppUpdateStatus.unsupported =>
+        UserStorage.l10n.appUpdateUnsupportedProvider,
+      UnifiedAppUpdateStatus.checkFailed =>
+        UserStorage.l10n.appUpdateCheckFailed(
+          check.error ?? 'manifest unavailable',
+        ),
+      UnifiedAppUpdateStatus.updateAvailable =>
+        check.canDownloadApk
+            ? UserStorage.l10n.appUpdateApkFound(
+                check.latestVersionName ?? '-',
+                check.latestBuild ?? 0,
+              )
+            : UserStorage.l10n.appUpdateStoreFound(
+                check.latestVersionName ?? '-',
+                check.latestBuild ?? 0,
+              ),
+    };
+  }
+}

--- a/lib/ui/settings/view_models/about_memex_viewmodel.dart
+++ b/lib/ui/settings/view_models/about_memex_viewmodel.dart
@@ -29,11 +29,65 @@ abstract class AboutMemexViewModelContract implements Listenable {
   Future<void> updateAutoDownloadAndInstall(bool value);
 }
 
+typedef AppBuildInfoLoader = Future<Result<AppBuildInfo>> Function();
+typedef AppUpdateSettingsLoader = Future<AppUpdateSettings> Function();
+typedef AppUpdateSettingsSaver = Future<void> Function(
+  AppUpdateSettings settings,
+);
+typedef AppUpdateCacheInfoLoader = Future<AppUpdateCacheInfo> Function();
+typedef AppUpdateCacheClearer = Future<Result<int>> Function();
+typedef AppUpdateChecker = Future<Result<UnifiedAppUpdateCheckResult>>
+    Function({
+  bool manual,
+});
+typedef AppUpdateActionPerformer = Future<Result<AppUpdateActionResult>>
+    Function(
+  UnifiedAppUpdateCheckResult check, {
+  void Function(int receivedBytes, int totalBytes)? onProgress,
+});
+
 class AboutMemexViewModel extends ChangeNotifier
     implements AboutMemexViewModelContract {
-  AboutMemexViewModel({required MemexRouter router}) : _router = router;
+  AboutMemexViewModel({
+    MemexRouter? router,
+    AppBuildInfoLoader? getAppBuildInfo,
+    AppUpdateSettingsLoader? getAppUpdateSettings,
+    AppUpdateSettingsSaver? saveAppUpdateSettings,
+    AppUpdateCacheInfoLoader? getAppUpdateCacheInfo,
+    AppUpdateCacheClearer? clearAppUpdateCache,
+    AppUpdateChecker? checkAppUpdate,
+    AppUpdateActionPerformer? performAppUpdateAction,
+  })  : assert(
+          router != null ||
+              (getAppBuildInfo != null &&
+                  getAppUpdateSettings != null &&
+                  saveAppUpdateSettings != null &&
+                  getAppUpdateCacheInfo != null &&
+                  clearAppUpdateCache != null &&
+                  checkAppUpdate != null &&
+                  performAppUpdateAction != null),
+          'Provide a router or all test dependencies',
+        ),
+        _getAppBuildInfo = getAppBuildInfo ?? router!.getAppBuildInfo,
+        _getAppUpdateSettings =
+            getAppUpdateSettings ?? router!.getAppUpdateSettings,
+        _saveAppUpdateSettings =
+            saveAppUpdateSettings ?? router!.saveAppUpdateSettings,
+        _getAppUpdateCacheInfo =
+            getAppUpdateCacheInfo ?? router!.getAppUpdateCacheInfo,
+        _clearAppUpdateCache =
+            clearAppUpdateCache ?? router!.clearAppUpdateCache,
+        _checkAppUpdate = checkAppUpdate ?? router!.checkAppUpdate,
+        _performAppUpdateAction =
+            performAppUpdateAction ?? router!.performAppUpdateAction;
 
-  final MemexRouter _router;
+  final AppBuildInfoLoader _getAppBuildInfo;
+  final AppUpdateSettingsLoader _getAppUpdateSettings;
+  final AppUpdateSettingsSaver _saveAppUpdateSettings;
+  final AppUpdateCacheInfoLoader _getAppUpdateCacheInfo;
+  final AppUpdateCacheClearer _clearAppUpdateCache;
+  final AppUpdateChecker _checkAppUpdate;
+  final AppUpdateActionPerformer _performAppUpdateAction;
 
   @override
   AppBuildInfo? buildInfo;
@@ -73,7 +127,7 @@ class AboutMemexViewModel extends ChangeNotifier
     loading = true;
     notifyListeners();
 
-    final buildResult = await _router.getAppBuildInfo();
+    final buildResult = await _getAppBuildInfo();
     buildResult.when(
       onOk: (value) => buildInfo = value,
       onError: (error, _) =>
@@ -81,8 +135,8 @@ class AboutMemexViewModel extends ChangeNotifier
     );
 
     try {
-      settings = await _router.getAppUpdateSettings();
-      cacheInfo = await _router.getAppUpdateCacheInfo();
+      settings = await _getAppUpdateSettings();
+      cacheInfo = await _getAppUpdateCacheInfo();
     } catch (e) {
       statusText = UserStorage.l10n.appUpdateCheckFailed(e);
     } finally {
@@ -98,7 +152,7 @@ class AboutMemexViewModel extends ChangeNotifier
     statusText = UserStorage.l10n.appUpdateChecking;
     notifyListeners();
 
-    final result = await _router.checkAppUpdate(manual: true);
+    final result = await _checkAppUpdate(manual: true);
     result.when(
       onOk: (value) {
         updateCheck = value;
@@ -109,8 +163,8 @@ class AboutMemexViewModel extends ChangeNotifier
     );
 
     try {
-      settings = await _router.getAppUpdateSettings();
-      cacheInfo = await _router.getAppUpdateCacheInfo();
+      settings = await _getAppUpdateSettings();
+      cacheInfo = await _getAppUpdateCacheInfo();
     } catch (_) {
       // The check result is the user-facing state; cache refresh is best effort.
     }
@@ -131,13 +185,12 @@ class AboutMemexViewModel extends ChangeNotifier
         : UserStorage.l10n.appUpdateOpeningStore;
     notifyListeners();
 
-    final result = await _router.performAppUpdateAction(
+    final result = await _performAppUpdateAction(
       check,
       onProgress: (receivedBytes, totalBytes) {
         if (totalBytes <= 0) return;
-        downloadPercent = ((receivedBytes / totalBytes) * 100)
-            .clamp(0, 100)
-            .round();
+        downloadPercent =
+            ((receivedBytes / totalBytes) * 100).clamp(0, 100).round();
         statusText = UserStorage.l10n.appUpdateDownloadingPercent(
           downloadPercent,
         );
@@ -170,7 +223,7 @@ class AboutMemexViewModel extends ChangeNotifier
     );
 
     try {
-      cacheInfo = await _router.getAppUpdateCacheInfo();
+      cacheInfo = await _getAppUpdateCacheInfo();
     } catch (_) {
       // Best effort.
     }
@@ -184,7 +237,7 @@ class AboutMemexViewModel extends ChangeNotifier
     clearingCache = true;
     notifyListeners();
 
-    final result = await _router.clearAppUpdateCache();
+    final result = await _clearAppUpdateCache();
     result.when(
       onOk: (_) {
         cacheInfo = AppUpdateCacheInfo.empty;
@@ -227,7 +280,7 @@ class AboutMemexViewModel extends ChangeNotifier
     final current = settings;
     if (current == null || _busy) return;
     final updated = current.copyWith(autoCheckEnabled: value);
-    await _router.saveAppUpdateSettings(updated);
+    await _saveAppUpdateSettings(updated);
     settings = updated;
     notifyListeners();
   }
@@ -237,7 +290,7 @@ class AboutMemexViewModel extends ChangeNotifier
     final current = settings;
     if (current == null || _busy) return;
     final updated = current.copyWith(wifiOnlyDownloads: value);
-    await _router.saveAppUpdateSettings(updated);
+    await _saveAppUpdateSettings(updated);
     settings = updated;
     notifyListeners();
   }
@@ -247,7 +300,7 @@ class AboutMemexViewModel extends ChangeNotifier
     final current = settings;
     if (current == null || _busy) return;
     final updated = current.copyWith(autoDownloadAndInstall: value);
-    await _router.saveAppUpdateSettings(updated);
+    await _saveAppUpdateSettings(updated);
     settings = updated;
     notifyListeners();
   }
@@ -261,16 +314,15 @@ class AboutMemexViewModel extends ChangeNotifier
         UserStorage.l10n.appUpdateCheckFailed(
           check.error ?? 'manifest unavailable',
         ),
-      UnifiedAppUpdateStatus.updateAvailable =>
-        check.canDownloadApk
-            ? UserStorage.l10n.appUpdateApkFound(
-                check.latestVersionName ?? '-',
-                check.latestBuild ?? 0,
-              )
-            : UserStorage.l10n.appUpdateStoreFound(
-                check.latestVersionName ?? '-',
-                check.latestBuild ?? 0,
-              ),
+      UnifiedAppUpdateStatus.updateAvailable => check.canDownloadApk
+          ? UserStorage.l10n.appUpdateApkFound(
+              check.latestVersionName ?? '-',
+              check.latestBuild ?? 0,
+            )
+          : UserStorage.l10n.appUpdateStoreFound(
+              check.latestVersionName ?? '-',
+              check.latestBuild ?? 0,
+            ),
     };
   }
 }

--- a/lib/ui/settings/widgets/about_memex_page.dart
+++ b/lib/ui/settings/widgets/about_memex_page.dart
@@ -1,0 +1,336 @@
+import 'package:flutter/material.dart';
+import 'package:memex/data/services/app_update_service.dart';
+import 'package:memex/ui/core/themes/app_colors.dart';
+import 'package:memex/ui/settings/view_models/about_memex_viewmodel.dart';
+import 'package:memex/utils/user_storage.dart';
+
+class AboutMemexPage extends StatefulWidget {
+  const AboutMemexPage({super.key, required this.viewModel});
+
+  final AboutMemexViewModelContract viewModel;
+
+  @override
+  State<AboutMemexPage> createState() => _AboutMemexPageState();
+}
+
+class _AboutMemexPageState extends State<AboutMemexPage> {
+  @override
+  void initState() {
+    super.initState();
+    widget.viewModel.load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(UserStorage.l10n.aboutMemexTitle),
+        backgroundColor: AppColors.background,
+        surfaceTintColor: AppColors.background,
+      ),
+      body: ListenableBuilder(
+        listenable: widget.viewModel,
+        builder: (context, _) {
+          final vm = widget.viewModel;
+          if (vm.loading && vm.buildInfo == null) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildHeader(vm),
+              const SizedBox(height: 16),
+              _buildInfoSection(vm),
+              const SizedBox(height: 16),
+              _buildUpdateSection(vm),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildHeader(AboutMemexViewModelContract vm) {
+    final info = vm.buildInfo;
+    return Column(
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(18),
+          child: Image.asset(
+            'assets/icon.png',
+            width: 72,
+            height: 72,
+            fit: BoxFit.cover,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          info?.appName ?? 'Memex',
+          style: const TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.w700,
+            color: AppColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          info?.displayVersion ?? UserStorage.l10n.appInfoUnknown,
+          style: const TextStyle(fontSize: 14, color: AppColors.textSecondary),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInfoSection(AboutMemexViewModelContract vm) {
+    final info = vm.buildInfo;
+    return _SectionCard(
+      child: Column(
+        children: [
+          _InfoRow(
+            label: UserStorage.l10n.appInfoVersion,
+            value: info?.versionName ?? UserStorage.l10n.appInfoUnknown,
+          ),
+          _InfoRow(
+            label: UserStorage.l10n.appInfoBuild,
+            value: '${info?.buildNumber ?? '-'}',
+          ),
+          _InfoRow(
+            label: UserStorage.l10n.appInfoFlavor,
+            value: info?.flavorName ?? UserStorage.l10n.appInfoUnknown,
+          ),
+          _InfoRow(
+            label: UserStorage.l10n.appInfoChannel,
+            value: info?.channelName ?? UserStorage.l10n.appInfoUnknown,
+          ),
+          _InfoRow(
+            label: UserStorage.l10n.appInfoInstallerSource,
+            value:
+                info?.installerDisplayName ?? UserStorage.l10n.appInfoUnknown,
+          ),
+          _InfoRow(
+            label: UserStorage.l10n.appInfoPackage,
+            value: info?.packageName ?? UserStorage.l10n.appInfoUnknown,
+            isLast: true,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUpdateSection(AboutMemexViewModelContract vm) {
+    final settings = vm.settings ?? const AppUpdateSettings();
+    final hasUpdate = vm.updateCheck?.hasUpdate ?? false;
+    final canActOnUpdate =
+        hasUpdate &&
+        ((vm.updateCheck?.canDownloadApk ?? false) ||
+            (vm.updateCheck?.canOpenExternalUpdate ?? false));
+    final busy = vm.checking || vm.performingUpdate || vm.clearingCache;
+
+    return _SectionCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.system_update_alt, color: AppColors.primary),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  UserStorage.l10n.appUpdateSectionTitle,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+            title: Text(UserStorage.l10n.appUpdateAutoCheckTitle),
+            subtitle: Text(UserStorage.l10n.appUpdateAutoCheckDesc),
+            value: settings.autoCheckEnabled,
+            onChanged: busy ? null : vm.updateAutoCheckEnabled,
+          ),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+            title: Text(UserStorage.l10n.appUpdateWifiOnlyTitle),
+            subtitle: Text(UserStorage.l10n.appUpdateWifiOnlyDesc),
+            value: settings.wifiOnlyDownloads,
+            onChanged: busy ? null : vm.updateWifiOnlyDownloads,
+          ),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+            title: Text(UserStorage.l10n.appUpdateAutoInstallTitle),
+            subtitle: Text(UserStorage.l10n.appUpdateAutoInstallDesc),
+            value: settings.autoDownloadAndInstall,
+            onChanged: busy ? null : vm.updateAutoDownloadAndInstall,
+          ),
+          if (vm.statusText != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              vm.statusText!,
+              style: const TextStyle(
+                fontSize: 13,
+                color: AppColors.textSecondary,
+                height: 1.35,
+              ),
+            ),
+          ],
+          if (vm.performingUpdate &&
+              (vm.updateCheck?.canDownloadApk ?? false)) ...[
+            const SizedBox(height: 10),
+            LinearProgressIndicator(
+              value: vm.downloadPercent <= 0 ? null : vm.downloadPercent / 100,
+              minHeight: 4,
+              color: AppColors.primary,
+            ),
+          ],
+          if (vm.cacheInfo.hasFiles) ...[
+            const SizedBox(height: 10),
+            Text(
+              UserStorage.l10n.appUpdateCacheInfo(
+                vm.cacheInfo.fileCount,
+                vm.cacheInfo.totalBytes,
+              ),
+              style: const TextStyle(
+                fontSize: 12,
+                color: AppColors.textSecondary,
+              ),
+            ),
+          ],
+          const SizedBox(height: 14),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: [
+              OutlinedButton.icon(
+                onPressed: busy ? null : vm.checkNow,
+                icon: vm.checking
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.refresh, size: 18),
+                label: Text(UserStorage.l10n.appUpdateCheckNow),
+              ),
+              if (canActOnUpdate)
+                FilledButton.icon(
+                  onPressed: busy ? null : vm.performUpdateAction,
+                  icon: Icon(
+                    vm.updateCheck?.canDownloadApk ?? false
+                        ? Icons.download
+                        : Icons.open_in_new,
+                    size: 18,
+                  ),
+                  label: Text(
+                    vm.updateCheck?.canDownloadApk ?? false
+                        ? UserStorage.l10n.appUpdateDownloadAndInstall
+                        : UserStorage.l10n.appUpdateOpenUpdatePage,
+                  ),
+                ),
+              OutlinedButton.icon(
+                onPressed: vm.buildInfo == null ? null : vm.copyDiagnostics,
+                icon: const Icon(Icons.copy, size: 18),
+                label: Text(UserStorage.l10n.appUpdateCopyDiagnostics),
+              ),
+              if (vm.cacheInfo.hasFiles)
+                OutlinedButton.icon(
+                  onPressed: busy ? null : vm.clearUpdateCache,
+                  icon: vm.clearingCache
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.delete_outline, size: 18),
+                  label: Text(UserStorage.l10n.appUpdateClearCache),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.textSecondary.withValues(alpha: 0.08),
+            blurRadius: 16,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        clipBehavior: Clip.antiAlias,
+        child: Padding(padding: const EdgeInsets.all(20), child: child),
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.label,
+    required this.value,
+    this.isLast = false,
+  });
+
+  final String label;
+  final String value;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: isLast ? 0 : 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 112,
+            child: Text(
+              label,
+              style: const TextStyle(
+                fontSize: 13,
+                color: AppColors.textSecondary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              value,
+              textAlign: TextAlign.right,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: AppColors.textPrimary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/settings/widgets/settings_page.dart
+++ b/lib/ui/settings/widgets/settings_page.dart
@@ -1,13 +1,14 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:memex/config/app_flavor.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/utils/user_storage.dart';
+import 'package:memex/ui/settings/view_models/about_memex_viewmodel.dart';
+import 'package:memex/ui/settings/widgets/about_memex_page.dart';
 import 'package:memex/ui/settings/widgets/backup_restore_page.dart';
 import 'package:memex/ui/settings/widgets/data_storage_page.dart';
 import 'package:memex/ui/settings/widgets/location_context_settings_page.dart';
-import 'package:memex/ui/settings/widgets/early_update_settings_card.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
@@ -202,10 +203,74 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
           ),
           const SizedBox(height: 16),
-          if (Platform.isAndroid && AppFlavor.isEarly) ...[
-            EarlyUpdateSettingsCard(),
-            const SizedBox(height: 16),
-          ],
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => AboutMemexPage(
+                      viewModel: AboutMemexViewModel(
+                        router: context.read<MemexRouter>(),
+                      ),
+                    ),
+                  ),
+                );
+              },
+              borderRadius: BorderRadius.circular(16),
+              child: Container(
+                padding: const EdgeInsets.all(20),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(16),
+                  boxShadow: [
+                    BoxShadow(
+                      color: AppColors.textSecondary.withValues(alpha: 0.08),
+                      blurRadius: 16,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
+                ),
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.info_outline,
+                      color: AppColors.primary,
+                      size: 22,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            UserStorage.l10n.aboutMemexTitle,
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                              color: AppColors.textPrimary,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            UserStorage.l10n.aboutMemexDesc,
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: Colors.grey[600],
+                              height: 1.4,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const Icon(Icons.chevron_right, color: Color(0xFFCBD5E1)),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
           // Show Insight Text toggle
           Container(
             padding: const EdgeInsets.all(20),

--- a/test/data/services/app_update_router_test.dart
+++ b/test/data/services/app_update_router_test.dart
@@ -1,0 +1,197 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:memex/config/app_flavor.dart';
+import 'package:memex/data/services/app_info_service.dart';
+import 'package:memex/data/services/app_update_router.dart';
+import 'package:memex/data/services/app_update_service.dart';
+import 'package:memex/data/services/update_manifest_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    AppFlavor.init('global');
+  });
+
+  test(
+    'selects GitHub APK provider for Android Early manifest channel',
+    () async {
+      AppFlavor.init('globalEarly');
+      final router = _routerFor(
+        packageName: 'com.memexlab.memex.early',
+        installerSource: 'com.android.packageinstaller',
+        manifest: {'android_global_early': _githubApkChannel(latestBuild: 118)},
+      );
+
+      final result = await router.checkForUpdate(manual: true);
+
+      expect(result.status, UnifiedAppUpdateStatus.updateAvailable);
+      expect(result.providerKind.wireName, 'github_apk');
+      expect(result.apkUpdate, isNotNull);
+      expect(result.apkUpdate!.sha256, _hash('1'));
+      expect(result.apkUpdate!.buildNumber, 118);
+    },
+  );
+
+  test('returns no update when manifest build is not newer', () async {
+    AppFlavor.init('globalEarly');
+    final router = _routerFor(
+      buildNumber: 118,
+      packageName: 'com.memexlab.memex.early',
+      installerSource: 'com.android.packageinstaller',
+      manifest: {'android_global_early': _githubApkChannel(latestBuild: 118)},
+    );
+
+    final result = await router.checkForUpdate(manual: true);
+
+    expect(result.status, UnifiedAppUpdateStatus.noUpdate);
+    expect(result.providerKind.wireName, 'github_apk');
+  });
+
+  test('selects store redirect for stable Android store channel', () async {
+    final router = _routerFor(
+      packageName: 'com.memexlab.memex',
+      installerSource: 'com.android.vending',
+      manifest: {
+        'android_global_stable': {
+          'provider': 'google_play',
+          'packageName': 'com.memexlab.memex',
+          'latestBuild': 118,
+          'minSupportedBuild': 117,
+          'fallbackStoreUrl': 'market://details?id=com.memexlab.memex',
+        },
+      },
+    );
+
+    final result = await router.checkForUpdate(manual: true);
+
+    expect(result.status, UnifiedAppUpdateStatus.updateAvailable);
+    expect(result.providerKind.wireName, 'google_play');
+    expect(result.apkUpdate, isNull);
+    expect(
+      result.actionUri.toString(),
+      'market://details?id=com.memexlab.memex',
+    );
+  });
+
+  test('does not route store-installed stable builds to GitHub APK', () async {
+    final router = _routerFor(
+      packageName: 'com.memexlab.memex',
+      installerSource: 'com.android.vending',
+      manifest: {
+        'android_global_stable': {
+          'provider': 'github_apk',
+          'packageName': 'com.memexlab.memex',
+          'latestBuild': 118,
+          'minSupportedBuild': 117,
+          'versionName': '1.0.35',
+          'apkUrl': 'https://example.com/memex_global_1.0.35_118.apk',
+          'sha256': _hash('1'),
+          'sizeBytes': 4,
+        },
+      },
+    );
+
+    final result = await router.checkForUpdate(manual: true);
+
+    expect(result.status, UnifiedAppUpdateStatus.unsupported);
+    expect(result.apkUpdate, isNull);
+  });
+
+  test('surfaces manifest fallback failure without throwing', () async {
+    final router = _routerFor(
+      packageName: 'com.memexlab.memex',
+      installerSource: 'com.android.vending',
+      manifest: null,
+      statusCode: 503,
+    );
+
+    final result = await router.checkForUpdate(manual: true);
+
+    expect(result.status, UnifiedAppUpdateStatus.checkFailed);
+    expect(result.usedBuiltInFallback, isTrue);
+    expect(result.error, isNotNull);
+  });
+}
+
+AppUpdateRouter _routerFor({
+  int buildNumber = 117,
+  required String packageName,
+  required String installerSource,
+  required Map<String, dynamic>? manifest,
+  int statusCode = 200,
+}) {
+  final appInfoService = AppInfoService(
+    environment: const AppInfoEnvironment(
+      isAndroid: true,
+      isIOS: false,
+      platformName: 'android',
+    ),
+    platform: _FakeAppInfoPlatform(installerSource),
+    packageLoader: () async => AppPackageMetadata(
+      appName: 'Memex',
+      packageName: packageName,
+      versionName: '1.0.34',
+      buildNumber: buildNumber,
+    ),
+  );
+  final manifestService = UpdateManifestService(
+    verifyManifestSha256: false,
+    endpoints: const [
+      UpdateManifestEndpoint(manifestUrl: 'https://example.com/manifest.json'),
+    ],
+    httpClient: MockClient((_) async {
+      if (manifest == null) return http.Response('unavailable', statusCode);
+      return http.Response(
+        jsonEncode({
+          'schemaVersion': 1,
+          'generatedAt': '2026-06-16T00:00:00Z',
+          'channels': manifest,
+        }),
+        statusCode,
+      );
+    }),
+  );
+
+  return AppUpdateRouter(
+    appInfoService: appInfoService,
+    manifestService: manifestService,
+    apkUpdateService: AppUpdateService(
+      environment: const AppUpdateEnvironment(
+        isAndroid: true,
+        isEarlyChannel: true,
+        flavorName: 'globalEarly',
+      ),
+    ),
+    clock: () => DateTime.utc(2026, 6, 16),
+  );
+}
+
+Map<String, dynamic> _githubApkChannel({required int latestBuild}) {
+  return {
+    'provider': 'github_apk',
+    'packageName': 'com.memexlab.memex.early',
+    'latestBuild': latestBuild,
+    'minSupportedBuild': 117,
+    'versionName': '1.0.35',
+    'apkUrl': 'https://example.com/memex_globalEarly_1.0.35_118.apk',
+    'sha256': _hash('1'),
+    'sizeBytes': 4,
+  };
+}
+
+String _hash(String char) => List.filled(64, char).join();
+
+class _FakeAppInfoPlatform implements AppInfoPlatform {
+  const _FakeAppInfoPlatform(this.installerSource);
+
+  final String installerSource;
+
+  @override
+  Future<String?> getInstallerSource() async => installerSource;
+}

--- a/test/data/services/app_update_service_test.dart
+++ b/test/data/services/app_update_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -384,6 +385,85 @@ void main() {
     );
 
     test(
+      'deletes corrupt partial APK when downloaded hash mismatches',
+      () async {
+        final service = buildService(
+          client: ControlledDownloadClient((_) async {
+            return http.StreamedResponse(
+              Stream.value([1, 2, 3, 4]),
+              200,
+              contentLength: 4,
+            );
+          }),
+        );
+        const update = AppUpdateInfo(
+          releaseName: 'Early',
+          tagName: 'v1.0.30+113',
+          versionName: '1.0.30',
+          buildNumber: 113,
+          assetName: 'memex_globalEarly_1.0.30_113.apk',
+          sizeBytes: 4,
+          downloadUrl: 'https://example.com/global.apk',
+          sha256:
+              '0000000000000000000000000000000000000000000000000000000000000000',
+          releaseNotes: '',
+        );
+
+        await expectLater(
+          service.downloadUpdate(update),
+          throwsA(isA<AppUpdateInvalidPackageException>()),
+        );
+
+        expect(
+          await File(p.join(tempDir.path, update.assetName)).exists(),
+          isFalse,
+        );
+        expect(
+          await File('${p.join(tempDir.path, update.assetName)}.part').exists(),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'redownloads when cached APK hash does not match manifest hash',
+      () async {
+        final expectedHash = sha256.convert([1, 2, 3, 4]).toString();
+        final update = AppUpdateInfo(
+          releaseName: _testUpdate.releaseName,
+          tagName: _testUpdate.tagName,
+          versionName: _testUpdate.versionName,
+          buildNumber: _testUpdate.buildNumber,
+          assetName: _testUpdate.assetName,
+          sizeBytes: _testUpdate.sizeBytes,
+          downloadUrl: _testUpdate.downloadUrl,
+          sha256: expectedHash,
+          releaseNotes: _testUpdate.releaseNotes,
+        );
+        final apk = File(p.join(tempDir.path, update.assetName));
+        await apk.writeAsBytes([9, 9, 9, 9]);
+        var fetched = false;
+        final service = buildService(
+          client: MockClient((request) async {
+            fetched = true;
+            expect(request.url.toString(), update.downloadUrl);
+            return http.Response.bytes(
+              [1, 2, 3, 4],
+              200,
+              headers: {'content-length': '4'},
+            );
+          }),
+        );
+
+        final download = await service.downloadUpdate(update);
+
+        expect(fetched, isTrue);
+        expect(download.reusedExistingFile, isFalse);
+        expect(await File(download.apkPath).readAsBytes(), [1, 2, 3, 4]);
+      },
+    );
+
+    test(
       'redownloads when cached APK size does not match asset size',
       () async {
         final apk = File(p.join(tempDir.path, _testUpdate.assetName));
@@ -558,7 +638,7 @@ class ControlledDownloadClient extends http.BaseClient {
   ControlledDownloadClient(this.handler);
 
   final Future<http.StreamedResponse> Function(http.BaseRequest request)
-      handler;
+  handler;
   int requestCount = 0;
 
   @override

--- a/test/data/services/update_manifest_service_test.dart
+++ b/test/data/services/update_manifest_service_test.dart
@@ -1,0 +1,165 @@
+import 'dart:convert';
+import 'dart:async';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:memex/data/services/update_manifest_service.dart';
+import 'package:memex/domain/models/update_manifest.dart';
+
+void main() {
+  test('loads and verifies the primary official-site manifest', () async {
+    final body = jsonEncode(_manifestJson());
+    final expectedHash = sha256.convert(utf8.encode(body)).toString();
+    final service = UpdateManifestService(
+      endpoints: const [
+        UpdateManifestEndpoint(
+          manifestUrl: 'https://example.com/manifest.json',
+          sha256Url: 'https://example.com/manifest.sha256',
+        ),
+      ],
+      httpClient: MockClient((request) async {
+        if (request.url.path.endsWith('.sha256')) {
+          return http.Response('$expectedHash  manifest.json', 200);
+        }
+        return http.Response(body, 200);
+      }),
+      clock: () => DateTime.utc(2026, 6, 16),
+    );
+
+    final result = await service.loadManifest();
+
+    expect(result.usedBuiltInFallback, isFalse);
+    expect(result.sourceUrl, 'https://example.com/manifest.json');
+    expect(
+      result.manifest.channels['android_global_early']!.provider,
+      UpdateProviderKind.githubApk,
+    );
+  });
+
+  test('falls back to the next endpoint when primary manifest fails', () async {
+    final body = jsonEncode(_manifestJson());
+    final service = UpdateManifestService(
+      verifyManifestSha256: false,
+      endpoints: const [
+        UpdateManifestEndpoint(
+          manifestUrl: 'https://primary.test/manifest.json',
+        ),
+        UpdateManifestEndpoint(
+          manifestUrl: 'https://fallback.test/manifest.json',
+        ),
+      ],
+      httpClient: MockClient((request) async {
+        if (request.url.host == 'primary.test') {
+          return http.Response('nope', 503);
+        }
+        return http.Response(body, 200);
+      }),
+    );
+
+    final result = await service.loadManifest();
+
+    expect(result.usedFallback, isTrue);
+    expect(result.usedBuiltInFallback, isFalse);
+    expect(result.sourceUrl, 'https://fallback.test/manifest.json');
+  });
+
+  test('returns built-in no-op fallback when all endpoints fail', () async {
+    final service = UpdateManifestService(
+      endpoints: const [
+        UpdateManifestEndpoint(
+          manifestUrl: 'https://primary.test/manifest.json',
+        ),
+      ],
+      httpClient: MockClient((_) async => http.Response('missing', 404)),
+    );
+
+    final result = await service.loadManifest();
+
+    expect(result.usedBuiltInFallback, isTrue);
+    expect(result.manifest.channels, isEmpty);
+    expect(result.error, isNotNull);
+  });
+
+  test('times out hung manifest requests and returns built-in fallback',
+      () async {
+    final service = UpdateManifestService(
+      requestTimeout: const Duration(milliseconds: 20),
+      endpoints: const [
+        UpdateManifestEndpoint(
+          manifestUrl: 'https://primary.test/manifest.json',
+        ),
+      ],
+      httpClient: MockClient((_) => Completer<http.Response>().future),
+    );
+
+    final stopwatch = Stopwatch()..start();
+    final result = await service.loadManifest();
+    stopwatch.stop();
+
+    expect(result.usedBuiltInFallback, isTrue);
+    expect(result.manifest.channels, isEmpty);
+    expect(result.error, isA<TimeoutException>());
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
+  });
+
+  test('rejects malformed manifest build numbers and APK hash', () {
+    expect(
+      () => UpdateManifest.fromJson({
+        'schemaVersion': 1,
+        'channels': {
+          'android_global_early': {
+            'provider': 'github_apk',
+            'latestBuild': '118',
+            'minSupportedBuild': 117,
+            'versionName': '1.0.35',
+            'apkUrl': 'https://example.com/app.apk',
+            'sha256': _hash('0'),
+            'sizeBytes': 4,
+          },
+        },
+      }),
+      throwsFormatException,
+    );
+
+    expect(
+      () => UpdateManifest.fromJson({
+        'schemaVersion': 1,
+        'channels': {
+          'android_global_early': {
+            'provider': 'github_apk',
+            'latestBuild': 118,
+            'minSupportedBuild': 117,
+            'versionName': '1.0.35',
+            'apkUrl': 'https://example.com/app.apk',
+            'sha256': 'not-a-hash',
+            'sizeBytes': 4,
+          },
+        },
+      }),
+      throwsFormatException,
+    );
+  });
+}
+
+Map<String, dynamic> _manifestJson() {
+  return {
+    'schemaVersion': 1,
+    'generatedAt': '2026-06-16T00:00:00Z',
+    'channels': {
+      'android_global_early': {
+        'provider': 'github_apk',
+        'packageName': 'com.memexlab.memex.early',
+        'latestBuild': 118,
+        'minSupportedBuild': 117,
+        'versionName': '1.0.35',
+        'apkUrl': 'https://example.com/memex_globalEarly_1.0.35_118.apk',
+        'sha256': _hash('0'),
+        'sizeBytes': 4,
+      },
+    },
+  };
+}
+
+String _hash(String char) => List.filled(64, char).join();

--- a/test/domain/models/app_build_info_test.dart
+++ b/test/domain/models/app_build_info_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/app_build_info.dart';
+
+void main() {
+  group('AppBuildInfo', () {
+    test('formats version, update channel, and known installer names', () {
+      const info = AppBuildInfo(
+        appName: 'Memex',
+        packageName: 'com.memexlab.memex.early',
+        versionName: '1.0.34',
+        buildNumber: 117,
+        flavorName: 'globalEarly',
+        regionName: 'global',
+        channelName: 'early',
+        platformName: 'android',
+        installerSource: 'com.android.vending',
+      );
+
+      expect(info.displayVersion, '1.0.34+117');
+      expect(info.updateChannelKey, 'android_global_early');
+      expect(info.isAndroid, isTrue);
+      expect(info.isIOS, isFalse);
+      expect(info.isEarly, isTrue);
+      expect(info.installerDisplayName, 'Google Play');
+      expect(info.isDirectInstall, isFalse);
+    });
+
+    test('detects direct installs and trims unknown installer sources', () {
+      const info = AppBuildInfo(
+        appName: 'Memex',
+        packageName: 'com.memexlab.memex.dev',
+        versionName: '1.0.34',
+        buildNumber: 117,
+        flavorName: 'globalDev',
+        regionName: 'global',
+        channelName: 'dev',
+        platformName: 'android',
+        installerSource: ' com.android.shell ',
+      );
+
+      expect(info.installerDisplayName, 'Direct install');
+      expect(info.isDirectInstall, isTrue);
+    });
+
+    test('diagnostics contain only safe app and update fields', () {
+      const info = AppBuildInfo(
+        appName: 'Memex',
+        packageName: 'com.memexlab.memex',
+        versionName: '1.0.34',
+        buildNumber: 117,
+        flavorName: 'global',
+        regionName: 'global',
+        channelName: 'stable',
+        platformName: 'android',
+        installerSource: null,
+      );
+
+      final diagnostics = info.diagnostics(
+        updateProvider: 'google_play',
+        updateChannel: 'android_global_stable',
+        manifestSource: 'https://example.com/manifest.json',
+        manifestGeneratedAt: DateTime.utc(2026, 6, 16),
+      );
+
+      expect(diagnostics, contains('appName=Memex'));
+      expect(diagnostics, contains('installerSource=unknown'));
+      expect(diagnostics, contains('installerDisplayName=Unknown'));
+      expect(diagnostics, contains('updateProvider=google_play'));
+      expect(diagnostics,
+          contains('manifestGeneratedAt=2026-06-16T00:00:00.000Z'));
+      expect(diagnostics, isNot(contains('userId')));
+      expect(diagnostics, isNot(contains('workspace')));
+    });
+  });
+}

--- a/test/domain/models/update_manifest_test.dart
+++ b/test/domain/models/update_manifest_test.dart
@@ -1,0 +1,122 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/app_build_info.dart';
+import 'package:memex/domain/models/update_manifest.dart';
+
+void main() {
+  group('UpdateManifest', () {
+    test('parses channels case-insensitively and resolves build channel', () {
+      final manifest = UpdateManifest.fromJson({
+        'schemaVersion': 1,
+        'generatedAt': '2026-06-16T00:00:00Z',
+        'expiresAt': '2026-06-17T00:00:00Z',
+        'channels': {
+          'ANDROID_GLOBAL_EARLY': _githubApkChannel(latestBuild: 118),
+        },
+      });
+      const buildInfo = AppBuildInfo(
+        appName: 'Memex',
+        packageName: 'com.memexlab.memex.early',
+        versionName: '1.0.34',
+        buildNumber: 117,
+        flavorName: 'globalEarly',
+        regionName: 'global',
+        channelName: 'early',
+        platformName: 'android',
+      );
+
+      final channel = manifest.channelFor(buildInfo);
+
+      expect(manifest.generatedAt, DateTime.utc(2026, 6, 16));
+      expect(manifest.expiresAt, DateTime.utc(2026, 6, 17));
+      expect(channel, isNotNull);
+      expect(channel!.key, 'android_global_early');
+      expect(channel.provider, UpdateProviderKind.githubApk);
+      expect(
+          channel.primaryActionUri.toString(), 'https://example.com/app.apk');
+      expect(channel.isNewerThan(117), isTrue);
+      expect(channel.isNewerThan(118), isFalse);
+      expect(channel.requiresUpdateFor(116), isTrue);
+      expect(channel.requiresUpdateFor(117), isFalse);
+    });
+
+    test('parses from JSON string and normalizes APK hash', () {
+      final manifest = UpdateManifest.fromJsonString(
+        jsonEncode({
+          'schemaVersion': 1,
+          'channels': {
+            'android_global_early': _githubApkChannel(
+              latestBuild: 118,
+              sha256: _hash('A'),
+            ),
+          },
+        }),
+      );
+
+      expect(
+        manifest.channels['android_global_early']!.sha256,
+        _hash('a'),
+      );
+    });
+
+    test('validates provider-specific required fields', () {
+      expect(
+        () => UpdateManifestChannel.fromJson(
+          key: 'android_global_early',
+          json: {
+            'provider': 'github_apk',
+            'latestBuild': 118,
+            'minSupportedBuild': 117,
+            'versionName': '1.0.35',
+            'apkUrl': 'https://example.com/app.apk',
+            'sha256': _hash('0'),
+            'sizeBytes': 0,
+          },
+        ),
+        throwsFormatException,
+      );
+
+      expect(
+        () => UpdateManifestChannel.fromJson(
+          key: 'ios_global_stable',
+          json: {
+            'provider': 'app_store',
+            'latestBuild': 118,
+            'minSupportedBuild': 117,
+          },
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects unsupported schema and non-object root', () {
+      expect(
+        () => UpdateManifest.fromJson({'schemaVersion': 2, 'channels': {}}),
+        throwsFormatException,
+      );
+      expect(
+        () => UpdateManifest.fromJsonString('[1,2,3]'),
+        throwsFormatException,
+      );
+    });
+  });
+}
+
+Map<String, dynamic> _githubApkChannel({
+  required int latestBuild,
+  String? sha256,
+}) {
+  return {
+    'provider': 'github_apk',
+    'packageName': 'com.memexlab.memex.early',
+    'latestBuild': latestBuild,
+    'minSupportedBuild': 117,
+    'versionName': '1.0.35',
+    'apkUrl': 'https://example.com/app.apk',
+    'sha256': sha256 ?? _hash('0'),
+    'sizeBytes': 4,
+  };
+}
+
+String _hash(String char) => List.filled(64, char).join();

--- a/test/ui/settings/view_models/about_memex_viewmodel_test.dart
+++ b/test/ui/settings/view_models/about_memex_viewmodel_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/app_update_router.dart';
+import 'package:memex/data/services/app_update_service.dart';
+import 'package:memex/domain/models/app_build_info.dart';
+import 'package:memex/domain/models/update_manifest.dart';
+import 'package:memex/ui/settings/view_models/about_memex_viewmodel.dart';
+import 'package:memex/utils/result.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  group('AboutMemexViewModel', () {
+    test('load populates build info, settings, and cache info', () async {
+      final harness = _AboutMemexHarness();
+      final viewModel = harness.createViewModel();
+
+      await viewModel.load();
+
+      expect(viewModel.loading, isFalse);
+      expect(viewModel.buildInfo, harness.buildInfo);
+      expect(viewModel.settings, harness.settings);
+      expect(viewModel.cacheInfo.fileCount, 2);
+      expect(viewModel.statusText, isNull);
+    });
+
+    test('checkNow stores result and refreshes status text', () async {
+      final harness = _AboutMemexHarness(
+        checkResult: _checkResult(
+          status: UnifiedAppUpdateStatus.noUpdate,
+        ),
+      );
+      final viewModel = harness.createViewModel();
+
+      await viewModel.checkNow();
+
+      expect(harness.manualCheckRequested, isTrue);
+      expect(viewModel.checking, isFalse);
+      expect(viewModel.updateCheck!.status, UnifiedAppUpdateStatus.noUpdate);
+      expect(viewModel.statusText, UserStorage.l10n.appUpdateNoUpdate);
+      expect(viewModel.cacheInfo.fileCount, 2);
+    });
+
+    test('performUpdateAction reports progress and refreshes cache', () async {
+      final harness = _AboutMemexHarness();
+      final viewModel = harness.createViewModel();
+      viewModel.updateCheck = _checkResult(
+        status: UnifiedAppUpdateStatus.updateAvailable,
+        apkUpdate: _apkUpdate(),
+      );
+
+      await viewModel.performUpdateAction();
+
+      expect(harness.performCalled, isTrue);
+      expect(viewModel.performingUpdate, isFalse);
+      expect(viewModel.downloadPercent, 50);
+      expect(viewModel.statusText, UserStorage.l10n.earlyUpdateInstallStarted);
+      expect(viewModel.cacheInfo.fileCount, 2);
+    });
+
+    test('settings toggles save and publish the updated value', () async {
+      final harness = _AboutMemexHarness();
+      final viewModel = harness.createViewModel();
+      viewModel.settings = harness.settings;
+
+      await viewModel.updateAutoCheckEnabled(false);
+      await viewModel.updateWifiOnlyDownloads(false);
+      await viewModel.updateAutoDownloadAndInstall(true);
+
+      expect(harness.savedSettings, hasLength(3));
+      expect(viewModel.settings!.autoCheckEnabled, isFalse);
+      expect(viewModel.settings!.wifiOnlyDownloads, isFalse);
+      expect(viewModel.settings!.autoDownloadAndInstall, isTrue);
+    });
+
+    test('clearUpdateCache clears cache and updates status', () async {
+      final harness = _AboutMemexHarness();
+      final viewModel = harness.createViewModel();
+      viewModel.cacheInfo = const AppUpdateCacheInfo(
+        fileCount: 2,
+        totalBytes: 128,
+      );
+
+      await viewModel.clearUpdateCache();
+
+      expect(harness.clearCacheCalled, isTrue);
+      expect(viewModel.clearingCache, isFalse);
+      expect(viewModel.cacheInfo, AppUpdateCacheInfo.empty);
+      expect(viewModel.statusText, UserStorage.l10n.appUpdateCacheCleared);
+    });
+  });
+}
+
+class _AboutMemexHarness {
+  _AboutMemexHarness({
+    UnifiedAppUpdateCheckResult? checkResult,
+  }) : checkResult = checkResult ?? _checkResult();
+
+  final AppBuildInfo buildInfo = _buildInfo();
+  final AppUpdateSettings settings = const AppUpdateSettings(
+    autoCheckEnabled: true,
+    wifiOnlyDownloads: true,
+    autoDownloadAndInstall: false,
+  );
+  final UnifiedAppUpdateCheckResult checkResult;
+  final savedSettings = <AppUpdateSettings>[];
+  bool manualCheckRequested = false;
+  bool performCalled = false;
+  bool clearCacheCalled = false;
+
+  AboutMemexViewModel createViewModel() {
+    return AboutMemexViewModel(
+      getAppBuildInfo: () async => Ok(buildInfo),
+      getAppUpdateSettings: () async => settings,
+      saveAppUpdateSettings: (settings) async {
+        savedSettings.add(settings);
+      },
+      getAppUpdateCacheInfo: () async => const AppUpdateCacheInfo(
+        fileCount: 2,
+        totalBytes: 128,
+      ),
+      clearAppUpdateCache: () async {
+        clearCacheCalled = true;
+        return const Ok(2);
+      },
+      checkAppUpdate: ({bool manual = false}) async {
+        manualCheckRequested = manual;
+        return Ok(checkResult);
+      },
+      performAppUpdateAction: (check, {onProgress}) async {
+        performCalled = true;
+        onProgress?.call(4, 8);
+        return const Ok(
+          AppUpdateActionResult(AppUpdateActionStatus.installStarted),
+        );
+      },
+    );
+  }
+}
+
+AppBuildInfo _buildInfo() {
+  return const AppBuildInfo(
+    appName: 'Memex',
+    packageName: 'com.memexlab.memex.early',
+    versionName: '1.0.34',
+    buildNumber: 117,
+    flavorName: 'globalEarly',
+    regionName: 'global',
+    channelName: 'early',
+    platformName: 'android',
+    installerSource: 'com.android.packageinstaller',
+  );
+}
+
+UnifiedAppUpdateCheckResult _checkResult({
+  UnifiedAppUpdateStatus status = UnifiedAppUpdateStatus.updateAvailable,
+  AppUpdateInfo? apkUpdate,
+}) {
+  return UnifiedAppUpdateCheckResult(
+    status: status,
+    buildInfo: _buildInfo(),
+    providerKind: UpdateProviderKind.githubApk,
+    manifestSource: 'https://example.com/manifest.json',
+    checkedAt: DateTime.utc(2026, 6, 16),
+    apkUpdate: apkUpdate,
+  );
+}
+
+AppUpdateInfo _apkUpdate() {
+  return const AppUpdateInfo(
+    releaseName: 'Memex 1.0.35',
+    tagName: 'v1.0.35',
+    versionName: '1.0.35',
+    buildNumber: 118,
+    assetName: 'memex.apk',
+    sizeBytes: 8,
+    downloadUrl: 'https://example.com/memex.apk',
+    sha256: null,
+    releaseNotes: 'Update notes',
+  );
+}

--- a/test/ui/settings/widgets/about_memex_page_test.dart
+++ b/test/ui/settings/widgets/about_memex_page_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/app_update_router.dart';
+import 'package:memex/data/services/app_update_service.dart';
+import 'package:memex/domain/models/app_build_info.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/settings/view_models/about_memex_viewmodel.dart';
+import 'package:memex/ui/settings/widgets/about_memex_page.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  String? clipboardText;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+    clipboardText = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        final args = Map<String, dynamic>.from(call.arguments as Map);
+        clipboardText = args['text'] as String?;
+        return null;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  testWidgets('loads and renders app build information', (tester) async {
+    final viewModel = FakeAboutMemexViewModel();
+
+    await pumpAboutPage(tester, viewModel);
+
+    expect(viewModel.loadCalled, isTrue);
+    expect(find.text(UserStorage.l10n.aboutMemexTitle), findsOneWidget);
+    expect(find.text('1.0.34'), findsWidgets);
+    expect(find.text('117'), findsOneWidget);
+    expect(find.text('globalEarly'), findsOneWidget);
+    expect(find.text('Direct install'), findsOneWidget);
+  });
+
+  testWidgets('manual update check shows failure status', (tester) async {
+    final viewModel = FakeAboutMemexViewModel();
+    await pumpAboutPage(tester, viewModel);
+
+    final checkButton = find.widgetWithText(
+      OutlinedButton,
+      UserStorage.l10n.appUpdateCheckNow,
+    );
+    await tester.ensureVisible(checkButton);
+    await tester.pumpAndSettle();
+    await tester.tap(checkButton);
+    await tester.pump();
+
+    expect(viewModel.checkNowCalled, isTrue);
+    expect(
+      find.text(UserStorage.l10n.appUpdateCheckFailed('network down')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('copies safe diagnostics to clipboard', (tester) async {
+    final viewModel = FakeAboutMemexViewModel();
+    await pumpAboutPage(tester, viewModel);
+
+    final copyButton = find.widgetWithText(
+      OutlinedButton,
+      UserStorage.l10n.appUpdateCopyDiagnostics,
+    );
+    await tester.ensureVisible(copyButton);
+    await tester.pumpAndSettle();
+    await tester.tap(copyButton);
+    await tester.pump();
+
+    expect(viewModel.copyDiagnosticsCalled, isTrue);
+    expect(
+      find.text(UserStorage.l10n.appUpdateDiagnosticsCopied),
+      findsOneWidget,
+    );
+    expect(clipboardText, contains('packageName=com.memexlab.memex.early'));
+    expect(
+      clipboardText,
+      contains('installerSource=com.android.packageinstaller'),
+    );
+    expect(clipboardText, isNot(contains('userId')));
+  });
+}
+
+Future<void> pumpAboutPage(
+  WidgetTester tester,
+  FakeAboutMemexViewModel viewModel,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: AboutMemexPage(viewModel: viewModel),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+class FakeAboutMemexViewModel extends ChangeNotifier
+    implements AboutMemexViewModelContract {
+  bool loadCalled = false;
+  bool checkNowCalled = false;
+  bool copyDiagnosticsCalled = false;
+
+  @override
+  AppBuildInfo? buildInfo = const AppBuildInfo(
+    appName: 'Memex',
+    packageName: 'com.memexlab.memex.early',
+    versionName: '1.0.34',
+    buildNumber: 117,
+    flavorName: 'globalEarly',
+    regionName: 'global',
+    channelName: 'early',
+    platformName: 'android',
+    installerSource: 'com.android.packageinstaller',
+  );
+
+  @override
+  AppUpdateSettings? settings = const AppUpdateSettings();
+
+  @override
+  AppUpdateCacheInfo cacheInfo = AppUpdateCacheInfo.empty;
+
+  @override
+  UnifiedAppUpdateCheckResult? updateCheck;
+
+  @override
+  bool loading = false;
+
+  @override
+  bool checking = false;
+
+  @override
+  bool performingUpdate = false;
+
+  @override
+  bool clearingCache = false;
+
+  @override
+  int downloadPercent = 0;
+
+  @override
+  String? statusText;
+
+  @override
+  Future<void> load() async {
+    loadCalled = true;
+  }
+
+  @override
+  Future<void> checkNow() async {
+    checkNowCalled = true;
+    statusText = UserStorage.l10n.appUpdateCheckFailed('network down');
+    notifyListeners();
+  }
+
+  @override
+  Future<void> copyDiagnostics() async {
+    copyDiagnosticsCalled = true;
+    await Clipboard.setData(ClipboardData(text: buildInfo!.diagnostics()));
+    statusText = UserStorage.l10n.appUpdateDiagnosticsCopied;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> clearUpdateCache() async {}
+
+  @override
+  Future<void> performUpdateAction() async {}
+
+  @override
+  Future<void> updateAutoCheckEnabled(bool value) async {
+    settings = settings!.copyWith(autoCheckEnabled: value);
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateAutoDownloadAndInstall(bool value) async {
+    settings = settings!.copyWith(autoDownloadAndInstall: value);
+    notifyListeners();
+  }
+
+  @override
+  Future<void> updateWifiOnlyDownloads(bool value) async {
+    settings = settings!.copyWith(wifiOnlyDownloads: value);
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
## 关联 issue

Closes #296

## 变更

- 新增 AppInfo、UpdateManifest、AppUpdateRouter 等服务，支持读取构建信息、解析更新清单、校验安装包大小/hash，并处理有界超时。
- 新增 About Memex 页面与设置入口，展示版本、build、flavor、channel、installer/package，并提供诊断信息复制。
- 接入 Android 原生 app info channel、启动后台检查和本地化文案。

## 测试

- `flutter test --no-pub test/data/services/update_manifest_service_test.dart test/data/services/app_update_service_test.dart test/data/services/app_update_router_test.dart test/ui/settings/widgets/about_memex_page_test.dart`
- `flutter build apk --debug --flavor globalDev --no-pub`
- `git diff --check`
- Android emulator `Medium_Phone_API_35`：进入 Personal Center → Settings → About Memex，确认版本/build/flavor/channel/installer/package 可见；Copy Diagnostics 只包含 app/package/version/platform/flavor/region/channel/installer/updateChannel；Check now 在无 manifest/404 场景会结束为可见错误，不会无限 spinner。
