### PR TITLE
记录输入事实的设备坐标

### DIFF
--- a/lib/data/repositories/submit_input.dart
+++ b/lib/data/repositories/submit_input.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:synchronized/synchronized.dart';
 
@@ -16,11 +18,21 @@ FileSystemService get _fileSystem => FileSystemService.instance;
 AgentRunService? _agentRunServiceOverride;
 AgentRunService get _agentRunService =>
     _agentRunServiceOverride ?? AgentRunService.instance;
+LocationContextService? _locationContextServiceOverride;
+LocationContextService get _locationContextService =>
+    _locationContextServiceOverride ?? LocationContextService.instance;
 final _lock = Lock();
 
 @visibleForTesting
 void setSubmitInputAgentRunServiceForTesting(AgentRunService? service) {
   _agentRunServiceOverride = service;
+}
+
+@visibleForTesting
+void setSubmitInputLocationContextServiceForTesting(
+  LocationContextService? service,
+) {
+  _locationContextServiceOverride = service;
 }
 
 /// Submit input locally
@@ -137,10 +149,17 @@ Future<Map<String, dynamic>> submitInput(
         .join('\n\n');
     final pureTextContent = textContent.isEmpty ? '' : textContent;
 
+    final factMetadata = <String, dynamic>{};
+    final inputLocation = await _locationContextService.captureInputLocation();
+    if (inputLocation != null) {
+      factMetadata['input_location'] = inputLocation.toJson();
+    }
+
     // 3. Append to Daily Fact
-    // Format: ## <id:ts_X> HH:MM:SS "{}"\n\nContent
+    // Format: ## <id:ts_X> HH:MM:SS {...}\n\nContent
+    final metadataJson = jsonEncode(factMetadata);
     final markdownEntry =
-        '## <id:$simpleFactId> $timeStr "{}"\n\n$combinedText\n';
+        '## <id:$simpleFactId> $timeStr $metadataJson\n\n$combinedText\n';
     try {
       await _fileSystem.appendToDailyFactFile(userId, now, markdownEntry);
 
@@ -229,8 +248,7 @@ Future<Map<String, dynamic>> submitInput(
     String? locationContextReminder;
     String? locationContextStatus;
     try {
-      final locationContext =
-          await LocationContextService.instance.getCurrentContext();
+      final locationContext = await _locationContextService.getCurrentContext();
       locationContextReminder = locationContext.toAgentSystemReminderContent();
       locationContextStatus = locationContext.status;
     } catch (e) {

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -2328,10 +2328,13 @@ class FileSystemService {
         return null;
       }
 
-      // Find matching entry in body_content (format: ## <id:ts_3> HH:MM:SS). Pattern: ## <id:ts_3> or ## <id:2025/11/26.md#ts_3>
+      // Find matching entry in body_content (format: ## <id:ts_3> HH:MM:SS {metadata}).
+      // Older entries may have no metadata or the quoted empty marker "{}".
       final escapedFactId = RegExp.escape(simpleFactId);
-      final pattern =
-          RegExp('##\\s*<id:$escapedFactId>\\s*(\\d{2}:\\d{2}:\\d{2})');
+      final pattern = RegExp(
+        '^##\\s*<id:$escapedFactId>\\s*(\\d{2}:\\d{2}:\\d{2})(?:\\s+(.*))?\$',
+        multiLine: true,
+      );
 
       final match = pattern.firstMatch(bodyContent);
       if (match == null) {
@@ -2340,6 +2343,7 @@ class FileSystemService {
 
       // Extract time string (HH:MM:SS)
       final timeStr = match.group(1)!;
+      final metadata = _parseFactEntryMetadata(match.group(2));
 
       // Entry start position
       final startPos = match.start;
@@ -2436,6 +2440,7 @@ class FileSystemService {
         timestamp: timestamp,
         datetime: entryDatetime,
         content: entryContent,
+        metadata: metadata,
         assetAnalyses: assetAnalyses,
         assetOcrTexts: assetOcrTexts,
       );
@@ -2443,6 +2448,34 @@ class FileSystemService {
       _logger.severe('Failed to extract fact content $factId: $e');
       return null;
     }
+  }
+
+  Map<String, dynamic> _parseFactEntryMetadata(String? rawMetadata) {
+    final raw = rawMetadata?.trim();
+    if (raw == null || raw.isEmpty) return {};
+
+    var candidate = raw;
+    if (candidate == '"{}"' || candidate == '{}') return {};
+
+    if (candidate.startsWith('"') && candidate.endsWith('"')) {
+      try {
+        final decoded = jsonDecode(candidate);
+        if (decoded is String) {
+          candidate = decoded.trim();
+        }
+      } catch (_) {
+        return {};
+      }
+    }
+
+    try {
+      final decoded = jsonDecode(candidate);
+      if (decoded is Map<String, dynamic>) return decoded;
+      if (decoded is Map) return Map<String, dynamic>.from(decoded);
+    } catch (e) {
+      _logger.warning('Failed to parse fact entry metadata: $e');
+    }
+    return {};
   }
 
   /// Get agent state directory path and ensure it exists (creates if not found).
@@ -2720,6 +2753,7 @@ class FactContentResult {
   final int timestamp;
   final DateTime datetime;
   final String content;
+  final Map<String, dynamic> metadata;
   final List<Map<String, dynamic>> assetAnalyses;
 
   /// On-device OCR text extracted from image assets.
@@ -2731,6 +2765,7 @@ class FactContentResult {
     required this.timestamp,
     required this.datetime,
     required this.content,
+    this.metadata = const {},
     required this.assetAnalyses,
     this.assetOcrTexts = const [],
   });

--- a/lib/data/services/location_context_service.dart
+++ b/lib/data/services/location_context_service.dart
@@ -1,19 +1,152 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:memex/data/services/geocoding_service.dart';
+import 'package:memex/domain/models/input_location.dart';
 import 'package:memex/domain/models/location_context_config.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
 
+typedef LocationServiceEnabledReader = Future<bool> Function();
+typedef LocationPermissionReader = Future<LocationPermission> Function();
+typedef DevicePositionReader = Future<Position> Function(
+    LocationSettings settings);
+typedef LastKnownDevicePositionReader = Future<Position?> Function();
+
 class LocationContextService {
   static final LocationContextService instance =
       LocationContextService._internal();
-  LocationContextService._internal();
+  LocationContextService._internal({
+    LocationServiceEnabledReader? isLocationServiceEnabled,
+    LocationPermissionReader? checkPermission,
+    LocationPermissionReader? requestPermission,
+    DevicePositionReader? getCurrentPosition,
+    LastKnownDevicePositionReader? getLastKnownPosition,
+  })  : _isLocationServiceEnabled =
+            isLocationServiceEnabled ?? Geolocator.isLocationServiceEnabled,
+        _checkPermission = checkPermission ?? Geolocator.checkPermission,
+        _requestPermission = requestPermission ?? Geolocator.requestPermission,
+        _getCurrentPosition = getCurrentPosition ??
+            ((settings) =>
+                Geolocator.getCurrentPosition(locationSettings: settings)),
+        _getLastKnownPosition =
+            getLastKnownPosition ?? Geolocator.getLastKnownPosition;
+
+  @visibleForTesting
+  factory LocationContextService.forTesting({
+    LocationServiceEnabledReader? isLocationServiceEnabled,
+    LocationPermissionReader? checkPermission,
+    LocationPermissionReader? requestPermission,
+    DevicePositionReader? getCurrentPosition,
+    LastKnownDevicePositionReader? getLastKnownPosition,
+  }) {
+    return LocationContextService._internal(
+      isLocationServiceEnabled: isLocationServiceEnabled,
+      checkPermission: checkPermission,
+      requestPermission: requestPermission,
+      getCurrentPosition: getCurrentPosition,
+      getLastKnownPosition: getLastKnownPosition,
+    );
+  }
 
   static const Duration _maxLastKnownPositionAge = Duration(minutes: 2);
+  static const Duration _inputLocationTimeout = Duration(seconds: 6);
 
   final _logger = getLogger('LocationContextService');
+  final LocationServiceEnabledReader _isLocationServiceEnabled;
+  final LocationPermissionReader _checkPermission;
+  final LocationPermissionReader _requestPermission;
+  final DevicePositionReader _getCurrentPosition;
+  final LastKnownDevicePositionReader _getLastKnownPosition;
   CurrentLocationContext? _cachedContext;
   String? _cachedConfigSignature;
+
+  Future<InputLocation?> captureInputLocation({
+    Duration timeout = _inputLocationTimeout,
+  }) {
+    return _captureInputLocation(timeout).timeout(
+      timeout + const Duration(seconds: 1),
+      onTimeout: () {
+        _logger.warning('Timed out while capturing input location');
+        return _recentLastKnownInputLocation();
+      },
+    );
+  }
+
+  Future<InputLocation?> _captureInputLocation(Duration timeout) async {
+    try {
+      final serviceEnabled = await _isLocationServiceEnabled();
+      if (!serviceEnabled) return null;
+
+      var permission = await _checkPermission();
+      if (permission == LocationPermission.denied) {
+        permission = await _requestPermission();
+      }
+      if (!_isUsablePermission(permission)) return null;
+
+      final position = await _getCurrentPosition(
+        LocationSettings(accuracy: LocationAccuracy.high, timeLimit: timeout),
+      ).timeout(timeout);
+      return _inputLocationFromPosition(position);
+    } on TimeoutException {
+      _logger.warning('Timed out while capturing input location');
+      return _recentLastKnownInputLocation();
+    } catch (e, stackTrace) {
+      _logger.warning(
+        'Failed to capture input location; continuing without GPS metadata',
+        e,
+        stackTrace,
+      );
+      return _recentLastKnownInputLocation();
+    }
+  }
+
+  Future<InputLocation?> _recentLastKnownInputLocation() async {
+    try {
+      final position = await _getLastKnownPosition()
+          .timeout(const Duration(milliseconds: 700));
+      if (position == null) return null;
+
+      final age = DateTime.now().difference(position.timestamp);
+      if (age > _maxLastKnownPositionAge) {
+        _logger.info(
+          'Skipping stale last known input location from ${position.timestamp.toIso8601String()}',
+        );
+        return null;
+      }
+
+      return _inputLocationFromPosition(
+        position,
+        source: InputLocation.lastKnownDeviceGpsSource,
+      );
+    } catch (e, stackTrace) {
+      _logger.warning(
+        'Failed to use last known input location; continuing without GPS metadata',
+        e,
+        stackTrace,
+      );
+      return null;
+    }
+  }
+
+  InputLocation _inputLocationFromPosition(
+    Position position, {
+    String source = InputLocation.deviceGpsSource,
+  }) {
+    return InputLocation(
+      lat: position.latitude,
+      lng: position.longitude,
+      accuracyMeters: position.accuracy,
+      capturedAt: position.timestamp,
+      source: source,
+    );
+  }
+
+  bool _isUsablePermission(LocationPermission permission) {
+    return permission == LocationPermission.whileInUse ||
+        permission == LocationPermission.always;
+  }
 
   /// Device GPS is the only source for current location.
   /// IP-based fallback is intentionally not used because proxy/VPN/network
@@ -45,7 +178,7 @@ class LocationContextService {
     }
 
     try {
-      final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      final serviceEnabled = await _isLocationServiceEnabled();
       if (!serviceEnabled) {
         return _unavailable(
           config,
@@ -55,9 +188,9 @@ class LocationContextService {
         );
       }
 
-      var permission = await Geolocator.checkPermission();
+      var permission = await _checkPermission();
       if (permission == LocationPermission.denied) {
-        permission = await Geolocator.requestPermission();
+        permission = await _requestPermission();
       }
 
       if (permission == LocationPermission.denied) {
@@ -77,8 +210,8 @@ class LocationContextService {
         );
       }
 
-      final position = await Geolocator.getCurrentPosition(
-        locationSettings: const LocationSettings(
+      final position = await _getCurrentPosition(
+        const LocationSettings(
           accuracy: LocationAccuracy.high,
           timeLimit: Duration(seconds: 6),
         ),
@@ -128,7 +261,7 @@ class LocationContextService {
     String configSignature,
   ) async {
     try {
-      final position = await Geolocator.getLastKnownPosition();
+      final position = await _getLastKnownPosition();
       if (position == null) return null;
       final now = DateTime.now();
       final age = now.difference(position.timestamp);

--- a/lib/domain/models/input_location.dart
+++ b/lib/domain/models/input_location.dart
@@ -1,0 +1,60 @@
+class InputLocation {
+  static const String deviceGpsSource = 'device_gps';
+  static const String lastKnownDeviceGpsSource = 'last_known_device_gps';
+  static const String wgs84CoordinateSystem = 'WGS84';
+
+  final double lat;
+  final double lng;
+  final double accuracyMeters;
+  final String source;
+  final String coordinateSystem;
+  final DateTime capturedAt;
+
+  const InputLocation({
+    required this.lat,
+    required this.lng,
+    required this.accuracyMeters,
+    required this.capturedAt,
+    this.source = deviceGpsSource,
+    this.coordinateSystem = wgs84CoordinateSystem,
+  });
+
+  factory InputLocation.fromJson(Map<String, dynamic> json) {
+    return InputLocation(
+      lat: (json['lat'] as num).toDouble(),
+      lng: (json['lng'] as num).toDouble(),
+      accuracyMeters: (json['accuracy_meters'] as num).toDouble(),
+      source: json['source']?.toString() ?? deviceGpsSource,
+      coordinateSystem:
+          json['coordinate_system']?.toString() ?? wgs84CoordinateSystem,
+      capturedAt: DateTime.parse(json['captured_at'].toString()),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'lat': lat,
+        'lng': lng,
+        'accuracy_meters': accuracyMeters,
+        'source': source,
+        'coordinate_system': coordinateSystem,
+        'captured_at': _toIso8601WithOffset(capturedAt),
+      };
+
+  static String _toIso8601WithOffset(DateTime value) {
+    final local = value.toLocal();
+    final offset = local.timeZoneOffset;
+    final sign = offset.isNegative ? '-' : '+';
+    final absOffset = offset.abs();
+    final offsetHours = absOffset.inHours.toString().padLeft(2, '0');
+    final offsetMinutes = (absOffset.inMinutes % 60).toString().padLeft(2, '0');
+
+    return '${local.year.toString().padLeft(4, '0')}-'
+        '${local.month.toString().padLeft(2, '0')}-'
+        '${local.day.toString().padLeft(2, '0')}T'
+        '${local.hour.toString().padLeft(2, '0')}:'
+        '${local.minute.toString().padLeft(2, '0')}:'
+        '${local.second.toString().padLeft(2, '0')}'
+        '${local.millisecond == 0 ? '' : '.${local.millisecond.toString().padLeft(3, '0')}'}'
+        '$sign$offsetHours:$offsetMinutes';
+  }
+}

--- a/test/data/repositories/submit_input_test.dart
+++ b/test/data/repositories/submit_input_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -5,7 +6,9 @@ import 'package:memex/data/repositories/submit_input.dart';
 import 'package:memex/data/services/agent_run_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_asset_server.dart';
+import 'package:memex/data/services/location_context_service.dart';
 import 'package:memex/utils/user_storage.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -21,10 +24,12 @@ void main() {
       root = await Directory.systemTemp.createTemp('memex_submit_input_');
       await FileSystemService.init(root.path);
       setSubmitInputAgentRunServiceForTesting(null);
+      setSubmitInputLocationContextServiceForTesting(null);
     });
 
     tearDown(() async {
       setSubmitInputAgentRunServiceForTesting(null);
+      setSubmitInputLocationContextServiceForTesting(null);
       await LocalAssetServer.stopServer();
       if (await root.exists()) {
         await root.delete(recursive: true);
@@ -57,7 +62,148 @@ void main() {
       expect(agentRunService.createCalls, 1);
       expect(agentRunService.refreshCalls, 1);
     });
+
+    test('writes device GPS input_location to Fact header metadata', () async {
+      final capturedAt = DateTime.utc(2026, 6, 16, 6, 22, 10);
+      setSubmitInputLocationContextServiceForTesting(
+        LocationContextService.forTesting(
+          isLocationServiceEnabled: () async => true,
+          checkPermission: () async => LocationPermission.whileInUse,
+          getCurrentPosition: (_) async => _position(
+            lat: 31.212345,
+            lng: 121.456789,
+            accuracy: 12.3,
+            timestamp: capturedAt,
+          ),
+        ),
+      );
+
+      final result = await submitInput('submit-input-user', [
+        {'type': 'text', 'text': 'finished the location metadata plan'},
+      ]);
+
+      final factId = result['fact_id'] as String;
+      final factFile = _factFileFor('submit-input-user', factId);
+      final factContent = await factFile.readAsString();
+      final headerLine = factContent.split('\n').first;
+      final headerMetadata =
+          jsonDecode(headerLine.substring(headerLine.indexOf('{')))
+              as Map<String, dynamic>;
+      final inputLocation =
+          headerMetadata['input_location'] as Map<String, dynamic>;
+
+      expect(inputLocation['lat'], 31.212345);
+      expect(inputLocation['lng'], 121.456789);
+      expect(inputLocation['accuracy_meters'], 12.3);
+      expect(inputLocation['source'], 'device_gps');
+      expect(inputLocation['coordinate_system'], 'WGS84');
+      expect(
+        DateTime.parse(inputLocation['captured_at'] as String).toUtc(),
+        capturedAt,
+      );
+
+      final extracted = await FileSystemService.instance
+          .extractFactContentFromFile('submit-input-user', factId);
+      final extractedLocation =
+          extracted!.metadata['input_location'] as Map<String, dynamic>;
+      expect(extractedLocation['source'], 'device_gps');
+      expect(extractedLocation['lat'], 31.212345);
+    });
+
+    test('does not infer input_location from location-looking text', () async {
+      setSubmitInputLocationContextServiceForTesting(
+        LocationContextService.forTesting(
+          isLocationServiceEnabled: () async => false,
+        ),
+      );
+
+      final result = await submitInput('submit-input-user', [
+        {'type': 'text', 'text': 'Lunch in Paris near 48.8566, 2.3522.'},
+      ]);
+
+      final factId = result['fact_id'] as String;
+      final extracted = await FileSystemService.instance
+          .extractFactContentFromFile('submit-input-user', factId);
+      final factContent = await _factFileFor(
+        'submit-input-user',
+        factId,
+      ).readAsString();
+      final headerLine = factContent.split('\n').first;
+
+      expect(extracted!.metadata, isNot(contains('input_location')));
+      expect(extracted.content, contains('48.8566'));
+      expect(headerLine, isNot(contains('input_location')));
+    });
+
+    test('parses old empty and missing Fact header metadata', () async {
+      final fs = FileSystemService.instance;
+      const userId = 'submit-input-user';
+      final date = DateTime(2026, 6, 16);
+      await fs.appendToDailyFactFile(
+        userId,
+        date,
+        '## <id:ts_1> 09:00:00 "{}"\n\nold quoted empty\n'
+        '## <id:ts_2> 10:00:00 {}\n\nold raw empty\n'
+        '## <id:ts_3> 11:00:00\n\nold missing metadata\n'
+        '## <id:ts_4> 12:00:00 {"input_location":{"lat":1.0,"lng":2.0,"accuracy_meters":3.0,"source":"device_gps","coordinate_system":"WGS84","captured_at":"2026-06-16T12:00:00+08:00"}}\n\nnew metadata\n',
+      );
+
+      final quoted = await fs.extractFactContentFromFile(
+        userId,
+        '2026/06/16.md#ts_1',
+      );
+      final raw = await fs.extractFactContentFromFile(
+        userId,
+        '2026/06/16.md#ts_2',
+      );
+      final missing = await fs.extractFactContentFromFile(
+        userId,
+        '2026/06/16.md#ts_3',
+      );
+      final withLocation = await fs.extractFactContentFromFile(
+        userId,
+        '2026/06/16.md#ts_4',
+      );
+
+      expect(quoted!.metadata, isEmpty);
+      expect(raw!.metadata, isEmpty);
+      expect(missing!.metadata, isEmpty);
+      expect(quoted.content, 'old quoted empty');
+      expect(raw.content, 'old raw empty');
+      expect(missing.content, 'old missing metadata');
+      expect(
+        withLocation!.metadata['input_location'],
+        containsPair('source', 'device_gps'),
+      );
+    });
   });
+}
+
+File _factFileFor(String userId, String factId) {
+  final factPath = factId.split('#').first;
+  return File(
+    p.join(FileSystemService.instance.getFactsPath(userId), factPath),
+  );
+}
+
+Position _position({
+  required double lat,
+  required double lng,
+  required double accuracy,
+  required DateTime timestamp,
+}) {
+  return Position(
+    latitude: lat,
+    longitude: lng,
+    timestamp: timestamp,
+    accuracy: accuracy,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    headingAccuracy: 0,
+    speed: 0,
+    speedAccuracy: 0,
+  );
 }
 
 class _ThrowingAgentRunService extends AgentRunService {

--- a/test/data/repositories/submit_input_test.dart
+++ b/test/data/repositories/submit_input_test.dart
@@ -145,7 +145,9 @@ void main() {
         '## <id:ts_1> 09:00:00 "{}"\n\nold quoted empty\n'
         '## <id:ts_2> 10:00:00 {}\n\nold raw empty\n'
         '## <id:ts_3> 11:00:00\n\nold missing metadata\n'
-        '## <id:ts_4> 12:00:00 {"input_location":{"lat":1.0,"lng":2.0,"accuracy_meters":3.0,"source":"device_gps","coordinate_system":"WGS84","captured_at":"2026-06-16T12:00:00+08:00"}}\n\nnew metadata\n',
+        '## <id:ts_4> 12:00:00 {"input_location":{"lat":1.0,"lng":2.0,"accuracy_meters":3.0,"source":"device_gps","coordinate_system":"WGS84","captured_at":"2026-06-16T12:00:00+08:00"}}\n\nnew metadata\n'
+        '## <id:ts_5> 13:00:00 {not-json}\n\nmalformed metadata\n'
+        '## <id:ts_6> 14:00:00 "{\\"nested\\":{\\"value\\":1}}"\n\nquoted nested metadata\n',
       );
 
       final quoted = await fs.extractFactContentFromFile(
@@ -164,6 +166,14 @@ void main() {
         userId,
         '2026/06/16.md#ts_4',
       );
+      final malformed = await fs.extractFactContentFromFile(
+        userId,
+        '2026/06/16.md#ts_5',
+      );
+      final quotedNested = await fs.extractFactContentFromFile(
+        userId,
+        '2026/06/16.md#ts_6',
+      );
 
       expect(quoted!.metadata, isEmpty);
       expect(raw!.metadata, isEmpty);
@@ -175,6 +185,13 @@ void main() {
         withLocation!.metadata['input_location'],
         containsPair('source', 'device_gps'),
       );
+      expect(malformed!.metadata, isEmpty);
+      expect(malformed.content, 'malformed metadata');
+      expect(
+        quotedNested!.metadata['nested'],
+        containsPair('value', 1),
+      );
+      expect(quotedNested.content, 'quoted nested metadata');
     });
   });
 }

--- a/test/data/services/location_context_service_test.dart
+++ b/test/data/services/location_context_service_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:memex/data/services/location_context_service.dart';
+
+void main() {
+  group('LocationContextService.captureInputLocation', () {
+    test('returns null when permission is denied', () async {
+      var requestedPermission = false;
+      var requestedPosition = false;
+      final service = LocationContextService.forTesting(
+        isLocationServiceEnabled: () async => true,
+        checkPermission: () async => LocationPermission.denied,
+        requestPermission: () async {
+          requestedPermission = true;
+          return LocationPermission.denied;
+        },
+        getCurrentPosition: (_) async {
+          requestedPosition = true;
+          return _position();
+        },
+        getLastKnownPosition: () async => null,
+      );
+
+      final location = await service.captureInputLocation(
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      expect(location, isNull);
+      expect(requestedPermission, isTrue);
+      expect(requestedPosition, isFalse);
+    });
+
+    test('falls back to fresh last known GPS when current position times out',
+        () async {
+      final service = LocationContextService.forTesting(
+        isLocationServiceEnabled: () async => true,
+        checkPermission: () async => LocationPermission.whileInUse,
+        getCurrentPosition: (_) async {
+          await Future<void>.delayed(const Duration(milliseconds: 250));
+          return _position();
+        },
+        getLastKnownPosition: () async => _position(
+          latitude: 31.212345,
+          longitude: 121.456789,
+          timestamp: DateTime.now().subtract(const Duration(seconds: 30)),
+        ),
+      );
+
+      final location = await service.captureInputLocation(
+        timeout: const Duration(milliseconds: 20),
+      );
+
+      expect(location, isNotNull);
+      expect(location!.lat, 31.212345);
+      expect(location.lng, 121.456789);
+      expect(location.source, 'last_known_device_gps');
+    });
+
+    test('returns null on timeout without a fresh last known position',
+        () async {
+      final service = LocationContextService.forTesting(
+        isLocationServiceEnabled: () async => true,
+        checkPermission: () async => LocationPermission.whileInUse,
+        getCurrentPosition: (_) async {
+          await Future<void>.delayed(const Duration(milliseconds: 250));
+          return _position();
+        },
+        getLastKnownPosition: () async => null,
+      );
+      final stopwatch = Stopwatch()..start();
+
+      final location = await service.captureInputLocation(
+        timeout: const Duration(milliseconds: 20),
+      );
+
+      stopwatch.stop();
+      expect(location, isNull);
+      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 200)));
+    });
+
+    test('ignores stale last known GPS when current position times out',
+        () async {
+      final service = LocationContextService.forTesting(
+        isLocationServiceEnabled: () async => true,
+        checkPermission: () async => LocationPermission.whileInUse,
+        getCurrentPosition: (_) async {
+          await Future<void>.delayed(const Duration(milliseconds: 250));
+          return _position();
+        },
+        getLastKnownPosition: () async => _position(
+          timestamp: DateTime.now().subtract(const Duration(minutes: 5)),
+        ),
+      );
+
+      final location = await service.captureInputLocation(
+        timeout: const Duration(milliseconds: 20),
+      );
+
+      expect(location, isNull);
+    });
+  });
+}
+
+Position _position({
+  double latitude = 31.2,
+  double longitude = 121.4,
+  DateTime? timestamp,
+}) {
+  return Position(
+    latitude: latitude,
+    longitude: longitude,
+    timestamp: timestamp ?? DateTime.utc(2026, 6, 16, 6),
+    accuracy: 10,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    headingAccuracy: 0,
+    speed: 0,
+    speedAccuracy: 0,
+  );
+}

--- a/test/domain/models/input_location_test.dart
+++ b/test/domain/models/input_location_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/input_location.dart';
+
+void main() {
+  group('InputLocation', () {
+    test('serializes device GPS location with explicit coordinate metadata',
+        () {
+      final location = InputLocation(
+        lat: 31.2123433,
+        lng: 121.4567883,
+        accuracyMeters: 5,
+        capturedAt: DateTime.utc(2026, 6, 16, 3, 31, 49, 888),
+      );
+
+      final json = location.toJson();
+
+      expect(json['lat'], 31.2123433);
+      expect(json['lng'], 121.4567883);
+      expect(json['accuracy_meters'], 5);
+      expect(json['source'], InputLocation.deviceGpsSource);
+      expect(json['coordinate_system'], InputLocation.wgs84CoordinateSystem);
+      expect(
+        json['captured_at'],
+        matches(RegExp(
+            r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.888[+-]\d{2}:\d{2}$')),
+      );
+    });
+
+    test('round-trips source, coordinate system, and captured instant', () {
+      final original = InputLocation(
+        lat: 31.2,
+        lng: 121.4,
+        accuracyMeters: 12.5,
+        capturedAt: DateTime.utc(2026, 6, 16, 3, 31, 49, 888),
+        source: InputLocation.lastKnownDeviceGpsSource,
+      );
+
+      final parsed = InputLocation.fromJson(original.toJson());
+
+      expect(parsed.lat, original.lat);
+      expect(parsed.lng, original.lng);
+      expect(parsed.accuracyMeters, original.accuracyMeters);
+      expect(parsed.source, InputLocation.lastKnownDeviceGpsSource);
+      expect(parsed.coordinateSystem, InputLocation.wgs84CoordinateSystem);
+      expect(parsed.capturedAt.toUtc(), original.capturedAt.toUtc());
+    });
+
+    test('defaults legacy JSON source fields when omitted', () {
+      final parsed = InputLocation.fromJson({
+        'lat': 1,
+        'lng': 2,
+        'accuracy_meters': 3,
+        'captured_at': '2026-06-16T12:00:00+08:00',
+      });
+
+      expect(parsed.source, InputLocation.deviceGpsSource);
+      expect(parsed.coordinateSystem, InputLocation.wgs84CoordinateSystem);
+      expect(parsed.capturedAt.toUtc(), DateTime.utc(2026, 6, 16, 4));
+    });
+  });
+}


### PR DESCRIPTION
## 关联 issue

Closes #295

## 变更

- 为输入 Fact header 增加结构化 `input_location`，只来自设备 GPS，不从文本地名推断。
- 新增 `InputLocation` domain model，并增强 Fact header metadata 解析，兼容旧的空 metadata。
- 当前 GPS 超时/失败时，仅使用 2 分钟内的 last-known device GPS 作为保守 fallback，陈旧坐标继续丢弃。

## 测试

- `flutter test --no-pub test/data/repositories/submit_input_test.dart test/data/services/location_context_service_test.dart`
- `flutter analyze --no-pub lib/domain/models/input_location.dart lib/data/services/location_context_service.dart lib/data/repositories/submit_input.dart test/data/repositories/submit_input_test.dart test/data/services/location_context_service_test.dart`
- `flutter build apk --debug --flavor globalDev --no-pub`
- `git diff --check`
- Android emulator `Medium_Phone_API_35`：grant fine/coarse location，`emu geo fix 121.456789 31.212345`，从 Timeline 输入 `GPS_QA_20260616_1145` 并提交；读取 Fact 文件确认 header 写入 `input_location`，lat/lng 与模拟坐标一致，source 为 `device_gps`。
