### PR TITLE
隔离时间线辅助查询加载

### DIFF
--- a/lib/ui/timeline/view_models/timeline_viewmodel.dart
+++ b/lib/ui/timeline/view_models/timeline_viewmodel.dart
@@ -18,6 +18,23 @@ import 'package:memex/utils/command.dart';
 
 enum TimelineViewMode { timeline, insight }
 
+typedef TimelineCardsFetcher = Future<Result<List<TimelineCardModel>>>
+    Function({
+  int page,
+  int limit,
+  List<String>? tags,
+  DateTime? dateFrom,
+  DateTime? dateTo,
+});
+
+typedef TimelineTagsFetcher = Future<Result<List<TagModel>>> Function();
+typedef ScheduleBriefingCardFetcher = Future<Result<TimelineCardModel?>>
+    Function();
+typedef TimelineAttachmentFetcher = Future<List<CardAttachmentData>> Function(
+    String factId);
+typedef PendingAttachmentsFetcher = Future<List<CardAttachmentData>> Function();
+typedef FailedCardCountFetcher = Future<int> Function();
+
 /// Upserts a card into a timeline list by stable card id.
 ///
 /// New local submissions and card-added events can describe the same fact, so
@@ -75,13 +92,113 @@ List<TimelineCardModel> dedupeTimelineCardsById(List<TimelineCardModel> cards) {
 /// ViewModel for the Timeline page. Holds cards, tags, loading state, and
 /// delegates data access to [MemexRouter]. Call [init] once after creation.
 class TimelineViewModel extends ChangeNotifier {
-  TimelineViewModel({required MemexRouter router}) : _router = router;
+  TimelineViewModel({
+    required MemexRouter router,
+    TimelineCardsFetcher? fetchTimelineCards,
+    TimelineTagsFetcher? fetchTags,
+    ScheduleBriefingCardFetcher? fetchScheduleBriefingCard,
+    TimelineAttachmentFetcher? fetchAttachmentForCard,
+    PendingAttachmentsFetcher? fetchPendingAttachments,
+    FailedCardCountFetcher? countFailedCardGenerations,
+    Duration auxiliaryQueryTimeout = defaultAuxiliaryQueryTimeout,
+    bool autoLoad = true,
+  }) : this._(
+          fetchTimelineCards: fetchTimelineCards ??
+              (({
+                int page = 1,
+                int limit = pageLimit,
+                List<String>? tags,
+                DateTime? dateFrom,
+                DateTime? dateTo,
+              }) =>
+                  router.fetchTimelineCards(
+                    page: page,
+                    limit: limit,
+                    tags: tags,
+                    dateFrom: dateFrom,
+                    dateTo: dateTo,
+                  )),
+          fetchTags: fetchTags ?? router.fetchTags,
+          fetchScheduleBriefingCard:
+              fetchScheduleBriefingCard ?? router.fetchScheduleBriefingCard,
+          fetchAttachmentForCard: fetchAttachmentForCard ??
+              CardAttachmentService.instance.getAttachments,
+          fetchPendingAttachments: fetchPendingAttachments ??
+              CardAttachmentService.instance.getPendingAttachments,
+          countFailedCardGenerations:
+              countFailedCardGenerations ?? router.countFailedCardGenerations,
+          auxiliaryQueryTimeout: auxiliaryQueryTimeout,
+          autoLoad: autoLoad,
+        );
 
-  final MemexRouter _router;
+  @visibleForTesting
+  factory TimelineViewModel.forTest({
+    TimelineCardsFetcher? fetchTimelineCards,
+    TimelineTagsFetcher? fetchTags,
+    ScheduleBriefingCardFetcher? fetchScheduleBriefingCard,
+    TimelineAttachmentFetcher? fetchAttachmentForCard,
+    PendingAttachmentsFetcher? fetchPendingAttachments,
+    FailedCardCountFetcher? countFailedCardGenerations,
+    Duration auxiliaryQueryTimeout = defaultAuxiliaryQueryTimeout,
+    bool autoLoad = false,
+  }) {
+    return TimelineViewModel._(
+      fetchTimelineCards: fetchTimelineCards ??
+          ({
+            int page = 1,
+            int limit = pageLimit,
+            List<String>? tags,
+            DateTime? dateFrom,
+            DateTime? dateTo,
+          }) async =>
+              const Ok(<TimelineCardModel>[]),
+      fetchTags: fetchTags ?? () async => const Ok(<TagModel>[]),
+      fetchScheduleBriefingCard:
+          fetchScheduleBriefingCard ?? () async => const Ok(null),
+      fetchAttachmentForCard:
+          fetchAttachmentForCard ?? (_) async => const <CardAttachmentData>[],
+      fetchPendingAttachments:
+          fetchPendingAttachments ?? () async => const <CardAttachmentData>[],
+      countFailedCardGenerations: countFailedCardGenerations ?? () async => 0,
+      auxiliaryQueryTimeout: auxiliaryQueryTimeout,
+      autoLoad: autoLoad,
+    );
+  }
+
+  TimelineViewModel._({
+    required TimelineCardsFetcher fetchTimelineCards,
+    required TimelineTagsFetcher fetchTags,
+    required ScheduleBriefingCardFetcher fetchScheduleBriefingCard,
+    required TimelineAttachmentFetcher fetchAttachmentForCard,
+    required PendingAttachmentsFetcher fetchPendingAttachments,
+    required FailedCardCountFetcher countFailedCardGenerations,
+    required Duration auxiliaryQueryTimeout,
+    required bool autoLoad,
+  })  : _fetchTimelineCards = fetchTimelineCards,
+        _fetchTags = fetchTags,
+        _fetchScheduleBriefingCard = fetchScheduleBriefingCard,
+        _fetchAttachmentForCard = fetchAttachmentForCard,
+        _fetchPendingAttachments = fetchPendingAttachments,
+        _countFailedCardGenerations = countFailedCardGenerations,
+        _auxiliaryQueryTimeout = auxiliaryQueryTimeout {
+    load = Command0<void>(_loadInitial);
+    if (autoLoad) {
+      unawaited(load.execute());
+    }
+  }
+
   final Logger _logger = getLogger('TimelineViewModel');
+  final TimelineCardsFetcher _fetchTimelineCards;
+  final TimelineTagsFetcher _fetchTags;
+  final ScheduleBriefingCardFetcher _fetchScheduleBriefingCard;
+  final TimelineAttachmentFetcher _fetchAttachmentForCard;
+  final PendingAttachmentsFetcher _fetchPendingAttachments;
+  final FailedCardCountFetcher _countFailedCardGenerations;
+  final Duration _auxiliaryQueryTimeout;
 
   static const int pageLimit = 20;
   static const Duration pollingInterval = Duration(seconds: 5);
+  static const Duration defaultAuxiliaryQueryTimeout = Duration(seconds: 2);
 
   // Timeline list state
   List<TimelineCardModel> cards = [];
@@ -90,6 +207,7 @@ class TimelineViewModel extends ChangeNotifier {
   bool hasMore = true;
   int _currentPage = 1;
   int _loadGeneration = 0;
+  int? _visibleLoadGeneration;
   String? errorMessage;
   bool isSubmitting = false;
 
@@ -107,17 +225,16 @@ class TimelineViewModel extends ChangeNotifier {
   Timer? _pollingTimer;
   bool _eventBusSetup = false;
 
-  late final Command0<void> load = Command0<void>(_loadInitial)..execute();
+  late final Command0<void> load;
 
   Future<Result<void>> _loadInitial({bool notifyLoading = false}) async {
     final generation = ++_loadGeneration;
     final filter = activeFilter;
     final viewModeAtRequest = viewMode;
     if (notifyLoading) {
-      isLoading = true;
-      notifyListeners();
+      _beginVisibleLoad(generation);
     }
-    final cardsResult = await _router.fetchTimelineCards(
+    final cardsResult = await _fetchTimelineCards(
       page: 1,
       limit: pageLimit,
       tags: filter == 'all' ? null : [filter],
@@ -125,6 +242,7 @@ class TimelineViewModel extends ChangeNotifier {
     return cardsResult.when(
       onOk: (list) async {
         if (_isStaleTimelineLoad(generation, filter)) {
+          _finishVisibleLoadIfCurrent(generation);
           return const Ok.v();
         }
         _currentPage = 1;
@@ -136,30 +254,28 @@ class TimelineViewModel extends ChangeNotifier {
               viewModeAtRequest == TimelineViewMode.timeline && filter == 'all',
         );
         if (_isStaleTimelineLoad(generation, filter)) {
+          _finishVisibleLoadIfCurrent(generation);
           return const Ok.v();
         }
         cards = nextCards;
         hasMore = loadedHasMore;
-        isLoading = false;
+        _finishVisibleLoadIfCurrent(generation, notify: false);
         errorMessage = null;
         _startPollingIfNeeded();
-        // Load attachments for all cards in parallel
-        await _loadAttachmentsForCards(list);
-        if (_isStaleTimelineLoad(generation, filter)) {
-          return const Ok.v();
-        }
-        await _refreshPendingCount();
-        if (_isStaleTimelineLoad(generation, filter)) {
-          return const Ok.v();
-        }
         notifyListeners();
+        _refreshAuxiliaryTimelineState(
+          generation: generation,
+          filter: filter,
+          cardList: list,
+        );
         return const Ok.v();
       },
       onError: (error, stackTrace) {
         if (_isStaleTimelineLoad(generation, filter)) {
+          _finishVisibleLoadIfCurrent(generation);
           return const Ok.v();
         }
-        isLoading = false;
+        _finishVisibleLoadIfCurrent(generation, notify: false);
         errorMessage = UserStorage.l10n.timelineLoadFailedRetry;
         notifyListeners();
         return Error<void>(error, stackTrace);
@@ -249,39 +365,107 @@ class TimelineViewModel extends ChangeNotifier {
       final factId = message.factId;
       if (factId != null && cards.any((c) => c.id == factId)) {
         // Refresh attachments for the specific card
-        _refreshAttachments(factId);
+        unawaited(_refreshAttachments(factId));
       } else {
         // Global change (no factId) — refresh all
-        _loadAttachmentsForCards(cards);
+        unawaited(_loadAttachmentsForCards(cards, notify: true));
       }
-      _refreshPendingCount();
+      unawaited(_refreshPendingCount());
     }
   }
 
-  Future<void> _loadAttachmentsForCards(
-    List<TimelineCardModel> cardList,
-  ) async {
-    if (cardList.isEmpty) return;
+  Future<bool> _loadAttachmentsForCards(
+    List<TimelineCardModel> cardList, {
+    int? generation,
+    String? filter,
+    bool notify = false,
+  }) async {
+    if (cardList.isEmpty) return false;
     final factIds = cardList.map((c) => c.id).toList();
-    final map = await CardAttachmentService.instance.getAttachmentsForFacts(
-      factIds,
+    final entries = await Future.wait(
+      factIds.map((factId) async {
+        final data = await _runAuxiliaryQuery<List<CardAttachmentData>>(
+          label: 'load attachments for $factId',
+          query: () => _fetchAttachmentForCard(factId),
+        );
+        return data == null ? null : MapEntry(factId, data);
+      }),
     );
+    if (generation != null &&
+        filter != null &&
+        _isStaleTimelineLoad(generation, filter)) {
+      return false;
+    }
+    final map = <String, List<CardAttachmentData>>{};
+    for (final entry in entries) {
+      if (entry != null) {
+        map[entry.key] = entry.value;
+      }
+    }
+    if (map.isEmpty) return false;
     attachments.addAll(map);
-    // Don't call notifyListeners here — caller is responsible.
+    if (notify) notifyListeners();
+    return true;
   }
 
   Future<void> _refreshAttachments(String factId) async {
-    final data = await CardAttachmentService.instance.getAttachments(factId);
+    final data = await _runAuxiliaryQuery<List<CardAttachmentData>>(
+      label: 'refresh attachments for $factId',
+      query: () => _fetchAttachmentForCard(factId),
+    );
+    if (data == null) return;
     attachments[factId] = data;
     notifyListeners();
   }
 
-  Future<void> _refreshPendingCount() async {
-    final pending =
-        await CardAttachmentService.instance.getPendingAttachments();
-    final failedCardCount = await _router.countFailedCardGenerations();
+  Future<bool> _refreshPendingCount({bool notify = true}) async {
+    final pending = await _runAuxiliaryQuery<List<CardAttachmentData>>(
+      label: 'refresh pending attachment count',
+      query: _fetchPendingAttachments,
+    );
+    final failedCardCount = await _runAuxiliaryQuery<int>(
+      label: 'refresh failed card generation count',
+      query: _countFailedCardGenerations,
+    );
+    if (pending == null || failedCardCount == null) {
+      return false;
+    }
     pendingAttachmentCount = pending.length + (failedCardCount > 0 ? 1 : 0);
-    notifyListeners();
+    if (notify) notifyListeners();
+    return true;
+  }
+
+  void _refreshAuxiliaryTimelineState({
+    required int generation,
+    required String filter,
+    required List<TimelineCardModel> cardList,
+  }) {
+    unawaited(() async {
+      final attachmentChanged = await _loadAttachmentsForCards(
+        cardList,
+        generation: generation,
+        filter: filter,
+      );
+      final pendingChanged = await _refreshPendingCount(notify: false);
+      if (_isStaleTimelineLoad(generation, filter)) return;
+      if (attachmentChanged || pendingChanged) {
+        notifyListeners();
+      }
+    }());
+  }
+
+  Future<T?> _runAuxiliaryQuery<T>({
+    required String label,
+    required Future<T> Function() query,
+  }) async {
+    try {
+      return await query().timeout(_auxiliaryQueryTimeout);
+    } on TimeoutException catch (e, st) {
+      _logger.warning('$label timed out', e, st);
+    } catch (e, st) {
+      _logger.warning('$label failed', e, st);
+    }
+    return null;
   }
 
   void _handleScheduleBriefingChanged(EventBusMessage message) {
@@ -337,7 +521,7 @@ class TimelineViewModel extends ChangeNotifier {
   /// Refresh timeline and tags (e.g. after pull-to-refresh or scroll-to-top).
   Future<void> refresh() async {
     await load.execute();
-    await fetchTags();
+    unawaited(fetchTags());
   }
 
   void addCard(TimelineCardModel card) {
@@ -364,6 +548,7 @@ class TimelineViewModel extends ChangeNotifier {
   void setActiveFilter(String tag) {
     if (activeFilter == tag) return;
     _loadGeneration++;
+    _visibleLoadGeneration = null;
     activeFilter = tag;
     cards = [];
     attachments.clear();
@@ -388,37 +573,46 @@ class TimelineViewModel extends ChangeNotifier {
     final generation = _loadGeneration;
     final filter = activeFilter;
     final viewModeAtRequest = viewMode;
-    isLoading = true;
-    notifyListeners();
-    final result = await _router.fetchTimelineCards(
+    _beginVisibleLoad(generation);
+    final result = await _fetchTimelineCards(
       page: _currentPage,
       limit: pageLimit,
       tags: filter == 'all' ? null : [filter],
     );
     switch (result) {
       case Ok(:final value):
-        if (_isStaleTimelineLoad(generation, filter)) return;
+        if (_isStaleTimelineLoad(generation, filter)) {
+          _finishVisibleLoadIfCurrent(generation);
+          return;
+        }
         final newCards = value;
         _currentPage++;
         final loadedHasMore = newCards.length >= pageLimit;
-        final nextCards = await _withScheduleBriefingCard([
-          ...cards,
-          ...newCards,
-        ],
-            hasMoreAfterList: loadedHasMore,
-            showScheduleBriefing:
-                viewModeAtRequest == TimelineViewMode.timeline &&
-                    filter == 'all');
-        if (_isStaleTimelineLoad(generation, filter)) return;
+        final nextCards = await _withScheduleBriefingCard(
+          [...cards, ...newCards],
+          hasMoreAfterList: loadedHasMore,
+          showScheduleBriefing:
+              viewModeAtRequest == TimelineViewMode.timeline && filter == 'all',
+        );
+        if (_isStaleTimelineLoad(generation, filter)) {
+          _finishVisibleLoadIfCurrent(generation);
+          return;
+        }
         cards = nextCards;
         hasMore = loadedHasMore;
         _startPollingIfNeeded();
-        await _loadAttachmentsForCards(newCards);
-        if (_isStaleTimelineLoad(generation, filter)) return;
+        _finishVisibleLoadIfCurrent(generation, notify: false);
+        notifyListeners();
+        _refreshAuxiliaryTimelineState(
+          generation: generation,
+          filter: filter,
+          cardList: newCards,
+        );
+        return;
       case Error():
         break;
     }
-    isLoading = false;
+    _finishVisibleLoadIfCurrent(generation, notify: false);
     notifyListeners();
   }
 
@@ -434,7 +628,7 @@ class TimelineViewModel extends ChangeNotifier {
       return withoutBriefing;
     }
 
-    final briefingResult = await _router.fetchScheduleBriefingCard();
+    final briefingResult = await _fetchScheduleBriefingCard();
     return briefingResult.when(
       onOk: (briefing) {
         return mergeScheduleBriefingInTimelineOrder(
@@ -464,36 +658,45 @@ class TimelineViewModel extends ChangeNotifier {
     final generation = _loadGeneration;
     final filter = activeFilter;
     final viewModeAtRequest = viewMode;
-    isLoading = true;
-    notifyListeners();
-    final result = await _router.fetchTimelineCards(
+    _beginVisibleLoad(generation);
+    final result = await _fetchTimelineCards(
       page: _currentPage + 1,
       limit: pageLimit,
       tags: filter == 'all' ? null : [filter],
     );
     switch (result) {
       case Ok(:final value):
-        if (_isStaleTimelineLoad(generation, filter)) return;
+        if (_isStaleTimelineLoad(generation, filter)) {
+          _finishVisibleLoadIfCurrent(generation);
+          return;
+        }
         final newCards = value;
         _currentPage++;
         final loadedHasMore = newCards.length >= pageLimit;
-        final nextCards = await _withScheduleBriefingCard([
-          ...cards,
-          ...newCards,
-        ],
-            hasMoreAfterList: loadedHasMore,
-            showScheduleBriefing:
-                viewModeAtRequest == TimelineViewMode.timeline &&
-                    filter == 'all');
-        if (_isStaleTimelineLoad(generation, filter)) return;
+        final nextCards = await _withScheduleBriefingCard(
+          [...cards, ...newCards],
+          hasMoreAfterList: loadedHasMore,
+          showScheduleBriefing:
+              viewModeAtRequest == TimelineViewMode.timeline && filter == 'all',
+        );
+        if (_isStaleTimelineLoad(generation, filter)) {
+          _finishVisibleLoadIfCurrent(generation);
+          return;
+        }
         cards = nextCards;
         hasMore = loadedHasMore;
-        await _loadAttachmentsForCards(newCards);
-        if (_isStaleTimelineLoad(generation, filter)) return;
+        _finishVisibleLoadIfCurrent(generation, notify: false);
+        notifyListeners();
+        _refreshAuxiliaryTimelineState(
+          generation: generation,
+          filter: filter,
+          cardList: newCards,
+        );
+        return;
       case Error():
         break;
     }
-    isLoading = false;
+    _finishVisibleLoadIfCurrent(generation, notify: false);
     notifyListeners();
   }
 
@@ -502,9 +705,22 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   Future<void> fetchTags() async {
-    final result = await _router.fetchTags();
+    final result = await _fetchTags();
     tags = result.when(onOk: (t) => t, onError: (_, __) => <TagModel>[]);
     notifyListeners();
+  }
+
+  void _beginVisibleLoad(int generation) {
+    _visibleLoadGeneration = generation;
+    isLoading = true;
+    notifyListeners();
+  }
+
+  void _finishVisibleLoadIfCurrent(int generation, {bool notify = true}) {
+    if (_visibleLoadGeneration != generation) return;
+    _visibleLoadGeneration = null;
+    isLoading = false;
+    if (notify) notifyListeners();
   }
 
   @override

--- a/lib/ui/timeline/view_models/timeline_viewmodel.dart
+++ b/lib/ui/timeline/view_models/timeline_viewmodel.dart
@@ -705,8 +705,13 @@ class TimelineViewModel extends ChangeNotifier {
   }
 
   Future<void> fetchTags() async {
-    final result = await _fetchTags();
-    tags = result.when(onOk: (t) => t, onError: (_, __) => <TagModel>[]);
+    try {
+      final result = await _fetchTags();
+      tags = result.when(onOk: (t) => t, onError: (_, __) => <TagModel>[]);
+    } catch (e, stackTrace) {
+      _logger.warning('Failed to fetch timeline tags: $e', e, stackTrace);
+      tags = <TagModel>[];
+    }
     notifyListeners();
   }
 

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui' as ui;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -33,12 +34,29 @@ import 'package:memex/ui/character/widgets/persona_chat_screen.dart';
 import 'package:memex/utils/share_service.dart';
 import 'package:memex/ui/core/cards/native_card_factory.dart';
 import 'package:memex/ui/timeline/widgets/failed_card_recovery_banner.dart';
+import 'package:memex/utils/logger.dart';
+
+typedef CardDetailFetcher = Future<CardDetailModel> Function(String cardId);
+typedef ActiveCardTaskFetcher = Future<bool> Function(String cardId);
 
 /// Timeline card detail screen - plays full card detail
 class TimelineCardDetailScreen extends StatefulWidget {
   final String cardId;
+  final CardDetailFetcher? fetchCardDetail;
+  final ActiveCardTaskFetcher? hasActiveTaskForCard;
+  final Duration activeTaskQueryTimeout;
+  final bool enableRouterSideEffects;
 
-  const TimelineCardDetailScreen({super.key, required this.cardId});
+  const TimelineCardDetailScreen({
+    super.key,
+    required this.cardId,
+    this.fetchCardDetail,
+    this.hasActiveTaskForCard,
+    this.activeTaskQueryTimeout = defaultActiveTaskQueryTimeout,
+    this.enableRouterSideEffects = true,
+  });
+
+  static const Duration defaultActiveTaskQueryTimeout = Duration(seconds: 2);
 
   @override
   State<TimelineCardDetailScreen> createState() =>
@@ -49,7 +67,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   CardDetailModel? _detail;
   bool _isLoading = true;
   String? _errorMessage;
-  late final MemexRouter _memexRouter;
+  MemexRouter? _memexRouter;
   String _userName = 'User';
   String? _userAvatar;
   double? _firstImageAspectRatio;
@@ -58,14 +76,21 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   String? _replyToCommentName;
   bool _isRetryingCard = false;
   bool _hasActiveCardTask = false;
+  int _detailFetchGeneration = 0;
+  final _logger = getLogger('TimelineCardDetailScreen');
+
+  MemexRouter get _router => _memexRouter ??= MemexRouter();
 
   @override
   void initState() {
     super.initState();
-    _memexRouter = MemexRouter();
-    _memexRouter.registerCardDetailForeground(widget.cardId);
+    if (widget.enableRouterSideEffects) {
+      _router.registerCardDetailForeground(widget.cardId);
+    }
     _fetchDetail();
-    _loadUserInfo();
+    if (widget.enableRouterSideEffects) {
+      _loadUserInfo();
+    }
     _setupEventBus();
   }
 
@@ -98,8 +123,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
 
   Future<void> _loadUserInfo() async {
     final name = await UserStorage.getUserId();
-    final avatar = await _memexRouter.getUserAvatar();
-    final settings = await _memexRouter.getCommentSettings();
+    final avatar = await _router.getUserAvatar();
+    final settings = await _router.getCommentSettings();
     if (mounted) {
       setState(() {
         _userName = name ?? 'User';
@@ -124,7 +149,10 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
 
   @override
   void dispose() {
-    _memexRouter.unregisterCardDetailForeground(widget.cardId);
+    _detailFetchGeneration++;
+    if (widget.enableRouterSideEffects) {
+      _memexRouter?.unregisterCardDetailForeground(widget.cardId);
+    }
     EventBusService.instance.removeHandler(
       EventBusMessageType.cardDetailUpdated,
       _handleCardDetailUpdated,
@@ -137,6 +165,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   }
 
   Future<void> _fetchDetail() async {
+    final generation = ++_detailFetchGeneration;
     if (_detail == null) {
       setState(() {
         _isLoading = true;
@@ -145,34 +174,49 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     }
 
     try {
-      final detailFuture = _memexRouter.fetchCardDetail(widget.cardId);
-      final activeTaskFuture = _memexRouter.hasActiveTaskForCard(
-        widget.cardId,
-      );
-      final detail = await detailFuture;
-      final hasActiveCardTask = await activeTaskFuture.catchError((_) => false);
-      if (!mounted) return;
+      final fetchDetail = widget.fetchCardDetail ?? _router.fetchCardDetail;
+      final detail = await fetchDetail(widget.cardId);
+      if (!mounted || generation != _detailFetchGeneration) return;
       setState(() {
         _detail = detail;
-        _hasActiveCardTask = hasActiveCardTask;
+        _hasActiveCardTask = false;
+        _isLoading = false;
+        _errorMessage = null;
       });
       _resolveFirstImageAspectRatio(detail);
 
       // Dismiss any pending card-detail notification for this card.
-      _memexRouter.dismissCardDetailOnViewed(widget.cardId);
+      if (widget.enableRouterSideEffects) {
+        unawaited(_router.dismissCardDetailOnViewed(widget.cardId));
+      }
+      unawaited(_refreshActiveCardTask(generation));
     } catch (e) {
-      if (!mounted) return;
+      if (!mounted || generation != _detailFetchGeneration) return;
       setState(() {
         _errorMessage = UserStorage.l10n.loadDetailFailedRetryShort;
+        _isLoading = false;
       });
       ToastHelper.showError(context, e);
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
-      }
     }
+  }
+
+  Future<void> _refreshActiveCardTask(int generation) async {
+    final fetchActiveTask =
+        widget.hasActiveTaskForCard ?? _router.hasActiveTaskForCard;
+    var hasActiveCardTask = false;
+    try {
+      hasActiveCardTask = await fetchActiveTask(
+        widget.cardId,
+      ).timeout(widget.activeTaskQueryTimeout);
+    } on TimeoutException catch (e, st) {
+      _logger.warning('hasActiveTaskForCard timed out', e, st);
+    } catch (e, st) {
+      _logger.warning('hasActiveTaskForCard failed', e, st);
+    }
+    if (!mounted || generation != _detailFetchGeneration) return;
+    setState(() {
+      _hasActiveCardTask = hasActiveCardTask;
+    });
   }
 
   void _showChatDialog() {
@@ -234,7 +278,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     if (_isRetryingCard) return;
 
     setState(() => _isRetryingCard = true);
-    final success = await _memexRouter.retryCardGeneration(widget.cardId);
+    final success = await _router.retryCardGeneration(widget.cardId);
     if (!mounted) return;
 
     setState(() => _isRetryingCard = false);
@@ -368,7 +412,8 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       // API call
       // Server expects unix timestamp in seconds
       final timestamp = newDateTime.millisecondsSinceEpoch ~/ 1000;
-      await _memexRouter.updateCardTime(widget.cardId, timestamp);
+      await _router.updateCardTime(widget.cardId, timestamp);
+      if (!mounted) return;
       ToastHelper.showSuccess(context, UserStorage.l10n.timeUpdated);
     } catch (e) {
       if (!mounted) return;
@@ -410,12 +455,13 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       });
 
       try {
-        await _memexRouter.updateCardLocation(
+        await _router.updateCardLocation(
           widget.cardId,
           result.point.latitude,
           result.point.longitude,
           result.name ?? result.address ?? '',
         );
+        if (!mounted) return;
         ToastHelper.showSuccess(context, UserStorage.l10n.locationUpdated);
       } catch (e) {
         if (!mounted) return;
@@ -459,7 +505,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
 
     try {
       // call delete API
-      await _memexRouter.deleteCard(widget.cardId);
+      await _router.deleteCard(widget.cardId);
 
       if (mounted) {
         ToastHelper.showSuccess(context, UserStorage.l10n.deleteSuccess);

--- a/test/ui/timeline/widgets/timeline_aux_query_isolation_test.dart
+++ b/test/ui/timeline/widgets/timeline_aux_query_isolation_test.dart
@@ -1,0 +1,300 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/domain/models/card_detail_model.dart';
+import 'package:memex/domain/models/tag_model.dart';
+import 'package:memex/domain/models/timeline_card_model.dart';
+import 'package:memex/ui/card_attachments/card_attachment_data.dart';
+import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
+import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
+import 'package:memex/ui/timeline/widgets/failed_card_recovery_banner.dart';
+import 'package:memex/ui/timeline/widgets/timeline_card_detail_screen.dart';
+import 'package:memex/utils/result.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp(
+      'memex_timeline_aux_query_isolation_',
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, (call) async {
+      switch (call.method) {
+        case 'getApplicationDocumentsDirectory':
+        case 'getApplicationSupportDirectory':
+        case 'getTemporaryDirectory':
+          return tempDir.path;
+        default:
+          return null;
+      }
+    });
+  });
+
+  setUp(() async {
+    EventBusService.instance.clearHandlers();
+    SharedPreferences.setMockInitialValues({'language': 'en'});
+    await UserStorage.initL10n();
+  });
+
+  tearDown(() {
+    EventBusService.instance.clearHandlers();
+  });
+
+  tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  testWidgets(
+    'timeline refresh renders cards and settles while auxiliary queries hang or fail',
+    (tester) async {
+      final hangingAttachments = Completer<List<CardAttachmentData>>();
+      final hangingFailedCount = Completer<int>();
+      final vm = _timelineViewModel(
+        fetchTimelineCards: ({
+          int page = 1,
+          int limit = TimelineViewModel.pageLimit,
+          List<String>? tags,
+          DateTime? dateFrom,
+          DateTime? dateTo,
+        }) async =>
+            Ok([
+          _timelineCard('card-hanging-aux', 'Card before hung aux'),
+          _timelineCard('card-failing-aux', 'Card before failed aux'),
+        ]),
+        fetchAttachmentForCard: (factId) {
+          if (factId == 'card-hanging-aux') {
+            return hangingAttachments.future;
+          }
+          throw StateError('attachment query failed');
+        },
+        fetchPendingAttachments: () =>
+            Future.error(StateError('pending badge failed')),
+        countFailedCardGenerations: () => hangingFailedCount.future,
+      );
+
+      await tester.pumpWidget(_TimelineHarness(viewModel: vm));
+
+      final refresh = vm.refresh();
+      await tester.pump();
+
+      await expectLater(refresh, completes);
+      await tester.pump();
+
+      expect(find.text('Card before hung aux'), findsOneWidget);
+      expect(find.text('Card before failed aux'), findsOneWidget);
+      expect(find.byKey(const ValueKey('timeline-loading')), findsNothing);
+      expect(vm.isLoading, isFalse);
+      expect(vm.load.running, isFalse);
+
+      await tester.pump(const Duration(milliseconds: 30));
+
+      expect(vm.pendingAttachmentCount, 0);
+      vm.dispose();
+    },
+  );
+
+  testWidgets(
+    'stale refresh return after tab switch does not leave loading on',
+    (tester) async {
+      final firstRefresh = Completer<Result<List<TimelineCardModel>>>();
+      final secondRefresh = Completer<Result<List<TimelineCardModel>>>();
+      var calls = 0;
+      final vm = _timelineViewModel(
+        fetchTimelineCards: ({
+          int page = 1,
+          int limit = TimelineViewModel.pageLimit,
+          List<String>? tags,
+          DateTime? dateFrom,
+          DateTime? dateTo,
+        }) {
+          calls += 1;
+          return calls == 1 ? firstRefresh.future : secondRefresh.future;
+        },
+      );
+
+      await tester.pumpWidget(_TimelineHarness(viewModel: vm));
+
+      final staleLoad = vm.loadCards(refresh: true);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('timeline-loading')), findsOneWidget);
+
+      vm.setActiveFilter('work');
+      final currentLoad = vm.loadCards(refresh: true);
+      await tester.pump();
+
+      firstRefresh.complete(Ok([_timelineCard('stale-card', 'Stale card')]));
+      await tester.pump();
+      expect(vm.isLoading, isTrue);
+      expect(find.text('Stale card'), findsNothing);
+
+      secondRefresh.complete(Ok([_timelineCard('work-card', 'Work card')]));
+      await Future.wait([staleLoad, currentLoad]);
+      await tester.pump();
+
+      expect(find.text('Work card'), findsOneWidget);
+      expect(find.byKey(const ValueKey('timeline-loading')), findsNothing);
+      expect(vm.isLoading, isFalse);
+
+      vm.dispose();
+    },
+  );
+
+  for (final scenario in [
+    _ActiveTaskScenario(
+      name: 'hangs',
+      fetcher: (_) => Completer<bool>().future,
+    ),
+    _ActiveTaskScenario(
+      name: 'fails',
+      fetcher: (_) => Future.error(StateError('task lookup failed')),
+    ),
+  ]) {
+    testWidgets(
+      'detail renders main content when hasActiveTaskForCard ${scenario.name}',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: TimelineCardDetailScreen(
+              cardId: 'detail-card',
+              activeTaskQueryTimeout: const Duration(milliseconds: 10),
+              enableRouterSideEffects: false,
+              fetchCardDetail: (_) async => _cardDetail(
+                title: 'Detail survives ${scenario.name} task lookup',
+                content: 'The detail body is visible.',
+                status: 'processing',
+              ),
+              hasActiveTaskForCard: scenario.fetcher,
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          find.text('Detail survives ${scenario.name} task lookup'),
+          findsOneWidget,
+        );
+        expect(find.text('The detail body is visible.'), findsOneWidget);
+        expect(find.byType(AgentLogoLoading), findsNothing);
+
+        await tester.pump(const Duration(milliseconds: 20));
+
+        expect(find.byType(CardProcessingStatusBanner), findsOneWidget);
+        expect(find.text(UserStorage.l10n.cardRegeneratingTitle), findsNothing);
+      },
+    );
+  }
+}
+
+TimelineViewModel _timelineViewModel({
+  TimelineCardsFetcher? fetchTimelineCards,
+  TimelineAttachmentFetcher? fetchAttachmentForCard,
+  PendingAttachmentsFetcher? fetchPendingAttachments,
+  FailedCardCountFetcher? countFailedCardGenerations,
+}) {
+  return TimelineViewModel.forTest(
+    autoLoad: false,
+    auxiliaryQueryTimeout: const Duration(milliseconds: 10),
+    fetchTimelineCards: fetchTimelineCards ??
+        ({
+          int page = 1,
+          int limit = TimelineViewModel.pageLimit,
+          List<String>? tags,
+          DateTime? dateFrom,
+          DateTime? dateTo,
+        }) async =>
+            const Ok([]),
+    fetchTags: () async => const Ok(<TagModel>[]),
+    fetchScheduleBriefingCard: () async => const Ok(null),
+    fetchAttachmentForCard:
+        fetchAttachmentForCard ?? (_) async => const <CardAttachmentData>[],
+    fetchPendingAttachments:
+        fetchPendingAttachments ?? () async => const <CardAttachmentData>[],
+    countFailedCardGenerations: countFailedCardGenerations ?? () async => 0,
+  );
+}
+
+class _TimelineHarness extends StatelessWidget {
+  const _TimelineHarness({required this.viewModel});
+
+  final TimelineViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: Listenable.merge([viewModel, viewModel.load]),
+          builder: (context, _) {
+            return ListView(
+              children: [
+                if (viewModel.isLoading || viewModel.load.running)
+                  const LinearProgressIndicator(
+                    key: ValueKey('timeline-loading'),
+                  ),
+                for (final card in viewModel.cards)
+                  ListTile(title: Text(card.title ?? card.id)),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _ActiveTaskScenario {
+  const _ActiveTaskScenario({required this.name, required this.fetcher});
+
+  final String name;
+  final ActiveCardTaskFetcher fetcher;
+}
+
+TimelineCardModel _timelineCard(String id, String title) {
+  return TimelineCardModel(
+    id: id,
+    timestamp: DateTime(2026, 6, 16, 9),
+    tags: const [],
+    status: 'completed',
+    title: title,
+    uiConfigs: [
+      UiConfig(templateId: 'classic_card', data: {'content': title}),
+    ],
+  );
+}
+
+CardDetailModel _cardDetail({
+  required String title,
+  required String content,
+  String status = 'completed',
+}) {
+  return CardDetailModel(
+    id: 'detail-card',
+    title: title,
+    timestamp: DateTime(2026, 6, 16, 9),
+    address: 'Unknown',
+    tags: const [],
+    rawContent: content,
+    insight: InsightData.fromJson(const {}),
+    assets: const [],
+    uiConfigs: [
+      UiConfig(templateId: 'classic_card', data: {'content': content}),
+    ],
+    status: status,
+  );
+}

--- a/test/ui/timeline/widgets/timeline_aux_query_isolation_test.dart
+++ b/test/ui/timeline/widgets/timeline_aux_query_isolation_test.dart
@@ -153,6 +153,36 @@ void main() {
     },
   );
 
+  testWidgets(
+    'refresh keeps timeline usable when unawaited fetchTags throws',
+    (tester) async {
+      final vm = _timelineViewModel(
+        fetchTimelineCards: ({
+          int page = 1,
+          int limit = TimelineViewModel.pageLimit,
+          List<String>? tags,
+          DateTime? dateFrom,
+          DateTime? dateTo,
+        }) async =>
+            Ok([_timelineCard('card-after-tags-fail', 'Card survives tags')]),
+        fetchTags: () async => throw StateError('tags failed'),
+      );
+
+      await tester.pumpWidget(_TimelineHarness(viewModel: vm));
+
+      await expectLater(vm.refresh(), completes);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 20));
+
+      expect(find.text('Card survives tags'), findsOneWidget);
+      expect(find.byKey(const ValueKey('timeline-loading')), findsNothing);
+      expect(vm.isLoading, isFalse);
+      expect(vm.tags, isEmpty);
+
+      vm.dispose();
+    },
+  );
+
   for (final scenario in [
     _ActiveTaskScenario(
       name: 'hangs',
@@ -203,6 +233,7 @@ void main() {
 
 TimelineViewModel _timelineViewModel({
   TimelineCardsFetcher? fetchTimelineCards,
+  TimelineTagsFetcher? fetchTags,
   TimelineAttachmentFetcher? fetchAttachmentForCard,
   PendingAttachmentsFetcher? fetchPendingAttachments,
   FailedCardCountFetcher? countFailedCardGenerations,
@@ -219,7 +250,7 @@ TimelineViewModel _timelineViewModel({
           DateTime? dateTo,
         }) async =>
             const Ok([]),
-    fetchTags: () async => const Ok(<TagModel>[]),
+    fetchTags: fetchTags ?? () async => const Ok(<TagModel>[]),
     fetchScheduleBriefingCard: () async => const Ok(null),
     fetchAttachmentForCard:
         fetchAttachmentForCard ?? (_) async => const <CardAttachmentData>[],


### PR DESCRIPTION
## 关联 issue

Closes #290

## 变更

- Timeline 首屏卡片加载与 active task 等辅助查询解耦，避免辅助查询慢/挂起时阻塞主列表。
- Card detail 先渲染核心内容，再异步刷新任务状态。
- 新增 widget regression，模拟辅助查询挂起时列表和详情仍可渲染。

## 测试

- `flutter test --no-pub test/ui/timeline/widgets/timeline_aux_query_isolation_test.dart`
- `flutter analyze --no-pub lib/ui/timeline/view_models/timeline_viewmodel.dart lib/ui/timeline/widgets/timeline_card_detail_screen.dart test/ui/timeline/widgets/timeline_aux_query_isolation_test.dart`（仅命中既有 info-level lint，无 error/warning）
- `flutter build apk --debug --flavor globalDev --no-pub`
- `git diff --check`
- Android emulator `Medium_Phone_API_35`：启动 Timeline 确认卡片先显示；下拉刷新后列表仍可用；打开第一张卡片详情，确认内容直接显示，没有卡在辅助查询 loading。
