### PR TITLE
刷新时间线模型配置提示

### DIFF
--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -1684,15 +1684,36 @@ class MemexRouter {
         reprocessPendingCards(userId);
       }
     }
+
+    _emitLLMConfigChanged(configs, reason: 'saved');
   }
 
-  Future<void> resetLLMConfigs() => UserStorage.resetLLMConfigs();
+  Future<void> resetLLMConfigs() async {
+    await UserStorage.resetLLMConfigs();
+    final configs = await UserStorage.getLLMConfigs();
+    _emitLLMConfigChanged(configs, reason: 'reset');
+  }
 
   Future<String> getDefaultLLMConfigKey() =>
       UserStorage.getDefaultLLMConfigKey();
 
-  Future<void> setDefaultLLMConfigKey(String configKey) =>
-      UserStorage.setDefaultLLMConfigKey(configKey);
+  Future<void> setDefaultLLMConfigKey(String configKey) async {
+    await UserStorage.setDefaultLLMConfigKey(configKey);
+    final configs = await UserStorage.getLLMConfigs();
+    _emitLLMConfigChanged(configs, reason: 'default_changed');
+  }
+
+  void _emitLLMConfigChanged(
+    List<LLMConfig> configs, {
+    required String reason,
+  }) {
+    EventBusService.instance.emitEvent(
+      LLMConfigChangedMessage(
+        hasValidConfig: configs.any((c) => c.isValid),
+        reason: reason,
+      ),
+    );
+  }
 
   Future<AgentConfig> getAgentConfig(String agentId) =>
       UserStorage.getAgentConfig(agentId);

--- a/lib/domain/models/event_bus_message.dart
+++ b/lib/domain/models/event_bus_message.dart
@@ -10,6 +10,7 @@ enum EventBusMessageType {
   newSystemAction('new_system_action'),
   attachmentsChanged('attachments_changed'),
   invalidModelConfig('invalid_model_config'),
+  llmConfigChanged('llm_config_changed'),
   errorNotification('error_notification'),
   profileUpdated('profile_updated'),
   characterUpdated('character_updated'),
@@ -56,6 +57,8 @@ abstract class EventBusMessage {
         return AttachmentsChangedMessage.fromJson(json);
       case EventBusMessageType.invalidModelConfig:
         return InvalidModelConfigMessage.fromJson(json);
+      case EventBusMessageType.llmConfigChanged:
+        return LLMConfigChangedMessage.fromJson(json);
       case EventBusMessageType.errorNotification:
         return ErrorNotificationMessage.fromJson(json);
       case EventBusMessageType.profileUpdated:
@@ -307,6 +310,26 @@ class InvalidModelConfigMessage extends EventBusMessage {
     return InvalidModelConfigMessage(
       agentId: data['agent_id'] as String,
       configKey: data['config_key'] as String,
+    );
+  }
+}
+
+/// LLM config changed message (refresh model-dependent UI state).
+class LLMConfigChangedMessage extends EventBusMessage {
+  final bool hasValidConfig;
+  final String reason;
+
+  LLMConfigChangedMessage({required this.hasValidConfig, required this.reason})
+    : super(
+        type: EventBusMessageType.llmConfigChanged,
+        data: {'has_valid_config': hasValidConfig, 'reason': reason},
+      );
+
+  factory LLMConfigChangedMessage.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>? ?? {};
+    return LLMConfigChangedMessage(
+      hasValidConfig: data['has_valid_config'] as bool? ?? false,
+      reason: data['reason'] as String? ?? 'updated',
     );
   }
 }

--- a/lib/ui/timeline/widgets/timeline_model_config_banner.dart
+++ b/lib/ui/timeline/widgets/timeline_model_config_banner.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/utils/user_storage.dart';
+
+class TimelineModelConfigBanner extends StatefulWidget {
+  const TimelineModelConfigBanner({super.key, required this.onConfigureTap});
+
+  final Future<void> Function() onConfigureTap;
+
+  @override
+  State<TimelineModelConfigBanner> createState() =>
+      _TimelineModelConfigBannerState();
+}
+
+class _TimelineModelConfigBannerState extends State<TimelineModelConfigBanner>
+    with WidgetsBindingObserver {
+  bool _showBanner = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    EventBusService.instance.addHandler(
+      EventBusMessageType.llmConfigChanged,
+      _handleLLMConfigChanged,
+    );
+    _checkModelConfig();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    EventBusService.instance.removeHandler(
+      EventBusMessageType.llmConfigChanged,
+      _handleLLMConfigChanged,
+    );
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _checkModelConfig();
+    }
+  }
+
+  Future<void> _checkModelConfig() async {
+    final configs = await UserStorage.getLLMConfigs();
+    final hasValid = configs.any((c) => c.isValid);
+    if (mounted && !hasValid != _showBanner) {
+      setState(() => _showBanner = !hasValid);
+    }
+  }
+
+  void _handleLLMConfigChanged(EventBusMessage message) {
+    if (!mounted) return;
+    if (message is LLMConfigChangedMessage) {
+      final shouldShowBanner = !message.hasValidConfig;
+      if (_showBanner != shouldShowBanner) {
+        setState(() => _showBanner = shouldShowBanner);
+      }
+    }
+    _checkModelConfig();
+  }
+
+  Future<void> _openModelConfig() async {
+    await widget.onConfigureTap();
+    await _checkModelConfig();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_showBanner) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 12, 24, 12),
+      child: GestureDetector(
+        onTap: _openModelConfig,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                Colors.white.withValues(alpha: 0.92),
+                Colors.white.withValues(alpha: 0.82),
+              ],
+            ),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: Colors.white.withValues(alpha: 0.6),
+              width: 0.5,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.06),
+                blurRadius: 16,
+                offset: const Offset(0, 4),
+              ),
+              BoxShadow(
+                color: const Color(0xFF6366F1).withValues(alpha: 0.08),
+                blurRadius: 24,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  gradient: const LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      Color(0xFF818CF8),
+                      Color(0xFF6366F1),
+                    ],
+                  ),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: const Icon(
+                  Icons.auto_awesome,
+                  size: 18,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      UserStorage.l10n.configureNow,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                        color: Color(0xFF1E293B),
+                        letterSpacing: 0,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      UserStorage.l10n.modelNotConfiguredBanner,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: const Color(0xFF64748B).withValues(alpha: 0.9),
+                        height: 1.3,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: const Color(0xFF6366F1).withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Icon(
+                  Icons.arrow_forward_ios,
+                  size: 12,
+                  color: Color(0xFF6366F1),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -17,6 +17,7 @@ import 'package:memex/ui/core/cards/card_action_notification.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
 import 'package:memex/ui/timeline/widgets/timeline_card_detail_screen.dart';
+import 'package:memex/ui/timeline/widgets/timeline_model_config_banner.dart';
 import 'package:memex/ui/settings/widgets/personal_center_screen.dart';
 import 'package:memex/ui/insight/view_models/insight_viewmodel.dart';
 import 'package:memex/ui/insight/widgets/insight_screen.dart';
@@ -58,7 +59,6 @@ class TimelineScreenState extends State<TimelineScreen> {
   final ScrollController _scrollController = ScrollController();
   bool _showPermissionBadge = false;
   String? _userAvatar;
-  bool _showModelConfigBanner = false;
   bool _showFitnessBanner = false;
   late PageController _pageController;
   int _currentPageIndex = 0;
@@ -135,16 +135,7 @@ class TimelineScreenState extends State<TimelineScreen> {
     );
     _checkPermissionBadge();
     _loadUserAvatar();
-    _checkModelConfig();
     _checkFitnessBanner();
-  }
-
-  Future<void> _checkModelConfig() async {
-    final configs = await UserStorage.getLLMConfigs();
-    final hasValid = configs.any((c) => c.isValid);
-    if (mounted && !hasValid != _showModelConfigBanner) {
-      setState(() => _showModelConfigBanner = !hasValid);
-    }
   }
 
   Future<void> _checkFitnessBanner() async {
@@ -487,112 +478,18 @@ class TimelineScreenState extends State<TimelineScreen> {
             const SizedBox(height: 16),
 
             // Tag Chips (All + Insight + user tags)
-            if (_showModelConfigBanner)
-              Padding(
-                padding: const EdgeInsets.fromLTRB(24, 12, 24, 12),
-                child: GestureDetector(
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => AppConfig.enableMemexModelService
-                            ? const AiServiceSetupPage()
-                            : const ModelConfigListPage(),
-                      ),
-                    ).then((_) => _checkModelConfig());
-                  },
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 16, vertical: 14),
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                        colors: [
-                          Colors.white.withOpacity(0.92),
-                          Colors.white.withOpacity(0.82),
-                        ],
-                      ),
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                        color: Colors.white.withOpacity(0.6),
-                        width: 0.5,
-                      ),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withOpacity(0.06),
-                          blurRadius: 16,
-                          offset: const Offset(0, 4),
-                        ),
-                        BoxShadow(
-                          color: const Color(0xFF6366F1).withOpacity(0.08),
-                          blurRadius: 24,
-                          offset: const Offset(0, 2),
-                        ),
-                      ],
-                    ),
-                    child: Row(
-                      children: [
-                        Container(
-                          width: 36,
-                          height: 36,
-                          decoration: BoxDecoration(
-                            gradient: const LinearGradient(
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                              colors: [
-                                Color(0xFF818CF8),
-                                Color(0xFF6366F1),
-                              ],
-                            ),
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          child: const Icon(Icons.auto_awesome,
-                              size: 18, color: Colors.white),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                UserStorage.l10n.configureNow,
-                                style: const TextStyle(
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w600,
-                                  color: Color(0xFF1E293B),
-                                  letterSpacing: -0.2,
-                                ),
-                              ),
-                              const SizedBox(height: 2),
-                              Text(
-                                UserStorage.l10n.modelNotConfiguredBanner,
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color:
-                                      const Color(0xFF64748B).withOpacity(0.9),
-                                  height: 1.3,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Container(
-                          width: 28,
-                          height: 28,
-                          decoration: BoxDecoration(
-                            color: const Color(0xFF6366F1).withOpacity(0.1),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: const Icon(Icons.arrow_forward_ios,
-                              size: 12, color: Color(0xFF6366F1)),
-                        ),
-                      ],
-                    ),
+            TimelineModelConfigBanner(
+              onConfigureTap: () async {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => AppConfig.enableMemexModelService
+                        ? const AiServiceSetupPage()
+                        : const ModelConfigListPage(),
                   ),
-                ),
-              ),
+                );
+              },
+            ),
             if (_showFitnessBanner)
               Padding(
                 padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),

--- a/test/data/repositories/memex_router_llm_config_event_test.dart
+++ b/test/data/repositories/memex_router_llm_config_event_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/config/app_flavor.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+import 'package:memex/domain/models/llm_config.dart';
+import 'package:memex/utils/user_storage.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+// ignore: depend_on_referenced_packages
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late PathProviderPlatform originalPathProvider;
+
+  setUp(() async {
+    AppFlavor.init('global');
+    tempDir = await Directory.systemTemp.createTemp('memex_router_llm_event_');
+    originalPathProvider = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = FakePathProviderPlatform(tempDir.path);
+    SharedPreferences.setMockInitialValues({'language': 'en'});
+    await UserStorage.initL10n();
+    EventBusService.instance.clearHandlers();
+    await EventBusService.instance.connect();
+  });
+
+  tearDown(() async {
+    EventBusService.instance.clearHandlers();
+    await EventBusService.instance.disconnect();
+    await LocalAssetServer.stopServer();
+    PathProviderPlatform.instance = originalPathProvider;
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('saveLLMConfigs emits typed config change event', () async {
+    final messages = <LLMConfigChangedMessage>[];
+    EventBusService.instance.addHandler(EventBusMessageType.llmConfigChanged, (
+      message,
+    ) {
+      if (message is LLMConfigChangedMessage) {
+        messages.add(message);
+      }
+    });
+
+    await MemexRouter().saveLLMConfigs(const [_validLocalModelConfig]);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(messages, hasLength(1));
+    expect(messages.single.hasValidConfig, isTrue);
+    expect(messages.single.reason, 'saved');
+  });
+
+  test('resetLLMConfigs emits invalid config change event', () async {
+    final messages = <LLMConfigChangedMessage>[];
+    await UserStorage.saveLLMConfigs(const [_validLocalModelConfig]);
+    EventBusService.instance.addHandler(EventBusMessageType.llmConfigChanged, (
+      message,
+    ) {
+      if (message is LLMConfigChangedMessage) {
+        messages.add(message);
+      }
+    });
+
+    await MemexRouter().resetLLMConfigs();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(messages, hasLength(1));
+    expect(messages.single.hasValidConfig, isFalse);
+    expect(messages.single.reason, 'reset');
+  });
+}
+
+const _validLocalModelConfig = LLMConfig(
+  key: 'local-ollama',
+  type: LLMConfig.typeOllama,
+  modelId: 'llama3',
+  apiKey: '',
+  baseUrl: 'http://127.0.0.1:11434',
+);
+
+class FakePathProviderPlatform extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  final String rootPath;
+
+  FakePathProviderPlatform(this.rootPath);
+
+  @override
+  Future<String?> getTemporaryPath() async => rootPath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => rootPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => rootPath;
+
+  @override
+  Future<String?> getExternalStoragePath() async => rootPath;
+}

--- a/test/data/repositories/memex_router_llm_config_event_test.dart
+++ b/test/data/repositories/memex_router_llm_config_event_test.dart
@@ -76,6 +76,28 @@ void main() {
     expect(messages.single.hasValidConfig, isFalse);
     expect(messages.single.reason, 'reset');
   });
+
+  test('setDefaultLLMConfigKey emits default changed event', () async {
+    final messages = <LLMConfigChangedMessage>[];
+    await UserStorage.saveLLMConfigs(const [
+      _validLocalModelConfig,
+      _validOpenAiModelConfig,
+    ]);
+    EventBusService.instance.addHandler(EventBusMessageType.llmConfigChanged, (
+      message,
+    ) {
+      if (message is LLMConfigChangedMessage) {
+        messages.add(message);
+      }
+    });
+
+    await MemexRouter().setDefaultLLMConfigKey(_validOpenAiModelConfig.key);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(messages, hasLength(1));
+    expect(messages.single.hasValidConfig, isTrue);
+    expect(messages.single.reason, 'default_changed');
+  });
 }
 
 const _validLocalModelConfig = LLMConfig(
@@ -84,6 +106,14 @@ const _validLocalModelConfig = LLMConfig(
   modelId: 'llama3',
   apiKey: '',
   baseUrl: 'http://127.0.0.1:11434',
+);
+
+const _validOpenAiModelConfig = LLMConfig(
+  key: 'openai-primary',
+  type: LLMConfig.typeChatCompletion,
+  modelId: 'gpt-4o-mini',
+  apiKey: 'test-key',
+  baseUrl: 'https://api.openai.com/v1',
 );
 
 class FakePathProviderPlatform extends PathProviderPlatform

--- a/test/ui/timeline/widgets/timeline_model_config_banner_test.dart
+++ b/test/ui/timeline/widgets/timeline_model_config_banner_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/domain/models/llm_config.dart';
+import 'package:memex/ui/timeline/widgets/timeline_model_config_banner.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'language': 'en'});
+    await UserStorage.initL10n();
+    EventBusService.instance.clearHandlers();
+    await EventBusService.instance.connect();
+  });
+
+  tearDown(() async {
+    EventBusService.instance.clearHandlers();
+    await EventBusService.instance.disconnect();
+  });
+
+  testWidgets('banner hides and shows when LLM config events are emitted', (
+    tester,
+  ) async {
+    await _pumpBanner(tester);
+
+    expect(_modelBannerFinder(), findsOneWidget);
+
+    await UserStorage.saveLLMConfigs(const [_validLocalModelConfig]);
+    EventBusService.instance.emitEvent(
+      LLMConfigChangedMessage(hasValidConfig: true, reason: 'saved'),
+    );
+    await _pumpAsyncWork(tester);
+
+    expect(_modelBannerFinder(), findsNothing);
+
+    await UserStorage.resetLLMConfigs();
+    EventBusService.instance.emitEvent(
+      LLMConfigChangedMessage(hasValidConfig: false, reason: 'reset'),
+    );
+    await _pumpAsyncWork(tester);
+
+    expect(_modelBannerFinder(), findsOneWidget);
+  });
+
+  testWidgets('banner rechecks persisted LLM config state on app resume', (
+    tester,
+  ) async {
+    await _pumpBanner(tester);
+
+    expect(_modelBannerFinder(), findsOneWidget);
+
+    await UserStorage.saveLLMConfigs(const [_validLocalModelConfig]);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await _pumpAsyncWork(tester);
+
+    expect(_modelBannerFinder(), findsNothing);
+
+    await UserStorage.resetLLMConfigs();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await _pumpAsyncWork(tester);
+
+    expect(_modelBannerFinder(), findsOneWidget);
+  });
+
+  testWidgets('banner rechecks after configure flow returns', (tester) async {
+    var openedConfig = false;
+    await _pumpBanner(
+      tester,
+      onConfigureTap: () async {
+        openedConfig = true;
+        await UserStorage.saveLLMConfigs(const [_validLocalModelConfig]);
+      },
+    );
+
+    expect(_modelBannerFinder(), findsOneWidget);
+
+    await tester.tap(_modelBannerFinder());
+    await _pumpAsyncWork(tester);
+
+    expect(openedConfig, isTrue);
+    expect(_modelBannerFinder(), findsNothing);
+  });
+}
+
+Finder _modelBannerFinder() {
+  return find.text(UserStorage.l10n.modelNotConfiguredBanner);
+}
+
+Future<void> _pumpBanner(
+  WidgetTester tester, {
+  Future<void> Function()? onConfigureTap,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: TimelineModelConfigBanner(
+          onConfigureTap: onConfigureTap ?? () async {},
+        ),
+      ),
+    ),
+  );
+  await _pumpAsyncWork(tester);
+}
+
+Future<void> _pumpAsyncWork(WidgetTester tester) async {
+  for (var i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+const _validLocalModelConfig = LLMConfig(
+  key: 'local-ollama',
+  type: LLMConfig.typeOllama,
+  modelId: 'llama3',
+  apiKey: '',
+  baseUrl: 'http://127.0.0.1:11434',
+);


### PR DESCRIPTION
## 关联 issue

Closes #289

## 变更

- 新增 `LLMConfigChangedMessage`，在保存、重置、切换默认模型配置时通过事件总线通知 UI。
- 抽出 `TimelineModelConfigBanner`，监听模型配置事件、app resume 和配置页返回，避免 banner 状态过期。
- 增加 MemexRouter 事件单测与 Timeline banner widget 测试。

## 测试

- `flutter test --no-pub test/data/repositories/memex_router_llm_config_event_test.dart test/ui/timeline/widgets/timeline_model_config_banner_test.dart`
- `flutter analyze --no-pub lib/data/repositories/memex_router.dart lib/domain/models/event_bus_message.dart lib/ui/timeline/widgets/timeline_screen.dart lib/ui/timeline/widgets/timeline_model_config_banner.dart test/data/repositories/memex_router_llm_config_event_test.dart test/ui/timeline/widgets/timeline_model_config_banner_test.dart`（仅命中既有 info-level lint，无 error/warning）
- `flutter build apk --debug --flavor globalDev --no-pub`
- `git diff --check`
- Android emulator `Medium_Phone_API_35`：启动 Timeline 确认首屏正常且没有错误的未配置 banner；进入个人中心模型设置再返回 Timeline，banner 状态保持正确；logcat 无相关 fatal/exception。
