### PR TITLE
Show non-standard PKM root items

### DIFF
--- a/lib/l10n/app_localizations_ext_de.dart
+++ b/lib/l10n/app_localizations_ext_de.dart
@@ -106,7 +106,7 @@ class AppLocalizationsExtDe extends AppLocalizationsDe
   String get pkmPARAStructureExample =>
       '''## P.A.R.A. Wissensdatenbank Strukturbeispiel (Flexibel organisiert nach tatsächlichen Nutzereingaben):
 │
-├── Projects (Projekte)
+├── Projects
 │   ├── 2025 Sanya Frühlingsfest Reise/      <-- Beinhaltet Reiseplan, Flüge, Hotels, nutze einen Ordner
 │   │   ├── Reiseplan und Zeitplan.md
 │   │   └── Flug- und Hotelbestätigungen.md
@@ -116,7 +116,7 @@ class AppLocalizationsExtDe extends AppLocalizationsDe
 │   ├── Führerschein Klasse B machen.md      <-- Einzelnes Ziel, eine Datei reicht
 │   └── Dezember Arbeitsbericht Vorbereitung.md
 │
-├── Areas (Verantwortungsbereiche)
+├── Areas
 │   ├── Gesundheit und Medizin/
 │   │   ├── Familien Check-up Berichte.md
 │   │   └── Fitness Logbuch und Gewichtsaufzeichnungen.md  <-- Gut zum Anfügen
@@ -128,7 +128,7 @@ class AppLocalizationsExtDe extends AppLocalizationsDe
 │   └── Karriereentwicklung/
 │       └── Pflege des Lebenslaufs.md      <-- Wird über die Zeit kontinuierlich aktualisiert
 │
-├── Resources (Ressourcen)
+├── Resources
 │   ├── Kochen und Essen/
 │   │   ├── Diät-Rezepte.md
 │   │   └── Anleitungen für Haushaltsgeräte.md
@@ -140,7 +140,7 @@ class AppLocalizationsExtDe extends AppLocalizationsDe
 │   └── Tipps zur Hausorganisation/
 │       └── Aufräum- und Aufbewahrungsnotizen.md
 │
-└── Archives (Archive)
+└── Archives
     ├── [Abgeschlossen] Erstes Auto kaufen.md
     └── [Abgelaufen] Alte Mietvertragsdaten/
            ├── Mietvertrag.md

--- a/lib/ui/knowledge/view_models/knowledge_base_viewmodel.dart
+++ b/lib/ui/knowledge/view_models/knowledge_base_viewmodel.dart
@@ -3,6 +3,68 @@ import 'package:flutter/foundation.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/utils/result.dart';
 
+const List<String> pkmParaRootPaths = [
+  'Projects',
+  'Areas',
+  'Resources',
+  'Archives',
+];
+
+const Set<String> _pkmParaRootPathSet = {
+  'Projects',
+  'Areas',
+  'Resources',
+  'Archives',
+};
+
+List<Map<String, dynamic>> additionalRootFoldersFromListing(
+  Map<String, dynamic> rootListing,
+) {
+  final items = rootListing['items'] as List<dynamic>? ?? const [];
+  final folders = <Map<String, dynamic>>[];
+
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    if (item['is_directory'] != true) continue;
+
+    final path = (item['path'] ?? item['name'])?.toString().trim() ?? '';
+    if (path.isEmpty || _pkmParaRootPathSet.contains(path)) continue;
+
+    folders.add(Map<String, dynamic>.from(item)..['path'] = path);
+  }
+
+  folders.sort((a, b) {
+    final aName = (a['name'] ?? a['path'] ?? '').toString().toLowerCase();
+    final bName = (b['name'] ?? b['path'] ?? '').toString().toLowerCase();
+    return aName.compareTo(bName);
+  });
+  return folders;
+}
+
+List<Map<String, dynamic>> rootFilesFromListing(
+  Map<String, dynamic> rootListing,
+) {
+  final items = rootListing['items'] as List<dynamic>? ?? const [];
+  final files = <Map<String, dynamic>>[];
+
+  for (final item in items) {
+    if (item is! Map<String, dynamic>) continue;
+    if (item['is_directory'] == true) continue;
+
+    final path = (item['path'] ?? item['name'])?.toString().trim() ?? '';
+    if (path.isEmpty) continue;
+
+    files.add(Map<String, dynamic>.from(item)..['path'] = path);
+  }
+
+  files.sort((a, b) {
+    final aName = (a['name'] ?? a['path'] ?? '').toString().toLowerCase();
+    final bName = (b['name'] ?? b['path'] ?? '').toString().toLowerCase();
+    return aName.compareTo(bName);
+  });
+  return files;
+}
+
 /// ViewModel for the Knowledge base page. Holds recent files, category counts.
 class KnowledgeBaseViewModel extends ChangeNotifier {
   KnowledgeBaseViewModel({required MemexRouter router}) : _router = router;
@@ -11,6 +73,8 @@ class KnowledgeBaseViewModel extends ChangeNotifier {
 
   bool isLoading = false;
   List<Map<String, dynamic>> recentFiles = [];
+  List<Map<String, dynamic>> additionalRootFolders = [];
+  List<Map<String, dynamic>> rootLevelFiles = [];
   Map<String, int> categoryCounts = {};
 
   int countItems(String category) => categoryCounts[category] ?? 0;
@@ -19,11 +83,24 @@ class KnowledgeBaseViewModel extends ChangeNotifier {
     isLoading = true;
     notifyListeners();
     final listResult = await _router.listPkmDirectory();
-    listResult.when(onOk: (_) {}, onError: (_, __) {});
-    final countResult = await _router
-        .countPkmItems(['Projects', 'Areas', 'Resources', 'Archives']);
+    final rootListing = listResult.when(
+      onOk: (data) => data,
+      onError: (_, __) => <String, dynamic>{},
+    );
+    additionalRootFolders = additionalRootFoldersFromListing(rootListing);
+    rootLevelFiles = rootFilesFromListing(rootListing);
+
+    final countPaths = [
+      ...pkmParaRootPaths,
+      ...additionalRootFolders.map((folder) => folder['path'] as String),
+    ];
+    final countResult = await _router.countPkmItems(countPaths);
     categoryCounts =
         countResult.when(onOk: (c) => c, onError: (_, __) => <String, int>{});
+    for (final folder in additionalRootFolders) {
+      final path = folder['path'] as String;
+      folder['item_count'] = categoryCounts[path] ?? 0;
+    }
     final recentResult = await _router.getRecentPkmFiles();
     recentFiles = recentResult.when(
         onOk: (r) => r, onError: (_, __) => <Map<String, dynamic>>[]);

--- a/lib/ui/knowledge/widgets/knowledge_base_screen.dart
+++ b/lib/ui/knowledge/widgets/knowledge_base_screen.dart
@@ -77,7 +77,7 @@ class KnowledgeBaseScreenState extends State<KnowledgeBaseScreen> {
                     physics: const AlwaysScrollableScrollPhysics(),
                     child: SizedBox(
                       height: MediaQuery.of(context).size.height * 0.6,
-                      child: Center(child: AgentLogoLoading()),
+                      child: const Center(child: AgentLogoLoading()),
                     ),
                   )
                 : SingleChildScrollView(
@@ -88,6 +88,11 @@ class KnowledgeBaseScreenState extends State<KnowledgeBaseScreen> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         _buildParaGrid(context, vm),
+                        if (vm.additionalRootFolders.isNotEmpty ||
+                            vm.rootLevelFiles.isNotEmpty) ...[
+                          const SizedBox(height: 16),
+                          _buildAdditionalRootItems(context, vm),
+                        ],
                         const SizedBox(height: 32),
                         _buildRecentChangesHeader(),
                         const SizedBox(height: 16),
@@ -169,7 +174,7 @@ class KnowledgeBaseScreenState extends State<KnowledgeBaseScreen> {
           borderRadius: BorderRadius.circular(28),
           boxShadow: [
             BoxShadow(
-                color: color.withOpacity(0.3),
+                color: color.withValues(alpha: 0.3),
                 blurRadius: 12,
                 offset: const Offset(0, 6)),
           ],
@@ -186,10 +191,10 @@ class KnowledgeBaseScreenState extends State<KnowledgeBaseScreen> {
                     Container(
                       padding: const EdgeInsets.all(10),
                       decoration: BoxDecoration(
-                        color: Colors.white.withOpacity(0.2),
+                        color: Colors.white.withValues(alpha: 0.2),
                         borderRadius: BorderRadius.circular(16),
-                        border:
-                            Border.all(color: Colors.white.withOpacity(0.1)),
+                        border: Border.all(
+                            color: Colors.white.withValues(alpha: 0.1)),
                       ),
                       child: Icon(icon, color: Colors.white, size: 24),
                     ),
@@ -198,7 +203,7 @@ class KnowledgeBaseScreenState extends State<KnowledgeBaseScreen> {
                         style: TextStyle(
                             fontSize: 10,
                             fontWeight: FontWeight.bold,
-                            color: Colors.white.withOpacity(0.6),
+                            color: Colors.white.withValues(alpha: 0.6),
                             letterSpacing: 1.5)),
                     const SizedBox(height: 4),
                     Text(title,
@@ -214,13 +219,13 @@ class KnowledgeBaseScreenState extends State<KnowledgeBaseScreen> {
                             child: Text(desc,
                                 style: TextStyle(
                                     fontSize: 11,
-                                    color: Colors.white.withOpacity(0.9)),
+                                    color: Colors.white.withValues(alpha: 0.9)),
                                 overflow: TextOverflow.ellipsis)),
                         Container(
                           padding: const EdgeInsets.symmetric(
                               horizontal: 6, vertical: 2),
                           decoration: BoxDecoration(
-                            color: Colors.black.withOpacity(0.2),
+                            color: Colors.black.withValues(alpha: 0.2),
                             borderRadius: BorderRadius.circular(6),
                           ),
                           child: Text('$count',
@@ -236,6 +241,91 @@ class KnowledgeBaseScreenState extends State<KnowledgeBaseScreen> {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAdditionalRootItems(
+    BuildContext context,
+    KnowledgeBaseViewModel vm,
+  ) {
+    return Column(
+      children: [
+        ...vm.additionalRootFolders
+            .map((folder) => _buildRootFolderCard(context, folder)),
+        ...vm.rootLevelFiles.map((file) => KnowledgeFileCard(item: file)),
+      ],
+    );
+  }
+
+  Widget _buildRootFolderCard(
+    BuildContext context,
+    Map<String, dynamic> item,
+  ) {
+    final name = (item['name'] ?? item['path'] ?? '').toString();
+    final path = (item['path'] ?? name).toString();
+    final count = item['item_count'] ?? 0;
+
+    return GestureDetector(
+      onTap: () => _navigateToFolder(context, path: path),
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.all(18),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          boxShadow: [
+            BoxShadow(
+              color: const Color(0xFF64748B).withValues(alpha: 0.05),
+              blurRadius: 10,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                color: const Color(0xFFEFF6FF),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: const Icon(
+                Icons.folder_rounded,
+                color: Color(0xFF3B82F6),
+                size: 24,
+              ),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    name,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: Color(0xFF1E293B),
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '$count items',
+                    style: const TextStyle(
+                      fontSize: 13,
+                      color: Color(0xFF94A3B8),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.chevron_right, color: Color(0xFFCBD5E1)),
+          ],
         ),
       ),
     );
@@ -282,7 +372,7 @@ class KnowledgeBaseScreenState extends State<KnowledgeBaseScreen> {
         padding: const EdgeInsets.symmetric(vertical: 20),
         alignment: Alignment.center,
         child: Text(UserStorage.l10n.noRecentChangesInThreeDays,
-            style: TextStyle(color: Color(0xFFCBD5E1), fontSize: 13)),
+            style: const TextStyle(color: Color(0xFFCBD5E1), fontSize: 13)),
       );
     }
 

--- a/test/ui/knowledge/knowledge_base_screen_test.dart
+++ b/test/ui/knowledge/knowledge_base_screen_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/ui/knowledge/view_models/knowledge_base_viewmodel.dart';
+import 'package:memex/ui/knowledge/widgets/knowledge_base_screen.dart';
+import 'package:memex/utils/user_storage.dart';
+
+void main() {
+  setUpAll(() async {
+    await UserStorage.initL10n();
+  });
+
+  test('root listing helpers keep non-PARA folders and root files', () {
+    final folders = additionalRootFoldersFromListing({
+      'items': [
+        {
+          'name': 'Projects',
+          'path': 'Projects',
+          'is_directory': true,
+        },
+        {
+          'name': 'Projects (Projekte)',
+          'path': 'Projects (Projekte)',
+          'is_directory': true,
+        },
+        {
+          'name': 'Inbox',
+          'path': 'Inbox',
+          'is_directory': true,
+        },
+        {
+          'name': 'Loose note.md',
+          'path': 'Loose note.md',
+          'is_directory': false,
+        },
+      ],
+    });
+
+    expect(
+      folders.map((folder) => folder['path']),
+      ['Inbox', 'Projects (Projekte)'],
+    );
+
+    final files = rootFilesFromListing({
+      'items': [
+        {
+          'name': 'Projects',
+          'path': 'Projects',
+          'is_directory': true,
+        },
+        {
+          'name': 'Loose note.md',
+          'path': 'Loose note.md',
+          'is_directory': false,
+        },
+      ],
+    });
+
+    expect(
+      files.map((file) => file['path']),
+      ['Loose note.md'],
+    );
+  });
+
+  testWidgets(
+      'renders additional root folders and files below fixed PARA cards',
+      (tester) async {
+    final viewModel = KnowledgeBaseViewModel(router: MemexRouter())
+      ..categoryCounts = {
+        'Projects': 0,
+        'Areas': 0,
+        'Resources': 0,
+        'Archives': 0,
+        'Projects (Projekte)': 2,
+      }
+      ..additionalRootFolders = [
+        {
+          'name': 'Projects (Projekte)',
+          'path': 'Projects (Projekte)',
+          'is_directory': true,
+          'item_count': 2,
+        },
+      ]
+      ..rootLevelFiles = [
+        {
+          'name': 'Loose note.md',
+          'path': 'Loose note.md',
+          'is_directory': false,
+          'is_ai_generated': false,
+        },
+      ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: KnowledgeBaseScreen(viewModel: viewModel),
+      ),
+    );
+
+    expect(find.text('PROJECTS'), findsOneWidget);
+    expect(find.text('Projects (Projekte)'), findsOneWidget);
+    expect(find.text('2 items'), findsOneWidget);
+    expect(find.text('Loose note.md'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- keep German PKM structure examples on the canonical Projects/Areas/Resources/Archives root folder names
- show non-standard PKM root folders on the Knowledge Base page while keeping the four PARA cards always present
- show root-level PKM files on the Knowledge Base page and keep extra folders/files covered by tests

## Tests
- dart analyze lib/ui/knowledge/view_models/knowledge_base_viewmodel.dart lib/ui/knowledge/widgets/knowledge_base_screen.dart lib/l10n/app_localizations_ext_de.dart test/ui/knowledge/knowledge_base_screen_test.dart
- flutter test test/ui/knowledge/knowledge_base_screen_test.dart -r expanded
- git diff --check