### PR TITLE
fix: security and side-effect violations (health, mint approval, templates, card emit)

### DIFF
--- a/lib/agent/common_tools.dart
+++ b/lib/agent/common_tools.dart
@@ -1,4 +1,5 @@
 import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:memex/agent/run_mode/agent_action_approval_service.dart';
 import 'package:memex/utils/date_util.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/utils/logger.dart';
@@ -51,6 +52,13 @@ final mintRecordFactIdTool = Tool(
       throw StateError(
           "mint_record_fact_id must be called within an agent execution context.");
     }
+
+    final denied = await gateMutatingToolCall(
+      toolName: 'mint_record_fact_id',
+      summary: 'Reserve a new card id (processing placeholder)',
+    );
+    if (denied != null) return denied;
+
     final userId = context.state.metadata['userId'] as String;
     final factId = await FileSystemService.instance.allocateCardFactId(userId);
     getLogger('CommonTools').info('Minted fact_id: $factId');

--- a/lib/agent/skills/manage_timeline_card/timeline_templates.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_templates.dart
@@ -387,10 +387,12 @@ void validateUiConfig(
         'ui_configs entry for template "$templateId": "data" must be an object (Map).');
   }
   final dataMap = Map<String, dynamic>.from(data);
-  if (customFields != null) {
-    validateCustomTemplateData(templateId, dataMap, customFields);
-  } else {
+  // Built-in template IDs always use native validators, even when a custom
+  // template metadata entry reuses the same template_id.
+  if (allowedTemplateIds.contains(templateId)) {
     validateTemplateData(templateId, dataMap);
+  } else if (customFields != null) {
+    validateCustomTemplateData(templateId, dataMap, customFields);
   }
 }
 

--- a/lib/data/repositories/health.dart
+++ b/lib/data/repositories/health.dart
@@ -41,16 +41,31 @@ Future<bool> reportDailyHealthSummaryEndpoint(
           continue;
         }
 
+        final yamlData = {
+          'health': healthData,
+          'health_updated_at': DateTime.now().toIso8601String(),
+        };
+
+        await _fileSystemService.updateDailyFactYamlData(
+          userId,
+          parsedDate,
+          yamlData,
+        );
+
         // Log event
         try {
+          final monthStr = month.toString().padLeft(2, '0');
+          final dayStr = day.toString().padLeft(2, '0');
+          final factPath = 'Facts/$year/$monthStr/$dayStr.md';
+
           await _fileSystemService.eventLogService.logEvent(
             userId: userId,
             eventType: 'health_data_update',
             description: 'Updated comprehensive health summary',
+            filePath: factPath,
             metadata: {
               'date': dateStr,
               'keys_updated': healthData.keys.toList(),
-              'health': healthData,
             },
           );
         } catch (e) {
@@ -66,6 +81,9 @@ Future<bool> reportDailyHealthSummaryEndpoint(
     }
 
     _logger.info('Reported health for ${updatedDates.length} days');
+    if (dailySummary.isNotEmpty && updatedDates.isEmpty) {
+      return false;
+    }
     return true;
   } catch (e) {
     _logger.severe('Failed to report daily health summary locally: $e');

--- a/lib/data/repositories/update_card_ui_config.dart
+++ b/lib/data/repositories/update_card_ui_config.dart
@@ -62,11 +62,6 @@ Future<bool> updateCardUiConfigEndpoint(
     }
 
     _logger.info('Updated ui_config at index $configIndex for $cardId');
-    await emitTimelineCardUpdated(
-      userId: userId,
-      cardId: cardId,
-      cardData: updatedCardData,
-    );
     await _publishCardUiConfigUpdated(
       userId: userId,
       cardId: cardId,
@@ -84,6 +79,15 @@ Future<bool> updateCardUiConfigEndpoint(
       previousData: previousData,
       updatedData: updatedData,
     );
+    try {
+      await emitTimelineCardUpdated(
+        userId: userId,
+        cardId: cardId,
+        cardData: updatedCardData,
+      );
+    } catch (e, st) {
+      _logger.warning('Failed to emit timeline card updated event', e, st);
+    }
     return true;
   } catch (e) {
     _logger.severe('Failed to update card ui config for $cardId: $e');

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -1656,6 +1656,82 @@ class FileSystemService {
     return DateTime(year, month, day);
   }
 
+  /// Daily fact file path (`Facts/YYYY/MM/DD.md`).
+  String getDailyFactPath(String userId, DateTime date) {
+    final factsPath = getFactsPath(userId);
+    final year = date.year.toString();
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+
+    return path.join(factsPath, year, month, '$day.md');
+  }
+
+  /// Read daily fact file and parse YAML frontmatter.
+  Future<({Map<String, dynamic>? yamlData, String bodyContent})>
+      readDailyFactFile(String userId, DateTime date) async {
+    final filePath = getDailyFactPath(userId, date);
+
+    if (!await _baseService.exists(filePath)) {
+      return (yamlData: null, bodyContent: '');
+    }
+
+    try {
+      final content = await _baseService.readFile(filePath);
+
+      final yamlPattern =
+          RegExp(r'^---\s*\n(.*?)\n---\s*\n(.*)$', dotAll: true);
+      final match = yamlPattern.firstMatch(content);
+
+      if (match != null) {
+        final yamlStr = match.group(1)!;
+        final bodyContent = match.group(2)!;
+
+        try {
+          final yamlData = _parseYaml(yamlStr);
+          return (
+            yamlData: yamlData.isEmpty ? null : yamlData,
+            bodyContent: bodyContent,
+          );
+        } catch (e) {
+          _logger.warning('Failed to parse yaml frontmatter: $e');
+          return (yamlData: null, bodyContent: content);
+        }
+      } else {
+        return (yamlData: null, bodyContent: content);
+      }
+    } catch (e) {
+      _logger.severe('Failed to read fact file: $e');
+      return (yamlData: null, bodyContent: '');
+    }
+  }
+
+  /// Merge [data] into the daily fact YAML frontmatter under `Facts/`.
+  Future<void> updateDailyFactYamlData(
+    String userId,
+    DateTime date,
+    Map<String, dynamic> data,
+  ) async {
+    final filePath = getDailyFactPath(userId, date);
+    final parentDir = path.dirname(filePath);
+
+    await ensureDirectory(parentDir);
+
+    final result = await readDailyFactFile(userId, date);
+    var yamlData = result.yamlData ?? <String, dynamic>{};
+    yamlData.addAll(data);
+
+    final yamlStr = _mapToYaml(yamlData);
+    final yamlContent = yamlStr.endsWith('\n') ? yamlStr : '$yamlStr\n';
+
+    final bodyContent = result.bodyContent;
+    final newContent = bodyContent.isNotEmpty
+        ? '---\n$yamlContent---\n$bodyContent'
+        : '---\n$yamlContent---\n';
+
+    await _baseService.writeFile(filePath, newContent);
+    _logger.info('Updated yaml frontmatter in fact file: $filePath');
+  }
+
   /// GetPKMdirectory path
   String getPkmPath(String userId) {
     return path.join(getWorkspacePath(userId), 'PKM');

--- a/test/agent/common_tools_mint_approval_test.dart
+++ b/test/agent/common_tools_mint_approval_test.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/run_mode/agent_action_approval_service.dart';
+import 'package:memex/agent/run_mode/agent_run_mode.dart';
+
+void main() {
+  test('gateMutatingToolCall denies mutating tools in confirm mode', () async {
+    final state = AgentState(
+      sessionId: 'session-1',
+      metadata: {
+        AgentRunMode.metadataKey: AgentRunMode.confirm.wireName,
+        'chat_session_id': 'session-1',
+      },
+    );
+
+    final denied = await runZoned(
+      () => gateMutatingToolCall(
+        toolName: 'mint_record_fact_id',
+        summary: 'Reserve a new card id (processing placeholder)',
+      ),
+      zoneValues: {
+        AgentCallToolContext.ZoneKey: AgentCallToolContext(
+          state: state,
+          agent: StatefulAgent(
+            name: 'test',
+            client: _NoOpClient(),
+            modelConfig: ModelConfig(model: 'test'),
+            state: state,
+            tools: const [],
+            withGeneralPrinciples: false,
+          ),
+          batchCallId: 'batch-1',
+          cancelToken: CancelToken(),
+        ),
+      },
+    );
+
+    expect(denied, isNotNull);
+    final textPart = denied!.content as TextPart;
+    expect(textPart.text, contains('declined'));
+  });
+}
+
+class _NoOpClient extends LLMClient {
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) {
+    throw UnsupportedError('not used');
+  }
+
+  @override
+  Future<Stream<StreamingMessage>> stream(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) {
+    throw UnsupportedError('not used');
+  }
+}

--- a/test/agent/skills/timeline_templates_validation_test.dart
+++ b/test/agent/skills/timeline_templates_validation_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/agent/skills/manage_timeline_card/timeline_templates.dart';
+import 'package:memex/data/services/file_system_service.dart';
+
+void main() {
+  test('native metric validator wins when custom metadata reuses template_id',
+      () {
+    const customFields = [
+      TimelineTemplateFieldMeta(
+        name: 'custom_only',
+        type: 'String',
+        required: true,
+        description: 'Custom-only field',
+      ),
+    ];
+
+    expect(
+      () => validateUiConfig(
+        {
+          'template_id': 'metric',
+          'data': {
+            'items': [
+              {'title': 'Sleep', 'value': 6.5},
+            ],
+          },
+        },
+        customTemplateFields: const {'metric': customFields},
+      ),
+      returnsNormally,
+    );
+  });
+
+  test('custom validator still applies to non-native template ids', () {
+    const customFields = [
+      TimelineTemplateFieldMeta(
+        name: 'score',
+        type: 'Number',
+        required: true,
+        description: 'Score',
+      ),
+    ];
+
+    expect(
+      () => validateUiConfig(
+        {
+          'template_id': 'my_custom_metric',
+          'data': {'score': 42},
+        },
+        customTemplateFields: const {'my_custom_metric': customFields},
+      ),
+      returnsNormally,
+    );
+
+    expect(
+      () => validateUiConfig(
+        {
+          'template_id': 'my_custom_metric',
+          'data': {},
+        },
+        customTemplateFields: const {'my_custom_metric': customFields},
+      ),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/data/repositories/health_endpoint_test.dart
+++ b/test/data/repositories/health_endpoint_test.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/health.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const userId = 'health_endpoint_user';
+  late Directory tempDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.saveUser(userId);
+    tempDir = await Directory.systemTemp.createTemp('memex_health_endpoint_');
+    await FileSystemService.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('persists health summary into daily fact yaml', () async {
+    final success = await reportDailyHealthSummaryEndpoint({
+      '2026-06-20': {
+        'steps': 8000,
+        'heart_rate_avg': 72,
+      },
+    });
+
+    expect(success, isTrue);
+
+    final result = await FileSystemService.instance.readDailyFactFile(
+      userId,
+      DateTime(2026, 6, 20),
+    );
+    expect(result.yamlData, isNotNull);
+    expect(result.yamlData!['health'], isA<Map>());
+    expect((result.yamlData!['health'] as Map)['steps'], 8000);
+    expect(result.yamlData!['health_updated_at'], isNotNull);
+  });
+
+  test('returns false when every date fails validation', () async {
+    final success = await reportDailyHealthSummaryEndpoint({
+      'not-a-date': {'steps': 1},
+    });
+
+    expect(success, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

- **Health:** Persist daily health summaries to `Facts/YYYY/MM/DD.md` YAML frontmatter again; event logs only record `date` + `keys_updated` (no raw health payload). Returns `false` when all dates fail.
- **Mint tool:** `mint_record_fact_id` now calls `gateMutatingToolCall` before writing the processing placeholder, respecting ask-first mode.
- **Templates:** Built-in `template_id` values always use native validators, even when custom template metadata reuses the same id.
- **Card UI config:** `_publishCardUiConfigUpdated` and stats logging run before `emitTimelineCardUpdated`; render/emit failures are caught and logged without skipping earlier side effects.
- Restored `getDailyFactPath` / `readDailyFactFile` / `updateDailyFactYamlData` on upstream (removed during Super Agent refactor but still required for health sync).

## Test plan

- [x] `flutter test test/data/repositories/health_endpoint_test.dart`
- [x] `flutter test test/agent/skills/timeline_templates_validation_test.dart`
- [x] `flutter test test/agent/common_tools_mint_approval_test.dart`
- [x] `flutter test test/data/repositories/update_card_ui_config_test.dart`
- [ ] Manual: health sync writes to daily fact file on device
- [ ] Manual: mint_record_fact_id shows approval card in confirm mode


Made with [Cursor](https://cursor.com)