### PR TITLE
fix: drive agent activity affordance from task state

### DIFF
--- a/lib/ui/agent_activity/widgets/agent_activity_widget.dart
+++ b/lib/ui/agent_activity/widgets/agent_activity_widget.dart
@@ -41,23 +41,14 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
   StreamSubscription<AgentRunSnapshot?>? _runSubscription;
   StreamSubscription<void>? _openActivitySubscription;
   Timer? _historyLoadTimer;
+  Timer? _initRetryTimer;
   TaskActivitySnapshot _taskSnapshot = const TaskActivitySnapshot.empty();
   AgentRunSnapshot? _runSnapshot;
 
   late AnimationController _bounceController;
 
-  bool get _hasRunningAgent {
-    if (_latestMessage == null) return false;
-    final t = _latestMessage!.type;
-    return t != AgentActivityType.agent_stop && t != AgentActivityType.error;
-  }
-
   bool get _isActive {
-    final status = _status;
-    return widget.forceVisible ||
-        _hasRunningAgent ||
-        _taskSnapshot.hasActiveTasks ||
-        status.shouldShowSystemSurface;
+    return widget.forceVisible || _taskSnapshot.hasActiveTasks;
   }
 
   AgentBackgroundStatus get _status => AgentBackgroundStatus.fromActivity(
@@ -84,11 +75,16 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
           .listen((_) => _showDetail());
       _subscribeToService();
     } catch (_) {
-      _historyLoadTimer = Timer(const Duration(seconds: 3), () {
-        if (mounted) _initService();
-      });
+      _scheduleInitRetry();
       return;
     }
+  }
+
+  void _scheduleInitRetry() {
+    _initRetryTimer?.cancel();
+    _initRetryTimer = Timer(const Duration(seconds: 1), () {
+      if (mounted) _initService();
+    });
   }
 
   void _initService() {
@@ -99,41 +95,74 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
           .instance.openActivityRequests
           .listen((_) => _showDetail());
       _subscribeToService();
-    } catch (_) {}
+    } catch (_) {
+      _scheduleInitRetry();
+    }
   }
 
   void _subscribeToService() {
-    _subscription = _service?.messageStream.listen((message) {
+    _initRetryTimer?.cancel();
+    _initRetryTimer = null;
+    var needsRetry = false;
+
+    _subscription ??= _service?.messageStream.listen((message) {
       if (mounted) setState(() => _latestMessage = message);
     });
 
     try {
       final taskStream = widget.taskActivitySnapshotStream ??
           _executor?.taskActivitySnapshotStream;
-      _taskSubscription = taskStream?.listen((snapshot) {
+      _taskSubscription ??= taskStream?.listen((snapshot) {
         if (mounted) {
           setState(() => _taskSnapshot = snapshot);
         }
       });
-    } catch (_) {}
+    } catch (_) {
+      needsRetry = true;
+    }
 
     try {
       final runStream = widget.runSnapshotStream ??
           AgentRunService.instance.watchLatestVisibleRun();
-      _runSubscription = runStream.listen((snapshot) {
+      _runSubscription ??= runStream.listen((snapshot) {
         if (mounted) {
           setState(() => _runSnapshot = snapshot);
         }
       });
-    } catch (_) {}
+    } catch (_) {
+      needsRetry = true;
+    }
 
-    _historyLoadTimer = Timer(const Duration(seconds: 3), () {
+    _historyLoadTimer ??= Timer(const Duration(seconds: 3), () {
       if (mounted) _loadLatestFromDb();
     });
+    unawaited(_loadCurrentState());
+    if (needsRetry) _scheduleInitRetry();
+  }
+
+  Future<void> _loadCurrentState() async {
+    try {
+      if (widget.taskActivitySnapshotStream == null && _executor != null) {
+        final snapshot = await _executor!.getTaskActivitySnapshot();
+        if (mounted) {
+          setState(() => _taskSnapshot = snapshot);
+        }
+      }
+    } catch (_) {}
+
+    try {
+      if (widget.runSnapshotStream == null) {
+        final snapshot = await AgentRunService.instance.getLatestVisibleRun();
+        if (mounted) {
+          setState(() => _runSnapshot = snapshot);
+        }
+      }
+    } catch (_) {}
   }
 
   Future<void> _loadLatestFromDb() async {
     try {
+      if (!_taskSnapshot.hasActiveTasks) return;
       final history = await _service?.getHistory(limit: 1) ?? [];
       if (history.isNotEmpty && mounted) {
         setState(() => _latestMessage = history.first);
@@ -148,6 +177,7 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
     _runSubscription?.cancel();
     _openActivitySubscription?.cancel();
     _historyLoadTimer?.cancel();
+    _initRetryTimer?.cancel();
     _bounceController.dispose();
     super.dispose();
   }
@@ -315,6 +345,7 @@ class _DetailSheetState extends State<_DetailSheet>
           AgentRunService.instance.watchLatestVisibleRun();
       _runSubscription = runStream.listen(_handleRunSnapshot);
     } catch (_) {}
+    unawaited(_loadCurrentState());
   }
 
   Future<void> _loadHistory() async {
@@ -324,6 +355,26 @@ class _DetailSheetState extends State<_DetailSheet>
         setState(() => _message = history.first);
       }
     }
+  }
+
+  Future<void> _loadCurrentState() async {
+    try {
+      if (widget.taskActivitySnapshotStream == null && _executor != null) {
+        final snapshot = await _executor!.getTaskActivitySnapshot();
+        if (mounted) {
+          setState(() => _taskSnapshot = snapshot);
+        }
+      }
+    } catch (_) {}
+
+    try {
+      if (widget.runSnapshotStream == null) {
+        final snapshot = await AgentRunService.instance.getLatestVisibleRun();
+        if (mounted) {
+          setState(() => _runSnapshot = snapshot);
+        }
+      }
+    } catch (_) {}
   }
 
   void _handleNewMessage(AgentActivityMessageModel newMessage) {

--- a/test/ui/agent_activity/agent_activity_widget_test.dart
+++ b/test/ui/agent_activity/agent_activity_widget_test.dart
@@ -153,7 +153,7 @@ void main() {
     await tester.pump();
   });
 
-  testWidgets('shows durable run status after returning from notification', (
+  testWidgets('shows active task status after returning from notification', (
     tester,
   ) async {
     final run = AgentRunSnapshot(
@@ -171,7 +171,16 @@ void main() {
       updatedAt: DateTime(2026, 1, 1),
     );
 
-    await tester.pumpWidget(buildHost(initialRunSnapshot: run));
+    await tester.pumpWidget(
+      buildHost(
+        initialTaskSnapshot: const TaskActivitySnapshot(
+          pending: 4,
+          processing: 0,
+          retrying: 0,
+        ),
+        initialRunSnapshot: run,
+      ),
+    );
     await tester.pump(const Duration(milliseconds: 350));
 
     expect(find.text('AI is processing...'), findsOneWidget);
@@ -187,6 +196,77 @@ void main() {
     await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
+  });
+
+  testWidgets('does not show stale non-terminal history without active work', (
+    tester,
+  ) async {
+    final activity = _FakeActivityService(history: [
+      _activityMessage(
+        id: 1,
+        type: AgentActivityType.info,
+        title: 'Old activity',
+        content: 'This should not reopen the processing affordance.',
+      ),
+    ]);
+    AgentActivityService.setInstance(activity);
+
+    await tester.pumpWidget(buildHost());
+    await tester.pump(const Duration(seconds: 4));
+
+    expect(find.text('AI is processing...'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    activity.dispose();
+  });
+
+  testWidgets('shows and hides from active task snapshots only', (
+    tester,
+  ) async {
+    final activity = _FakeActivityService();
+    AgentActivityService.setInstance(activity);
+    final taskSnapshots = StreamController<TaskActivitySnapshot>.broadcast();
+
+    await tester.pumpWidget(
+      buildHost(
+        taskActivitySnapshotStream: taskSnapshots.stream,
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(find.text('AI is processing...'), findsNothing);
+
+    await activity.pushMessage(
+      type: AgentActivityType.info,
+      title: 'Still working',
+      content: 'A non-terminal activity update.',
+      agentName: 'Worker Agent',
+      agentId: 'worker-agent',
+      userId: 'agent-activity-test',
+    );
+    await tester.pump();
+
+    expect(find.text('AI is processing...'), findsNothing);
+
+    taskSnapshots.add(
+      const TaskActivitySnapshot(pending: 1, processing: 0, retrying: 0),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(find.text('AI is processing...'), findsOneWidget);
+
+    taskSnapshots.add(const TaskActivitySnapshot.empty());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(find.text('AI is processing...'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    await taskSnapshots.close();
+    activity.dispose();
   });
 
   testWidgets('opens detail sheet from a buffered notification action', (
@@ -265,6 +345,74 @@ void main() {
       platform.dispose();
     },
   );
+}
+
+AgentActivityMessageModel _activityMessage({
+  required int id,
+  required AgentActivityType type,
+  required String title,
+  String? content,
+}) {
+  return AgentActivityMessageModel(
+    id: id,
+    type: type,
+    title: title,
+    content: content,
+    agentName: 'Worker Agent',
+    agentId: 'worker-agent',
+    userId: 'agent-activity-test',
+    timestamp: DateTime(2026, 1, 1),
+  );
+}
+
+class _FakeActivityService implements AgentActivityService {
+  _FakeActivityService({List<AgentActivityMessageModel> history = const []})
+      : _history = List<AgentActivityMessageModel>.from(history);
+
+  final _controller = StreamController<AgentActivityMessageModel>.broadcast();
+  final List<AgentActivityMessageModel> _history;
+  var _nextId = 100;
+
+  @override
+  Stream<AgentActivityMessageModel> get messageStream => _controller.stream;
+
+  @override
+  Future<List<AgentActivityMessageModel>> getHistory({int limit = 10}) async {
+    return _history.take(limit).toList();
+  }
+
+  @override
+  Future<void> pushMessage({
+    required AgentActivityType type,
+    required String title,
+    String? content,
+    String? icon,
+    required String agentName,
+    required String agentId,
+    String? scene,
+    String? sceneId,
+    String? userId,
+  }) async {
+    final message = AgentActivityMessageModel(
+      id: _nextId++,
+      type: type,
+      title: title,
+      content: content,
+      icon: icon,
+      agentName: agentName,
+      agentId: agentId,
+      scene: scene,
+      sceneId: sceneId,
+      userId: userId,
+      timestamp: DateTime(2026, 1, 1),
+    );
+    _history.insert(0, message);
+    _controller.add(message);
+  }
+
+  void dispose() {
+    unawaited(_controller.close());
+  }
 }
 
 class _FakePlatform implements AgentBackgroundPlatform {


### PR DESCRIPTION
## Summary
- drive the foreground agent activity affordance from active task snapshots only
- hydrate task/run state on widget startup so existing active tasks show after app resume
- keep activity/run history for detail text without letting stale messages keep the affordance visible

## Tests
- dart analyze lib/ui/agent_activity/widgets/agent_activity_widget.dart test/ui/agent_activity/agent_activity_widget_test.dart
- flutter test test/ui/agent_activity/agent_activity_widget_test.dart -r compact