### PR TITLE
Fix shared image import routing

### DIFF
--- a/lib/ui/main_screen/widgets/share_intent_handler.dart
+++ b/lib/ui/main_screen/widgets/share_intent_handler.dart
@@ -116,17 +116,6 @@ class ShareIntentHandler {
         return;
       }
 
-      // Ensure model is configured before accepting shared content
-      final configs = await UserStorage.getLLMConfigs();
-      final hasValidConfig = configs.any((c) => c.isValid);
-      if (!hasValidConfig) {
-        ToastHelper.showErrorWithKey(
-          scaffoldMessengerKey,
-          UserStorage.l10n.modelNotConfiguredSubmitHint,
-        );
-        return;
-      }
-
       final trimmedText = media.content == null || media.content!.trim().isEmpty
           ? null
           : media.content!.trim();
@@ -165,6 +154,10 @@ class ShareIntentHandler {
   @visibleForTesting
   Future<void> handleSharedMediaForTesting(SharedMedia media) =>
       _handleSharedMedia(media);
+
+  @visibleForTesting
+  Future<void> handleExternalFilesForTesting(List<String> rawPaths) =>
+      _handleExternalFiles(rawPaths);
 
   void dispose() {
     _mediaSubscription?.cancel();
@@ -205,9 +198,30 @@ class ShareIntentHandler {
         .toList(growable: false);
     if (filePaths.isEmpty) return;
 
+    var hasNonImageFile = false;
+    for (final path in filePaths) {
+      if (!_looksLikeImageFile(path)) {
+        hasNonImageFile = true;
+        break;
+      }
+    }
+
     _isHandlingExternalFiles = true;
     try {
-      await onImportFilesShared(filePaths);
+      if (hasNonImageFile) {
+        await onImportFilesShared(filePaths);
+        return;
+      }
+
+      if (filePaths.isNotEmpty) {
+        onSharedDraft(
+          SharedDraft(
+            images: filePaths
+                .map((path) => XFile(path))
+                .toList(growable: false),
+          ),
+        );
+      }
     } catch (e, stackTrace) {
       logger.severe('Error handling external files: $e', e, stackTrace);
       ToastHelper.showErrorWithKey(scaffoldMessengerKey, e);
@@ -232,7 +246,7 @@ class ShareIntentHandler {
 
   List<String> _sharedImportFilePaths(List<SharedAttachment?> attachments) {
     final filePaths = <String>[];
-    var hasNonDraftAttachment = false;
+    var hasNonImageFile = false;
 
     for (final attachment in attachments) {
       if (attachment == null) continue;
@@ -245,12 +259,13 @@ class ShareIntentHandler {
       final isImageAttachment = attachment.type == SharedAttachmentType.image ||
           _looksLikeImageFile(normalizedPath);
       if (!isImageAttachment) {
-        hasNonDraftAttachment = true;
+        hasNonImageFile = true;
       }
+
       filePaths.add(normalizedPath);
     }
 
-    if (!hasNonDraftAttachment) return const [];
+    if (!hasNonImageFile) return const [];
     return filePaths.toSet().toList(growable: false);
   }
 

--- a/test/ui/main_screen/widgets/share_intent_handler_test.dart
+++ b/test/ui/main_screen/widgets/share_intent_handler_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logging/logging.dart';
-import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/ui/main_screen/widgets/share_intent_handler.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:share_handler/share_handler.dart';
@@ -72,8 +71,7 @@ void main() {
     expect(importedPaths, isEmpty);
   });
 
-  test('image-only shares still open a draft', () async {
-    await UserStorage.saveLLMConfigs(const [_validLocalModelConfig]);
+  test('image-only shares still open a draft without model config', () async {
     final importedPaths = <List<String>>[];
     final drafts = <SharedDraft>[];
     final handler = _handler(
@@ -98,6 +96,139 @@ void main() {
     expect(drafts.single.text, 'photo note');
     expect(drafts.single.images.single.path, '/tmp/photo.png');
   });
+
+  test('file attachments with image extensions still open a draft', () async {
+    final importedPaths = <List<String>>[];
+    final drafts = <SharedDraft>[];
+    final handler = _handler(
+      onSharedDraft: drafts.add,
+      onImportFilesShared: (paths) async => importedPaths.add(paths),
+    );
+
+    await handler.handleSharedMediaForTesting(
+      SharedMedia(
+        attachments: [
+          SharedAttachment(
+            path: '/tmp/photo.heic',
+            type: SharedAttachmentType.file,
+          ),
+        ],
+      ),
+    );
+
+    expect(importedPaths, isEmpty);
+    expect(drafts, hasLength(1));
+    expect(drafts.single.images.single.path, '/tmp/photo.heic');
+  });
+
+  test('generic non-image file shares route to import', () async {
+    final importedPaths = <List<String>>[];
+    final drafts = <SharedDraft>[];
+    final handler = _handler(
+      onSharedDraft: drafts.add,
+      onImportFilesShared: (paths) async => importedPaths.add(paths),
+    );
+
+    await handler.handleSharedMediaForTesting(
+      SharedMedia(
+        attachments: [
+          SharedAttachment(
+            path: '/tmp/shared_payload',
+            type: SharedAttachmentType.file,
+          ),
+        ],
+      ),
+    );
+
+    expect(importedPaths, [
+      ['/tmp/shared_payload'],
+    ]);
+    expect(drafts, isEmpty);
+  });
+
+  test('mixed file shares import all attachments', () async {
+    final importedPaths = <List<String>>[];
+    final drafts = <SharedDraft>[];
+    final handler = _handler(
+      onSharedDraft: drafts.add,
+      onImportFilesShared: (paths) async => importedPaths.add(paths),
+    );
+
+    await handler.handleSharedMediaForTesting(
+      SharedMedia(
+        attachments: [
+          SharedAttachment(
+            path: '/tmp/photo.png',
+            type: SharedAttachmentType.file,
+          ),
+          SharedAttachment(
+            path: '/tmp/archive.zip',
+            type: SharedAttachmentType.file,
+          ),
+        ],
+      ),
+    );
+
+    expect(importedPaths, [
+      ['/tmp/photo.png', '/tmp/archive.zip'],
+    ]);
+    expect(drafts, isEmpty);
+  });
+
+  test('external opened image files open a draft without model config',
+      () async {
+    final importedPaths = <List<String>>[];
+    final drafts = <SharedDraft>[];
+    final handler = _handler(
+      onSharedDraft: drafts.add,
+      onImportFilesShared: (paths) async => importedPaths.add(paths),
+    );
+
+    await handler.handleExternalFilesForTesting([
+      'file:///tmp/opened_photo.jpg',
+    ]);
+
+    expect(importedPaths, isEmpty);
+    expect(drafts, hasLength(1));
+    expect(drafts.single.images.single.path, '/tmp/opened_photo.jpg');
+  });
+
+  test('external opened non-image files route to import', () async {
+    final importedPaths = <List<String>>[];
+    final drafts = <SharedDraft>[];
+    final handler = _handler(
+      onSharedDraft: drafts.add,
+      onImportFilesShared: (paths) async => importedPaths.add(paths),
+    );
+
+    await handler.handleExternalFilesForTesting([
+      '/tmp/opened_document.pdf',
+    ]);
+
+    expect(importedPaths, [
+      ['/tmp/opened_document.pdf'],
+    ]);
+    expect(drafts, isEmpty);
+  });
+
+  test('external opened mixed files route all files to import', () async {
+    final importedPaths = <List<String>>[];
+    final drafts = <SharedDraft>[];
+    final handler = _handler(
+      onSharedDraft: drafts.add,
+      onImportFilesShared: (paths) async => importedPaths.add(paths),
+    );
+
+    await handler.handleExternalFilesForTesting([
+      '/tmp/opened_photo.jpg',
+      '/tmp/opened_document.pdf',
+    ]);
+
+    expect(importedPaths, [
+      ['/tmp/opened_photo.jpg', '/tmp/opened_document.pdf'],
+    ]);
+    expect(drafts, isEmpty);
+  });
 }
 
 ShareIntentHandler _handler({
@@ -113,11 +244,3 @@ ShareIntentHandler _handler({
     onImportFilesShared: onImportFilesShared ?? (_) async {},
   );
 }
-
-const _validLocalModelConfig = LLMConfig(
-  key: 'local-ollama',
-  type: LLMConfig.typeOllama,
-  modelId: 'llama3',
-  apiKey: '',
-  baseUrl: 'http://127.0.0.1:11434',
-);


### PR DESCRIPTION
## Summary
- route pure shared/opened image files to the Super Agent draft instead of file import
- keep non-image files routed to import, and route mixed image + non-image batches entirely to import
- remove model-config gating from shared image draft creation

## Tests
- flutter test test/ui/main_screen/widgets/share_intent_handler_test.dart -r expanded
- dart analyze lib/ui/main_screen/widgets/share_intent_handler.dart test/ui/main_screen/widgets/share_intent_handler_test.dart