### PR TITLE
Hide chat run mode selector

### DIFF
--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -350,6 +350,8 @@ class AgentChatDialog extends StatefulWidget {
 
 class _AgentChatDialogState extends State<AgentChatDialog>
     with SingleTickerProviderStateMixin {
+  static const bool _showRunModeSelector = false;
+
   final Logger _logger = getLogger('AgentChatDialog');
 
   // Services
@@ -1896,7 +1898,9 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                     Expanded(
                       child: Align(
                         alignment: Alignment.centerLeft,
-                        child: _buildRunModeChip(),
+                        child: _showRunModeSelector
+                            ? _buildRunModeChip()
+                            : const SizedBox.shrink(),
                       ),
                     ),
                     const SizedBox(width: 12),

--- a/test/ui/chat/widgets/agent_chat_dialog_test.dart
+++ b/test/ui/chat/widgets/agent_chat_dialog_test.dart
@@ -286,6 +286,10 @@ void main() {
       );
       expect(find.byIcon(Icons.open_in_full), findsOneWidget);
       expect(find.byTooltip(UserStorage.l10n.close), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('super_agent_run_mode_chip')),
+        findsNothing,
+      );
 
       final container = tester.widget<AnimatedContainer>(
         find.byKey(const ValueKey('agent_chat_dialog_container')),


### PR DESCRIPTION
## Summary
- hide the Super Agent chat dialog run mode selector from the input toolbar
- keep run mode state and backend execution logic unchanged
- add widget coverage that the selector chip is not rendered

## Tests
- flutter test test/ui/chat/widgets/agent_chat_dialog_test.dart -r expanded
- dart analyze lib/ui/chat/widgets/agent_chat_dialog.dart test/ui/chat/widgets/agent_chat_dialog_test.dart