### PR TITLE
Migrate agents to dart_agent_core hooks

### DIFF
--- a/lib/agent/agent_system_prompt_helper.dart
+++ b/lib/agent/agent_system_prompt_helper.dart
@@ -43,6 +43,18 @@ class AgentPromptConfig {
   final Map<String, ToolOverride> toolOverrides = {};
 }
 
+class AgentPromptHookResult {
+  final SystemMessage? systemMessage;
+  final List<Tool> tools;
+  final List<LLMMessage> requestMessages;
+
+  const AgentPromptHookResult({
+    required this.systemMessage,
+    required this.tools,
+    required this.requestMessages,
+  });
+}
+
 /// Extract content from lines[start] up to (but not including) the endTag line.
 /// Returns (content, nextLineIndex).
 (String, int) _extractBlock(List<String> lines, int start, String endTag) {
@@ -158,7 +170,7 @@ Future<AgentPromptConfig?> loadAgentPromptConfig(
   }
 }
 
-SystemCallbackResult applyPromptConfig(
+AgentPromptHookResult applyPromptConfig(
   AgentPromptConfig config,
   SystemMessage? systemMessage,
   List<Tool> tools,
@@ -198,61 +210,73 @@ SystemCallbackResult applyPromptConfig(
     }
   }
 
-  return SystemCallbackResult(
+  return AgentPromptHookResult(
     systemMessage: newSystemMessage,
     tools: newTools,
     requestMessages: newRequestMessages,
   );
 }
 
-/// Create a systemCallback to pass to StatefulAgent.
-/// user_id is captured by closure; agent_name is taken from agent.name at callback time.
+/// Create a prompt hook to pass to StatefulAgent.
+/// user_id is captured by closure; agent_name is taken from agent.name at hook time.
 ///
-/// Usage: StatefulAgent(..., systemCallback: createSystemCallback(userId))
-SystemCallback createSystemCallback(String userId) {
-  return (
-    StatefulAgent agent,
-    SystemMessage? systemMessage,
-    List<Tool> tools,
-    List<LLMMessage> requestMessages,
-  ) async {
-    final config = await loadAgentPromptConfig(userId, agent.name);
-    if (config == null) {
-      return SystemCallbackResult(
-        systemMessage: systemMessage,
-        tools: tools,
-        requestMessages: requestMessages,
-      );
-    }
-    return applyPromptConfig(config, systemMessage, tools, requestMessages);
-  };
+/// Usage: StatefulAgent(..., hooks: [createAgentPromptHook(userId)])
+AgentHook createAgentPromptHook(String userId) {
+  return _AgentPromptHook(userId: userId);
 }
 
-/// Create a systemCallback that also masks [workingDirectory] from all paths
+/// Create a prompt hook that also masks [workingDirectory] from all paths
 /// visible to the model (system prompt, skill instructions, RunJavaScript tool).
 ///
 /// This keeps the model's view consistent with file tools that already strip
 /// the workingDirectory prefix, so the model always sees virtual paths like
 /// `/skills/my_skill/SKILL.md` instead of real absolute paths.
 ///
-/// Usage: StatefulAgent(..., systemCallback: createSystemCallbackWithWorkingDirectory(userId, workingDirectory))
-SystemCallback createSystemCallbackWithWorkingDirectory(
+/// Usage: StatefulAgent(..., hooks: [createAgentPromptHookWithWorkingDirectory(userId, workingDirectory)])
+AgentHook createAgentPromptHookWithWorkingDirectory(
   String userId,
   String workingDirectory,
 ) {
-  // Ensure workingDirectory doesn't end with '/' for consistent replacement.
-  final wd = workingDirectory.endsWith('/')
-      ? workingDirectory.substring(0, workingDirectory.length - 1)
-      : workingDirectory;
+  return _AgentPromptHook(userId: userId, workingDirectory: workingDirectory);
+}
 
-  return (
-    StatefulAgent agent,
-    SystemMessage? systemMessage,
-    List<Tool> tools,
-    List<LLMMessage> requestMessages,
+class _AgentPromptHook extends AgentHook {
+  final String userId;
+  final String? workingDirectory;
+
+  _AgentPromptHook({required this.userId, this.workingDirectory});
+
+  @override
+  Future<ModelCallHookResult> beforeModelCall(
+    ModelCallHookContext context,
   ) async {
-    // 1. Apply user prompt config first (same as createSystemCallback).
-    final config = await loadAgentPromptConfig(userId, agent.name);
+    try {
+      final result = await _apply(context);
+      return ModelCallHookResult.proceed(
+        request: context.request.copyWith(
+          systemMessage: result.systemMessage,
+          clearSystemMessage: result.systemMessage == null,
+          tools: result.tools,
+          requestMessages: result.requestMessages,
+        ),
+      );
+    } catch (e, st) {
+      _logger.warning(
+        '[${context.agent.name}] agent prompt hook failed; using original model request.',
+        e,
+        st,
+      );
+      return ModelCallHookResult.proceed(request: context.request);
+    }
+  }
+
+  Future<AgentPromptHookResult> _apply(ModelCallHookContext context) async {
+    var systemMessage = context.request.systemMessage;
+    var tools = List<Tool>.from(context.request.tools);
+    var requestMessages =
+        List<LLMMessage>.from(context.request.requestMessages);
+
+    final config = await loadAgentPromptConfig(userId, context.agent.name);
     if (config != null) {
       final result = applyPromptConfig(
         config,
@@ -265,26 +289,40 @@ SystemCallback createSystemCallbackWithWorkingDirectory(
       requestMessages = result.requestMessages;
     }
 
-    // 2. Mask workingDirectory in system message (skill paths appear here).
+    final wd = workingDirectory;
+    if (wd == null) {
+      return AgentPromptHookResult(
+        systemMessage: systemMessage,
+        tools: tools,
+        requestMessages: requestMessages,
+      );
+    }
+
+    final normalizedWd = wd.endsWith('/') ? wd.substring(0, wd.length - 1) : wd;
+
+    // Skill paths appear in the system prompt.
     if (systemMessage != null) {
-      final masked = _maskWorkingDirectory(systemMessage.content, wd);
+      final masked = _maskWorkingDirectory(systemMessage.content, normalizedWd);
       if (masked != systemMessage.content) {
         systemMessage = SystemMessage(masked);
       }
     }
 
-    // 3. Mask workingDirectory in request messages (skill injection messages).
-    requestMessages = _maskMessagesWorkingDirectory(requestMessages, wd);
+    // Skill injection messages may contain absolute workspace paths.
+    requestMessages = _maskMessagesWorkingDirectory(
+      requestMessages,
+      normalizedWd,
+    );
 
-    // 4. Wrap RunJavaScript tool to resolve virtual paths back to absolute.
-    tools = _wrapRunJavaScriptTool(tools, wd);
+    // Resolve virtual paths back to absolute paths before executing JS tools.
+    tools = _wrapRunJavaScriptTool(tools, normalizedWd);
 
-    return SystemCallbackResult(
+    return AgentPromptHookResult(
       systemMessage: systemMessage,
       tools: tools,
       requestMessages: requestMessages,
     );
-  };
+  }
 }
 
 /// Replace `workingDirectory` prefix with `/` in a string, matching the

--- a/lib/agent/built_in_tools/file_tools.dart
+++ b/lib/agent/built_in_tools/file_tools.dart
@@ -115,15 +115,10 @@ class FileToolFactory {
   Tool buildViewImageTool() {
     return Tool(
       name: 'view_image',
-      description:
-          'View a local image file by attaching it to the next model message. '
+      description: 'View a local image file. '
           'Use this when you need to view an image that is not already in your '
           'context. Provide the image by its `fs://<filename>` reference (the '
-          'same form used in card media and in-text attachments). Images loaded '
-          'by this tool are visible for the next model call only and are not '
-          'kept in message history; if you need to compare multiple images, '
-          'call view_image for all of them in the same turn before inspecting '
-          'them.',
+          'same form used in card media and in-text attachments).',
       parameters: {
         'type': 'object',
         'properties': {
@@ -185,7 +180,7 @@ class FileToolFactory {
           message: message.toString(),
         );
 
-        return 'Image attached to the next model message (${_formatBytes(originalSize)}).'
+        return 'Image attached to the next message (${_formatBytes(originalSize)}).'
             '${exifInfo == null || exifInfo.isEmpty ? '' : ' EXIF metadata is included.'}';
       },
     );

--- a/lib/agent/comment_agent/comment_agent.dart
+++ b/lib/agent/comment_agent/comment_agent.dart
@@ -148,7 +148,7 @@ class CommentAgent {
       autoSaveStateFunc: (state) async {
         await saveAgentState(state);
       },
-      systemCallback: createSystemCallback(userId),
+      hooks: [createAgentPromptHook(userId)],
     );
 
     _logger.info(

--- a/lib/agent/companion_agent/companion_agent.dart
+++ b/lib/agent/companion_agent/companion_agent.dart
@@ -118,7 +118,7 @@ class CompanionAgent {
       withGeneralPrinciples: true,
       planMode: PlanMode.none,
       autoSaveStateFunc: (s) async => saveAgentState(s),
-      systemCallback: createSystemCallback(userId),
+      hooks: [createAgentPromptHook(userId)],
     );
   }
 

--- a/lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart
+++ b/lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart
@@ -78,8 +78,9 @@ class MemexSkillHostAgent {
       autoSaveStateFunc: (state) async {
         await saveAgentState(state);
       },
-      systemCallback:
-          createSystemCallbackWithWorkingDirectory(userId, workingDirectory),
+      hooks: [
+        createAgentPromptHookWithWorkingDirectory(userId, workingDirectory),
+      ],
     );
 
     _logger.info(

--- a/lib/agent/memory_agent/memory_agent.dart
+++ b/lib/agent/memory_agent/memory_agent.dart
@@ -90,7 +90,7 @@ If a batch contains only casual chat, tasks, or temporary context, **DO NOT call
       autoSaveStateFunc: (s) async {
         await saveAgentState(state);
       },
-      systemCallback: createSystemCallback(userId),
+      hooks: [createAgentPromptHook(userId)],
     );
 
     _logger.info('MemoryAgent running analysis on buffer...');

--- a/lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart
+++ b/lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart
@@ -82,8 +82,9 @@ class PureSkillHostAgent {
       autoSaveStateFunc: (state) async {
         await saveAgentState(state);
       },
-      systemCallback:
-          createSystemCallbackWithWorkingDirectory(userId, workingDirectory),
+      hooks: [
+        createAgentPromptHookWithWorkingDirectory(userId, workingDirectory),
+      ],
     );
 
     _logger.info(

--- a/lib/agent/skills/dynamic_timeline_ui/dynamic_timeline_ui_skill.dart
+++ b/lib/agent/skills/dynamic_timeline_ui/dynamic_timeline_ui_skill.dart
@@ -63,7 +63,7 @@ You are a template designer. Your job is to create or update reusable HTML templ
 - The template is display-only. If the user asks for actual system actions, use the appropriate action/tool skill instead of faking controls in HTML.
 - Before generating HTML, call `recommend_dynamic_timeline_design_patterns` or `get_dynamic_timeline_design_pattern` unless the user explicitly provides a complete design direction.
 - Treat design patterns as reference material, not rigid templates. Adapt the HTML to the user content and constraints.
-- After generating HTML and BEFORE calling `save_timeline_template`, call `preview_dynamic_timeline_card_render` to render the template exactly as the Timeline WebView card will show it. Use plausible sample text in placeholders before previewing if needed. The rendered image arrives as the next message and is provided ONLY ONCE this turn — inspect it in the same turn (layout, spacing, overflow, contrast, clipped/empty content) and decide right then whether to revise the HTML, re-preview, or save. Do not assume the image will still be visible on a later turn; if you need to look again, call `preview_dynamic_timeline_card_render` again. If the preview tool reports that rendering is unavailable, fall back to checking the HTML against the rules above.
+- After generating HTML and BEFORE calling `save_timeline_template`, call `preview_dynamic_timeline_card_render` to render the template exactly as the Timeline WebView card will show it. Use plausible sample text in placeholders before previewing if needed. The rendered image arrives as the next message, so inspect it for layout, spacing, overflow, contrast, and clipped/empty content before deciding whether to revise the HTML, re-preview, or save. If the preview tool reports that rendering is unavailable, fall back to checking the HTML against the rules above.
 - The outermost element must not set border-radius; Flutter applies the card radius. Inner elements may use rounded corners.
 - When updating an existing template_id, `save_timeline_template` overwrites the old template.
 
@@ -350,24 +350,21 @@ Finish by returning a concise result: what template was saved, template_id, use_
 
     // Do NOT return the image inside the tool result: OpenAI-compatible
     // providers reject images in a function-result message. Instead stash it in
-    // the per-session buffer; the SuperAgent systemCallback injects it as a
-    // UserMessage on the next LLM call (supported by every provider). The image
-    // is delivered exactly once — the model must inspect it this turn.
+    // the per-session buffer; the SuperAgent after-tool hook injects it as a
+    // UserMessage (supported by every provider).
     final sessionId = AgentCallToolContext.current?.state.sessionId ?? '';
     PendingToolImageBuffer.instance.add(
       sessionId,
       ImagePart(base64Png, 'image/png'),
       message: 'Rendered preview(s) of the dynamic timeline card HTML you '
-          'generated. Inspect now and decide this turn:',
+          'generated. Inspect the preview before deciding:',
     );
 
     return AgentToolResult(
       content: TextPart(
         '$summary The rendered image is attached as the next message — inspect '
         'it now for layout, spacing, overflow, contrast, and clipped/empty '
-        'content. The image is provided only once this turn, so decide within '
-        'this turn whether to revise the HTML, re-preview, or call '
-        'save_timeline_template.',
+        'content.',
       ),
     );
   }

--- a/lib/agent/super_agent/pending_tool_image_buffer.dart
+++ b/lib/agent/super_agent/pending_tool_image_buffer.dart
@@ -1,18 +1,16 @@
 import 'package:dart_agent_core/dart_agent_core.dart';
 
-/// In-memory, per-session relay for images that a tool wants the model to
-/// "see".
+/// In-memory, per-session relay for images that a tool wants the model to see.
 ///
 /// Why this exists: OpenAI-compatible providers reject images inside a tool
 /// (function) result message — only text is allowed there. But a `UserMessage`
 /// carrying an `ImagePart` is accepted by every provider (OpenAI, Gemini,
 /// Claude). So instead of returning the image in the tool result, a tool stores
-/// it here, returns text only, and the SuperAgent `systemCallback` drains it on
-/// the next LLM call and injects it as a `UserMessage`.
+/// it here and returns text only; an agent `afterToolCall` hook drains this
+/// relay and injects a `UserMessage`.
 ///
-/// The buffer is pure memory and is never persisted. Drained images are sent to
-/// the model exactly once (on the immediately following call) and are not added
-/// to `state.history`, so they do not bloat the agent state file.
+/// The buffer itself is pure memory and is never persisted. Drained images are
+/// added to `state.history` by the hook.
 class PendingToolImage {
   const PendingToolImage({
     required this.message,
@@ -47,5 +45,18 @@ class PendingToolImageBuffer {
     final images = _bySession.remove(sessionId);
     if (images == null || images.isEmpty) return const [];
     return images;
+  }
+
+  /// Take and clear pending images as model-visible messages.
+  List<LLMMessage> drainAsMessages(String sessionId) {
+    final images = drain(sessionId);
+    if (images.isEmpty) return const [];
+    return [
+      for (final pending in images)
+        UserMessage([
+          TextPart(pending.message),
+          pending.image,
+        ]),
+    ];
   }
 }

--- a/lib/agent/super_agent/subagent/super_agent_child.dart
+++ b/lib/agent/super_agent/subagent/super_agent_child.dart
@@ -407,7 +407,7 @@ StatefulAgent createSuperAgentChild({
     },
     // PKM organization now happens inside these workers, so the PKM
     // structural-health reminders ride along here (only fire on /PKM reads).
-    postToolCallHook: SuperAgentHarness.buildChildPostToolCallHook(userId),
+    hooks: [SuperAgentHarness.buildChildHook(userId)],
   );
 }
 

--- a/lib/agent/super_agent/super_agent.dart
+++ b/lib/agent/super_agent/super_agent.dart
@@ -16,7 +16,6 @@ import 'package:memex/agent/skills/timeline_diagnostics/timeline_diagnostics_ski
 import 'package:memex/agent/common_tools.dart';
 import 'package:memex/agent/state_util.dart';
 import 'package:memex/agent/super_agent/prompts.dart';
-import 'package:memex/agent/super_agent/pending_tool_image_buffer.dart';
 import 'package:memex/agent/super_agent/subagent/delegate_subagent_tool.dart';
 import 'package:memex/agent/super_agent/super_agent_harness.dart';
 import 'package:memex/agent/super_agent/super_agent_loop_detector.dart';
@@ -249,74 +248,15 @@ class SuperAgent {
         autoSaveStateFunc: (state) async {
           await saveAgentState(state);
         },
-        // Harness control plane: PKM structural-health reminders on /PKM reads,
-        // and a one-shot "you saved a card but didn't organize it" nudge when a
-        // capture turn ends. Both default to no-op on non-capture turns.
-        postToolCallHook: SuperAgentHarness.buildPostToolCallHook(userId),
-        turnCompletionHook: SuperAgentHarness.buildTurnCompletionHook(userId),
-        systemCallback: _createSuperAgentSystemCallback(userId));
+        hooks: [
+          createAgentPromptHook(userId),
+          _SuperAgentPromptHook(),
+          SuperAgentHarness.buildParentHook(userId),
+        ]);
 
     _logger.info(
         'SuperAgent created, userId: $userId, sessionId: ${state.sessionId}');
     return agent;
-  }
-
-  static SystemCallback _createSuperAgentSystemCallback(String userId) {
-    final baseCallback = createSystemCallback(userId);
-    return (
-      StatefulAgent agent,
-      SystemMessage? systemMessage,
-      List<Tool> tools,
-      List<LLMMessage> requestMessages,
-    ) async {
-      final result = await baseCallback(
-        agent,
-        systemMessage,
-        tools,
-        requestMessages,
-      );
-
-      var nextSystemMessage = result.systemMessage;
-      var nextTools = result.tools;
-
-      if (nextSystemMessage != null && nextSystemMessage.content.isNotEmpty) {
-        final systemLines = nextSystemMessage.content.split('\n');
-        final sanitizedLines = <String>[];
-        for (final line in systemLines) {
-          if (line.trim() == _cloneSubAgentPromptLine) continue;
-          sanitizedLines.add(line);
-        }
-        final sanitizedContent = sanitizedLines.join('\n').trimRight();
-        if (sanitizedContent != nextSystemMessage.content) {
-          nextSystemMessage = SystemMessage(sanitizedContent);
-        }
-      }
-
-      // Deliver any images a tool stashed for the model (e.g. the dynamic
-      // timeline UI render preview). They cannot ride in the tool result —
-      // OpenAI-compatible providers reject images there — so inject them as a
-      // UserMessage on this call only. requestMessages is a per-call copy of
-      // state.history, so this is never persisted into the agent state.
-      var nextRequestMessages = result.requestMessages;
-      final pendingToolImages =
-          PendingToolImageBuffer.instance.drain(agent.state.sessionId);
-      if (pendingToolImages.isNotEmpty) {
-        nextRequestMessages = [
-          ...nextRequestMessages,
-          for (final pending in pendingToolImages)
-            UserMessage([
-              TextPart(pending.message),
-              pending.image,
-            ]),
-        ];
-      }
-
-      return SystemCallbackResult(
-        systemMessage: nextSystemMessage,
-        tools: nextTools,
-        requestMessages: nextRequestMessages,
-      );
-    };
   }
 
   @visibleForTesting
@@ -341,5 +281,41 @@ class SuperAgent {
       '${state.sessionId}: $removed',
     );
     return true;
+  }
+}
+
+class _SuperAgentPromptHook extends AgentHook {
+  @override
+  ModelCallHookResult beforeModelCall(ModelCallHookContext context) {
+    try {
+      var nextSystemMessage = context.request.systemMessage;
+
+      if (nextSystemMessage != null && nextSystemMessage.content.isNotEmpty) {
+        final systemLines = nextSystemMessage.content.split('\n');
+        final sanitizedLines = <String>[];
+        for (final line in systemLines) {
+          if (line.trim() == _cloneSubAgentPromptLine) continue;
+          sanitizedLines.add(line);
+        }
+        final sanitizedContent = sanitizedLines.join('\n').trimRight();
+        if (sanitizedContent != nextSystemMessage.content) {
+          nextSystemMessage = SystemMessage(sanitizedContent);
+        }
+      }
+
+      return ModelCallHookResult.proceed(
+        request: context.request.copyWith(
+          systemMessage: nextSystemMessage,
+          clearSystemMessage: nextSystemMessage == null,
+        ),
+      );
+    } catch (e, st) {
+      SuperAgent._logger.warning(
+        '[${context.agent.name}] super agent prompt hook failed; using original model request.',
+        e,
+        st,
+      );
+      return ModelCallHookResult.proceed(request: context.request);
+    }
   }
 }

--- a/lib/agent/super_agent/super_agent_harness.dart
+++ b/lib/agent/super_agent/super_agent_harness.dart
@@ -6,6 +6,10 @@ import 'package:path/path.dart' as p;
 import 'package:memex/data/services/file_operation_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/agent/super_agent/pkm_stats_service.dart';
+import 'package:memex/agent/super_agent/pending_tool_image_buffer.dart';
+import 'package:memex/utils/logger.dart';
+
+final _logger = getLogger('SuperAgentHarness');
 
 /// Harness control plane for the SuperAgent and its capture child workers.
 ///
@@ -15,7 +19,7 @@ import 'package:memex/agent/super_agent/pkm_stats_service.dart';
 /// - **PKM structural-health reminders**: when an agent reads a `/PKM` file,
 ///   append "file too long / fragmented / churned" advice. PKM organization
 ///   can happen in child workers or in parent repair flows, so this is wired
-///   into both [buildPostToolCallHook] and [buildChildPostToolCallHook].
+///   into both [buildParentHook] and [buildChildHook].
 /// - **Idle-skill reminder** (parent only): when the parent keeps a skill
 ///   active but unused for several turns, gently suggest deactivating it.
 ///
@@ -50,63 +54,29 @@ class SuperAgentHarness {
   static _CaptureTurnState _stateFor(String sessionId) =>
       _captureState.putIfAbsent(sessionId, () => _CaptureTurnState());
 
-  /// Parent post-tool hook: idle-skill tracking + PKM structural-health
-  /// reminders on `/PKM` reads.
-  static PostToolCallHook buildPostToolCallHook(String userId) {
-    return (StatefulAgent agent, AgentState state,
-        FunctionExecutionResult result) async {
-      final sessionId = state.sessionId;
-
-      // Note which optional skill (if any) this tool belongs to, so the
-      // turn-completion hook can age idle-skill counters.
-      if (!result.isError) {
-        final owningSkill = _optionalSkillForTool(agent, result.name);
-        if (owningSkill != null) {
-          _stateFor(sessionId).usedSkills.add(owningSkill);
-        }
-      }
-
-      return _pkmHealthPostToolResult(userId, result);
-    };
+  /// Parent hook: idle-skill tracking + PKM structural-health reminders on
+  /// `/PKM` reads + end-of-turn idle reminder maintenance.
+  static AgentHook buildParentHook(String userId) {
+    return _SuperAgentHarnessHook(userId: userId, trackIdleSkills: true);
   }
 
-  /// Child-worker post-tool hook: PKM structural-health reminders only. Child
+  /// Child-worker hook: PKM structural-health reminders only. Child
   /// workers don't persist across turns and don't manage their own skill
   /// lifecycle, so the idle-skill tracking does not apply to them. Harmless on
   /// card/schedule workers — it only fires when a `/PKM` file is actually read.
-  static PostToolCallHook buildChildPostToolCallHook(String userId) {
-    return (StatefulAgent agent, AgentState state,
-            FunctionExecutionResult result) async =>
-        _pkmHealthPostToolResult(userId, result);
+  static AgentHook buildChildHook(String userId) {
+    return _SuperAgentHarnessHook(userId: userId, trackIdleSkills: false);
   }
 
-  static Future<PostToolCallResult> _pkmHealthPostToolResult(
+  static Future<List<LLMMessage>> _pkmHealthInjectedMessages(
       String userId, FunctionExecutionResult result) async {
     if (result.name == 'Read' && !result.isError) {
       final reminder = await _buildPkmHealthReminder(userId, result);
       if (reminder != null) {
-        return PostToolCallResult(reminderMessage: UserMessage.text(reminder));
+        return [UserMessage.text(reminder)];
       }
     }
-    return const PostToolCallResult();
-  }
-
-  /// Build the turn-completion hook for a given user. Ages the idle-skill
-  /// counters and (re)builds or clears the deactivate reminder.
-  static TurnCompletionHook buildTurnCompletionHook(String userId) {
-    return (StatefulAgent agent, AgentState state,
-        ModelMessage finalMessage) async {
-      final sessionId = state.sessionId;
-      final turn = _captureState[sessionId];
-
-      _ageIdleSkillsAndBuildReminder(
-        agent,
-        state,
-        turn?.usedSkills ?? const <String>{},
-      );
-      _captureState.remove(sessionId);
-      return const TurnCompletionResult.accept();
-    };
+    return const [];
   }
 
   // --- helpers ---
@@ -324,4 +294,82 @@ class SuperAgentHarness {
 class _CaptureTurnState {
   /// Optional skills whose tools were used during this user turn.
   final Set<String> usedSkills = {};
+}
+
+class _SuperAgentHarnessHook extends AgentHook {
+  final String userId;
+  final bool trackIdleSkills;
+
+  _SuperAgentHarnessHook({
+    required this.userId,
+    required this.trackIdleSkills,
+  });
+
+  @override
+  Future<ToolResultHookResult> afterToolCall(
+    ToolResultHookContext context,
+  ) async {
+    try {
+      final result = context.result;
+      if (trackIdleSkills && !result.isError) {
+        final owningSkill = SuperAgentHarness._optionalSkillForTool(
+          context.agent,
+          result.name,
+        );
+        if (owningSkill != null) {
+          SuperAgentHarness._stateFor(context.state.sessionId)
+              .usedSkills
+              .add(owningSkill);
+        }
+      }
+
+      final injectedMessages = <LLMMessage>[
+        ...PendingToolImageBuffer.instance.drainAsMessages(
+          context.state.sessionId,
+        ),
+        ...await SuperAgentHarness._pkmHealthInjectedMessages(userId, result),
+      ];
+
+      return ToolResultHookResult.proceed(
+        result: result,
+        injectedMessages: injectedMessages,
+      );
+    } catch (e, st) {
+      _logger.warning(
+        '[${context.agent.name}] super agent after-tool hook failed; skipping reminder.',
+        e,
+        st,
+      );
+      return ToolResultHookResult.proceed(result: context.result);
+    }
+  }
+
+  @override
+  TurnCompletionHookResult onTurnCompletion(
+    TurnCompletionHookContext context,
+  ) {
+    if (!trackIdleSkills) {
+      return const TurnCompletionHookResult.accept();
+    }
+
+    try {
+      final sessionId = context.state.sessionId;
+      final turn = SuperAgentHarness._captureState[sessionId];
+
+      SuperAgentHarness._ageIdleSkillsAndBuildReminder(
+        context.agent,
+        context.state,
+        turn?.usedSkills ?? const <String>{},
+      );
+      SuperAgentHarness._captureState.remove(sessionId);
+    } catch (e, st) {
+      _logger.warning(
+        '[${context.agent.name}] super agent turn-completion hook failed; accepting completion.',
+        e,
+        st,
+      );
+    }
+
+    return const TurnCompletionHookResult.accept();
+  }
 }

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart' show CancelToken;
 import 'package:image_picker/image_picker.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/agent/memex_skill_host_agent/memex_skill_host_agent.dart';
@@ -836,9 +837,15 @@ class ChatService {
 
     await DelegateProgressContext.run(progressSink, () async {
       try {
+        final cancelToken = CancelToken();
         final agentFuture = resumeExistingRun
-            ? activeAgent.resume()
-            : activeAgent.run(userMessages);
+            ? activeAgent.resume(
+                cancelToken: cancelToken,
+              )
+            : activeAgent.run(
+                userMessages,
+                cancelToken: cancelToken,
+              );
         await agentFuture.whenComplete(() async {
           if (activeAgent.state.metadata[_runningChatTurnIdKey] == turnId) {
             activeAgent.state.metadata.remove(_runningChatTurnIdKey);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -357,10 +357,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_agent_core
-      sha256: c156fa735a0743670215a2d013cb31193b97af0e868703089cd91d7da6e22fc6
+      sha256: "5828c4de2fc89b3c7b3b4c4268b1805930aa8730a12c24686f61e6a98c927889"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   dart_jsonwebtoken:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   health: ^13.2.1
   pedometer: ^4.0.0
   workmanager: ^0.9.0
-  dart_agent_core: ^2.0.2
+  dart_agent_core: ^2.0.3
   flutter_js: ^0.8.7
   drift: ^2.30.0
   sqlite3_flutter_libs: ^0.5.41

--- a/test/agent/agent_system_prompt_helper_test.dart
+++ b/test/agent/agent_system_prompt_helper_test.dart
@@ -56,7 +56,7 @@ void main() {
       expect(result.systemMessage?.content, 'third prompt');
     });
 
-    test('returns SystemCallbackResult and preserves tool parameter mode', () {
+    test('returns AgentPromptHookResult and preserves tool parameter mode', () {
       final config = AgentPromptConfig();
       config.systemPrompt.replacements.add(('old system', 'new system'));
       config.toolOverrides['object_tool'] = ToolOverride(
@@ -87,7 +87,7 @@ void main() {
         requestMessages,
       );
 
-      expect(result, isA<SystemCallbackResult>());
+      expect(result, isA<AgentPromptHookResult>());
       expect(result.systemMessage?.content, 'new system prompt');
       expect(result.tools, hasLength(1));
       expect(result.tools.single.description, 'Updated description');

--- a/test/agent/file_tool_view_image_test.dart
+++ b/test/agent/file_tool_view_image_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/agent/built_in_tools/file_tools.dart';
 import 'package:memex/agent/security/file_permission_manager.dart';
 import 'package:memex/agent/super_agent/pending_tool_image_buffer.dart';
+import 'package:memex/agent/super_agent/super_agent_harness.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -25,7 +26,7 @@ void main() {
       }
     });
 
-    test('compresses image and queues it for the next model message', () async {
+    test('compresses image and queues it for model-visible messages', () async {
       final image = File('${tempDir.path}/sample.png');
       await image.writeAsBytes(_pngHeader(width: 320, height: 240));
       final compressed = Uint8List.fromList([1, 2, 3, 4]);
@@ -63,6 +64,8 @@ void main() {
       final properties = tool.parameters['properties'] as Map;
       expect(properties.keys, contains('path'));
       expect(properties.keys, isNot(contains('detail')));
+      expect(tool.description, isNot(contains('next model call only')));
+      expect(tool.description, startsWith('View a local image file.'));
       final state = AgentState(
         sessionId: 'view_image_test',
         metadata: const {'userId': 'test_user'},
@@ -76,7 +79,9 @@ void main() {
 
       expect(result.isError, isFalse);
       expect(
-          _text(result), contains('Image attached to the next model message'));
+        _text(result),
+        contains('Image attached to the next message'),
+      );
       expect(_text(result), contains('EXIF metadata is included'));
       expect(compressedPath, image.path);
       expect(targetSizeSeen, 2048);
@@ -128,11 +133,79 @@ void main() {
 
       expect(result.isError, isFalse);
       expect(
-          _text(result), contains('Image attached to the next model message'));
+        _text(result),
+        contains('Image attached to the next message'),
+      );
 
       final pending = PendingToolImageBuffer.instance.drain(state.sessionId);
       expect(pending, hasLength(1));
       expect(pending.single.image.base64Data, base64Encode(compressed));
+    });
+
+    test('after-tool hook persists viewed image into agent history', () async {
+      final image = File('${tempDir.path}/Facts/assets/persisted.png');
+      await image.create(recursive: true);
+      await image.writeAsBytes(_pngHeader(width: 80, height: 80));
+      final compressed = Uint8List.fromList([4, 3, 2, 1]);
+
+      final factory = FileToolFactory(
+        permissionManager: FilePermissionManager(
+          'test_user',
+          const [],
+          withDefaultRules: false,
+        ),
+        workingDirectory: tempDir.path,
+        viewImageCompressor: (
+          String filePath, {
+          int targetSize = 2048,
+          int quality = 85,
+        }) async {
+          expect(filePath, image.path);
+          return compressed;
+        },
+      );
+      final tool = factory.buildViewImageTool();
+      final state = AgentState(
+        sessionId: 'view_image_persisted_test',
+        metadata: const {'userId': 'test_user'},
+      );
+      final client = _SingleToolCallClient(
+        toolName: tool.name,
+        arguments: {'path': 'fs://persisted.png'},
+      );
+      final agent = StatefulAgent(
+        name: 'view_image_test_agent',
+        client: client,
+        modelConfig: ModelConfig(model: 'test-model'),
+        state: state,
+        tools: [tool],
+        hooks: [SuperAgentHarness.buildChildHook('test_user')],
+        withGeneralPrinciples: false,
+        maxTurns: 3,
+      );
+
+      await agent.run([UserMessage.text('run the tool')], useStream: false);
+
+      final imageMessages =
+          state.history.messages.whereType<UserMessage>().where(
+                (message) => message.contents.any((part) => part is ImagePart),
+              );
+      expect(imageMessages, hasLength(1));
+      final imagePart =
+          imageMessages.single.contents.whereType<ImagePart>().single;
+      expect(imagePart.mimeType, 'image/webp');
+      expect(imagePart.base64Data, base64Encode(compressed));
+
+      expect(client.capturedMessages, hasLength(2));
+      final secondRequestImageMessages =
+          client.capturedMessages.last.whereType<UserMessage>().where(
+                (message) => message.contents.any((part) => part is ImagePart),
+              );
+      expect(secondRequestImageMessages, hasLength(1));
+      expect(
+        PendingToolImageBuffer.instance.drain(state.sessionId),
+        isEmpty,
+      );
     });
   });
 
@@ -245,6 +318,7 @@ class _SingleToolCallClient extends LLMClient {
 
   final String toolName;
   final Map<String, dynamic> arguments;
+  final capturedMessages = <List<LLMMessage>>[];
   var _callCount = 0;
 
   @override
@@ -256,6 +330,7 @@ class _SingleToolCallClient extends LLMClient {
     bool? jsonOutput,
     CancelToken? cancelToken,
   }) async {
+    capturedMessages.add(List<LLMMessage>.from(messages));
     _callCount += 1;
     if (_callCount == 1) {
       return ModelMessage(

--- a/test/agent/super_agent_harness_test.dart
+++ b/test/agent/super_agent_harness_test.dart
@@ -48,15 +48,17 @@ void main() {
       );
       final agent = _agent(state);
 
-      await SuperAgentHarness.buildPostToolCallHook('test_user')(
-        agent,
-        state,
-        FunctionExecutionResult(
-          id: 'call_1',
-          name: 'optional_tool',
-          isError: false,
-          arguments: '{}',
-          content: [TextPart('ok')],
+      await SuperAgentHarness.buildParentHook('test_user').afterToolCall(
+        ToolResultHookContext(
+          agent,
+          result: FunctionExecutionResult(
+            id: 'call_1',
+            name: 'optional_tool',
+            isError: false,
+            arguments: '{}',
+            content: [TextPart('ok')],
+          ),
+          modelMessage: ModelMessage(model: 'test-model'),
         ),
       );
       await _completeTurn(agent);
@@ -69,10 +71,13 @@ void main() {
 }
 
 Future<void> _completeTurn(StatefulAgent agent) async {
-  await SuperAgentHarness.buildTurnCompletionHook('test_user')(
-    agent,
-    agent.state,
-    ModelMessage(model: 'test-model', textOutput: 'done'),
+  await SuperAgentHarness.buildParentHook('test_user').onTurnCompletion(
+    TurnCompletionHookContext(
+      agent,
+      finalMessage: ModelMessage(model: 'test-model', textOutput: 'done'),
+      continuationCount: 0,
+      maxContinuations: 3,
+    ),
   );
 }
 


### PR DESCRIPTION
Summary:
- Upgrade dart_agent_core to 2.0.3 and migrate old agent callbacks to the new AgentHook pipeline.
- Move view_image pending-image delivery to afterToolCall so images enter agent history and the next model request.
- Pass a CancelToken through SuperAgent chat run/resume paths.

Test plan:
- dart analyze lib/agent/agent_system_prompt_helper.dart lib/agent/built_in_tools/file_tools.dart lib/agent/comment_agent/comment_agent.dart lib/agent/companion_agent/comment_agent.dart lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart lib/agent/memory_agent/memory_agent.dart lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart lib/agent/skills/dynamic_timeline_ui/dynamic_timeline_ui_skill.dart lib/agent/super_agent/pending_tool_image_buffer.dart lib/agent/super_agent/subagent/super_agent_child.dart lib/agent/super_agent/super_agent.dart lib/agent/super_agent/super_agent_harness.dart lib/data/services/chat_service.dart test/agent/agent_system_prompt_helper_test.dart test/agent/file_tool_view_image_test.dart test/agent/super_agent_harness_test.dart
- flutter test test/agent/agent_system_prompt_helper_test.dart test/agent/file_tool_view_image_test.dart test/agent/super_agent_harness_test.dart test/agent/super_agent_child_test.dart test/agent/skills/dynamic_timeline_ui_skill_test.dart test/data/services/chat_service_test.dart -r expanded