### PR TITLE
Polish chat dialog and activity indicators

### DIFF
--- a/lib/ui/agent_activity/widgets/agent_activity_widget.dart
+++ b/lib/ui/agent_activity/widgets/agent_activity_widget.dart
@@ -31,8 +31,7 @@ class AgentActivityWidget extends StatefulWidget {
   State<AgentActivityWidget> createState() => _AgentActivityWidgetState();
 }
 
-class _AgentActivityWidgetState extends State<AgentActivityWidget>
-    with SingleTickerProviderStateMixin {
+class _AgentActivityWidgetState extends State<AgentActivityWidget> {
   AgentActivityMessageModel? _latestMessage;
   AgentActivityService? _service;
   LocalTaskExecutor? _executor;
@@ -44,8 +43,6 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
   Timer? _initRetryTimer;
   TaskActivitySnapshot _taskSnapshot = const TaskActivitySnapshot.empty();
   AgentRunSnapshot? _runSnapshot;
-
-  late AnimationController _bounceController;
 
   bool get _isActive {
     return widget.forceVisible || _taskSnapshot.hasActiveTasks;
@@ -60,10 +57,6 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
   @override
   void initState() {
     super.initState();
-    _bounceController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 400),
-    )..repeat(reverse: true);
     _taskSnapshot = widget.initialTaskSnapshot;
     _runSnapshot = widget.initialRunSnapshot;
 
@@ -178,7 +171,6 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
     _openActivitySubscription?.cancel();
     _historyLoadTimer?.cancel();
     _initRetryTimer?.cancel();
-    _bounceController.dispose();
     super.dispose();
   }
 
@@ -233,16 +225,7 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget>
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            // Animated writing icon (alternates between two frames)
-            AnimatedBuilder(
-              animation: _bounceController,
-              builder: (context, child) {
-                final frame = _bounceController.value < 0.5
-                    ? 'assets/icons/processing_1.png'
-                    : 'assets/icons/processing_2.png';
-                return Image.asset(frame, width: 36, height: 36);
-              },
-            ),
+            const _AgentActivityLogo(size: 36),
             const SizedBox(width: 8),
             // Text
             Flexible(
@@ -306,8 +289,7 @@ class _DetailSheet extends StatefulWidget {
   State<_DetailSheet> createState() => _DetailSheetState();
 }
 
-class _DetailSheetState extends State<_DetailSheet>
-    with SingleTickerProviderStateMixin {
+class _DetailSheetState extends State<_DetailSheet> {
   AgentActivityMessageModel? _message;
   TaskActivitySnapshot _taskSnapshot = const TaskActivitySnapshot.empty();
   AgentRunSnapshot? _runSnapshot;
@@ -317,15 +299,9 @@ class _DetailSheetState extends State<_DetailSheet>
   AgentActivityService? _service;
   LocalTaskExecutor? _executor;
 
-  late AnimationController _pulseController;
-
   @override
   void initState() {
     super.initState();
-    _pulseController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 400),
-    )..repeat(reverse: true);
     _message = widget.initialMessage;
     _taskSnapshot = widget.initialTaskSnapshot;
     _runSnapshot = widget.initialRunSnapshot;
@@ -397,7 +373,6 @@ class _DetailSheetState extends State<_DetailSheet>
     _subscription?.cancel();
     _taskSubscription?.cancel();
     _runSubscription?.cancel();
-    _pulseController.dispose();
     super.dispose();
   }
 
@@ -432,15 +407,7 @@ class _DetailSheetState extends State<_DetailSheet>
               children: [
                 Row(
                   children: [
-                    AnimatedBuilder(
-                      animation: _pulseController,
-                      builder: (context, child) {
-                        final frame = _pulseController.value < 0.5
-                            ? 'assets/icons/processing_1.png'
-                            : 'assets/icons/processing_2.png';
-                        return Image.asset(frame, width: 38, height: 38);
-                      },
-                    ),
+                    const _AgentActivityLogo(size: 38),
                     const SizedBox(width: 10),
                     Text(
                       UserStorage.l10n.activityDetail,
@@ -684,6 +651,25 @@ class _DetailSheetState extends State<_DetailSheet>
       ),
       alignment: Alignment.center,
       child: Icon(iconData, size: 24, color: color),
+    );
+  }
+}
+
+class _AgentActivityLogo extends StatelessWidget {
+  final double size;
+
+  const _AgentActivityLogo({required this.size});
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(size * 0.28),
+      child: Image.asset(
+        'assets/icon.png',
+        width: size,
+        height: size,
+        fit: BoxFit.cover,
+      ),
     );
   }
 }

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -20,13 +19,13 @@ import 'package:memex/data/services/demo_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/input_draft_service.dart';
 import 'package:memex/ui/core/widgets/html_webview_card.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
 import 'package:memex/ui/timeline/widgets/timeline_card_detail_screen.dart';
 import 'package:memex/data/services/photo_suggestion_service.dart';
 import 'package:memex/utils/toast_helper.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/result.dart';
 import 'package:memex/utils/user_storage.dart';
-import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/utils/token_usage_utils.dart';
 import 'package:memex/utils/time_context.dart';
@@ -185,6 +184,11 @@ const Duration _agentChatKeyboardHideAnimationDuration = Duration.zero;
 const BorderRadius _agentChatSheetBorderRadius = BorderRadius.vertical(
   top: Radius.circular(32),
 );
+@visibleForTesting
+const Key superAgentPhotoSuggestionSlotKey =
+    ValueKey('super_agent_photo_suggestion_slot');
+@visibleForTesting
+const double superAgentPhotoSuggestionSlotHeight = 68;
 
 @visibleForTesting
 double resolveAgentChatDialogHeight(
@@ -287,11 +291,12 @@ Duration resolveSuperAgentKeyboardInsetAnimationDuration({
 }
 
 @visibleForTesting
-bool shouldShowSuperAgentPhotoSuggestions({
+bool shouldShowSuperAgentPhotoSuggestionStatus({
   required bool isLoading,
   required bool hasSuggestions,
+  required bool hasLoadedSuggestions,
 }) {
-  return isLoading || hasSuggestions;
+  return !hasSuggestions && (isLoading || !hasLoadedSuggestions);
 }
 
 @visibleForTesting
@@ -387,6 +392,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   Timer? _draftSaveDebounce;
   bool _isApplyingDraft = false;
   bool _isLoadingPhotoSuggestions = false;
+  bool _hasLoadedPhotoSuggestions = false;
   List<List<EnhancedPhoto>> _photoSuggestionClusters = [];
   double _lastKeyboardBottomOffset = 0;
 
@@ -416,7 +422,6 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       ),
     );
     unawaited(_loadActiveDraftIfNeeded());
-    unawaited(_loadPhotoSuggestions());
 
     // Animations
     _controller = AnimationController(
@@ -431,13 +436,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       begin: 0,
       end: 1,
     ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+    _controller.addStatusListener(_handleEntranceAnimationStatus);
     _controller.forward();
-
-    UserStorage.getSuperAgentRunMode().then((value) {
-      if (mounted) {
-        setState(() => _runMode = AgentRunMode.fromWire(value));
-      }
-    });
 
     final sessionId = _currentSessionId;
     if (sessionId != null) {
@@ -448,6 +448,13 @@ class _AgentChatDialogState extends State<AgentChatDialog>
 
     if (_currentSessionId != null) {
       _loadSessionHistory();
+    }
+  }
+
+  void _handleEntranceAnimationStatus(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
+      _controller.removeStatusListener(_handleEntranceAnimationStatus);
+      unawaited(_loadPhotoSuggestions());
     }
   }
 
@@ -467,6 +474,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     _flushDraftOnDispose();
     _messageController.removeListener(_handleDraftTextChanged);
     _scrollController.removeListener(_handleHistoryScroll);
+    _controller.removeStatusListener(_handleEntranceAnimationStatus);
     _controller.dispose();
     _messageController.dispose();
     _scrollController.dispose();
@@ -535,6 +543,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       _scrollToBottom();
     } catch (e) {
       _logger.severe('Error loading history', e);
+      unawaited(_clearLatestSuperAgentHomeSessionIdIfCurrent());
       setState(() => _isLoading = false);
       if (mounted) ToastHelper.showError(context, 'Failed to load history: $e');
     }
@@ -705,11 +714,15 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         _photoSuggestionClusters =
             clusters.where((cluster) => cluster.isNotEmpty).take(8).toList();
         _isLoadingPhotoSuggestions = false;
+        _hasLoadedPhotoSuggestions = true;
       });
     } catch (e, st) {
       _logger.warning('Failed to load photo suggestions: $e', e, st);
       if (!mounted) return;
-      setState(() => _isLoadingPhotoSuggestions = false);
+      setState(() {
+        _isLoadingPhotoSuggestions = false;
+        _hasLoadedPhotoSuggestions = true;
+      });
     }
   }
 
@@ -971,6 +984,17 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     _scrollToBottom();
   }
 
+  Future<void> _clearLatestSuperAgentHomeSessionIdIfCurrent() async {
+    final sessionId = _currentSessionId;
+    if (sessionId == null || sessionId.isEmpty) return;
+
+    final cachedSessionId =
+        await UserStorage.getLatestSuperAgentHomeSessionId();
+    if (cachedSessionId == sessionId) {
+      await UserStorage.clearLatestSuperAgentHomeSessionId();
+    }
+  }
+
   Future<void> _handleRefreshAgentState() async {
     final sessionId = _currentSessionId;
     if (sessionId == null || sessionId.isEmpty || _isRefreshingAgentState) {
@@ -1170,6 +1194,9 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       if (event is ChatSessionCreatedEvent) {
         _currentSessionId = event.sessionId;
         AgentActionApprovalService.instance.attachSession(event.sessionId);
+        unawaited(
+          UserStorage.setLatestSuperAgentHomeSessionId(event.sessionId),
+        );
         return;
       }
 
@@ -1480,39 +1507,38 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                             onTap: _messageFocusNode.unfocus,
                             child: Container(
                               color: Colors.white,
-                              child: _isLoading
-                                  ? const Center(child: AgentLogoLoading())
-                                  : _items.isEmpty
-                                      ? _buildEmptyState()
-                                      : ListView.builder(
-                                          controller: _scrollController,
-                                          reverse: true,
-                                          keyboardDismissBehavior:
-                                              ScrollViewKeyboardDismissBehavior
-                                                  .onDrag,
-                                          padding: const EdgeInsets.all(24),
-                                          itemCount: _agentChatListItemCount(),
-                                          itemBuilder: (context, index) {
-                                            final extraItems =
-                                                _showAgentThinkingRow ? 1 : 0;
-                                            if (extraItems == 1 && index == 0) {
-                                              return _buildAgentThinkingItem();
-                                            }
-                                            if (_shouldShowHistoryLoaderAt(
-                                                index)) {
-                                              return _buildHistoryLoadMoreIndicator();
-                                            }
-                                            final itemIndex =
-                                                superAgentItemIndexForReversedList(
-                                              listIndex: index,
-                                              itemCount: _items.length,
-                                              extraItems: extraItems,
-                                            );
-                                            return _buildItemWithTimeDivider(
-                                              itemIndex,
-                                            );
-                                          },
-                                        ),
+                              child: _items.isEmpty
+                                  ? _isLoading
+                                      ? const SizedBox.expand()
+                                      : _buildEmptyState()
+                                  : ListView.builder(
+                                      controller: _scrollController,
+                                      reverse: true,
+                                      keyboardDismissBehavior:
+                                          ScrollViewKeyboardDismissBehavior
+                                              .onDrag,
+                                      padding: const EdgeInsets.all(24),
+                                      itemCount: _agentChatListItemCount(),
+                                      itemBuilder: (context, index) {
+                                        final extraItems =
+                                            _showAgentThinkingRow ? 1 : 0;
+                                        if (extraItems == 1 && index == 0) {
+                                          return _buildAgentThinkingItem();
+                                        }
+                                        if (_shouldShowHistoryLoaderAt(index)) {
+                                          return _buildHistoryLoadMoreIndicator();
+                                        }
+                                        final itemIndex =
+                                            superAgentItemIndexForReversedList(
+                                          listIndex: index,
+                                          itemCount: _items.length,
+                                          extraItems: extraItems,
+                                        );
+                                        return _buildItemWithTimeDivider(
+                                          itemIndex,
+                                        );
+                                      },
+                                    ),
                             ),
                           ),
                         ),
@@ -1707,45 +1733,56 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   }
 
   Widget _buildPhotoSuggestionRow() {
-    if (_isLoadingPhotoSuggestions) {
-      return SizedBox(
-        height: 48,
-        child: Row(
-          children: [
-            Icon(
-              Icons.photo_library_outlined,
-              size: 18,
-              color: AppColors.primary.withValues(alpha: 0.55),
-            ),
-            const SizedBox(width: 10),
-            Flexible(
-              child: Text(
-                _agentChat.findingRecentPhotos,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: AppColors.textTertiary,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    if (_photoSuggestionClusters.isEmpty) return const SizedBox.shrink();
+    final showStatus = shouldShowSuperAgentPhotoSuggestionStatus(
+      isLoading: _isLoadingPhotoSuggestions,
+      hasSuggestions: _photoSuggestionClusters.isNotEmpty,
+      hasLoadedSuggestions: _hasLoadedPhotoSuggestions,
+    );
 
     return SizedBox(
-      height: 68,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        itemCount: _photoSuggestionClusters.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 8),
-        itemBuilder: (context, index) {
-          return _buildPhotoSuggestionChip(_photoSuggestionClusters[index]);
-        },
+      key: superAgentPhotoSuggestionSlotKey,
+      height: superAgentPhotoSuggestionSlotHeight,
+      child: Stack(
+        alignment: Alignment.centerLeft,
+        children: [
+          ListView.separated(
+            scrollDirection: Axis.horizontal,
+            itemCount: _photoSuggestionClusters.length,
+            separatorBuilder: (_, __) => const SizedBox(width: 8),
+            itemBuilder: (context, index) {
+              return _buildPhotoSuggestionChip(_photoSuggestionClusters[index]);
+            },
+          ),
+          if (showStatus) _buildPhotoSuggestionStatus(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPhotoSuggestionStatus() {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Row(
+        children: [
+          Icon(
+            Icons.photo_library_outlined,
+            size: 18,
+            color: AppColors.primary.withValues(alpha: 0.55),
+          ),
+          const SizedBox(width: 10),
+          Flexible(
+            child: Text(
+              _agentChat.findingRecentPhotos,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: AppColors.textTertiary,
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -1813,11 +1850,6 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   }
 
   Widget _buildSuperAgentInput() {
-    final showPhotoSuggestions = shouldShowSuperAgentPhotoSuggestions(
-      isLoading: _isLoadingPhotoSuggestions,
-      hasSuggestions: _photoSuggestionClusters.isNotEmpty,
-    );
-
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
       decoration: const BoxDecoration(
@@ -1828,10 +1860,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          if (showPhotoSuggestions) ...[
-            _buildPhotoSuggestionRow(),
-            const SizedBox(height: 10),
-          ],
+          _buildPhotoSuggestionRow(),
+          const SizedBox(height: 10),
           if (_selectedImages.isNotEmpty) ...[
             SizedBox(
               height: 72,
@@ -2170,8 +2200,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       children: [
         ClipRRect(
           borderRadius: BorderRadius.circular(14),
-          child: Image.file(
-            File(image.path),
+          child: LocalImage(
+            url: image.path,
             width: 72,
             height: 72,
             fit: BoxFit.cover,
@@ -2204,8 +2234,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       children: imagePaths.map((imagePath) {
         return ClipRRect(
           borderRadius: BorderRadius.circular(10),
-          child: Image.file(
-            File(imagePath),
+          child: LocalImage(
+            url: imagePath,
             width: 88,
             height: 88,
             fit: BoxFit.cover,
@@ -2918,8 +2948,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                       _resolveDisplayImagePath(artifact.imagePaths[index]);
                   return ClipRRect(
                     borderRadius: BorderRadius.circular(10),
-                    child: Image.file(
-                      File(path),
+                    child: LocalImage(
+                      url: path,
                       width: 64,
                       height: 64,
                       fit: BoxFit.cover,

--- a/lib/ui/chat/widgets/open_super_agent_dialog.dart
+++ b/lib/ui/chat/widgets/open_super_agent_dialog.dart
@@ -3,14 +3,18 @@ import 'package:image_picker/image_picker.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
 import 'package:memex/utils/result.dart';
+import 'package:memex/utils/user_storage.dart';
 
 Future<String?> latestSuperAgentSessionId() async {
+  final cachedSessionId = await UserStorage.getLatestSuperAgentHomeSessionId();
+  if (cachedSessionId != null) return cachedSessionId;
+
   try {
     final result = await MemexRouter().fetchChatSessions(
       agentName: 'memex_agent',
       limit: 30,
     );
-    return result.when(
+    final sessionId = result.when(
       onOk: (sessions) {
         for (final session in sessions) {
           if (session['scene'] == 'super_agent_home') {
@@ -21,6 +25,12 @@ Future<String?> latestSuperAgentSessionId() async {
       },
       onError: (_, __) => null,
     );
+    if (sessionId == null || sessionId.isEmpty) {
+      await UserStorage.clearLatestSuperAgentHomeSessionId();
+      return null;
+    }
+    await UserStorage.setLatestSuperAgentHomeSessionId(sessionId);
+    return sessionId;
   } catch (_) {
     return null;
   }
@@ -34,6 +44,7 @@ void openSuperAgentDialog(
   String? sceneId,
   List<Map<String, String>>? initialRefs,
 }) {
+  final sessionIdFuture = latestSuperAgentSessionId();
   showGeneralDialog(
     context: context,
     barrierDismissible: true,
@@ -41,20 +52,43 @@ void openSuperAgentDialog(
     barrierColor: Colors.transparent,
     transitionDuration: const Duration(milliseconds: 500),
     pageBuilder: (context, animation, secondaryAnimation) {
-      return FutureBuilder<String?>(
-        future: latestSuperAgentSessionId(),
-        builder: (context, snapshot) {
-          final sessionId = snapshot.data;
-          return AgentChatDialog(
-            key: ValueKey(sessionId ?? 'super_agent_new_session'),
-            initialSessionId: sessionId,
-            sceneId: sceneId,
-            initialRefs: initialRefs,
-            initialDraftText: initialDraftText,
-            initialImages: initialImages,
-            initialImageOriginalFilenames: initialImageOriginalFilenames,
-          );
-        },
+      return buildSuperAgentDialogSessionGate(
+        sessionIdFuture: sessionIdFuture,
+        sceneId: sceneId,
+        initialRefs: initialRefs,
+        initialDraftText: initialDraftText,
+        initialImages: initialImages,
+        initialImageOriginalFilenames: initialImageOriginalFilenames,
+      );
+    },
+  );
+}
+
+@visibleForTesting
+Widget buildSuperAgentDialogSessionGate({
+  required Future<String?> sessionIdFuture,
+  String? initialDraftText,
+  List<XFile> initialImages = const [],
+  Map<String, String> initialImageOriginalFilenames = const {},
+  String? sceneId,
+  List<Map<String, String>>? initialRefs,
+}) {
+  return FutureBuilder<String?>(
+    future: sessionIdFuture,
+    builder: (context, snapshot) {
+      if (snapshot.connectionState != ConnectionState.done) {
+        return const SizedBox.shrink();
+      }
+
+      final sessionId = snapshot.data;
+      return AgentChatDialog(
+        key: ValueKey(sessionId ?? 'super_agent_new_session'),
+        initialSessionId: sessionId,
+        sceneId: sceneId,
+        initialRefs: initialRefs,
+        initialDraftText: initialDraftText,
+        initialImages: initialImages,
+        initialImageOriginalFilenames: initialImageOriginalFilenames,
       );
     },
   );

--- a/lib/utils/user_storage.dart
+++ b/lib/utils/user_storage.dart
@@ -44,6 +44,8 @@ class UserStorage {
   static const String _keyUserAvatar = 'user_avatar';
   static const String _keyLocationContextConfig = 'location_context_config';
   static const String _keyGeocodingCache = 'geocoding_cache';
+  static const String _keyLatestSuperAgentHomeSessionIdPrefix =
+      'latest_super_agent_home_session_id_';
 
   /// Per-user workspace storage preference keys.
   static const String _keyStorageLocationPrefix = 'memex_storage_location_';
@@ -213,6 +215,54 @@ class UserStorage {
       await prefs.remove(_keyUserId);
     } catch (e) {
       // ignore error
+    }
+  }
+
+  static String _latestSuperAgentHomeSessionIdKey(String userId) {
+    return '$_keyLatestSuperAgentHomeSessionIdPrefix$userId';
+  }
+
+  static Future<String?> getLatestSuperAgentHomeSessionId() async {
+    try {
+      final userId = await getUserId();
+      if (userId == null || userId.isEmpty) return null;
+
+      final prefs = await SharedPreferences.getInstance();
+      final sessionId =
+          prefs.getString(_latestSuperAgentHomeSessionIdKey(userId))?.trim();
+      return sessionId == null || sessionId.isEmpty ? null : sessionId;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  static Future<void> setLatestSuperAgentHomeSessionId(String sessionId) async {
+    final normalized = sessionId.trim();
+    if (normalized.isEmpty) return;
+
+    try {
+      final userId = await getUserId();
+      if (userId == null || userId.isEmpty) return;
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        _latestSuperAgentHomeSessionIdKey(userId),
+        normalized,
+      );
+    } catch (e) {
+      // Cache misses are non-fatal; callers fall back to session discovery.
+    }
+  }
+
+  static Future<void> clearLatestSuperAgentHomeSessionId() async {
+    try {
+      final userId = await getUserId();
+      if (userId == null || userId.isEmpty) return;
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_latestSuperAgentHomeSessionIdKey(userId));
+    } catch (e) {
+      // Cache misses are non-fatal.
     }
   }
 

--- a/test/ui/agent_activity/agent_activity_widget_test.dart
+++ b/test/ui/agent_activity/agent_activity_widget_test.dart
@@ -77,6 +77,29 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets('uses fixed app logo instead of rotating processing frames', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildHost(forceVisible: true));
+    await tester.pump();
+
+    expect(_assetImage('assets/icon.png'), findsOneWidget);
+    expect(_assetImage('assets/icons/processing_1.png'), findsNothing);
+    expect(_assetImage('assets/icons/processing_2.png'), findsNothing);
+
+    await tester.tap(find.text('AI is processing...'));
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(_assetImage('assets/icon.png'), findsNWidgets(2));
+    expect(_assetImage('assets/icons/processing_1.png'), findsNothing);
+    expect(_assetImage('assets/icons/processing_2.png'), findsNothing);
+
+    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+
   testWidgets('updates background task count while detail sheet is open', (
     tester,
   ) async {
@@ -345,6 +368,14 @@ void main() {
       platform.dispose();
     },
   );
+}
+
+Finder _assetImage(String assetName) {
+  return find.byWidgetPredicate((widget) {
+    if (widget is! Image) return false;
+    final image = widget.image;
+    return image is AssetImage && image.assetName == assetName;
+  });
 }
 
 AgentActivityMessageModel _activityMessage({

--- a/test/ui/chat/widgets/agent_chat_dialog_test.dart
+++ b/test/ui/chat/widgets/agent_chat_dialog_test.dart
@@ -6,6 +6,8 @@ import 'package:memex/data/model/chat_events.dart';
 import 'package:memex/data/services/demo_service.dart';
 import 'package:memex/l10n/app_localizations.dart';
 import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
+import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -172,28 +174,30 @@ void main() {
       expect(text, isNot(contains('0.12345')));
     });
 
-    test('keeps photo suggestions available while the super agent is sending',
-        () {
+    test('shows the photo suggestion status until suggestions resolve', () {
       expect(
-        shouldShowSuperAgentPhotoSuggestions(
+        shouldShowSuperAgentPhotoSuggestionStatus(
           isLoading: true,
           hasSuggestions: false,
+          hasLoadedSuggestions: false,
         ),
         isTrue,
       );
       expect(
-        shouldShowSuperAgentPhotoSuggestions(
+        shouldShowSuperAgentPhotoSuggestionStatus(
           isLoading: false,
           hasSuggestions: true,
+          hasLoadedSuggestions: true,
         ),
-        isTrue,
+        isFalse,
       );
       expect(
-        shouldShowSuperAgentPhotoSuggestions(
-          isLoading: true,
-          hasSuggestions: true,
+        shouldShowSuperAgentPhotoSuggestionStatus(
+          isLoading: false,
+          hasSuggestions: false,
+          hasLoadedSuggestions: true,
         ),
-        isTrue,
+        isFalse,
       );
     });
 
@@ -364,6 +368,48 @@ void main() {
       expect(find.byIcon(Icons.open_in_full), findsOneWidget);
     });
 
+    testWidgets('does not show a loading logo while opening a session', (
+      tester,
+    ) async {
+      await _pumpDialogFrame(
+        tester,
+        dialog: const AgentChatDialog(initialSessionId: 'session-1'),
+      );
+
+      expect(find.byType(AgentLogoLoading), findsNothing);
+    });
+
+    testWidgets('reserves the photo suggestion slot on the first frame', (
+      tester,
+    ) async {
+      await _pumpDialogFrame(tester);
+
+      final slotFinder = find.byKey(superAgentPhotoSuggestionSlotKey);
+
+      expect(slotFinder, findsOneWidget);
+      expect(
+        tester.getSize(slotFinder).height,
+        superAgentPhotoSuggestionSlotHeight,
+      );
+      expect(
+        find.text(UserStorage.l10n.agentChat.findingRecentPhotos),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders selected images through the cached image widget', (
+      tester,
+    ) async {
+      await _pumpDialogFrame(
+        tester,
+        dialog: AgentChatDialog(
+          initialImages: [XFile('/tmp/memex-selected-image.jpg')],
+        ),
+      );
+
+      expect(find.byType(LocalImage), findsOneWidget);
+    });
+
     testWidgets(
       'keeps header actions inside the compact header on narrow screens',
       (tester) async {
@@ -450,19 +496,28 @@ Future<void> _pumpDialog(
   WidgetTester tester, {
   Size viewportSize = const Size(390, 800),
 }) async {
+  await _pumpDialogFrame(tester, viewportSize: viewportSize);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _pumpDialogFrame(
+  WidgetTester tester, {
+  Size viewportSize = const Size(390, 800),
+  Widget dialog = const AgentChatDialog(),
+}) async {
   tester.view.physicalSize = viewportSize;
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
 
   await tester.pumpWidget(
-    const MaterialApp(
+    MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        body: AgentChatDialog(),
+        body: dialog,
       ),
     ),
   );
-  await tester.pumpAndSettle();
+  await tester.pump();
 }

--- a/test/ui/chat/widgets/open_super_agent_dialog_test.dart
+++ b/test/ui/chat/widgets/open_super_agent_dialog_test.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
+import 'package:memex/ui/chat/widgets/open_super_agent_dialog.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      'language': 'en',
+      'user_id': 'open-super-agent-test',
+    });
+    await UserStorage.initL10n();
+  });
+
+  test('returns cached latest Super Agent home session id', () async {
+    await UserStorage.setLatestSuperAgentHomeSessionId('cached-session');
+
+    await expectLater(
+        latestSuperAgentSessionId(), completion('cached-session'));
+  });
+
+  testWidgets('waits for session lookup before building chat dialog', (
+    tester,
+  ) async {
+    final sessionId = Completer<String?>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: buildSuperAgentDialogSessionGate(
+          sessionIdFuture: sessionId.future,
+        ),
+      ),
+    );
+
+    expect(find.byType(AgentChatDialog), findsNothing);
+
+    sessionId.complete('session-1');
+    await tester.pump();
+
+    expect(find.byType(AgentChatDialog), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Use the fixed app logo for the activity widget instead of rotating processing frames.
- Cache the latest Super Agent home session id in UserStorage and gate dialog construction on the resolved session.
- Keep the photo suggestion strip stable, remove the dialog opening loader, and render chat images via the shared LocalImage cache.

## Validation
- flutter analyze lib/ui/agent_activity/widgets/agent_activity_widget.dart lib/ui/chat/widgets/agent_chat_dialog.dart lib/ui/chat/widgets/open_super_agent_dialog.dart lib/utils/user_storage.dart test/ui/agent_activity/agent_activity_widget_test.dart test/ui/chat/widgets/agent_chat_dialog_test.dart test/ui/chat/widgets/open_super_agent_dialog_test.dart
- flutter test test/ui/agent_activity/agent_activity_widget_test.dart test/ui/chat/widgets/agent_chat_dialog_test.dart test/ui/chat/widgets/open_super_agent_dialog_test.dart