### PR TITLE
Add markdown download to knowledge files

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "إدارة المهارات",
   "skillsManagementEmpty": "لا توجد مهارات بعد",
   "downloadSkill": "تحميل مهارة",
+  "downloadFile": "تنزيل الملف",
   "downloading": "جار التحميل...",
   "downloadSuccess": "تم تحميل المهارة بنجاح",
   "downloadFailed": "فشل التحميل: {error}",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "Kompetenzmanagement",
   "skillsManagementEmpty": "Noch keine Fähigkeiten",
   "downloadSkill": "Laden Sie Skill herunter",
+  "downloadFile": "Datei herunterladen",
   "downloading": "Herunterladen...",
   "downloadSuccess": "Der Skill wurde erfolgreich heruntergeladen",
   "downloadFailed": "Download fehlgeschlagen: {error}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1113,6 +1113,7 @@
   "skillsManagement": "Skills Management",
   "skillsManagementEmpty": "No skills yet",
   "downloadSkill": "Download Skill",
+  "downloadFile": "Download file",
   "downloading": "Downloading...",
   "downloadSuccess": "Skill downloaded successfully",
   "downloadFailed": "Download failed: {error}",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "Gestión de Skills",
   "skillsManagementEmpty": "Aún no hay Skills",
   "downloadSkill": "Descargar Skill",
+  "downloadFile": "Descargar archivo",
   "downloading": "Descargando...",
   "downloadSuccess": "Skill descargada correctamente",
   "downloadFailed": "Descarga fallida: {error}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "Gestion des skills",
   "skillsManagementEmpty": "Aucune skill pour l'instant",
   "downloadSkill": "Télécharger la skill",
+  "downloadFile": "Télécharger le fichier",
   "downloading": "Téléchargement...",
   "downloadSuccess": "Skill téléchargée avec succès",
   "downloadFailed": "Échec du téléchargement : {error}",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "कौशल प्रबंधन",
   "skillsManagementEmpty": "अभी कोई कौशल नहीं",
   "downloadSkill": "कौशल डाउनलोड करें",
+  "downloadFile": "फ़ाइल डाउनलोड करें",
   "downloading": "डाउनलोड हो रहा है...",
   "downloadSuccess": "कौशल सफलतापूर्वक डाउनलोड हुई",
   "downloadFailed": "डाउनलोड विफल: {error}",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "Manajemen Skill",
   "skillsManagementEmpty": "Belum ada skill",
   "downloadSkill": "Unduh Skill",
+  "downloadFile": "Unduh file",
   "downloading": "Mengunduh...",
   "downloadSuccess": "Skill berhasil diunduh",
   "downloadFailed": "Unduhan gagal: {error}",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "スキル 管理",
   "skillsManagementEmpty": "スキル はまだありません",
   "downloadSkill": "スキル をダウンロード",
+  "downloadFile": "ファイルをダウンロード",
   "downloading": "ダウンロード中...",
   "downloadSuccess": "スキル を正常にダウンロードしました",
   "downloadFailed": "ダウンロードに失敗しました: {error}",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "스킬 관리",
   "skillsManagementEmpty": "아직 스킬이 없습니다",
   "downloadSkill": "스킬 다운로드",
+  "downloadFile": "파일 다운로드",
   "downloading": "다운로드 중...",
   "downloadSuccess": "스킬을 성공적으로 다운로드했습니다",
   "downloadFailed": "다운로드 실패: {error}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4542,6 +4542,12 @@ abstract class AppLocalizations {
   /// **'Download Skill'**
   String get downloadSkill;
 
+  /// No description provided for @downloadFile.
+  ///
+  /// In en, this message translates to:
+  /// **'Download file'**
+  String get downloadFile;
+
   /// No description provided for @downloading.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2477,6 +2477,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get downloadSkill => 'تحميل مهارة';
 
   @override
+  String get downloadFile => 'تنزيل الملف';
+
+  @override
   String get downloading => 'جار التحميل...';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2534,6 +2534,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadSkill => 'Laden Sie Skill herunter';
 
   @override
+  String get downloadFile => 'Datei herunterladen';
+
+  @override
   String get downloading => 'Herunterladen...';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2488,6 +2488,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get downloadSkill => 'Download Skill';
 
   @override
+  String get downloadFile => 'Download file';
+
+  @override
   String get downloading => 'Downloading...';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2525,6 +2525,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get downloadSkill => 'Descargar Skill';
 
   @override
+  String get downloadFile => 'Descargar archivo';
+
+  @override
   String get downloading => 'Descargando...';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2530,6 +2530,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get downloadSkill => 'Télécharger la skill';
 
   @override
+  String get downloadFile => 'Télécharger le fichier';
+
+  @override
   String get downloading => 'Téléchargement...';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2494,6 +2494,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get downloadSkill => 'कौशल डाउनलोड करें';
 
   @override
+  String get downloadFile => 'फ़ाइल डाउनलोड करें';
+
+  @override
   String get downloading => 'डाउनलोड हो रहा है...';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2508,6 +2508,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get downloadSkill => 'Unduh Skill';
 
   @override
+  String get downloadFile => 'Unduh file';
+
+  @override
   String get downloading => 'Mengunduh...';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2440,6 +2440,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get downloadSkill => 'スキル をダウンロード';
 
   @override
+  String get downloadFile => 'ファイルをダウンロード';
+
+  @override
   String get downloading => 'ダウンロード中...';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2440,6 +2440,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get downloadSkill => '스킬 다운로드';
 
   @override
+  String get downloadFile => '파일 다운로드';
+
+  @override
   String get downloading => '다운로드 중...';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2510,6 +2510,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get downloadSkill => 'Baixar skill';
 
   @override
+  String get downloadFile => 'Baixar arquivo';
+
+  @override
   String get downloading => 'Baixando...';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2511,6 +2511,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get downloadSkill => 'Скачать skill';
 
   @override
+  String get downloadFile => 'Скачать файл';
+
+  @override
   String get downloading => 'Загрузка...';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2413,6 +2413,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get downloadSkill => '下载 Skill';
 
   @override
+  String get downloadFile => '下载文件';
+
+  @override
   String get downloading => '下载中...';
 
   @override
@@ -5626,6 +5629,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get downloadSkill => '下載 技能';
+
+  @override
+  String get downloadFile => '下載檔案';
 
   @override
   String get downloading => '下載中...';

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "Gerenciamento de skills",
   "skillsManagementEmpty": "Ainda não há skills",
   "downloadSkill": "Baixar skill",
+  "downloadFile": "Baixar arquivo",
   "downloading": "Baixando...",
   "downloadSuccess": "Skill baixada com sucesso",
   "downloadFailed": "Download falhou: {error}",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "Управление skills",
   "skillsManagementEmpty": "Skills пока нет",
   "downloadSkill": "Скачать skill",
+  "downloadFile": "Скачать файл",
   "downloading": "Загрузка...",
   "downloadSuccess": "Skill успешно скачан",
   "downloadFailed": "Загрузка не удалась: {error}",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1093,6 +1093,7 @@
   "skillsManagement": "Skills 管理",
   "skillsManagementEmpty": "暂无 Skill",
   "downloadSkill": "下载 Skill",
+  "downloadFile": "下载文件",
   "downloading": "下载中...",
   "downloadSuccess": "Skill 下载成功",
   "downloadFailed": "下载失败：{error}",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1132,6 +1132,7 @@
   "skillsManagement": "技能 管理",
   "skillsManagementEmpty": "尚無 技能",
   "downloadSkill": "下載 技能",
+  "downloadFile": "下載檔案",
   "downloading": "下載中...",
   "downloadSuccess": "技能 已成功下載",
   "downloadFailed": "下載失敗：{error}",

--- a/lib/ui/knowledge/widgets/knowledge_file_page.dart
+++ b/lib/ui/knowledge/widgets/knowledge_file_page.dart
@@ -5,9 +5,14 @@ import 'package:memex/domain/models/timeline_card_model.dart';
 import 'package:memex/ui/timeline/widgets/timeline_card_detail_screen.dart';
 import 'package:memex/ui/core/cards/templates/classic_card.dart';
 import 'package:path/path.dart' as path;
+import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/share_service.dart';
+import 'package:memex/utils/toast_helper.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/core/widgets/back_button.dart';
+
+final _logger = getLogger('KnowledgeFilePage');
 
 class KnowledgeFilePage extends StatefulWidget {
   final String filePath;
@@ -25,6 +30,7 @@ class _KnowledgeFilePageState extends State<KnowledgeFilePage> {
   List<TimelineCardModel> _sourceCards = [];
   bool _isLoading = true;
   bool _isLoadingCards = false;
+  bool _isDownloading = false;
 
   @override
   void initState() {
@@ -64,7 +70,11 @@ class _KnowledgeFilePageState extends State<KnowledgeFilePage> {
 
   List<String> _extractFactIds(String content) {
     final regex = RegExp(r'<!--\s*fact_id:\s*(.*?)\s*-->');
-    return regex.allMatches(content).map((m) => m.group(1)!.trim()).toList();
+    return regex
+        .allMatches(content)
+        .map((m) => m.group(1)!.trim())
+        .where((id) => id.isNotEmpty)
+        .toList();
   }
 
   Future<void> _fetchSourceCards(List<String> ids) async {
@@ -73,13 +83,47 @@ class _KnowledgeFilePageState extends State<KnowledgeFilePage> {
       final cards = await _memexRouter.fetchCardByIds(ids);
       if (mounted) {
         setState(() {
-          _sourceCards = cards;
+          _sourceCards = _dedupeSourceCards(cards);
           _isLoadingCards = false;
         });
       }
     } catch (e) {
       if (mounted) setState(() => _isLoadingCards = false);
-      print('Error fetching source cards: $e');
+      _logger.warning('Error fetching source cards: $e');
+    }
+  }
+
+  List<TimelineCardModel> _dedupeSourceCards(List<TimelineCardModel> cards) {
+    final seen = <String>{};
+    return cards.where((card) => seen.add(card.id)).toList();
+  }
+
+  int get _uniqueFactIdCount => _factIds.toSet().length;
+
+  Future<void> _downloadFile() async {
+    if (_isLoading || _isDownloading) return;
+
+    setState(() => _isDownloading = true);
+    try {
+      await ShareService.shareTextAsFile(
+        context,
+        fileName: path.basename(widget.filePath),
+        content: _content,
+        mimeType: 'text/markdown',
+        text: UserStorage.l10n.sharedFromMemex,
+      );
+    } catch (e, stackTrace) {
+      _logger.severe('Failed to download knowledge file: $e', e, stackTrace);
+      if (mounted) {
+        ToastHelper.showError(
+          context,
+          UserStorage.l10n.downloadFailed(e.toString()),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isDownloading = false);
+      }
     }
   }
 
@@ -107,9 +151,23 @@ class _KnowledgeFilePageState extends State<KnowledgeFilePage> {
         elevation: 0,
         leading: const AppBackButton(),
         iconTheme: const IconThemeData(color: Color(0xFF64748B)),
+        actions: [
+          IconButton(
+            key: const ValueKey('knowledge_file_download_button'),
+            tooltip: UserStorage.l10n.downloadFile,
+            onPressed: (_isLoading || _isDownloading) ? null : _downloadFile,
+            icon: _isDownloading
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.download_rounded),
+          ),
+        ],
       ),
       body: _isLoading
-          ? Center(child: AgentLogoLoading())
+          ? const Center(child: AgentLogoLoading())
           : SingleChildScrollView(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -159,10 +217,10 @@ class _KnowledgeFilePageState extends State<KnowledgeFilePage> {
                   if (_factIds.isNotEmpty) ...[
                     const SizedBox(height: 24),
                     Container(
-                      decoration: BoxDecoration(
-                        color: const Color(0xFFF8F9FA),
-                        borderRadius: const BorderRadius.vertical(
-                            top: Radius.circular(24)),
+                      decoration: const BoxDecoration(
+                        color: Color(0xFFF8F9FA),
+                        borderRadius:
+                            BorderRadius.vertical(top: Radius.circular(24)),
                       ),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -189,7 +247,7 @@ class _KnowledgeFilePageState extends State<KnowledgeFilePage> {
                                       const SizedBox(width: 4),
                                       Text(
                                           UserStorage.l10n.sourceTraceWithCount(
-                                              _factIds.length),
+                                              _uniqueFactIdCount),
                                           style: const TextStyle(
                                               fontSize: 10,
                                               fontWeight: FontWeight.bold,

--- a/lib/utils/share_service.dart
+++ b/lib/utils/share_service.dart
@@ -152,4 +152,36 @@ class ShareService {
     await Share.shareXFiles([XFile(file.path)],
         text: UserStorage.l10n.sharedFromMemex);
   }
+
+  /// Shares plain text content as a temporary file so the user can save it.
+  static Future<void> shareTextAsFile(
+    BuildContext context, {
+    required String fileName,
+    required String content,
+    String mimeType = 'text/plain',
+    String? text,
+  }) async {
+    final box = context.findRenderObject() as RenderBox?;
+    final sharePositionOrigin = box != null
+        ? box.localToGlobal(Offset.zero) & box.size
+        : const Rect.fromLTWH(0, 0, 100, 100);
+    final tempDir = await getTemporaryDirectory();
+    final safeFileName = _safeFileName(fileName);
+    final file = File('${tempDir.path}/$safeFileName');
+    await file.writeAsString(content);
+
+    await Share.shareXFiles(
+      [XFile(file.path, mimeType: mimeType, name: safeFileName)],
+      text: text,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+  }
+
+  static String _safeFileName(String fileName) {
+    final sanitized = fileName
+        .trim()
+        .replaceAll(RegExp(r'[\\/:*?"<>|]'), '_')
+        .replaceAll(RegExp(r'\s+'), ' ');
+    return sanitized.isEmpty ? 'memex.md' : sanitized;
+  }
 }


### PR DESCRIPTION
## Summary
- Add a download action to the Knowledge Base Markdown file page.
- Share the currently loaded Markdown content as a .md file through the system share/save sheet.
- Deduplicate Source Trace counts and rendered source cards by fact/card ID while preserving repeated source markers in the Markdown preview.
- Add localized label text for the new download file action.

## Validation
- flutter test test/ui/knowledge -r expanded
- flutter analyze (fails on existing repository info-level lints; no new blocking errors from this change)