### PR TITLE
Preserve Super Agent chat turn metadata on retry

### DIFF
--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -850,7 +850,8 @@ class ChatService {
                 cancelToken: cancelToken,
               );
         await agentFuture.whenComplete(() async {
-          if (activeAgent.state.metadata[_runningChatTurnIdKey] == turnId) {
+          if (!activeAgent.state.isRunning &&
+              activeAgent.state.metadata[_runningChatTurnIdKey] == turnId) {
             activeAgent.state.metadata.remove(_runningChatTurnIdKey);
             await saveAgentState(activeAgent.state);
           }

--- a/test/data/services/chat_service_test.dart
+++ b/test/data/services/chat_service_test.dart
@@ -66,6 +66,21 @@ void main() {
     });
   });
 
+  group('Super Agent chat turn resume guard', () {
+    test('keeps the running turn id while the agent can still resume', () {
+      final source =
+          File('lib/data/services/chat_service.dart').readAsStringSync();
+      final cleanupBlock = RegExp(
+        r'if \(!activeAgent\.state\.isRunning &&\s*'
+        r'activeAgent\.state\.metadata\[_runningChatTurnIdKey\] == turnId\) \{\s*'
+        r'activeAgent\.state\.metadata\.remove\(_runningChatTurnIdKey\);',
+        multiLine: true,
+      );
+
+      expect(cleanupBlock.hasMatch(source), isTrue);
+    });
+  });
+
   group('Super Agent state refresh', () {
     const userId = 'chat-state-refresh-user';
     const sessionId = 'memex_agent_state_refresh_session';


### PR DESCRIPTION
## Summary
- Keep the running chat turn metadata while a Super Agent state is still resumable.
- Prevent retrying chat turn tasks from clearing the turn id after partial state commit, so retries resume instead of re-sending the user message.
- Add a regression guard for the cleanup condition.

## Validation
- flutter test test/data/services/chat_service_test.dart -r expanded
- flutter analyze (fails with existing info-level lint findings unrelated to this change)