### PR TITLE
Improve subagent reminders and finish summaries

### DIFF
--- a/lib/agent/built_in_tools/file_tools.dart
+++ b/lib/agent/built_in_tools/file_tools.dart
@@ -627,14 +627,10 @@ class FileToolFactory {
             'items': {'type': 'string'},
             'description': 'List of glob patterns to ignore'
           },
-          'depth': {
-            'type': 'integer',
-            'description': 'Depth to list files and directories, default is 3'
-          },
         },
         'required': ['path']
       },
-      executable: (String path, List? ignore, int? depth) {
+      executable: (String path, List? ignore) {
         path = _resolvePath(path);
         if (!permissionManager.canTraverseForRead(path)) {
           throw ApiException(
@@ -645,7 +641,7 @@ class FileToolFactory {
           dirPath: path,
           workingDirectory: workingDirectory,
           ignore: ignore?.cast<String>(),
-          depth: depth ?? 3,
+          depth: 1,
           filter: (p) => permissionManager.allowsRead(p),
           traversalFilter: (p) => permissionManager.canTraverseForRead(p),
         );

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -115,7 +115,7 @@ This tool is your ONLY way to touch a card. A card file is not yours to edit —
 When the user provides new raw input, follow this sequence:
 0. **Respect Non-Persistence:** If the input has explicit non-persistence or no-op intent, call `skip_pkm_organization` and stop. Do not write or edit P.A.R.A. files for this input.
 1. **Analyze:** Extract all distinct information from the user's raw input.
-2. **Categorize:** Determine the storage location in the P.A.R.A. knowledge base based on `LS` results. If those are insufficient, use `Grep`, `Read` to gather more context.
+2. **Categorize:** Determine the storage location in the P.A.R.A. knowledge base based on the PKM structure tree. If that is insufficient, use file tools to gather more context.
 3. **Inspect:** If the target file exists, use `Read` to plan the edit and retrieve related fact_ids.
 4. **Store:** Create or update the file content, ensuring proper association with `fact_id`.
 5. **Update Insight:** Use `update_timeline_card_insight` to update the timeline card’s insight and related facts.

--- a/lib/agent/skills/manage_pkm/pkm_skill.dart
+++ b/lib/agent/skills/manage_pkm/pkm_skill.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/agent/prompts.dart';
 import 'package:memex/agent/run_mode/agent_action_approval_service.dart';
@@ -6,6 +8,7 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
+import 'package:path/path.dart' as p;
 
 // Tool executable parameter names mirror JSON schema keys.
 // ignore_for_file: non_constant_identifier_names
@@ -18,6 +21,7 @@ class PkmSkill extends Skill {
   PkmSkill({
     super.forceActivate,
     List<bool>? stopAfterUpdateCardInsightRef,
+    bool enableFinishSummary = false,
     String? workingDirectory,
   }) : super(
           name: "manage_pkm", // Renamed to capability-focused name
@@ -31,22 +35,61 @@ class PkmSkill extends Skill {
             UserStorage.l10n.pkmFileLanguageInstruction,
             UserStorage.l10n.pkmInsightLanguageInstruction,
           ),
-          tools: _buildTools(stopAfterUpdateCardInsightRef),
+          tools: _buildTools(
+            stopAfterUpdateCardInsightRef,
+            enableFinishSummary: enableFinishSummary,
+          ),
         );
 
-  static List<Tool> _buildTools(List<bool>? stopAfterUpdateCardInsightRef) {
+  static List<Tool> _buildTools(
+    List<bool>? stopAfterUpdateCardInsightRef, {
+    required bool enableFinishSummary,
+  }) {
     final logger = getLogger('PkmSkill');
+    final updateInsightParameters = Map<String, dynamic>.from(
+        Prompts.pkmSkillUpdateCardInsightToolParameters);
+    final updateInsightProperties =
+        Map<String, dynamic>.from(updateInsightParameters['properties'] as Map);
+    if (enableFinishSummary) {
+      updateInsightProperties['finish_summary'] = {
+        'type': 'string',
+        'description':
+            'If this successful update completes the requested work, set this to the exact concise final summary to return. Include relevant work already done in this run. Omit it if another tool call, inspection, or repair is still needed.',
+      };
+    }
+    updateInsightParameters['properties'] = updateInsightProperties;
+
+    final getPkmOverviewTool = Tool(
+      name: 'get_pkm_overview',
+      description:
+          'Get current directory structure and file information of the PKM knowledge base.',
+      parameters: {
+        'type': 'object',
+        'properties': {},
+      },
+      executable: () async {
+        final context = AgentCallToolContext.current;
+        if (context == null) {
+          throw StateError(
+              "get_pkm_overview must be called within an agent execution context.");
+        }
+        final userId = context.state.metadata['userId'] as String;
+        return buildPkmOverviewForUser(userId);
+      },
+    );
 
     return [
+      getPkmOverviewTool,
       Tool(
         name: 'update_timeline_card_insight',
         description: Prompts.pkmSkillUpdateCardInsightToolDescription,
-        parameters: Prompts.pkmSkillUpdateCardInsightToolParameters,
+        parameters: updateInsightParameters,
         executable: (
           String fact_id,
           String insight_text,
-          List? related_fact_ids,
-        ) async {
+          List? related_fact_ids, [
+          String? finish_summary,
+        ]) async {
           final context = AgentCallToolContext.current;
           if (context == null) {
             throw StateError(
@@ -122,9 +165,13 @@ class PkmSkill extends Skill {
             (card) => card.copyWith(insight: insightData),
           );
 
-          final stopFlag = stopAfterUpdateCardInsightRef != null
-              ? stopAfterUpdateCardInsightRef[0]
-              : false;
+          final isSubAgent = context.state.metadata['sub_agent_mode'] == true;
+          final hasFinishSummary =
+              finish_summary != null && finish_summary.trim().isNotEmpty;
+          final stopFlag = (stopAfterUpdateCardInsightRef != null
+                  ? stopAfterUpdateCardInsightRef[0]
+                  : false) ||
+              (isSubAgent && hasFinishSummary);
 
           if (updatedCardData == null) {
             logger.warning(
@@ -142,6 +189,16 @@ class PkmSkill extends Skill {
             content: TextPart(Prompts.pkmSkillUpdateCardInsightSuccess(
                 cardPath, fact_id, relatedCount)),
             stopFlag: stopFlag,
+            metadata: {
+              if (isSubAgent && hasFinishSummary)
+                'child_terminal_result': {
+                  'status': 'completed',
+                  'summary': finish_summary.trim(),
+                  'fact_id': fact_id,
+                  'pkm_changed': true,
+                  'related_count': relatedCount,
+                },
+            },
           );
         },
       ),
@@ -165,9 +222,137 @@ class PkmSkill extends Skill {
               'PKM organization skipped. evidence=$evidence',
             ),
             stopFlag: true,
+            metadata: {
+              'child_terminal_result': {
+                'status': 'no_op',
+                'summary': 'PKM organization skipped. evidence=$evidence',
+                if (factId is String) 'fact_id': factId,
+                'pkm_changed': false,
+              },
+            },
           );
         },
       ),
     ];
   }
 }
+
+Future<String> buildPkmOverviewForUser(
+  String userId, {
+  int maxEntries = 800,
+}) {
+  return buildPkmOverview(
+    pkmRootPath: FileSystemService.instance.getPkmPath(userId),
+    maxEntries: maxEntries,
+  );
+}
+
+Future<String> buildPkmOverview({
+  required String pkmRootPath,
+  int maxEntries = 800,
+}) async {
+  try {
+    final rootType =
+        await FileSystemEntity.type(pkmRootPath, followLinks: false);
+    if (rootType == FileSystemEntityType.notFound) {
+      return 'P.A.R.A. knowledge base has not been created yet, currently empty.';
+    }
+    if (rootType != FileSystemEntityType.directory) {
+      return _formatPkmOverviewError('/PKM is not a directory.');
+    }
+
+    return _buildPkmOverviewTree(
+      root: Directory(pkmRootPath),
+      maxEntries: maxEntries,
+    );
+  } catch (e) {
+    return _formatPkmOverviewError(e.toString());
+  }
+}
+
+Future<String> _buildPkmOverviewTree({
+  required Directory root,
+  required int maxEntries,
+}) async {
+  final buffer = StringBuffer()
+    ..writeln('PKM structure tree')
+    ..writeln('Root: /PKM')
+    ..writeln('Legend: directories end with /')
+    ..writeln();
+
+  var directoryCount = 1;
+  var fileCount = 0;
+  var emitted = 0;
+  var truncated = false;
+
+  buffer.writeln('/PKM/');
+
+  Future<void> visit(Directory dir, int depth) async {
+    if (truncated) return;
+
+    final children = <FileSystemEntity>[];
+    try {
+      await for (final entity
+          in dir.list(recursive: false, followLinks: false)) {
+        final name = p.basename(entity.path);
+        if (name.startsWith('.')) continue;
+        children.add(entity);
+      }
+    } catch (e) {
+      buffer.writeln('${'  ' * depth}(unreadable: $e)');
+      return;
+    }
+
+    children.sort((a, b) {
+      final aIsDir = a is Directory;
+      final bIsDir = b is Directory;
+      if (aIsDir && !bIsDir) return -1;
+      if (!aIsDir && bIsDir) return 1;
+      return p.basename(a.path).compareTo(p.basename(b.path));
+    });
+
+    if (children.isEmpty && depth == 1) {
+      buffer.writeln('  (empty)');
+      return;
+    }
+
+    for (final child in children) {
+      if (emitted >= maxEntries) {
+        truncated = true;
+        buffer
+            .writeln('${'  ' * depth}... truncated after $maxEntries entries');
+        return;
+      }
+
+      final name = p.basename(child.path);
+      final isDir = child is Directory;
+      buffer.writeln('${'  ' * depth}$name${isDir ? '/' : ''}');
+      emitted++;
+
+      if (isDir) {
+        directoryCount++;
+        await visit(child, depth + 1);
+      } else {
+        fileCount++;
+      }
+    }
+  }
+
+  await visit(root, 1);
+
+  buffer
+    ..writeln()
+    ..writeln('Summary: $directoryCount directories, $fileCount files');
+  if (truncated) {
+    buffer
+        .writeln('Note: overview truncated; use file tools to inspect deeper.');
+  } else {
+    buffer.writeln(
+      'Note: this overview contains the complete PKM structure; usually no additional LS or Glob call is needed to inspect the tree.',
+    );
+  }
+  return buffer.toString().trimRight();
+}
+
+String _formatPkmOverviewError(String error) =>
+    'Unable to get P.A.R.A. knowledge base structure: $error';

--- a/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
@@ -18,11 +18,14 @@ import 'package:memex/utils/user_storage.dart';
 
 final logger = Logger('TimelineCardSkill');
 
+bool _nonEmpty(String? value) => value != null && value.trim().isNotEmpty;
+
 /// Skill for managing Timeline Cards
 class TimelineCardSkill extends Skill {
   TimelineCardSkill({
     super.forceActivate,
     bool stopAfterSuccessSaveCard = false,
+    bool enableFinishSummary = false,
   }) : super(
           name: "manage_timeline_card", // Renamed as requested
           description:
@@ -30,7 +33,10 @@ class TimelineCardSkill extends Skill {
               "Handles information extraction, template selection, and card data persistence for the Timeline view. "
               "Use when: 1. User posts new content needing a timeline card. 2. User provides feedback to modify an existing timeline card.",
           systemPrompt: _buildSystemPrompt(),
-          tools: _buildTools(stopAfterSuccessSaveCard),
+          tools: _buildTools(
+            stopAfterSuccessSaveCard,
+            enableFinishSummary: enableFinishSummary,
+          ),
         );
 
   static String _buildSystemPrompt() {
@@ -89,7 +95,92 @@ class TimelineCardSkill extends Skill {
     return sb.toString();
   }
 
-  static List<Tool> _buildTools(bool stopAfterSuccessSaveCard) {
+  static List<Tool> _buildTools(
+    bool stopAfterSuccessSaveCard, {
+    required bool enableFinishSummary,
+  }) {
+    final saveProperties = <String, dynamic>{
+      'fact_id': {
+        'type': 'string',
+        'description':
+            'REQUIRED. For a brand-new record: the id you minted with `mint_record_fact_id` first. For editing/repairing: the existing card id (e.g. 2025/01/01.md#ts_123). Never invent an id — it must come from mint_record_fact_id or be an existing card.'
+      },
+      'title': {
+        'type': 'string',
+        'description':
+            'A concise summary displayed on detail page header. Required for a new card; omit when editing to keep the existing title.'
+      },
+      'ui_configs': {
+        'type': 'array',
+        'description':
+            'UI rendering configuration list. Required for a new card; omit when editing to keep the existing layout. When provided, you MUST give the full data object for the selected template.',
+        'items': {
+          'type': 'object',
+          'properties': {
+            'template_id': {'type': 'string', 'description': 'Template ID'},
+            'data': {
+              'type': 'object',
+              'description':
+                  'Template data object. CRITICAL: This MUST NOT be empty. You must populate all required fields for the chosen template_id as defined in the available templates.'
+            }
+          },
+          'required': ['template_id', 'data']
+        }
+      },
+      'address': {
+        'type': 'string',
+        'description':
+            'Location information for where the recorded card actually happened. Use raw input named places only when they are the actual occurrence, check-in, visit, photo capture, or activity location. For tasks, todos, reminders, plans, wishes, future destinations, or places the user merely wants to go to, omit address even if a place is mentioned. If raw input describes an immediate present-time event, check-in, photo capture, or daily activity and current_location_context is available, use its location_summary or full_address_candidate as a conservative default. Do not use current_location_context for memories, plans, remote events, or when raw input names a conflicting place. Do not be too specific. Use the format "City · Specific Location" (e.g., Beijing · Chaoyang Park) if possible, otherwise just the specific location name is fine.'
+      },
+      'user_mark_address': {
+        'type': 'string',
+        'description':
+            'User-marked location information, set when raw input contains very close user-marked location'
+      },
+      'content_creation_date': {
+        'type': 'string',
+        'description':
+            'The creation date of the content (e.g. image capture time), in format "YYYY-MM-DD HH:MM:SS". If not provided, current time will be used.'
+      },
+      'tags': {
+        'type': 'array',
+        'description':
+            'Select 1-3 most appropriate tags strictly from internal pre-defined list. Do not invent new tags.',
+        'items': {
+          'type': 'object',
+          'properties': {
+            'name': {
+              'type': 'string',
+              'description':
+                  "Tag name. MUST be one of: 'Project', 'Trip', 'Milestone', 'Health', 'Relationship', 'Finance', 'Knowledge', 'Emotion', 'Visual', 'Audio'."
+            },
+            'icon': {
+              'type': 'string',
+              'description': 'Not used anymore, internal icons are hardcoded.'
+            },
+          },
+          'required': ['name']
+        }
+      },
+      'fact': {
+        'type': 'string',
+        'description':
+            "The source-of-truth record content. Write a coherent record in the user's own words and speaking/writing style, combining the user's text with the image/audio content that matters to this record. This is the faithful original content, not a summary, paraphrase, or your own commentary. If the user wrote text, preserve their wording where it matters. Do NOT put an `fs://` reference here — attachment references go only in `assets`. Required for a new card; omit when editing to keep the existing fact."
+      },
+      'assets': {
+        'type': 'array',
+        'description':
+            "The image and audio files attached to this card, as bare `fs://...` references extracted from the attachment markers in the user message (for example `fs://photo.jpg`) — copied exactly, never invented or altered. Omit this field entirely to keep the card's existing assets unchanged; pass the full list to replace them. Required only when a new card has attachments.",
+        'items': {'type': 'string'}
+      },
+      if (enableFinishSummary)
+        'finish_summary': {
+          'type': 'string',
+          'description':
+              'If this successful save completes the requested work, set this to the exact concise final summary to return. Include relevant work already done in this run. Omit it if another tool call, inspection, or repair is still needed.',
+        },
+    };
+
     return [
       Tool(
         name: 'get_card_metadata',
@@ -114,85 +205,7 @@ class TimelineCardSkill extends Skill {
             "`fact`.",
         parameters: {
           'type': 'object',
-          'properties': {
-            'fact_id': {
-              'type': 'string',
-              'description':
-                  'REQUIRED. For a brand-new record: the id you minted with `mint_record_fact_id` first. For editing/repairing: the existing card id (e.g. 2025/01/01.md#ts_123). Never invent an id — it must come from mint_record_fact_id or be an existing card.'
-            },
-            'title': {
-              'type': 'string',
-              'description':
-                  'A concise summary displayed on detail page header. Required for a new card; omit when editing to keep the existing title.'
-            },
-            'ui_configs': {
-              'type': 'array',
-              'description':
-                  'UI rendering configuration list. Required for a new card; omit when editing to keep the existing layout. When provided, you MUST give the full data object for the selected template.',
-              'items': {
-                'type': 'object',
-                'properties': {
-                  'template_id': {
-                    'type': 'string',
-                    'description': 'Template ID'
-                  },
-                  'data': {
-                    'type': 'object',
-                    'description':
-                        'Template data object. CRITICAL: This MUST NOT be empty. You must populate all required fields for the chosen template_id as defined in the available templates.'
-                  }
-                },
-                'required': ['template_id', 'data']
-              }
-            },
-            'address': {
-              'type': 'string',
-              'description':
-                  'Location information for where the recorded card actually happened. Use raw input named places only when they are the actual occurrence, check-in, visit, photo capture, or activity location. For tasks, todos, reminders, plans, wishes, future destinations, or places the user merely wants to go to, omit address even if a place is mentioned. If raw input describes an immediate present-time event, check-in, photo capture, or daily activity and current_location_context is available, use its location_summary or full_address_candidate as a conservative default. Do not use current_location_context for memories, plans, remote events, or when raw input names a conflicting place. Do not be too specific. Use the format "City · Specific Location" (e.g., Beijing · Chaoyang Park) if possible, otherwise just the specific location name is fine.'
-            },
-            'user_mark_address': {
-              'type': 'string',
-              'description':
-                  'User-marked location information, set when raw input contains very close user-marked location'
-            },
-            'content_creation_date': {
-              'type': 'string',
-              'description':
-                  'The creation date of the content (e.g. image capture time), in format "YYYY-MM-DD HH:MM:SS". If not provided, current time will be used.'
-            },
-            'tags': {
-              'type': 'array',
-              'description':
-                  'Select 1-3 most appropriate tags strictly from internal pre-defined list. Do not invent new tags.',
-              'items': {
-                'type': 'object',
-                'properties': {
-                  'name': {
-                    'type': 'string',
-                    'description':
-                        "Tag name. MUST be one of: 'Project', 'Trip', 'Milestone', 'Health', 'Relationship', 'Finance', 'Knowledge', 'Emotion', 'Visual', 'Audio'."
-                  },
-                  'icon': {
-                    'type': 'string',
-                    'description':
-                        'Not used anymore, internal icons are hardcoded.'
-                  },
-                },
-                'required': ['name']
-              }
-            },
-            'fact': {
-              'type': 'string',
-              'description':
-                  "The source-of-truth record content. Write a coherent record in the user's own words and speaking/writing style, combining the user's text with the image/audio content that matters to this record. This is the faithful original content, not a summary, paraphrase, or your own commentary. If the user wrote text, preserve their wording where it matters. Do NOT put an `fs://` reference here — attachment references go only in `assets`. Required for a new card; omit when editing to keep the existing fact."
-            },
-            'assets': {
-              'type': 'array',
-              'description':
-                  "The image and audio files attached to this card, as bare `fs://...` references extracted from the attachment markers in the user message (for example `fs://photo.jpg`) — copied exactly, never invented or altered. Omit this field entirely to keep the card's existing assets unchanged; pass the full list to replace them. Required only when a new card has attachments.",
-              'items': {'type': 'string'}
-            },
-          },
+          'properties': saveProperties,
           'required': ['fact_id']
         },
         executable: (String? fact_id,
@@ -203,7 +216,8 @@ class TimelineCardSkill extends Skill {
             String? content_creation_date,
             dynamic tags,
             String? fact,
-            dynamic assets) async {
+            dynamic assets,
+            [String? finish_summary]) async {
           final fileService = FileSystemService.instance;
 
           // Access context
@@ -218,6 +232,9 @@ class TimelineCardSkill extends Skill {
           logger.info("Saving card for fact: ${fact_id ?? '(new)'}");
 
           final userId = AgentCallToolContext.current!.state.metadata['userId'];
+          final isSubAgent =
+              AgentCallToolContext.current!.state.metadata['sub_agent_mode'] ==
+                  true;
 
           final denied = await gateMutatingToolCall(
             toolName: 'save_timeline_card',
@@ -567,7 +584,8 @@ class TimelineCardSkill extends Skill {
                   "$resolvedFactId — use this exact id when organizing this "
                   "record into PKM (e.g. `<!-- fact_id: $resolvedFactId -->`) "
                   "so the knowledge base links back to this card."),
-              stopFlag: stopAfterSuccessSaveCard,
+              stopFlag: stopAfterSuccessSaveCard ||
+                  (isSubAgent && _nonEmpty(finish_summary)),
               metadata: {
                 'artifact': {
                   'type': 'card',
@@ -576,6 +594,13 @@ class TimelineCardSkill extends Skill {
                   'tags': tagNames,
                   'updated': true,
                 },
+                if (isSubAgent && _nonEmpty(finish_summary))
+                  'child_terminal_result': {
+                    'status': 'completed',
+                    'summary': finish_summary!.trim(),
+                    'fact_id': resolvedFactId,
+                    'card_changed': true,
+                  },
               },
             );
           } catch (e, stack) {

--- a/lib/agent/super_agent/subagent/delegate_subagent_tool.dart
+++ b/lib/agent/super_agent/subagent/delegate_subagent_tool.dart
@@ -53,7 +53,10 @@ final Map<String, _SubagentPreset> _subagentPresets = {
         'Creates or updates Timeline Cards. Skills: manage_timeline_card active, dynamic_timeline_ui available.',
     toolProfile: ChildToolProfile.none,
     buildSkills: () => [
-      TimelineCardSkill(forceActivate: true),
+      TimelineCardSkill(
+        forceActivate: true,
+        enableFinishSummary: true,
+      ),
       DynamicTimelineUiSkill(forceActivate: false),
     ],
     writeRoots: const ['/_UserSettings/Templates'],
@@ -63,8 +66,13 @@ final Map<String, _SubagentPreset> _subagentPresets = {
     description:
         'Organizes information into the P.A.R.A knowledge base. Skills: manage_pkm active.',
     toolProfile: ChildToolProfile.full,
-    buildSkills: () =>
-        [PkmSkill(forceActivate: true, workingDirectory: '/PKM')],
+    buildSkills: () => [
+      PkmSkill(
+        forceActivate: true,
+        workingDirectory: '/PKM',
+        enableFinishSummary: true,
+      )
+    ],
     readRoots: const ['/PKM'],
     writeRoots: const ['/PKM'],
   ),
@@ -224,6 +232,29 @@ Tool buildDelegateToSubagentTool() {
         contextPacket['attachment_exif'] = exifBlocks;
       }
 
+      if (agent_type == 'pkm') {
+        try {
+          final overview = await buildPkmOverviewForUser(userId);
+          if (overview.trim().isNotEmpty) {
+            contextPacket['pkm_overview'] = overview.trim();
+          }
+        } catch (e) {
+          _logger.warning('Failed to attach PKM overview to child: $e');
+        }
+      }
+
+      if (agent_type == 'timeline_card') {
+        try {
+          final metadata =
+              await TimelineCardSkill.getTimelineCardMetadata(userId);
+          if (metadata.trim().isNotEmpty) {
+            contextPacket['card_metadata'] = metadata.trim();
+          }
+        } catch (e) {
+          _logger.warning('Failed to attach card metadata to child: $e');
+        }
+      }
+
       final config = SuperAgentChildConfig(
         childName: preset.childName,
         taskBrief: task_brief,
@@ -268,10 +299,30 @@ Tool buildDelegateToSubagentTool() {
       }
 
       return AgentToolResult(
-        content: TextPart(
-            '[${preset.childName}] status=${result.status.name}\n${result.summary}'),
+        content: TextPart(_formatSubagentResultForParent(
+          agentType: agent_type,
+          result: result,
+        )),
         metadata: {'child_result': result.toJson()},
       );
     },
   );
+}
+
+String _formatSubagentResultForParent({
+  required String agentType,
+  required SuperAgentChildResult result,
+}) {
+  return '<subagent_result agent_type="${_escapeAttr(agentType)}" '
+      'status="${result.status.name}">\n'
+      '${result.summary.trim()}\n'
+      '</subagent_result>';
+}
+
+String _escapeAttr(String value) {
+  return value
+      .replaceAll('&', '&amp;')
+      .replaceAll('"', '&quot;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
 }

--- a/lib/agent/super_agent/subagent/super_agent_child.dart
+++ b/lib/agent/super_agent/subagent/super_agent_child.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:dio/dio.dart';
@@ -121,9 +120,8 @@ class SuperAgentChildResult {
   /// to the separate child state file.
   final String? childSessionId;
 
-  /// Best-effort structured payload parsed from the child's final message
-  /// (the child is asked to end with a JSON object). Empty when the child
-  /// returned plain prose or nothing parseable.
+  /// Runtime-provided structured payload, usually from the terminal tool
+  /// result. Kept separate from the model-written summary.
   final Map<String, dynamic> structured;
 
   /// Set when the run threw / timed out before the child could report.
@@ -137,6 +135,24 @@ class SuperAgentChildResult {
     this.structured = const {},
     this.error,
   });
+
+  SuperAgentChildResult copyWith({
+    String? childName,
+    SuperAgentChildStatus? status,
+    String? summary,
+    String? childSessionId,
+    Map<String, dynamic>? structured,
+    String? error,
+  }) {
+    return SuperAgentChildResult(
+      childName: childName ?? this.childName,
+      status: status ?? this.status,
+      summary: summary ?? this.summary,
+      childSessionId: childSessionId ?? this.childSessionId,
+      structured: structured ?? this.structured,
+      error: error ?? this.error,
+    );
+  }
 
   factory SuperAgentChildResult.failed(
     String childName,
@@ -192,15 +208,14 @@ message is parsed by the parent runtime.
   provide, return `needs_parent_input` naming the exact missing field.
 
 ## Output
-End your run with a concise plain-text summary, then a single fenced JSON object
-on its own describing the structured result, e.g.:
+When a successful terminal tool call completes your task, pass
+`finish_summary` on that tool call. Use it for the exact concise final summary,
+including relevant work already done in this run. Leave it unset if another
+tool call, inspection, or repair is still needed.
 
-```json
-{"status": "completed | no_op | failed | needs_parent_input", "summary": "..."}
-```
-
-Include any branch-specific fields your skill instructions ask for (such as
-`fact_id`, `card_changed`, `pkm_changed`, `schedule_changed`, `changed_files`).
+If no terminal tool applies, end with a concise plain-text summary. For no-op
+work, explicitly say `no_op` and the reason. If you genuinely need missing
+parent input, explicitly say `needs_parent_input` and name the missing field.
 ''';
 }
 
@@ -235,6 +250,19 @@ String _buildContextReminder(Map<String, dynamic> packet) {
     if (blocks.isNotEmpty) {
       sections.add(blocks.join('\n\n'));
     }
+  }
+
+  final pkmOverview = packet['pkm_overview'];
+  if (pkmOverview is String && pkmOverview.trim().isNotEmpty) {
+    sections.add('Current PKM structure tree:\n${pkmOverview.trim()}');
+  }
+
+  final cardMetadata = packet['card_metadata'];
+  if (cardMetadata is String && cardMetadata.trim().isNotEmpty) {
+    sections.add(
+      'Latest get_card_metadata result. Use this metadata instead of calling '
+      'get_card_metadata again:\n${cardMetadata.trim()}',
+    );
   }
 
   return '<system-reminder>\n${sections.join('\n\n')}\n</system-reminder>';
@@ -456,18 +484,26 @@ Future<SuperAgentChildResult> runSuperAgentChild({
     final messages = await agent.run([initial],
         cancelToken: cancelToken, useStream: false).timeout(config.timeout);
 
+    final terminalResult = _terminalResultFromMessages(messages);
+    if (terminalResult != null) {
+      _logger.info(
+          'Child ${config.childName} finished: status=${terminalResult.status.name}');
+      return terminalResult.copyWith(
+        childName: config.childName,
+        childSessionId: agent.state.sessionId,
+      );
+    }
+
     final finalText = _lastText(messages);
-    final structured = _extractJson(finalText);
-    final status = _statusFromWire(structured['status'] as String?);
+    final status = _statusFromPlainText(finalText);
 
     _logger.info('Child ${config.childName} finished: status=${status.name}');
 
     return SuperAgentChildResult(
       childName: config.childName,
       status: status,
-      summary: (structured['summary'] as String?) ?? finalText,
+      summary: finalText,
       childSessionId: agent.state.sessionId,
-      structured: structured,
     );
   } on TimeoutException {
     final message = 'child timed out after ${_formatTimeout(config.timeout)}';
@@ -520,26 +556,43 @@ String _lastText(List<LLMMessage> messages) {
   return '';
 }
 
-/// Pull the first {...} JSON object out of [text]. Tolerant of markdown fences
-/// and surrounding prose. Returns an empty map when nothing parses.
-Map<String, dynamic> _extractJson(String text) {
-  if (text.isEmpty) return const {};
-  var s = text;
-  final fence = text.indexOf('```');
-  if (fence >= 0) {
-    final after = text.substring(fence + 3);
-    final lf = after.indexOf('\n');
-    final body = lf >= 0 ? after.substring(lf + 1) : after;
-    final end = body.indexOf('```');
-    s = end >= 0 ? body.substring(0, end) : body;
+SuperAgentChildResult? _terminalResultFromMessages(List<LLMMessage> messages) {
+  for (var i = messages.length - 1; i >= 0; i -= 1) {
+    final message = messages[i];
+    if (message is! FunctionExecutionResultMessage) continue;
+    for (var j = message.results.length - 1; j >= 0; j -= 1) {
+      final result = message.results[j];
+      if (result.isError) continue;
+      final metadata = result.metadata;
+      final raw = metadata?['child_terminal_result'];
+      if (raw is! Map) continue;
+      final terminal = Map<String, dynamic>.from(raw);
+      final summary = terminal['summary']?.toString().trim();
+      if (summary == null || summary.isEmpty) continue;
+      return SuperAgentChildResult(
+        childName: '',
+        status: _statusFromWire(terminal['status']?.toString()),
+        summary: summary,
+        structured: terminal,
+      );
+    }
   }
-  final lo = s.indexOf('{');
-  final hi = s.lastIndexOf('}');
-  if (lo < 0 || hi <= lo) return const {};
-  try {
-    final decoded = jsonDecode(s.substring(lo, hi + 1));
-    return decoded is Map<String, dynamic> ? decoded : const {};
-  } catch (_) {
-    return const {};
+  return null;
+}
+
+SuperAgentChildStatus _statusFromPlainText(String text) {
+  final normalized = text.toLowerCase().replaceAll('-', '_');
+  if (normalized.contains('needs_parent_input') ||
+      normalized.contains('needs parent input')) {
+    return SuperAgentChildStatus.needsParentInput;
   }
+  if (normalized.contains('no_op') || normalized.contains('no op')) {
+    return SuperAgentChildStatus.noOp;
+  }
+  if (normalized.contains('failed') || normalized.contains('error')) {
+    return SuperAgentChildStatus.failed;
+  }
+  return text.trim().isEmpty
+      ? SuperAgentChildStatus.failed
+      : SuperAgentChildStatus.completed;
 }

--- a/lib/agent/super_agent/super_agent.dart
+++ b/lib/agent/super_agent/super_agent.dart
@@ -23,6 +23,8 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/utils/logger.dart';
 
+export 'package:memex/agent/super_agent/super_agent_pre_minted_record_hook.dart';
+
 /// Read-only tool names available in Quick Query mode.
 const _readOnlyToolNames = {
   'LS',
@@ -96,6 +98,7 @@ class SuperAgent {
       required String name,
       required AgentState state,
       AgentController? controller,
+      List<AgentHook> extraHooks = const [],
       List<String>? forceActiveSkills,
       bool quickQuery = false,
       String? additionalSystemPrompt,
@@ -251,6 +254,7 @@ class SuperAgent {
         hooks: [
           createAgentPromptHook(userId),
           _SuperAgentPromptHook(),
+          ...extraHooks,
           SuperAgentHarness.buildParentHook(userId),
         ]);
 

--- a/lib/agent/super_agent/super_agent_pre_minted_record_hook.dart
+++ b/lib/agent/super_agent/super_agent_pre_minted_record_hook.dart
@@ -1,0 +1,265 @@
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:logging/logging.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:memex/utils/logger.dart';
+
+const _factIdMetadataKey = 'super_agent_pre_minted_record_fact_id';
+const _turnIdMetadataKey = 'super_agent_pre_minted_record_turn_id';
+const _userMessageTimestampMetadataKey =
+    'super_agent_pre_minted_record_user_message_timestamp';
+
+class SuperAgentPreMintedRecordHook extends AgentHook {
+  SuperAgentPreMintedRecordHook({
+    required this.userId,
+    required this.turnId,
+  });
+
+  @visibleForTesting
+  SuperAgentPreMintedRecordHook.forTesting({
+    required this.userId,
+    required this.turnId,
+    required String factId,
+  }) : _factId = factId;
+
+  static final Logger _logger = getLogger('SuperAgentPreMintedRecordHook');
+
+  @visibleForTesting
+  static const factIdMetadataKey = _factIdMetadataKey;
+
+  @visibleForTesting
+  static const turnIdMetadataKey = _turnIdMetadataKey;
+
+  @visibleForTesting
+  static const userMessageTimestampMetadataKey =
+      _userMessageTimestampMetadataKey;
+
+  final String userId;
+  final String turnId;
+  String? _factId;
+  int? _userMessageTimestamp;
+
+  Future<void> preallocate(AgentState state) async {
+    _loadFromState(state);
+    final factId = _factId?.trim();
+    if (factId != null && factId.isNotEmpty) return;
+
+    await _clearDifferentTurnPlaceholderIfNeeded(state);
+    _factId = await FileSystemService.instance.allocateCardFactId(userId);
+    _writeToState(state);
+  }
+
+  @visibleForTesting
+  String? get factIdForTesting => _factId;
+
+  @override
+  BeforeRunHookResult beforeRun(BeforeRunHookContext context) {
+    _loadFromState(context.state);
+    _userMessageTimestamp ??= _firstUserMessageTimestamp(context.input);
+    _writeToState(context.state);
+    return BeforeRunHookResult.proceed(context.input);
+  }
+
+  @override
+  ModelCallHookResult beforeModelCall(ModelCallHookContext context) {
+    _loadFromState(context.state);
+    final factId = _factId?.trim();
+    final userMessageTimestamp = _userMessageTimestamp;
+    if (factId == null || factId.isEmpty || userMessageTimestamp == null) {
+      return ModelCallHookResult.proceed(request: context.request);
+    }
+
+    final nextRequestMessages = annotatePreMintedRecordFactIdReminder(
+      context.request.requestMessages,
+      factId,
+      userMessageTimestamp: userMessageTimestamp,
+    );
+    return ModelCallHookResult.proceed(
+      request: context.request.copyWith(requestMessages: nextRequestMessages),
+      changed: !identical(
+        nextRequestMessages,
+        context.request.requestMessages,
+      ),
+    );
+  }
+
+  @override
+  Future<void> afterRun(AfterRunHookContext context) async {
+    _loadFromState(context.state);
+    final factId = _factId?.trim();
+    if (factId == null || factId.isEmpty) return;
+    if (context.error != null && context.state.isRunning) {
+      return;
+    }
+
+    try {
+      final card =
+          await FileSystemService.instance.readCardFile(userId, factId);
+      if (isUnusedPreallocatedRecordPlaceholder(card, factId)) {
+        await FileSystemService.instance.deleteCard(userId, factId);
+        return;
+      }
+      final userMessageTimestamp = _userMessageTimestamp;
+      if (card != null && userMessageTimestamp != null) {
+        final annotated = annotateUserMessageSystemReminder(
+          context.state.history.messages,
+          userMessageTimestamp: userMessageTimestamp,
+          reminder: 'Pre-minted record fact_id used this turn: $factId.',
+        );
+        if (!identical(annotated, context.state.history.messages)) {
+          context.state.history.messages = annotated;
+        }
+      }
+    } catch (e) {
+      _logger.warning(
+        'Failed to clean up pre-minted record fact_id $factId: $e',
+      );
+    } finally {
+      _factId = null;
+      _userMessageTimestamp = null;
+      _clearState(context.state);
+    }
+  }
+
+  void _loadFromState(AgentState state) {
+    final metadataTurnId = _metadataString(state, _turnIdMetadataKey);
+    if (metadataTurnId != turnId) return;
+
+    _factId ??= _metadataString(state, _factIdMetadataKey);
+    _userMessageTimestamp ??=
+        _metadataInt(state, _userMessageTimestampMetadataKey);
+  }
+
+  void _writeToState(AgentState state) {
+    final factId = _factId?.trim();
+    if (factId == null || factId.isEmpty) return;
+
+    state.metadata[_factIdMetadataKey] = factId;
+    state.metadata[_turnIdMetadataKey] = turnId;
+    final userMessageTimestamp = _userMessageTimestamp;
+    if (userMessageTimestamp != null) {
+      state.metadata[_userMessageTimestampMetadataKey] = userMessageTimestamp;
+    }
+  }
+
+  void _clearState(AgentState state) {
+    state.metadata.remove(_factIdMetadataKey);
+    state.metadata.remove(_turnIdMetadataKey);
+    state.metadata.remove(_userMessageTimestampMetadataKey);
+  }
+
+  Future<void> _clearDifferentTurnPlaceholderIfNeeded(AgentState state) async {
+    final metadataTurnId = _metadataString(state, _turnIdMetadataKey);
+    final metadataFactId = _metadataString(state, _factIdMetadataKey);
+    if (metadataFactId == null) return;
+    if (metadataTurnId == turnId) return;
+
+    try {
+      final card =
+          await FileSystemService.instance.readCardFile(userId, metadataFactId);
+      if (isUnusedPreallocatedRecordPlaceholder(card, metadataFactId)) {
+        await FileSystemService.instance.deleteCard(userId, metadataFactId);
+      }
+    } catch (e) {
+      _logger.warning(
+        'Failed to clean up stale pre-minted record fact_id '
+        '$metadataFactId: $e',
+      );
+    } finally {
+      _clearState(state);
+    }
+  }
+}
+
+@visibleForTesting
+List<LLMMessage> annotatePreMintedRecordFactIdReminder(
+  List<LLMMessage> messages,
+  String? factId, {
+  required int? userMessageTimestamp,
+}) {
+  final id = factId?.trim();
+  if (id == null || id.isEmpty || userMessageTimestamp == null) {
+    return messages;
+  }
+  final reminder =
+      'Pre-minted record fact_id: $id. You can use it directly; mint more only if needed.';
+  return annotateUserMessageSystemReminder(
+    messages,
+    userMessageTimestamp: userMessageTimestamp,
+    reminder: reminder,
+  );
+}
+
+@visibleForTesting
+bool isUnusedPreallocatedRecordPlaceholder(CardData? card, String factId) {
+  if (card == null) return false;
+  if (card.factId != factId) return false;
+  if (card.status != 'processing') return false;
+  if ((card.title ?? '').trim().isNotEmpty) return false;
+  if ((card.fact ?? '').trim().isNotEmpty) return false;
+  if (card.assets.isNotEmpty) return false;
+  if (card.tags.isNotEmpty) return false;
+  if (card.comments.isNotEmpty) return false;
+  if (card.insight != null) return false;
+  if (card.uiConfigs.length != 1) return false;
+  final config = card.uiConfigs.single;
+  if (config.templateId != 'classic_card') return false;
+  return (config.data['content']?.toString() ?? '').trim().isEmpty;
+}
+
+@visibleForTesting
+List<LLMMessage> annotateUserMessageSystemReminder(
+  List<LLMMessage> messages, {
+  required int userMessageTimestamp,
+  required String reminder,
+}) {
+  final rewritten = List<LLMMessage>.from(messages);
+  for (var i = rewritten.length - 1; i >= 0; i -= 1) {
+    final message = rewritten[i];
+    if (message is! UserMessage) continue;
+    if (message.timestamp != userMessageTimestamp) continue;
+
+    final contents = List<UserContentPart>.from(message.contents);
+    for (var j = 0; j < contents.length; j += 1) {
+      final part = contents[j];
+      if (part is! TextPart) continue;
+      if (!part.text.contains('<system-reminder>')) continue;
+      if (part.text.contains(reminder)) return messages;
+
+      final updatedText = part.text.contains('</system-reminder>')
+          ? part.text.replaceFirst(
+              '</system-reminder>',
+              '\n\n$reminder\n</system-reminder>',
+            )
+          : '${part.text}\n\n$reminder';
+      contents[j] = TextPart(updatedText);
+      rewritten[i] = UserMessage(
+        contents,
+        timestamp: message.timestamp,
+        metadata: message.metadata,
+      );
+      return rewritten;
+    }
+  }
+  return messages;
+}
+
+int? _firstUserMessageTimestamp(List<LLMMessage> messages) {
+  for (final message in messages) {
+    if (message is UserMessage) return message.timestamp;
+  }
+  return null;
+}
+
+String? _metadataString(AgentState state, String key) {
+  final value = state.metadata[key]?.toString().trim();
+  return value == null || value.isEmpty ? null : value;
+}
+
+int? _metadataInt(AgentState state, String key) {
+  final value = state.metadata[key];
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse(value?.toString() ?? '');
+}

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -569,6 +569,7 @@ class ChatService {
     StatefulAgent? agent;
     AgentController? controller;
     SkillSyncResult? skillSync;
+    SuperAgentPreMintedRecordHook? preMintedRecordHook;
 
     try {
       // Check if this session belongs to a custom agent by reading session metadata,
@@ -657,6 +658,12 @@ class ChatService {
             break;
         }
       } else {
+        preMintedRecordHook = isQuickQuery
+            ? null
+            : SuperAgentPreMintedRecordHook(
+                userId: userId,
+                turnId: turnId,
+              );
         // Default: use SuperAgent for normal chat sessions. Behavioral
         // guidance (orchestration, truthfulness, comprehensive correction,
         // tone, judgment) lives in superAgentSystemPrompt; only the dynamic
@@ -679,6 +686,9 @@ class ChatService {
           name: agentName,
           state: state,
           controller: controller,
+          extraHooks: [
+            if (preMintedRecordHook != null) preMintedRecordHook,
+          ],
           forceActiveSkills: forceActiveSkills,
           quickQuery: isQuickQuery,
           additionalSystemPrompt: additionalSystemPrompt,
@@ -825,17 +835,24 @@ class ChatService {
         }
       }
 
-      userMessages = [
-        UserMessage(
-          userContentParts,
-          metadata: {
-            // Lets the context compressor replace archived image bytes with
-            // fs:// filename placeholders (see SuperAgentContextCompressor).
-            if (inlinedImageFileNames.isNotEmpty)
-              'image_fs_paths': inlinedImageFileNames,
-          },
-        ),
-      ];
+      final userMessage = UserMessage(
+        userContentParts,
+        metadata: {
+          // Lets the context compressor replace archived image bytes with
+          // fs:// filename placeholders (see SuperAgentContextCompressor).
+          if (inlinedImageFileNames.isNotEmpty)
+            'image_fs_paths': inlinedImageFileNames,
+        },
+      );
+      try {
+        await preMintedRecordHook?.preallocate(activeAgent.state);
+        if (preMintedRecordHook != null) {
+          await saveAgentState(activeAgent.state);
+        }
+      } catch (e) {
+        _logger.warning('Failed to pre-mint record fact_id: $e');
+      }
+      userMessages = [userMessage];
     }
 
     await DelegateProgressContext.run(progressSink, () async {

--- a/lib/data/services/geocoding_service.dart
+++ b/lib/data/services/geocoding_service.dart
@@ -11,11 +11,8 @@ class GeocodingService {
   GeocodingService._internal();
 
   static const int _maxCacheEntries = 100;
-  static const int _maxTransientAttempts = 3;
-  static const List<Duration> _transientRetryDelays = [
-    Duration(milliseconds: 300),
-    Duration(milliseconds: 800),
-  ];
+  static const int _maxTransientAttempts = 1;
+  static const List<Duration> _transientRetryDelays = <Duration>[];
   final _logger = getLogger('GeocodingService');
   final Map<String, GeocodedAddress> _memoryCache = {};
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -364,10 +364,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_agent_core
-      sha256: "5828c4de2fc89b3c7b3b4c4268b1805930aa8730a12c24686f61e6a98c927889"
+      sha256: dc6772a2b169da9748eee18d0b45b666e2ec17496118c274981203f726772895
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   dart_jsonwebtoken:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,7 +67,7 @@ dependencies:
   health: ^13.2.1
   pedometer: ^4.0.0
   workmanager: ^0.9.0
-  dart_agent_core: ^2.0.3
+  dart_agent_core: ^2.0.4
   flutter_js: ^0.8.7
   drift: ^2.30.0
   sqlite3_flutter_libs: ^0.5.41

--- a/test/agent/super_agent_child_test.dart
+++ b/test/agent/super_agent_child_test.dart
@@ -7,12 +7,15 @@ import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/agent/skills/dynamic_timeline_ui/dynamic_timeline_ui_skill.dart';
+import 'package:memex/agent/skills/manage_pkm/pkm_skill.dart';
+import 'package:memex/agent/skills/manage_timeline_card/timeline_card_skill.dart';
 import 'package:memex/agent/super_agent/subagent/delegate_progress.dart';
 import 'package:memex/agent/super_agent/subagent/delegate_subagent_tool.dart';
 import 'package:memex/agent/super_agent/subagent/super_agent_child.dart';
 import 'package:memex/data/services/api_exception.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -132,9 +135,12 @@ void main() {
           (agent.tools ?? const []).singleWhere((t) => t.name == 'LS');
       final rootList = await _callTool<String>(lsTool, {'path': '/'});
       expect(rootList, contains('PKM'));
-      expect(rootList, contains('note.md'));
       expect(rootList, isNot(contains('Cards')));
       expect(rootList, isNot(contains('card.yaml')));
+
+      final pkmList = await _callTool<String>(lsTool, {'path': '/PKM'});
+      expect(pkmList, contains('note.md'));
+      expect(pkmList, contains('new.md'));
 
       expect(
         () => _callTool<String>(lsTool, {'path': '/Cards'}),
@@ -262,8 +268,7 @@ void main() {
         client: _SingleToolCallClient(
           toolName: 'LS',
           arguments: {'path': '/'},
-          finalText:
-              '```json\n{"status":"completed","summary":"listed workspace"}\n```',
+          finalText: 'Listed the workspace.',
         ),
         modelConfig: ModelConfig(model: 'test'),
         userId: userId,
@@ -278,19 +283,209 @@ void main() {
       expect(sink.events, contains('finish:delegate_1:LS:false'));
     });
 
-    test('run extracts a structured no_op result from the final message',
+    test('pkm overview formats a model-oriented structure tree', () async {
+      final workspace = FileSystemService.instance.getWorkspacePath(userId);
+      await Directory('$workspace/PKM/Projects/App').create(recursive: true);
+      await File('$workspace/PKM/Projects/App/note.md').writeAsString('note');
+      await Directory('$workspace/Cards').create(recursive: true);
+      await File('$workspace/Cards/card.yaml').writeAsString('secret');
+
+      final overview = await buildPkmOverviewForUser(userId);
+
+      expect(overview, contains('PKM structure tree'));
+      expect(overview, contains('Root: /PKM'));
+      expect(overview, contains('Projects/'));
+      expect(overview, contains('App/'));
+      expect(overview, contains('note.md'));
+      expect(overview, contains('Summary:'));
+      expect(overview, contains('complete PKM structure'));
+      expect(overview, contains('no additional LS or Glob'));
+      expect(overview, isNot(contains('Cards')));
+      expect(overview, isNot(contains('card.yaml')));
+    });
+
+    test('pkm overview reports an empty PKM when the root is missing',
         () async {
+      final overview = await buildPkmOverview(
+        pkmRootPath: '${tempRoot.path}/missing/PKM',
+      );
+
+      expect(
+        overview,
+        'P.A.R.A. knowledge base has not been created yet, currently empty.',
+      );
+    });
+
+    test('pkm overview marks incomplete trees when truncated', () async {
+      final workspace = FileSystemService.instance.getWorkspacePath(userId);
+      await Directory('$workspace/PKM/Projects/App').create(recursive: true);
+      await File('$workspace/PKM/Projects/App/a.md').writeAsString('a');
+      await File('$workspace/PKM/Projects/App/b.md').writeAsString('b');
+
+      final overview = await buildPkmOverviewForUser(userId, maxEntries: 1);
+
+      expect(overview, contains('PKM structure tree'));
+      expect(overview, contains('... truncated after 1 entries'));
+      expect(
+        overview,
+        contains('Note: overview truncated; use file tools to inspect deeper.'),
+      );
+      expect(overview, isNot(contains('complete PKM structure')));
+    });
+
+    test('delegate injects PKM overview reminder into pkm child', () async {
+      final workspace = FileSystemService.instance.getWorkspacePath(userId);
+      await Directory('$workspace/PKM/Projects/App').create(recursive: true);
+      await File('$workspace/PKM/Projects/App/note.md').writeAsString('note');
+      await Directory('$workspace/Cards').create(recursive: true);
+      await File('$workspace/Cards/card.yaml').writeAsString('secret');
+
+      final tool = buildDelegateToSubagentTool();
+      final state = AgentState(
+        sessionId: 'delegate_pkm_overview_test',
+        metadata: {'userId': userId},
+      );
+      final client = _SingleToolCallClient(
+        toolName: tool.name,
+        arguments: {
+          'task_brief': 'File this record in PKM.',
+          'agent_type': 'pkm',
+        },
+        finalText: 'Filed the record in PKM.',
+      );
+      final agent = StatefulAgent(
+        name: 'delegate_pkm_overview_agent',
+        client: client,
+        modelConfig: ModelConfig(model: 'test'),
+        state: state,
+        tools: [tool],
+        withGeneralPrinciples: false,
+        maxTurns: 3,
+      );
+
+      await agent.run([UserMessage.text('delegate')], useStream: false);
+
+      expect(client.generateInputs.length, greaterThanOrEqualTo(2));
+      final childPrompt = _messagesText(client.generateInputs[1]);
+      expect(childPrompt, contains('Current PKM structure tree'));
+      expect(childPrompt, contains('Projects/'));
+      expect(childPrompt, contains('App/'));
+      expect(childPrompt, contains('note.md'));
+      expect(childPrompt, isNot(contains('Cards')));
+      expect(childPrompt, isNot(contains('card.yaml')));
+    });
+
+    test('delegate injects latest card metadata reminder into card child',
+        () async {
+      final tool = buildDelegateToSubagentTool();
+      final state = AgentState(
+        sessionId: 'delegate_card_metadata_test',
+        metadata: {'userId': userId},
+      );
+      final client = _SingleToolCallClient(
+        toolName: tool.name,
+        arguments: {
+          'task_brief': 'Create a timeline card for this record.',
+          'agent_type': 'timeline_card',
+        },
+        finalText: 'Created the timeline card.',
+      );
+      final agent = StatefulAgent(
+        name: 'delegate_card_metadata_agent',
+        client: client,
+        modelConfig: ModelConfig(model: 'test'),
+        state: state,
+        tools: [tool],
+        withGeneralPrinciples: false,
+        maxTurns: 3,
+      );
+
+      await agent.run([UserMessage.text('delegate')], useStream: false);
+
+      expect(client.generateInputs.length, greaterThanOrEqualTo(2));
+      final childPrompt = _messagesText(client.generateInputs[1]);
+      expect(
+        childPrompt,
+        contains('Latest get_card_metadata result.'),
+      );
+      expect(
+        childPrompt,
+        contains(
+            'Use this metadata instead of calling get_card_metadata again'),
+      );
+      expect(childPrompt, contains('# Available Templates'));
+      expect(childPrompt, contains('## template_id: article'));
+      expect(childPrompt, contains('# Existing Tags'));
+    });
+
+    test('run infers no_op from the final plain-text message', () async {
       final result = await runSuperAgentChild(
         config: cfg(ChildToolProfile.read),
         client: _ScriptedClient(texts: const [
-          'Nothing schedule-related here.\n\n'
-              '```json\n{"status":"no_op","summary":"no dated content"}\n```',
+          'no_op: no dated content',
         ]),
         modelConfig: ModelConfig(model: 'test'),
         userId: userId,
       );
       expect(result.status, SuperAgentChildStatus.noOp);
-      expect(result.summary, 'no dated content');
+      expect(result.summary, 'no_op: no dated content');
+    });
+
+    test('terminal tool finish_summary completes child without final LLM call',
+        () async {
+      const factId = '2026/06/26.md#ts_1';
+      await FileSystemService.instance.safeWriteCardFile(
+        userId,
+        factId,
+        CardData(
+          factId: factId,
+          timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          status: 'completed',
+          tags: const [],
+          uiConfigs: const [
+            UiConfig(templateId: 'classic_card', data: {'content': 'before'}),
+          ],
+          fact: 'record content',
+        ),
+      );
+      final client = _SingleToolCallClient(
+        toolName: 'update_timeline_card_insight',
+        arguments: {
+          'fact_id': factId,
+          'insight_text': 'A useful insight.',
+          'related_fact_ids': [],
+          'finish_summary':
+              'Updated the card insight and found no related facts.',
+        },
+        finalText: 'should not be called',
+      );
+
+      final result = await runSuperAgentChild(
+        config: SuperAgentChildConfig(
+          childName: 'pkm_child',
+          taskBrief: 'Update insight.',
+          skills: [
+            PkmSkill(
+              forceActivate: true,
+              workingDirectory: '/PKM',
+              enableFinishSummary: true,
+            )
+          ],
+          toolProfile: ChildToolProfile.none,
+        ),
+        client: client,
+        modelConfig: ModelConfig(model: 'test'),
+        userId: userId,
+      );
+
+      expect(client.generateInputs, hasLength(1));
+      expect(result.status, SuperAgentChildStatus.completed);
+      expect(
+        result.summary,
+        'Updated the card insight and found no related facts.',
+      );
+      expect(result.structured['fact_id'], factId);
+      expect(result.structured['pkm_changed'], isTrue);
     });
 
     test('run reports failed when the child errors out', () async {
@@ -418,8 +613,7 @@ void main() {
             'task_brief': 'Capture this image attachment `fs://photo.jpg`）。',
             'agent_type': 'research',
           },
-          finalText:
-              '```json\n{"status":"completed","summary":"asset ok"}\n```',
+          finalText: 'Asset reference accepted.',
         ),
         modelConfig: ModelConfig(model: 'test'),
         state: state,
@@ -436,7 +630,7 @@ void main() {
           .results
           .single;
       expect(result.isError, isFalse);
-      expect(_text(result), contains('asset ok'));
+      expect(_text(result), contains('Asset reference accepted.'));
     });
 
     test('delegate rejects unknown agent types', () async {
@@ -488,8 +682,7 @@ void main() {
             'task_brief': 'Summarize what is in the knowledge base.',
             'agent_type': 'research',
           },
-          finalText:
-              '```json\n{"status":"completed","summary":"nothing yet"}\n```',
+          finalText: 'Nothing yet.',
         ),
         modelConfig: ModelConfig(model: 'test'),
         state: state,
@@ -508,7 +701,9 @@ void main() {
       // The validation gate let the fixed research child through: the result is
       // a normal child report, not a rejection.
       expect(result.isError, isFalse);
-      expect(_text(result), contains('research_child'));
+      expect(_text(result), contains('agent_type="research"'));
+      expect(_text(result), contains('Nothing yet.'));
+      expect(_text(result), isNot(contains('child=')));
     });
 
     test('delegate schema exposes agent_type instead of profile and skills',
@@ -535,6 +730,37 @@ void main() {
       );
     });
 
+    test('finish_summary is only exposed by child-specialized skills', () {
+      Tool saveTool(Skill skill) =>
+          skill.tools!.singleWhere((tool) => tool.name == 'save_timeline_card');
+      Tool updateInsightTool(Skill skill) => skill.tools!
+          .singleWhere((tool) => tool.name == 'update_timeline_card_insight');
+
+      final rootSaveProperties =
+          saveTool(TimelineCardSkill()).parameters['properties'] as Map;
+      final childSaveProperties = saveTool(TimelineCardSkill(
+        enableFinishSummary: true,
+      )).parameters['properties'] as Map;
+      final rootInsightProperties =
+          updateInsightTool(PkmSkill()).parameters['properties'] as Map;
+      final childInsightProperties = updateInsightTool(PkmSkill(
+        enableFinishSummary: true,
+      )).parameters['properties'] as Map;
+
+      expect(rootSaveProperties, isNot(contains('finish_summary')));
+      expect(rootInsightProperties, isNot(contains('finish_summary')));
+      expect(childSaveProperties, contains('finish_summary'));
+      expect(childInsightProperties, contains('finish_summary'));
+      expect(
+        (childSaveProperties['finish_summary'] as Map)['description'],
+        isNot(contains('parent')),
+      );
+      expect(
+        (childInsightProperties['finish_summary'] as Map)['description'],
+        isNot(contains('child')),
+      );
+    });
+
     test('delegate accepts a fixed agent_type call without profile or skills',
         () async {
       await Directory(FileSystemService.instance.getWorkspacePath(userId))
@@ -552,8 +778,7 @@ void main() {
             'task_brief': 'Summarize what is in the knowledge base.',
             'agent_type': 'research',
           },
-          finalText:
-              '```json\n{"status":"completed","summary":"nothing yet"}\n```',
+          finalText: 'Nothing yet.',
         ),
         modelConfig: ModelConfig(model: 'test'),
         state: state,
@@ -570,7 +795,9 @@ void main() {
           .results
           .single;
       expect(result.isError, isFalse);
-      expect(_text(result), contains('research_child'));
+      expect(_text(result), contains('agent_type="research"'));
+      expect(_text(result), contains('Nothing yet.'));
+      expect(_text(result), isNot(contains('child=')));
     });
   });
 }
@@ -653,6 +880,26 @@ String _text(FunctionExecutionResult result) {
       .join('\n');
 }
 
+String _messagesText(List<LLMMessage> messages) {
+  final buffer = StringBuffer();
+  for (final message in messages) {
+    if (message is SystemMessage) {
+      buffer.writeln(message.content);
+    } else if (message is UserMessage) {
+      for (final part in message.contents) {
+        if (part is TextPart) buffer.writeln(part.text);
+      }
+    } else if (message is ModelMessage) {
+      if (message.textOutput != null) buffer.writeln(message.textOutput);
+    } else if (message is FunctionExecutionResultMessage) {
+      for (final result in message.results) {
+        buffer.writeln(_text(result));
+      }
+    }
+  }
+  return buffer.toString();
+}
+
 /// Returns the i-th scripted text as a plain (no tool call) model message, so
 /// the agent run ends immediately.
 class _ScriptedClient extends LLMClient {
@@ -701,6 +948,7 @@ class _SingleToolCallClient extends LLMClient {
   final String toolName;
   final Map<String, dynamic> arguments;
   final String finalText;
+  final generateInputs = <List<LLMMessage>>[];
   var _callCount = 0;
 
   @override
@@ -712,6 +960,7 @@ class _SingleToolCallClient extends LLMClient {
     bool? jsonOutput,
     CancelToken? cancelToken,
   }) async {
+    generateInputs.add(List<LLMMessage>.from(messages));
     _callCount += 1;
     if (_callCount == 1) {
       return ModelMessage(

--- a/test/agent/super_agent_permissions_test.dart
+++ b/test/agent/super_agent_permissions_test.dart
@@ -1,7 +1,9 @@
 import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/agent/security/file_permission_manager.dart';
 import 'package:memex/agent/super_agent/super_agent.dart';
+import 'package:memex/domain/models/card_model.dart';
 
 void main() {
   const workspace = '/ws/_u';
@@ -120,4 +122,208 @@ void main() {
       expect(state.activeSkills, ['manage_timeline_card']);
     });
   });
+
+  group('SuperAgent transient pre-minted record reminder', () {
+    test('matches only the empty processing placeholder', () {
+      const factId = '2026/06/26.md#ts_1';
+      const placeholder = CardData(
+        factId: factId,
+        timestamp: 1782441600,
+        status: 'processing',
+        tags: [],
+        uiConfigs: [
+          UiConfig(templateId: 'classic_card', data: {'content': ''}),
+        ],
+      );
+
+      expect(
+        isUnusedPreallocatedRecordPlaceholder(placeholder, factId),
+        isTrue,
+      );
+      expect(
+        isUnusedPreallocatedRecordPlaceholder(
+          placeholder.copyWith(status: 'completed'),
+          factId,
+        ),
+        isFalse,
+      );
+      expect(
+        isUnusedPreallocatedRecordPlaceholder(
+          placeholder.copyWith(fact: 'recorded content'),
+          factId,
+        ),
+        isFalse,
+      );
+    });
+
+    test('annotates the matching user message only in model requests', () {
+      final userMessage = UserMessage([
+        TextPart(
+            '<system-reminder>\nCurrent Local Time: now\n</system-reminder>'),
+        TextPart('current user message'),
+      ]);
+      final messages = <LLMMessage>[
+        userMessage,
+      ];
+
+      final requestMessages = annotatePreMintedRecordFactIdReminder(
+        messages,
+        '2026/06/26.md#ts_2',
+        userMessageTimestamp: userMessage.timestamp,
+      );
+      final text = requestMessages
+          .whereType<UserMessage>()
+          .expand((message) => message.contents)
+          .whereType<TextPart>()
+          .map((part) => part.text)
+          .join('\n');
+
+      expect(text, contains('2026/06/26.md#ts_2'));
+      expect(text, contains('current user message'));
+      expect(requestMessages, hasLength(messages.length));
+      expect(messages.single, isNot(same(requestMessages.first)));
+    });
+
+    test('does not append when no pre-minted fact_id exists', () {
+      final messages = <LLMMessage>[
+        UserMessage([TextPart('current user message')]),
+      ];
+
+      final requestMessages = annotatePreMintedRecordFactIdReminder(
+        messages,
+        null,
+        userMessageTimestamp: null,
+      );
+
+      expect(requestMessages, same(messages));
+    });
+
+    test('reuses persisted same-turn fact_id after task restart', () async {
+      final state = AgentState(
+        sessionId: 'restart_session',
+        metadata: {
+          SuperAgentPreMintedRecordHook.turnIdMetadataKey: 'turn-1',
+          SuperAgentPreMintedRecordHook.factIdMetadataKey: '2026/06/26.md#ts_1',
+        },
+      );
+      final hook = SuperAgentPreMintedRecordHook(
+        userId: 'test_user',
+        turnId: 'turn-1',
+      );
+
+      await hook.preallocate(state);
+
+      expect(hook.factIdForTesting, '2026/06/26.md#ts_1');
+      expect(
+        state.metadata[SuperAgentPreMintedRecordHook.factIdMetadataKey],
+        '2026/06/26.md#ts_1',
+      );
+    });
+
+    test('keeps same-turn fact_id when a running agent will retry', () async {
+      final state = AgentState(
+        sessionId: 'retry_session',
+        isRunning: true,
+        metadata: {
+          SuperAgentPreMintedRecordHook.turnIdMetadataKey: 'turn-1',
+          SuperAgentPreMintedRecordHook.factIdMetadataKey: '2026/06/26.md#ts_1',
+          SuperAgentPreMintedRecordHook.userMessageTimestampMetadataKey: 123,
+        },
+      );
+      final agent = StatefulAgent(
+        name: 'retry_agent',
+        client: _NoopClient(),
+        modelConfig: ModelConfig(model: 'test'),
+        state: state,
+      );
+      final hook = SuperAgentPreMintedRecordHook(
+        userId: 'test_user',
+        turnId: 'turn-1',
+      );
+
+      await hook.afterRun(
+        AfterRunHookContext(
+          agent,
+          input: const [],
+          modelMessages: const [],
+          error: AgentException(AgentExceptionCode.unknown, 'retryable'),
+        ),
+      );
+
+      expect(
+        state.metadata[SuperAgentPreMintedRecordHook.factIdMetadataKey],
+        '2026/06/26.md#ts_1',
+      );
+      expect(
+        state.metadata[SuperAgentPreMintedRecordHook.turnIdMetadataKey],
+        'turn-1',
+      );
+      expect(
+        state.metadata[
+            SuperAgentPreMintedRecordHook.userMessageTimestampMetadataKey],
+        123,
+      );
+    });
+
+    test('annotates the matching history user message after the id is used',
+        () {
+      final userMessage = UserMessage([
+        TextPart(
+            '<system-reminder>\nCurrent Local Time: now\n</system-reminder>'),
+        TextPart('record this'),
+      ]);
+      final messages = <LLMMessage>[
+        userMessage,
+        ModelMessage(
+          model: 'test',
+          stopReason: 'stop',
+          textOutput: 'done',
+        ),
+      ];
+
+      final annotated = annotateUserMessageSystemReminder(
+        messages,
+        userMessageTimestamp: userMessage.timestamp,
+        reminder:
+            'Pre-minted record fact_id used this turn: 2026/06/26.md#ts_1.',
+      );
+
+      expect(annotated, hasLength(2));
+      expect(messages.singleWhere((m) => m is UserMessage), same(userMessage));
+      final user = annotated.first as UserMessage;
+      final reminder = (user.contents.first as TextPart).text;
+      expect(
+        reminder,
+        contains(
+            'Pre-minted record fact_id used this turn: 2026/06/26.md#ts_1.'),
+      );
+      expect(reminder, contains('</system-reminder>'));
+    });
+  });
+}
+
+class _NoopClient extends LLMClient {
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Stream<StreamingMessage>> stream(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    throw UnimplementedError();
+  }
 }

--- a/test/ui/settings/widgets/agent_state_viewer_page_test.dart
+++ b/test/ui/settings/widgets/agent_state_viewer_page_test.dart
@@ -70,7 +70,8 @@ void main() {
                 'content': [
                   {
                     'type': 'text',
-                    'text': '[timeline_card_child] status=completed\nsaved',
+                    'text':
+                        '<subagent_result agent_type="timeline_card" status="completed">\nsaved\n</subagent_result>',
                   },
                 ],
                 'metadata': {


### PR DESCRIPTION
## Summary
- Align LS behavior with one-level directory listings and add PKM structure reminders for PKM child agents.
- Preload card metadata and pre-minted record IDs into the relevant turn context to avoid redundant tool calls.
- Let PKM/card child agents finish from terminal tool calls with model-provided summaries, and simplify child result output.
- Reduce geocoding retry latency and update dart_agent_core to 2.0.4.

## Validation
- dart analyze targeted changed Dart files
- flutter test test/agent/super_agent_child_test.dart test/agent/super_agent_permissions_test.dart test/ui/settings/widgets/agent_state_viewer_page_test.dart test/data/services/chat_service_test.dart test/data/services/geocoding_service_test.dart --reporter compact