### PR TITLE
Tighten agent tool success messages

### DIFF
--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -178,12 +178,7 @@ Examples:
   static String pkmSkillUpdateCardInsightErrorCardNotFound(String factId) =>
       'Card file not found for fact_id: $factId, maybe it has been deleted';
 
-  static String pkmSkillUpdateCardInsightSuccess(
-    String cardPath,
-    String factId,
-    int relatedCount,
-  ) =>
-      'Card insight updated: $cardPath\nFact ID: $factId\nRelated facts count: $relatedCount';
+  static String get pkmSkillUpdateCardInsightSuccess => 'Card insight updated.';
 
   static String get fileToolReadDescription =>
       '''Reads files from the local file system. You can use this tool to directly access any file.

--- a/lib/agent/skills/manage_pkm/pkm_skill.dart
+++ b/lib/agent/skills/manage_pkm/pkm_skill.dart
@@ -148,9 +148,6 @@ class PkmSkill extends Skill {
                 'update_timeline_card_insight dropped non-existent related_fact_ids: ${droppedRelated.join(', ')}');
           }
 
-          final relatedCount = validRelated.length;
-          final cardPath = fileService.getCardPath(userId, fact_id);
-
           final relatedFacts =
               validRelated.map((id) => RelatedFact(id: id)).toList();
           final insightData = CardInsight(
@@ -186,8 +183,7 @@ class PkmSkill extends Skill {
           ));
 
           return AgentToolResult(
-            content: TextPart(Prompts.pkmSkillUpdateCardInsightSuccess(
-                cardPath, fact_id, relatedCount)),
+            content: TextPart(Prompts.pkmSkillUpdateCardInsightSuccess),
             stopFlag: stopFlag,
             metadata: {
               if (isSubAgent && hasFinishSummary)
@@ -196,7 +192,6 @@ class PkmSkill extends Skill {
                   'summary': finish_summary.trim(),
                   'fact_id': fact_id,
                   'pkm_changed': true,
-                  'related_count': relatedCount,
                 },
             },
           );

--- a/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
@@ -579,11 +579,7 @@ class TimelineCardSkill extends Skill {
             }
 
             return AgentToolResult(
-              content: TextPart(
-                  "Successfully saved timeline card. This record's fact_id is "
-                  "$resolvedFactId — use this exact id when organizing this "
-                  "record into PKM (e.g. `<!-- fact_id: $resolvedFactId -->`) "
-                  "so the knowledge base links back to this card."),
+              content: TextPart('Successfully saved timeline card.'),
               stopFlag: stopAfterSuccessSaveCard ||
                   (isSubAgent && _nonEmpty(finish_summary)),
               metadata: {

--- a/test/agent/mint_and_save_fact_id_test.dart
+++ b/test/agent/mint_and_save_fact_id_test.dart
@@ -128,6 +128,10 @@ void main() {
         metadata: {'userId': userId},
       );
       expect(saveResult.isError, isFalse);
+      expect(_text(saveResult), 'Successfully saved timeline card.');
+      expect(_text(saveResult), isNot(contains('PKM')));
+      expect(_text(saveResult), isNot(contains('fact_id')));
+      expect(_text(saveResult), isNot(contains(factId)));
 
       final card =
           await FileSystemService.instance.readCardFile(userId, factId);

--- a/test/agent/super_agent_child_test.dart
+++ b/test/agent/super_agent_child_test.dart
@@ -488,6 +488,62 @@ void main() {
       expect(result.structured['pkm_changed'], isTrue);
     });
 
+    test('update insight success output does not expose card paths', () async {
+      const factId = '2026/06/26.md#ts_2';
+      await FileSystemService.instance.safeWriteCardFile(
+        userId,
+        factId,
+        CardData(
+          factId: factId,
+          timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          status: 'completed',
+          tags: const [],
+          uiConfigs: const [
+            UiConfig(templateId: 'classic_card', data: {'content': 'before'}),
+          ],
+          fact: 'record content',
+        ),
+      );
+      final tool = PkmSkill(forceActivate: true)
+          .tools!
+          .singleWhere((tool) => tool.name == 'update_timeline_card_insight');
+      final state = AgentState(
+        sessionId: 'pkm_update_${DateTime.now().microsecondsSinceEpoch}',
+        metadata: {'userId': userId},
+      );
+      final agent = StatefulAgent(
+        name: 'pkm_update_test_agent',
+        client: _SingleToolCallClient(
+          toolName: tool.name,
+          arguments: const {
+            'fact_id': factId,
+            'insight_text': 'A useful insight.',
+            'related_fact_ids': [],
+          },
+        ),
+        modelConfig: ModelConfig(model: 'test'),
+        state: state,
+        tools: [tool],
+        withGeneralPrinciples: false,
+        maxTurns: 3,
+      );
+
+      await agent.run([UserMessage.text('update insight')], useStream: false);
+
+      final result = state.history.messages
+          .whereType<FunctionExecutionResultMessage>()
+          .single
+          .results
+          .single;
+      final text = _text(result);
+      expect(result.isError, isFalse);
+      expect(text, 'Card insight updated.');
+      expect(text, isNot(contains(tempRoot.path)));
+      expect(text, isNot(contains('Cards')));
+      expect(text, isNot(contains(factId)));
+      expect(text, isNot(contains('Related facts count')));
+    });
+
     test('run reports failed when the child errors out', () async {
       final result = await runSuperAgentChild(
         config: cfg(ChildToolProfile.read),


### PR DESCRIPTION
## Summary
- Simplify save_timeline_card success output to a neutral confirmation.
- Remove card paths, fact IDs, and related counts from update_timeline_card_insight success output and child metadata.
- Add regression coverage for tool output hygiene.

## Validation
- flutter test test/agent/mint_and_save_fact_id_test.dart test/agent/super_agent_child_test.dart
- flutter analyze lib/agent/skills/manage_timeline_card/timeline_card_skill.dart lib/agent/skills/manage_pkm/pkm_skill.dart lib/agent/prompts.dart test/agent/mint_and_save_fact_id_test.dart test/agent/super_agent_child_test.dart