### PR TITLE
Hide paths in permission errors

### DIFF
--- a/lib/agent/security/file_permission_manager.dart
+++ b/lib/agent/security/file_permission_manager.dart
@@ -17,8 +17,8 @@ class PermissionDeniedException implements Exception {
 
   @override
   String toString() =>
-      'Access denied for "$path": outside your allowed scope. This is a fixed '
-      'boundary, not a transient error — do not retry.';
+      'Access denied: target path is outside your allowed scope. This is a '
+      'fixed boundary, not a transient error - do not retry.';
 }
 
 class PermissionRule {

--- a/test/agent/super_agent_permissions_test.dart
+++ b/test/agent/super_agent_permissions_test.dart
@@ -44,6 +44,22 @@ void main() {
       );
     });
 
+    test('permission denial message does not expose absolute paths', () {
+      try {
+        manager.checkPermission(
+          '$facts/2026/06/10.md',
+          FileAccessType.write,
+        );
+        fail('Expected permission denial');
+      } on PermissionDeniedException catch (e) {
+        final message = e.toString();
+        expect(message, contains('Access denied'));
+        expect(message, isNot(contains('/ws')));
+        expect(message, isNot(contains(workspace)));
+        expect(message, isNot(contains(facts)));
+      }
+    });
+
     test('media files under assets stay writable', () {
       manager.checkPermission('$assets/photo.jpg', FileAccessType.write);
       manager.checkPermission('$assets/voice.m4a', FileAccessType.write);


### PR DESCRIPTION
## Summary
- Stop PermissionDeniedException.toString() from exposing denied target paths.
- Add regression coverage for SuperAgent permission denial messages.

## Validation
- flutter test test/agent/super_agent_permissions_test.dart
- flutter analyze lib/agent/security/file_permission_manager.dart test/agent/super_agent_permissions_test.dart