### PR TITLE
Make agent activity status non-interactive

### DIFF
--- a/docs/agent_overview.html
+++ b/docs/agent_overview.html
@@ -1,0 +1,1041 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Memex Agent 能力地图</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f3;
+      --surface: #ffffff;
+      --surface-soft: #eef3ea;
+      --ink: #1b241d;
+      --muted: #5c665e;
+      --line: #d7ddd2;
+      --accent: #2d6a4f;
+      --accent-2: #c36a2d;
+      --accent-3: #3662a8;
+      --danger: #b54b4b;
+      --shadow: 0 16px 40px rgba(37, 50, 39, 0.08);
+      --radius: 8px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+
+    a {
+      color: var(--accent-3);
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    code {
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #f8faf6;
+      padding: 0.08rem 0.32rem;
+      font-size: 0.92em;
+    }
+
+    .shell {
+      width: min(1180px, calc(100vw - 32px));
+      margin: 0 auto;
+    }
+
+    header {
+      border-bottom: 1px solid var(--line);
+      background: linear-gradient(180deg, #ffffff 0%, #f7f9f4 100%);
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.75fr);
+      gap: 28px;
+      padding: 56px 0 30px;
+      align-items: end;
+    }
+
+    .eyebrow {
+      margin: 0 0 12px;
+      color: var(--accent);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      max-width: 800px;
+      font-size: clamp(2.1rem, 5vw, 4.2rem);
+      line-height: 1.02;
+      letter-spacing: 0;
+    }
+
+    .intro {
+      max-width: 760px;
+      margin: 18px 0 0;
+      color: var(--muted);
+      font-size: 1.04rem;
+    }
+
+    .hero-panel {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      padding: 18px;
+    }
+
+    .hero-panel h2 {
+      margin: 0 0 12px;
+      font-size: 1rem;
+    }
+
+    .metric-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .metric {
+      min-height: 82px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #fbfcfa;
+      padding: 12px;
+    }
+
+    .metric strong {
+      display: block;
+      font-size: 1.72rem;
+      line-height: 1.05;
+    }
+
+    .metric span {
+      display: block;
+      margin-top: 6px;
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+
+    nav {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 12px 0;
+    }
+
+    nav a {
+      flex: 0 0 auto;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: #fff;
+      color: var(--ink);
+      padding: 8px 12px;
+      font-size: 0.9rem;
+    }
+
+    main {
+      padding: 28px 0 64px;
+    }
+
+    section {
+      margin-top: 32px;
+    }
+
+    .section-heading {
+      display: flex;
+      justify-content: space-between;
+      gap: 18px;
+      align-items: end;
+      margin-bottom: 14px;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: 1.55rem;
+      letter-spacing: 0;
+    }
+
+    .section-note {
+      max-width: 700px;
+      margin: 6px 0 0;
+      color: var(--muted);
+    }
+
+    .pipeline {
+      display: grid;
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .flow-node {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      min-height: 112px;
+      padding: 14px;
+      box-shadow: 0 10px 24px rgba(37, 50, 39, 0.05);
+      position: relative;
+    }
+
+    .flow-node::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      right: -11px;
+      width: 10px;
+      border-top: 2px solid var(--line);
+    }
+
+    .flow-node:last-child::after,
+    .flow-node.no-arrow::after {
+      display: none;
+    }
+
+    .flow-node h3 {
+      margin: 0 0 6px;
+      font-size: 1rem;
+    }
+
+    .flow-node p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .span-3 { grid-column: span 3; }
+    .span-4 { grid-column: span 4; }
+    .span-6 { grid-column: span 6; }
+
+    .controls {
+      display: grid;
+      grid-template-columns: minmax(220px, 1fr) auto;
+      gap: 10px;
+      margin: 16px 0;
+    }
+
+    .search {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #fff;
+      padding: 11px 12px;
+      color: var(--ink);
+      font: inherit;
+    }
+
+    .filter-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+
+    .filter {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: #fff;
+      color: var(--ink);
+      cursor: pointer;
+      font: inherit;
+      padding: 9px 12px;
+    }
+
+    .filter.active {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .agent-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .agent-card {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      padding: 18px;
+      box-shadow: var(--shadow);
+    }
+
+    .agent-card[hidden] {
+      display: none;
+    }
+
+    .agent-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: flex-start;
+    }
+
+    .agent-title {
+      margin: 0;
+      font-size: 1.22rem;
+    }
+
+    .agent-id {
+      display: inline-block;
+      margin-top: 5px;
+      color: var(--muted);
+      font-size: 0.86rem;
+    }
+
+    .badge {
+      border-radius: 999px;
+      padding: 5px 9px;
+      background: var(--surface-soft);
+      color: var(--accent);
+      font-size: 0.78rem;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+
+    .badge.task { color: var(--accent); }
+    .badge.chat { color: var(--accent-3); }
+    .badge.support { color: var(--accent-2); }
+    .badge.experimental { color: var(--danger); }
+
+    .agent-summary {
+      margin: 12px 0 14px;
+      color: var(--ink);
+    }
+
+    .detail-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .detail {
+      border-top: 1px solid var(--line);
+      padding-top: 10px;
+    }
+
+    .detail strong {
+      display: block;
+      margin-bottom: 5px;
+      font-size: 0.82rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0;
+    }
+
+    .detail p,
+    .detail ul {
+      margin: 0;
+      color: var(--ink);
+      font-size: 0.93rem;
+    }
+
+    .detail ul {
+      padding-left: 18px;
+    }
+
+    .detail li + li {
+      margin-top: 4px;
+    }
+
+    .wide {
+      grid-column: 1 / -1;
+    }
+
+    .source-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .source-list a,
+    .source-list span {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: #fbfcfa;
+      padding: 5px 9px;
+      font-size: 0.82rem;
+    }
+
+    .matrix {
+      width: 100%;
+      border-collapse: collapse;
+      overflow: hidden;
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow);
+    }
+
+    .matrix th,
+    .matrix td {
+      border: 1px solid var(--line);
+      padding: 10px;
+      text-align: left;
+      vertical-align: top;
+      font-size: 0.92rem;
+    }
+
+    .matrix th {
+      background: var(--surface-soft);
+      color: var(--ink);
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0;
+    }
+
+    .read-order {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .step {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      padding: 16px;
+    }
+
+    .step-number {
+      display: inline-grid;
+      place-items: center;
+      width: 28px;
+      height: 28px;
+      margin-bottom: 10px;
+      border-radius: 50%;
+      background: var(--accent);
+      color: #fff;
+      font-weight: 700;
+      font-size: 0.86rem;
+    }
+
+    .step h3 {
+      margin: 0 0 8px;
+      font-size: 1rem;
+    }
+
+    .step p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .callout {
+      border-left: 4px solid var(--accent-2);
+      background: #fff9f2;
+      padding: 14px 16px;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      color: #4c392a;
+    }
+
+    footer {
+      border-top: 1px solid var(--line);
+      padding: 24px 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 900px) {
+      .hero,
+      .agent-grid,
+      .detail-grid,
+      .read-order,
+      .controls {
+        grid-template-columns: 1fr;
+      }
+
+      .filter-group {
+        justify-content: flex-start;
+      }
+
+      .span-3,
+      .span-4,
+      .span-6 {
+        grid-column: 1 / -1;
+      }
+
+      .flow-node::after {
+        display: none;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="shell">
+      <div class="hero">
+        <div>
+          <p class="eyebrow">Memex Agent Architecture</p>
+          <h1>当前所有 Agent 的能力、Prompt 和 Tools 地图</h1>
+          <p class="intro">这份页面基于当前代码梳理，不是产品说明稿。重点放在每个 Agent 何时触发、用哪些 prompt、拥有哪些工具、写入哪些数据，以及后续深挖源码的入口。</p>
+        </div>
+        <aside class="hero-panel" aria-label="Agent summary">
+          <h2>当前快照</h2>
+          <div class="metric-grid">
+            <div class="metric"><strong>12</strong><span>设置页可配置的内置 Agent ID</span></div>
+            <div class="metric"><strong>5</strong><span>用户输入后自动触发的主链路任务</span></div>
+            <div class="metric"><strong>8+</strong><span>核心 Skill 封装</span></div>
+            <div class="metric"><strong>3</strong><span>自定义/宿主型 Agent 路径</span></div>
+          </div>
+        </aside>
+      </div>
+      <nav aria-label="Page navigation">
+        <a href="#pipeline">输入管线</a>
+        <a href="#agents">Agent 清单</a>
+        <a href="#tools">工具矩阵</a>
+        <a href="#prompts">Prompt 深挖顺序</a>
+        <a href="#notes">架构观察</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="shell">
+    <section id="pipeline">
+      <div class="section-heading">
+        <div>
+          <h2>输入处理管线</h2>
+          <p class="section-note">`MemexRouter._registerEventSubscriptions()` 是主入口。用户提交输入后，系统通过 `GlobalEventBus` 投递持久任务到 `LocalTaskExecutor`，再由对应 handler 创建 Agent。</p>
+        </div>
+      </div>
+      <div class="pipeline" aria-label="User input pipeline">
+        <article class="flow-node span-3">
+          <h3>1. UserInputSubmitted</h3>
+          <p>原始输入写入 Facts，并发布系统事件。</p>
+        </article>
+        <article class="flow-node span-3">
+          <h3>2. analyze_assets</h3>
+          <p>先处理图片/音频、EXIF、GPS、OCR，输出 asset analysis。</p>
+        </article>
+        <article class="flow-node span-3">
+          <h3>3. Cards / PKM / Router</h3>
+          <p>CardAgent 和 PkmAgent 使用媒体分析结果；Post-Card Router 判断是否触发后续 Agent。</p>
+        </article>
+        <article class="flow-node span-3 no-arrow">
+          <h3>4. Comments / Schedule / Clarification</h3>
+          <p>评论在 PKM 后执行；路由按需触发日程聚合和澄清问题。</p>
+        </article>
+        <article class="flow-node span-6">
+          <h3>手动刷新</h3>
+          <p>KnowledgeInsightAgent 和 ScheduleAggregatorAgent 也可由设置页/页面按钮通过对应事件手动刷新。</p>
+        </article>
+        <article class="flow-node span-6 no-arrow">
+          <h3>对话入口</h3>
+          <p>ChatService 默认创建 SuperAgent；角色聊天走 CompanionAgent；自定义 Agent 走 Pure/Memex Skill Host。</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="agents">
+      <div class="section-heading">
+        <div>
+          <h2>Agent 清单</h2>
+          <p class="section-note">可用搜索或分类筛选。每张卡片都给出源码入口，方便继续读 prompt 和 tools。</p>
+        </div>
+      </div>
+      <div class="controls">
+        <input class="search" id="agentSearch" type="search" placeholder="搜索 Agent、工具、prompt、文件路径">
+        <div class="filter-group" aria-label="Agent filters">
+          <button class="filter active" data-filter="all">全部</button>
+          <button class="filter" data-filter="task">事件任务</button>
+          <button class="filter" data-filter="chat">交互/聊天</button>
+          <button class="filter" data-filter="support">支撑/宿主</button>
+          <button class="filter" data-filter="experimental">实验/未注册</button>
+        </div>
+      </div>
+
+      <div class="agent-grid" id="agentGrid">
+        <article class="agent-card" data-category="task" data-search="analyze_assets media analysis asset exif gps ocr asset_analysis_tool prompts assetAnalysisPrompt">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Media analysis</h3>
+              <span class="agent-id">Agent ID: <code>analyze_assets</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">对输入中的图片/音频做预处理和多模态分析。它不是 `StatefulAgent` 类，而是一个 LLM 工具型 handler，但在模型设置中作为 Agent 独立配置。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`userInputSubmitted` 后第一阶段执行，后续 Card/PKM/Router 依赖其结果。</p></div>
+            <div class="detail"><strong>核心能力</strong><p>图片/音频安全检查、EXIF 尺寸和 GPS、反向地理编码、LLM 媒体描述、Google ML Kit OCR。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`Prompts.assetAnalysisPrompt()`，带语言指令和图片元数据补充。</p></div>
+            <div class="detail"><strong>输出</strong><p>写入 `{asset}.analysis.txt` 和可选 `{asset}.ocr.txt`，任务结果包含结构化 asset analyses。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/data/services/task_handlers/analyze_assets_handler.dart">analyze_assets_handler.dart</a><a href="../lib/agent/built_in_tools/asset_analysis_tool.dart">asset_analysis_tool.dart</a><a href="../lib/agent/prompts.dart">agent/prompts.dart</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="task" data-search="card_agent cards timeline card TimelineCardSkill save_timeline_card get_card_metadata">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Cards</h3>
+              <span class="agent-id">Agent ID: <code>card_agent</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">把每条原始输入转成时间线卡片。重点是理解多模态内容、选择 Native Card 模板、填充 `ui_configs`，并保证 `fact_id` 与卡片一致。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`card_agent_task`，依赖 `analyze_assets`；LLM 未配置时回退到 rule-based 模板匹配。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`cardAgentSystemPrompt` + `TimelineCardSkill` 的模板/标签说明 + 动态发布时间和 fact 内容。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>强制启用 `manage_timeline_card`：`get_card_metadata`、`save_timeline_card`。Agent 自身无额外 tools。</p></div>
+            <div class="detail"><strong>边界</strong><p>只负责 Cards；用户长期记忆以 read-only reminder 形式进入上下文。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/card_agent/card_agent.dart">card_agent.dart</a><a href="../lib/agent/card_agent/prompts.dart">card prompts</a><a href="../lib/agent/skills/manage_timeline_card/timeline_card_skill.dart">timeline_card_skill.dart</a><a href="../lib/data/services/task_handlers/card_agent_handler.dart">card handler</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="task" data-search="pkm_agent PKM PARA manage_pkm update_timeline_card_insight skip_pkm_organization file tools">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">PKM</h3>
+              <span class="agent-id">Agent ID: <code>pkm_agent</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">将输入沉淀进 `/PKM` 的 P.A.R.A. 结构，并把知识化后的 insight 回写到对应卡片。它是当前最强的文件写入型自动 Agent。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`pkm_agent_task`，依赖媒体分析，并通过 `getLastTaskByType('pkm_agent_task')` 串行化，避免并发改 PKM。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`pkmAgentSystemPrompt` + `Prompts.pkmSkillSystemPrompt()` + 当前 PKM overview + 用户长期记忆 read-only reminder。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>`Read`、`BatchRead`、`Write`、`Edit`、`Move`、`Remove`、`LS`、`Glob`、`Grep`；`manage_pkm` 工具：`update_timeline_card_insight`、`skip_pkm_organization`。</p></div>
+            <div class="detail"><strong>边界</strong><p>文件权限只写 `/PKM`；不允许写 memory。显式“不记/不保存”输入会在进 LLM 前或通过 skip tool 跳过。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/pkm_agent/pkm_agent.dart">pkm_agent.dart</a><a href="../lib/agent/pkm_agent/prompts.dart">pkm prompts</a><a href="../lib/agent/skills/manage_pkm/pkm_skill.dart">pkm_skill.dart</a><a href="../lib/data/services/task_handlers/pkm_agent_handler.dart">pkm handler</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="task" data-search="knowledge_insight_agent insights update_knowledge_insight save_knowledge_insight_cards charts stats event logs">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Insights</h3>
+              <span class="agent-id">Agent ID: <code>knowledge_insight_agent</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">周期性或手动分析 Facts、Cards、PKM 和事件日志，维护 Knowledge Insight 卡片，用图表/地图/摘要呈现用户长期模式。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`knowledgeInsightRefreshRequested` 事件进入 `knowledge_insight_task`；首次运行会要求全量分析。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`knowledgeInsightAgentSystemPrompt` + `KnowledgeInsightSkill` prompt + memory read-only prompt + run context。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>读文件工具、`search_workspace_event_logs`、`getCurrentTime`；`update_knowledge_insight` 工具组用于查、存、删洞察卡和读取用户活动统计。</p></div>
+            <div class="detail"><strong>边界</strong><p>工作区大部分只读；仅通过 insight skill 写 `/KnowledgeInsights`。允许 subagent clone 做大范围资料收集。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/insight_agent/knowledge_insight_agent.dart">knowledge_insight_agent.dart</a><a href="../lib/agent/insight_agent/prompt.dart">insight prompt</a><a href="../lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart">knowledge_insight_skill.dart</a><a href="../lib/agent/skills/knowledge_insight/native_widgets.dart">native_widgets.dart</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="task" data-search="comment_agent comments persona_comment SaveComment SkipComment character memory HistorySearch">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Comments</h3>
+              <span class="agent-id">Agent ID: <code>comment_agent</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">让虚拟角色在用户私密时间线下进行短评论，也处理用户对角色评论的回复。它强调角色边界、自然短文本和长期互动连续性。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>新输入在 PKM 后跑 `comment_agent_task`；用户回复评论会触发 `process_ai_reply`。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`commentAgentSystemPrompt` + `Prompts.commentSkillSystemPrompt()` + 角色 persona、角色记忆、近期互动、PKM/卡片上下文。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>`persona_comment`：`Read`、`Grep`、`SaveComment`、`SkipComment`；有角色时增加 `MemoryRead/Write/Edit/Remove` 和 `HistorySearch`；回复场景可启用用户级 `append_memories`。</p></div>
+            <div class="detail"><strong>边界</strong><p>可读工作区，评论写入卡片；角色记忆是 character-level，用户长期记忆只在特定回复场景开启。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/comment_agent/comment_agent.dart">comment_agent.dart</a><a href="../lib/agent/comment_agent/prompts.dart">comment prompts</a><a href="../lib/agent/skills/comment_agent/comment_agent_skill.dart">comment_agent_skill.dart</a><a href="../lib/data/services/task_handlers/comment_agent_handler.dart">comment handler</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="chat" data-search="chat_agent SuperAgent memex_agent manage_timeline_card manage_pkm system action calendar reminders quick query">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Chat / SuperAgent</h3>
+              <span class="agent-id">Agent ID: <code>chat_agent</code>，运行名通常是 <code>memex_agent</code></span>
+            </div>
+            <span class="badge chat">交互/聊天</span>
+          </div>
+          <p class="agent-summary">用户主动聊天的中央 Agent。它先判断意图，再按需调用检索、文件工具或业务 Skill；在不同页面会强制激活特定 Skill。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`ChatService.sendMessage()` 默认创建 `SuperAgent`。时间线详情页会强制 `manage_timeline_card` 和 `manage_pkm`；洞察聊天会强制 `update_knowledge_insight`。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`superAgentSystemPrompt` + ChatService 注入的“综合纠错原则/交互准则” + memory prompt；Quick Query 追加只读约束。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>全工作区文件工具、`search_workspace_event_logs`、`getCurrentTime`、`get_pkm_overview`、memory tools；Skills：洞察、卡片、PKM、系统日历提醒、澄清。</p></div>
+            <div class="detail"><strong>边界</strong><p>普通聊天可写工作区；Quick Query 只保留 `LS/Glob/Grep/Read/BatchRead/search_event_logs/getCurrentTime/get_pkm_overview`。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/data/services/chat_service.dart">chat_service.dart</a><a href="../lib/agent/super_agent/super_agent.dart">super_agent.dart</a><a href="../lib/agent/super_agent/prompts.dart">super prompt</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="chat" data-search="companion_agent companion_chat character chat SendActionMessage character memory HistorySearch append_memories">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Companion</h3>
+              <span class="agent-id">Agent ID: <code>companion_agent</code></span>
+            </div>
+            <span class="badge chat">交互/聊天</span>
+          </div>
+          <p class="agent-summary">角色私聊 Agent，强调持续关系、自然短回复、角色语气和安全边界。它同时能更新用户级长期记忆和角色级关系记忆。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`CompanionAgent.chat()`，角色聊天界面直接流式调用。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`CompanionAgentSkill._buildSystemPrompt()` 动态拼接角色 persona、style examples、user profile、character memories、互动历史和 memory guidance。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>`companion_chat`：`MemoryRead/Write/Edit/Remove`、`HistorySearch`、`SendActionMessage`；Agent 外层增加用户级 `append_memories`。</p></div>
+            <div class="detail"><strong>边界</strong><p>角色记忆用于关系/支持偏好；用户级 memory 只记录跨角色长期事实。上下文过长后会触发 `CharacterContextCompressor`。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/companion_agent/companion_agent.dart">companion_agent.dart</a><a href="../lib/agent/skills/companion_agent/companion_agent_skill.dart">companion_agent_skill.dart</a><a href="../lib/agent/skills/character_tools_factory.dart">character_tools_factory.dart</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="task" data-search="profile_agent memory_agent memory summary MemorySyncService append_memories ask_clarification">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Memory summary</h3>
+              <span class="agent-id">Agent ID: <code>profile_agent</code>，实现类 <code>MemoryAgent</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">批量从已沉淀输入中筛出“值得长期保存的用户属性”，写入用户级 memory。它采取 default-deny 策略，宁可不记也不污染记忆。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`PkmAgent` 成功后把 fact 加入 `MemorySyncService`；累积 5 条触发批处理。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`MemoryAgent` 内联 Strict Memory Curator prompt，包含排除清单、纳入清单、同语言规则和澄清策略。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>用户级 `append_memories`；可用 `ask_clarification` skill 为高价值模糊事实创建问题。</p></div>
+            <div class="detail"><strong>边界</strong><p>只写稳定身份、偏好、长期资产、习惯、AI 交互偏好；任务、提醒、一次性事件不写 memory。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/memory_agent/memory_agent.dart">memory_agent.dart</a><a href="../lib/data/services/memory_sync_service.dart">memory_sync_service.dart</a><a href="../lib/agent/memory/memory_management.dart">memory_management.dart</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="task" data-search="post_card_router_agent router select_downstream_agents schedule_aggregator ask_clarification">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Post-Card Router</h3>
+              <span class="agent-id">Agent ID: <code>post_card_router_agent</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">轻量级选择器。它不改数据，只判断新输入是否需要触发日程维护或澄清问题，并把后续任务入队。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`post_card_router_task`，依赖 `analyze_assets`，priority 为 -1。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`postCardRouterSystemPrompt`：要求保守、一次性调用 `select_downstream_agents`。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>唯一工具 `select_downstream_agents`，候选为 `schedule_aggregator` 和 `ask_clarification`。</p></div>
+            <div class="detail"><strong>边界</strong><p>不能写 PKM、不能创建卡片、不能改 schedule；只发事件或入队。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/post_card_router_agent/post_card_router_agent.dart">post_card_router_agent.dart</a><a href="../lib/agent/post_card_router_agent/prompt.dart">router prompt</a><a href="../lib/data/services/task_handlers/post_card_router_handler.dart">router handler</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="task" data-search="schedule_aggregator_agent schedule update_schedule_aggregation add_pending_item set_presentation todo event">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Schedule</h3>
+              <span class="agent-id">Agent ID: <code>schedule_aggregator_agent</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">维护 `schedule_state` 和日程杂志式呈现。它把输入中的任务、事件、完成、延期、取消等转换为 pending/completed 状态和展示文案。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`scheduleAggregationRequested` 事件，可能来自 Post-Card Router，也可手动刷新。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`scheduleAggregatorSystemPrompt` + `Prompts.scheduleAggregatorSkillPrompt()` + 当前 schedule_state + router hint 或近期 schedule 输入。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>`update_schedule_aggregation`：`get_schedule_state`、`add_pending_item`、`update_pending_item`、`complete_pending_item`、`complete_subtask`、`set_presentation`、`search_completed`。</p></div>
+            <div class="detail"><strong>边界</strong><p>无外层 tools，所有状态变更走 `ScheduleStateService`。`set_presentation` 可结束 agent loop。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart">schedule_aggregator_agent.dart</a><a href="../lib/agent/schedule_aggregator_agent/prompt.dart">schedule prompt</a><a href="../lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart">schedule skill</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="task" data-search="ask_clarification_agent clarification create_clarification_request get_recent_clarification_requests">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Ask Clarification</h3>
+              <span class="agent-id">Agent ID: <code>ask_clarification_agent</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">判断是否需要向用户问一个高价值短问题，用来改善未来记忆、实体理解、PKM 组织、卡片修正或洞察质量。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>由 Post-Card Router 入队 `ask_clarification_task`。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`askClarificationAgentSystemPrompt` + read-only 用户 memory + pending/recent clarification 列表。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>强制 `ask_clarification`：`create_clarification_request`、`get_pending_clarification_requests`、`get_recent_clarification_requests`。</p></div>
+            <div class="detail"><strong>边界</strong><p>只创建澄清请求，不写长期 memory；回答后的落库由 Resolution Agent 处理。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/ask_clarification_agent/ask_clarification_agent.dart">ask_clarification_agent.dart</a><a href="../lib/agent/ask_clarification_agent/prompt.dart">ask prompt</a><a href="../lib/agent/skills/ask_clarification/ask_clarification_skill.dart">ask skill</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="task" data-search="clarification_resolution_agent ask resolution append_memories proposed_memory fallback">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Ask resolution</h3>
+              <span class="agent-id">Agent ID: <code>clarification_resolution_agent</code></span>
+            </div>
+            <span class="badge task">事件任务</span>
+          </div>
+          <p class="agent-summary">用户回答澄清问题后，判断答案是否应转成长期记忆。它负责从“问题/选项/答案/证据 fact”里提取可持久化事实。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`clarificationAnswered` 事件进入 `clarification_resolution_task`。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>内联系统 prompt：只把稳定事实、偏好、关系、身份、习惯、长期项目上下文写入 memory。</p></div>
+            <div class="detail"><strong>Tools / Skills</strong><p>用户级 `append_memories`。失败时 handler 有 deterministic fallback，优先使用 option.memory 或 proposed_memory。</p></div>
+            <div class="detail"><strong>边界</strong><p>不处理 card-only 修正、临时标签或低价值答案；会标记 clarification request completed。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/clarification_resolution_agent/clarification_resolution_agent.dart">clarification_resolution_agent.dart</a><a href="../lib/data/services/task_handlers/clarification_resolution_handler.dart">resolution handler</a><a href="../lib/agent/memory/memory_management.dart">memory_management.dart</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="support" data-search="persona_agent character designer CreateOrUpdateCharacterPersona GetCharacterPersona PKM read">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Persona Agent</h3>
+              <span class="agent-id">Runtime name: <code>persona_agent</code></span>
+            </div>
+            <span class="badge support">支撑/宿主</span>
+          </div>
+          <p class="agent-summary">角色设计 Agent。它读用户 PKM 和现有角色列表，生成或更新角色 persona，服务虚拟角色系统。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>由角色相关流程调用 `PersonaAgent.run()`，不是主输入管线中的固定订阅。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`_buildSystemPrompt()` 内联：强调私密记录场景、情感支持、短文本风格、不要在 persona 中写具体对话示例。</p></div>
+            <div class="detail"><strong>Tools</strong><p>PKM read-only 文件工具：`LS`、`Glob`、`Grep`、`Read`；角色工具：`GetCharacterPersona`、`CreateOrUpdateCharacterPersona`。</p></div>
+            <div class="detail"><strong>边界</strong><p>文件工具只能读 PKM；角色更新通过 `CharacterService` / YAML 写入。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/persona_agent/persona_agent.dart">persona_agent.dart</a><a href="../lib/data/services/character_service.dart">character_service.dart</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="support" data-search="custom agents PureSkillHostAgent MemexSkillHostAgent skillDirectoryPath RunJavaScript custom_agent_config_service">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Custom Agent Hosts</h3>
+              <span class="agent-id">Host types: <code>pure</code> / <code>memex</code></span>
+            </div>
+            <span class="badge support">支撑/宿主</span>
+          </div>
+          <p class="agent-summary">用户自定义 Agent 的执行宿主。配置文件声明事件、工作目录、skill 目录、host 类型和额外系统 prompt；运行时把事件序列化为 XML 交给宿主 Agent。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>触发</strong><p>`CustomAgentConfigService.registerAll()` 动态订阅任意 `SystemEventTypes`，可 async 或 sync 执行。</p></div>
+            <div class="detail"><strong>Prompt</strong><p>`PureSkillHostAgent` 使用简短个人助理 prompt；`MemexSkillHostAgent` 使用 Memex 语境 prompt；二者都可追加用户配置的 `systemPrompt`。</p></div>
+            <div class="detail"><strong>Tools</strong><p>工作目录内文件工具、`search_workspace_event_logs`、`getCurrentTime`、文件系统 Skill 和 `RunJavaScript` runtime。</p></div>
+            <div class="detail"><strong>边界</strong><p>权限限定在配置的 workingDirectory；媒体引用会从事件 XML 中抽取并以内联多模态 part 传给模型。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/data/services/custom_agent_config_service.dart">custom_agent_config_service.dart</a><a href="../lib/data/services/task_handlers/custom_agent_task_handler.dart">custom_agent_task_handler.dart</a><a href="../lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart">pure host</a><a href="../lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart">memex host</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="support" data-search="MemexSkillHostAgent full featured skill host file operations search event logs RunJavaScript">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Memex Skill Host</h3>
+              <span class="agent-id">Runtime class: <code>MemexSkillHostAgent</code></span>
+            </div>
+            <span class="badge support">支撑/宿主</span>
+          </div>
+          <p class="agent-summary">带 Memex 世界观的技能宿主，用于自定义 Agent。它支持文件型 skill、JS runtime 和工作目录内读写，但不内置 memory management 或 PKM overview。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>Prompt</strong><p>`memexSkillHostAgentSystemPrompt`：解释 Memex 核心功能、意图识别职责、默认文件检索能力和工具使用建议。</p></div>
+            <div class="detail"><strong>Tools</strong><p>`LS/Glob/Grep/Read/BatchRead/Write/Move/Remove/Edit`、`search_workspace_event_logs`、`getCurrentTime`，另有 `skillDirectoryPath` 和 `FlutterJavaScriptRuntime`。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart">memex_skill_host_agent.dart</a><a href="../lib/agent/memex_skill_host_agent/prompts.dart">host prompt</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="support" data-search="PureSkillHostAgent lightweight skill host RunJavaScript custom agent">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">Pure Skill Host</h3>
+              <span class="agent-id">Runtime class: <code>PureSkillHostAgent</code></span>
+            </div>
+            <span class="badge support">支撑/宿主</span>
+          </div>
+          <p class="agent-summary">更轻的自定义技能宿主，系统 prompt 只有“手机上的个人助理，简洁、有帮助、友好”。适合不需要 Memex 世界观的 custom agent。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>Prompt</strong><p>`pureSkillHostAgentSystemPrompt` + custom agent 配置中的额外 prompt。</p></div>
+            <div class="detail"><strong>Tools</strong><p>与 Memex Skill Host 相同的工作目录文件工具、事件日志、当前时间和 JS runtime。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart">pure_skill_host_agent.dart</a></div></div>
+          </div>
+        </article>
+
+        <article class="agent-card" data-category="experimental" data-search="file_system_skill_agent submit_summary RunJavaScript unregistered experimental handler">
+          <div class="agent-head">
+            <div>
+              <h3 class="agent-title">File-system Skill Agent</h3>
+              <span class="agent-id">Runtime name: <code>file_system_skill_agent</code></span>
+            </div>
+            <span class="badge experimental">实验/未注册</span>
+          </div>
+          <p class="agent-summary">一个示例/实验 handler：动态创建 `submit_summary` 文件系统 Skill，要求 Agent 读取 `SKILL.md` 并通过 `RunJavaScript` 执行脚本。</p>
+          <div class="detail-grid">
+            <div class="detail"><strong>状态</strong><p>当前代码中未在 `MemexRouter._init()` 注册 `file_system_skill_agent_task`，因此不是默认运行链路。</p></div>
+            <div class="detail"><strong>Tools</strong><p>只读 `Read`、`LS`，外加 skillDirectoryPath 带来的 JS skill runtime。</p></div>
+            <div class="detail wide"><strong>源码</strong><div class="source-list"><a href="../lib/data/services/task_handlers/file_system_skill_agent_handler.dart">file_system_skill_agent_handler.dart</a></div></div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="tools">
+      <div class="section-heading">
+        <div>
+          <h2>工具矩阵</h2>
+          <p class="section-note">把工具按“谁拥有”和“能写哪里”拆开看，最容易理解 Agent 的真实边界。</p>
+        </div>
+      </div>
+      <table class="matrix">
+        <thead>
+          <tr>
+            <th>工具 / Skill</th>
+            <th>主要使用者</th>
+            <th>关键工具名</th>
+            <th>数据边界</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>文件系统工具</td>
+            <td>PKM、Insights、SuperAgent、自定义宿主、Comment 部分场景</td>
+            <td><code>Read</code> <code>BatchRead</code> <code>Write</code> <code>Edit</code> <code>Move</code> <code>Remove</code> <code>LS</code> <code>Glob</code> <code>Grep</code></td>
+            <td>由 <code>FilePermissionManager</code> 按 Agent 配置具体 root 和 read/write 权限。</td>
+          </tr>
+          <tr>
+            <td>Timeline Card Skill</td>
+            <td>CardAgent、SuperAgent</td>
+            <td><code>get_card_metadata</code> <code>save_timeline_card</code></td>
+            <td>通过 <code>FileSystemService.updateCardFile</code> 写 Cards，并刷新 UI。</td>
+          </tr>
+          <tr>
+            <td>PKM Skill</td>
+            <td>PkmAgent、SuperAgent</td>
+            <td><code>update_timeline_card_insight</code> <code>skip_pkm_organization</code></td>
+            <td>PKM 文件写入依赖文件工具；卡片 insight 通过专用 tool 写入。</td>
+          </tr>
+          <tr>
+            <td>Knowledge Insight Skill</td>
+            <td>KnowledgeInsightAgent、SuperAgent</td>
+            <td><code>get_exists_knowledge_insight_cards</code> <code>save_knowledge_insight_cards</code> <code>delete_knowledge_insight_card</code> <code>delete_knowledge_insight_tags</code> <code>get_available_insight_card_templates</code> <code>get_user_activity_stats</code></td>
+            <td>只通过 skill 写 KnowledgeInsights，支持 native widget 图表模板。</td>
+          </tr>
+          <tr>
+            <td>Schedule Aggregation Skill</td>
+            <td>ScheduleAggregatorAgent</td>
+            <td><code>get_schedule_state</code> <code>add_pending_item</code> <code>update_pending_item</code> <code>complete_pending_item</code> <code>complete_subtask</code> <code>set_presentation</code> <code>search_completed</code></td>
+            <td>所有变更走 <code>ScheduleStateService</code>。</td>
+          </tr>
+          <tr>
+            <td>Ask Clarification Skill</td>
+            <td>AskClarificationAgent、MemoryAgent、SuperAgent</td>
+            <td><code>create_clarification_request</code> <code>get_pending_clarification_requests</code> <code>get_recent_clarification_requests</code></td>
+            <td>写入 ClarificationRequestService；真正 memory 写入延后到 Resolution。</td>
+          </tr>
+          <tr>
+            <td>角色评论/记忆工具</td>
+            <td>CommentAgent、CompanionAgent</td>
+            <td><code>SaveComment</code> <code>SkipComment</code> <code>MemoryRead</code> <code>MemoryWrite</code> <code>MemoryEdit</code> <code>MemoryRemove</code> <code>HistorySearch</code> <code>SendActionMessage</code></td>
+            <td>评论写 Cards；角色记忆写 character memory；action message 写 persona chat。</td>
+          </tr>
+          <tr>
+            <td>用户长期记忆工具</td>
+            <td>MemoryAgent、ClarificationResolutionAgent、SuperAgent、CompanionAgent、部分 Comment 回复</td>
+            <td><code>append_memories</code></td>
+            <td>写 <code>_System/memory/memory.json</code>，并由 memory prompt 控制何时可写。</td>
+          </tr>
+          <tr>
+            <td>系统动作 Skill</td>
+            <td>SuperAgent</td>
+            <td><code>create_calendar_event</code> <code>create_reminder</code> <code>get_recent_actions</code> <code>cancel_action</code></td>
+            <td>通过 <code>SystemActionService</code> 创建本机日历/提醒待执行动作。</td>
+          </tr>
+          <tr>
+            <td>通用上下文工具</td>
+            <td>SuperAgent、Insights、自定义宿主等</td>
+            <td><code>search_workspace_event_logs</code> <code>getCurrentTime</code> <code>get_pkm_overview</code></td>
+            <td>事件日志从 2026-01-23 起可用；PKM overview 是只读结构概览。</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="prompts">
+      <div class="section-heading">
+        <div>
+          <h2>Prompt 深挖顺序</h2>
+          <p class="section-note">建议按这个顺序读，不要先陷进某个大 prompt。先理解事件、状态和工具边界，再看语言指令。</p>
+        </div>
+      </div>
+      <div class="read-order">
+        <article class="step">
+          <span class="step-number">1</span>
+          <h3>事件和任务入口</h3>
+          <p>先读 <a href="../lib/data/repositories/memex_router.dart">memex_router.dart</a> 的 handler 注册和事件订阅，确认谁会跑、依赖谁。</p>
+        </article>
+        <article class="step">
+          <span class="step-number">2</span>
+          <h3>Agent 构造函数</h3>
+          <p>读 <a href="../lib/agent/">lib/agent/</a> 下每个 Agent 的 `StatefulAgent` 参数：prompt、tools、skills、permission、memory。</p>
+        </article>
+        <article class="step">
+          <span class="step-number">3</span>
+          <h3>Skill prompt 和 schema</h3>
+          <p>重点读 <a href="../lib/agent/prompts.dart">agent/prompts.dart</a> 与 <a href="../lib/agent/skills/">agent/skills/</a>，这里定义了大部分 tool schema 和业务流程。</p>
+        </article>
+        <article class="step">
+          <span class="step-number">4</span>
+          <h3>上下文装配</h3>
+          <p>最后读 memory、character context、location context 和 run context，理解 prompt 里动态注入的内容。</p>
+        </article>
+      </div>
+      <p class="callout">关键判断：Memex 的 Agent 能力不是只由 system prompt 决定，而是由“事件触发 + 状态恢复 + 文件权限 + skill/tool schema + 动态 reminders”共同决定。读 prompt 时要同步看 tool 的 side effect。</p>
+    </section>
+
+    <section id="notes">
+      <div class="section-heading">
+        <div>
+          <h2>架构观察</h2>
+          <p class="section-note">这些点适合作为后续改 prompt/tools 前的检查清单。</p>
+        </div>
+      </div>
+      <table class="matrix">
+        <tbody>
+          <tr>
+            <th>最容易误解的点</th>
+            <td><code>chat_agent</code> 不是一个单独目录，而是 ChatService 默认创建的 <code>SuperAgent</code>；<code>profile_agent</code> 对应实现是 <code>MemoryAgent</code>。</td>
+          </tr>
+          <tr>
+            <th>写权限最大</th>
+            <td>普通 <code>SuperAgent</code> 和自定义宿主可在各自 working directory 写文件；<code>PkmAgent</code> 只写 PKM；<code>KnowledgeInsightAgent</code> 只通过 skill 写 KnowledgeInsights。</td>
+          </tr>
+          <tr>
+            <th>最强约束</th>
+            <td><code>PkmAgent</code> 串行执行，避免 PKM 并发编辑；<code>CardAgent</code> 会检查保存工具调用和卡片完整性；<code>AskClarificationAgent</code> 要求 aggressive skip。</td>
+          </tr>
+          <tr>
+            <th>Prompt 复用</th>
+            <td>很多 Agent 的短 prompt 只定义角色，真正业务步骤在 <code>agent/prompts.dart</code> 的 Skill prompt 中。</td>
+          </tr>
+          <tr>
+            <th>下一步深挖建议</th>
+            <td>如果要调 Agent 行为，优先定位对应 Skill 的 tool schema 和 stopFlag 逻辑，再改 system prompt。否则模型可能“想做”，但工具边界不允许。</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+
+  <footer>
+    <div class="shell">Generated from the current repository structure under <code>lib/agent</code>, <code>lib/data/services/task_handlers</code>, and <code>lib/data/repositories/memex_router.dart</code>.</div>
+  </footer>
+
+  <script>
+    const searchInput = document.getElementById('agentSearch');
+    const cards = Array.from(document.querySelectorAll('.agent-card'));
+    const filters = Array.from(document.querySelectorAll('.filter'));
+    let activeFilter = 'all';
+
+    function applyFilters() {
+      const query = searchInput.value.trim().toLowerCase();
+      for (const card of cards) {
+        const categoryMatch = activeFilter === 'all' || card.dataset.category === activeFilter;
+        const haystack = `${card.innerText} ${card.dataset.search || ''}`.toLowerCase();
+        const queryMatch = query === '' || haystack.includes(query);
+        card.hidden = !(categoryMatch && queryMatch);
+      }
+    }
+
+    searchInput.addEventListener('input', applyFilters);
+    for (const button of filters) {
+      button.addEventListener('click', () => {
+        activeFilter = button.dataset.filter;
+        filters.forEach((item) => item.classList.toggle('active', item === button));
+        applyFilters();
+      });
+    }
+  </script>
+</body>
+</html>

--- a/docs/agent_overview.md
+++ b/docs/agent_overview.md
@@ -1,0 +1,580 @@
+# Memex Agent 能力梳理
+
+本文档基于当前代码整理 Memex 内置 Agent、宿主型 Agent、Prompt 和 Tools。它的目标不是做产品介绍，而是帮助继续深入理解每个 Agent 的职责边界、触发方式、Prompt 来源和工具写入范围。
+
+相关入口：
+
+- HTML 可视化页：[agent_overview.html](agent_overview.html)
+- 代码阅读索引：[agent_prompt_tools_code_index.md](agent_prompt_tools_code_index.md)
+- Agent ID 注册表：[`lib/domain/models/agent_definitions.dart`](../lib/domain/models/agent_definitions.dart)
+- 事件订阅和任务注册：[`lib/data/repositories/memex_router.dart`](../lib/data/repositories/memex_router.dart)
+
+## 1. 总体心智模型
+
+Memex 的 Agent 能力不是只由 system prompt 决定，而是由五层共同约束：
+
+1. **事件触发**：`GlobalEventBus` 决定哪些事件会让哪些任务入队。
+2. **任务执行**：`LocalTaskExecutor` 持久化任务、处理重试、依赖和并发策略。
+3. **Agent 构造**：每个 Agent 在 `StatefulAgent(...)` 里声明 `systemPrompts`、`tools`、`skills`、`planMode`、`disableSubAgents`、压缩器和状态保存。
+4. **权限边界**：文件工具全部经由 `FilePermissionManager`，不同 Agent 的可读写 root 不同。
+5. **动态上下文**：memory、location、event logs、schedule state、character context、PKM overview 等通过 prompt/reminder 注入。
+
+因此，调 Agent 行为时应同时看 prompt、tools schema、handler payload、权限和 stopFlag。
+
+## 2. 用户输入后的主链路
+
+主入口在 `MemexRouter._registerEventSubscriptions()`。
+
+用户提交一条输入后，系统发布 `SystemEventTypes.userInputSubmitted`，然后进入以下链路：
+
+1. `handle_analyze_assets`
+   - 订阅 ID：`analyze_assets`
+   - 任务类型：`handle_analyze_assets`
+   - 负责图片/音频分析、EXIF、GPS、OCR。
+
+2. `card_agent_task`
+   - 订阅 ID：`card_agent`
+   - 依赖：`analyze_assets`
+   - 生成或更新 Timeline Card。
+
+3. `pkm_agent_task`
+   - 订阅 ID：`pkm_agent`
+   - 依赖：`analyze_assets`
+   - 串行依赖上一条 PKM task，避免并发修改 PKM。
+   - 写 PKM，并更新卡片 insight。
+
+4. `comment_agent_task`
+   - 订阅 ID：`comment_agent`
+   - 依赖：`pkm_agent`
+   - 选择角色并生成私密时间线评论。
+
+5. `post_card_router_task`
+   - 订阅 ID：`post_card_router`
+   - 依赖：`analyze_assets`
+   - 只做路由判断，按需触发：
+     - `schedule_aggregator_task`
+     - `ask_clarification_task`
+
+其他重要事件：
+
+- `cardCommentPosted` -> `process_ai_reply`
+- `knowledgeInsightRefreshRequested` -> `knowledge_insight_task`
+- `scheduleAggregationRequested` -> `schedule_aggregator_task`
+- `clarificationAnswered` -> `clarification_resolution_task`
+
+## 3. 设置页可配置的内置 Agent
+
+可配置 Agent ID 来自 `AgentDefinitions.displayNames`。
+
+| Agent ID | 显示名 | 实现/入口 | 核心职责 |
+| --- | --- | --- | --- |
+| `analyze_assets` | Media analysis | `analyze_assets_handler.dart` | 分析输入附件，产出 `.analysis.txt` 和 OCR |
+| `card_agent` | Cards | `CardAgent` | 将输入生成结构化 Timeline Card |
+| `pkm_agent` | PKM | `PkmAgent` | 将输入组织进 P.A.R.A. PKM，并回写卡片 insight |
+| `knowledge_insight_agent` | Insights | `KnowledgeInsightAgent` | 分析 Facts/PKM/Cards，维护 Knowledge Insight 卡片 |
+| `comment_agent` | Comments | `CommentAgent` | 角色评论和用户回复处理 |
+| `chat_agent` | Chat | `SuperAgent` | 默认聊天中枢，按需调用工具和技能 |
+| `companion_agent` | Companion | `CompanionAgent` | 角色私聊，维护角色级和用户级记忆 |
+| `profile_agent` | Memory summary | `MemoryAgent` | 批量抽取长期用户记忆 |
+| `post_card_router_agent` | Post-Card Router | `PostCardRouterAgent` | 判断是否触发日程或澄清 Agent |
+| `schedule_aggregator_agent` | Schedule | `ScheduleAggregatorAgent` | 维护 schedule state 和展示 |
+| `ask_clarification_agent` | Ask Clarification | `AskClarificationAgent` | 判断是否需要创建澄清问题 |
+| `clarification_resolution_agent` | Ask resolution | `ClarificationResolutionAgent` | 用户回答澄清后，决定是否写入长期 memory |
+
+## 4. Agent 逐个说明
+
+### 4.1 Media analysis
+
+实现不是完整 `StatefulAgent`，而是 LLM 工具型任务 handler，但它在模型设置中独立配置。
+
+- 入口：[`lib/data/services/task_handlers/analyze_assets_handler.dart`](../lib/data/services/task_handlers/analyze_assets_handler.dart)
+- Prompt：`Prompts.assetAnalysisPrompt(...)`
+- LLM 资源 ID：`AgentDefinitions.analyzeAssets`
+- 能力：
+  - 附件安全检查
+  - 图片尺寸、EXIF 时间、GPS 坐标
+  - 反向地理编码和用户标记地点匹配
+  - 图片/音频多模态描述
+  - Google ML Kit OCR
+- 写入：
+  - `{asset}.analysis.txt`
+  - `{asset}.ocr.txt`
+- 后续依赖：
+  - `CardAgent`
+  - `PkmAgent`
+  - `PostCardRouterAgent`
+
+### 4.2 CardAgent
+
+把每条原始输入变成时间线卡片。
+
+- 入口：[`lib/agent/card_agent/card_agent.dart`](../lib/agent/card_agent/card_agent.dart)
+- Handler：[`lib/data/services/task_handlers/card_agent_handler.dart`](../lib/data/services/task_handlers/card_agent_handler.dart)
+- Prompt：
+  - [`lib/agent/card_agent/prompts.dart`](../lib/agent/card_agent/prompts.dart)
+  - `Prompts.cardAgentUserMessagePromptForPublishNewContent(...)`
+  - `Prompts.timelineCardSkillSystemPrompt(...)`
+- Skill：
+  - `TimelineCardSkill(forceActivate: true, stopAfterSuccessSaveCard: true)`
+- Tools：
+  - `get_card_metadata`
+  - `save_timeline_card`
+- Memory：
+  - 注入用户 memory reminder，只读。
+- 写入：
+  - Cards YAML
+  - 渲染卡片后通过 `EventBusService` 刷新 UI。
+- 兜底：
+  - LLM 未配置时使用 `rule_based_card_matcher.dart`。
+- 关键约束：
+  - `fact_id` 必须和原始输入一致。
+  - `ui_configs` 必须完整，不能空。
+  - 运行后会检查卡片是否存在、状态是否 completed、标题和 ui config 是否齐全。
+
+### 4.3 PkmAgent
+
+把输入组织进 `/PKM` 的 P.A.R.A. 结构，并把知识化 insight 写回卡片。
+
+- 入口：[`lib/agent/pkm_agent/pkm_agent.dart`](../lib/agent/pkm_agent/pkm_agent.dart)
+- Handler：[`lib/data/services/task_handlers/pkm_agent_handler.dart`](../lib/data/services/task_handlers/pkm_agent_handler.dart)
+- Prompt：
+  - [`lib/agent/pkm_agent/prompts.dart`](../lib/agent/pkm_agent/prompts.dart)
+  - `Prompts.pkmAgentInstructionForNewPublishedContent(...)`
+  - `Prompts.pkmSkillSystemPrompt(...)`
+- Skill：
+  - `PkmSkill(forceActivate: true, workingDirectory: '/')`
+- 文件工具：
+  - `Read`
+  - `BatchRead`
+  - `Write`
+  - `Edit`
+  - `Move`
+  - `Remove`
+  - `LS`
+  - `Glob`
+  - `Grep`
+- Skill tools：
+  - `update_timeline_card_insight`
+  - `skip_pkm_organization`
+- 权限：
+  - 只写 `FileSystemService.getPkmPath(userId)`。
+- Memory：
+  - 用户 memory 注入为只读 reminder。
+  - 不给 PkmAgent memory 写入工具。
+- 关键约束：
+  - `detectNonPersistentInput()` 会在进 LLM 前识别“不要记/不要保存/不要写长期记忆”等输入。
+  - PKM task 串行，避免并发编辑。
+  - 读文件工具会在结构过大、碎片化、日期文件名、频繁编辑等场景追加 system reminder，让 Agent 可主动整理。
+
+### 4.4 KnowledgeInsightAgent
+
+维护 Knowledge Insights，输出统计、趋势、地图、图表、摘要等 insight cards。
+
+- 入口：[`lib/agent/insight_agent/knowledge_insight_agent.dart`](../lib/agent/insight_agent/knowledge_insight_agent.dart)
+- Prompt：[`lib/agent/insight_agent/prompt.dart`](../lib/agent/insight_agent/prompt.dart)
+- Skill：[`KnowledgeInsightSkill`](../lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart)
+- Tools：
+  - 文件读工具：`LS`、`Glob`、`Grep`、`Read`、`BatchRead`
+  - `search_workspace_event_logs`
+  - `getCurrentTime`
+  - `get_exists_knowledge_insight_cards`
+  - `save_knowledge_insight_cards`
+  - `delete_knowledge_insight_card`
+  - `delete_knowledge_insight_tags`
+  - `get_available_insight_card_templates`
+  - `get_user_activity_stats`
+- 权限：
+  - Facts、Cards、PKM、Workspace 只读。
+  - KnowledgeInsights 可写。
+- Memory：
+  - memory read-only prompt。
+- 关键约束：
+  - 第一次运行如果没有现有 insight，会要求全量分析。
+  - `planMode: PlanMode.auto`
+  - `disableSubAgents: false`，prompt 允许复杂任务用 clone subagent。
+
+### 4.5 CommentAgent
+
+为用户私密时间线生成角色评论，也处理用户对评论的回复。
+
+- 入口：[`lib/agent/comment_agent/comment_agent.dart`](../lib/agent/comment_agent/comment_agent.dart)
+- Handler：[`lib/data/services/task_handlers/comment_agent_handler.dart`](../lib/data/services/task_handlers/comment_agent_handler.dart)
+- Prompt：
+  - [`lib/agent/comment_agent/prompts.dart`](../lib/agent/comment_agent/prompts.dart)
+  - `Prompts.commentSkillSystemPrompt(...)`
+  - 角色 persona、system prompt override、style examples
+  - 用户 profile、角色记忆、角色世界、近期互动、PKM/card 上下文
+- Skill：
+  - `CommentAgentSkill`
+- Tools：
+  - `Read`
+  - `Grep`
+  - `SaveComment`
+  - `SkipComment`
+  - 有角色时：`MemoryRead`、`MemoryWrite`、`MemoryEdit`、`MemoryRemove`、`HistorySearch`
+  - 用户回复场景可开启用户级 `append_memories`
+- 选择角色：
+  - 显式 `@角色` 优先。
+  - 单角色模式走 `CharacterSelectionService.selectCharacter(...)`。
+  - 多角色模式走 `selectMultipleCharacters(...)`。
+- 关键约束：
+  - 可见输出必须来自角色身份。
+  - 不表现为 Memex、助理、分析师、治疗师。
+  - 评论要短、自然、低打扰。
+
+### 4.6 Chat / SuperAgent
+
+默认聊天入口的中央 Agent。
+
+- 入口：[`lib/data/services/chat_service.dart`](../lib/data/services/chat_service.dart)
+- Agent：[`lib/agent/super_agent/super_agent.dart`](../lib/agent/super_agent/super_agent.dart)
+- Prompt：[`lib/agent/super_agent/prompts.dart`](../lib/agent/super_agent/prompts.dart)
+- ChatService 额外注入：
+  - 综合纠错原则
+  - 交互准则
+  - 页面场景 context
+  - location context
+  - refs context
+  - 当前时间
+- Tools：
+  - 文件工具全套
+  - `search_workspace_event_logs`
+  - `getCurrentTime`
+  - `get_pkm_overview`
+  - 非 Quick Query 模式下加入 memory tools
+- Skills：
+  - `KnowledgeInsightSkill`
+  - `TimelineCardSkill`
+  - `PkmSkill`
+  - `SystemActionSkill`
+  - `AskClarificationSkill`
+- Quick Query：
+  - 只读模式。
+  - 只保留 `LS`、`Glob`、`Grep`、`Read`、`BatchRead`、`search_event_logs`、`getCurrentTime`、`get_pkm_overview`。
+  - 排除 `manage_timeline_card` 和 `ask_clarification`。
+
+### 4.7 CompanionAgent
+
+角色私聊 Agent。
+
+- 入口：[`lib/agent/companion_agent/companion_agent.dart`](../lib/agent/companion_agent/companion_agent.dart)
+- Skill：[`CompanionAgentSkill`](../lib/agent/skills/companion_agent/companion_agent_skill.dart)
+- Prompt 动态来源：
+  - 角色 persona
+  - character system prompt override
+  - style examples
+  - user profile
+  - character memory entries
+  - character world
+  - compressed interaction history
+  - recent cross-scene interactions
+  - user knowledge cards
+  - memory update guidance
+- Tools：
+  - character-level：`MemoryRead`、`MemoryWrite`、`MemoryEdit`、`MemoryRemove`、`HistorySearch`
+  - action：`SendActionMessage`
+  - user-level：`append_memories`
+- 关键约束：
+  - 要像真实聊天，不像助理、教练、治疗师或产品界面。
+  - 普通情绪聊天先给可见回复，工具不能替代回复。
+  - 用户级 memory 和角色级 memory 分开。
+  - 对自伤、伤害他人、虐待或急性危机有安全响应规则。
+
+### 4.8 MemoryAgent / profile_agent
+
+批量抽取长期用户记忆。
+
+- 入口：[`lib/agent/memory_agent/memory_agent.dart`](../lib/agent/memory_agent/memory_agent.dart)
+- 触发服务：[`lib/data/services/memory_sync_service.dart`](../lib/data/services/memory_sync_service.dart)
+- LLM 资源 ID：`AgentDefinitions.profileAgent`
+- Prompt：
+  - 内联 `Strict Memory Curator` prompt。
+- Tools：
+  - `append_memories`
+  - `AskClarificationSkill`
+- 触发：
+  - PkmAgent 成功后 `MemorySyncService.enqueueFact(...)`。
+  - 默认累计 5 条 fact 后处理。
+- 关键约束：
+  - Default deny：大多数输入不写 memory。
+  - 排除任务、提醒、临时上下文、一次性动作、已有信息。
+  - 只保留身份、强偏好、长期资产/环境、习惯、AI 交互偏好。
+  - memory 语言必须跟输入一致。
+
+### 4.9 PostCardRouterAgent
+
+轻量级后置路由 Agent。
+
+- 入口：[`lib/agent/post_card_router_agent/post_card_router_agent.dart`](../lib/agent/post_card_router_agent/post_card_router_agent.dart)
+- Prompt：[`lib/agent/post_card_router_agent/prompt.dart`](../lib/agent/post_card_router_agent/prompt.dart)
+- Tool：
+  - `select_downstream_agents`
+- 可激活目标：
+  - `schedule_aggregator`
+  - `ask_clarification`
+- 关键约束：
+  - 只做一次工具调用。
+  - 可以返回空列表。
+  - 不能写 PKM、不能建卡、不能改 schedule。
+
+### 4.10 ScheduleAggregatorAgent
+
+维护 schedule state 和日程展示。
+
+- 入口：[`lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart`](../lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart)
+- Prompt：[`lib/agent/schedule_aggregator_agent/prompt.dart`](../lib/agent/schedule_aggregator_agent/prompt.dart)
+- Skill：[`ScheduleAggregationSkill`](../lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart)
+- Tools：
+  - `get_schedule_state`
+  - `add_pending_item`
+  - `update_pending_item`
+  - `complete_pending_item`
+  - `complete_subtask`
+  - `set_presentation`
+  - `search_completed`
+- 数据：
+  - `ScheduleStateService`
+- 关键约束：
+  - `set_presentation` 可 stop agent loop。
+  - state mutation 要按依赖顺序执行。
+  - presentation timeline 最多 7 天。
+  - 输出语言必须跟用户输入一致。
+
+### 4.11 AskClarificationAgent
+
+判断是否创建高价值澄清问题。
+
+- 入口：[`lib/agent/ask_clarification_agent/ask_clarification_agent.dart`](../lib/agent/ask_clarification_agent/ask_clarification_agent.dart)
+- Prompt：[`lib/agent/ask_clarification_agent/prompt.dart`](../lib/agent/ask_clarification_agent/prompt.dart)
+- Skill：[`AskClarificationSkill`](../lib/agent/skills/ask_clarification/ask_clarification_skill.dart)
+- Tools：
+  - `create_clarification_request`
+  - `get_pending_clarification_requests`
+  - `get_recent_clarification_requests`
+- Memory：
+  - read-only 用户 memory snapshot。
+- 关键约束：
+  - aggressive skip。
+  - 只问一个问题。
+  - 优先 one-tap 类型：`confirm`、`single_choice`、`multi_choice`。
+  - 必须避免语义重复。
+  - 不阻塞其他 Agent。
+
+### 4.12 ClarificationResolutionAgent
+
+用户回答澄清后，判断答案是否成为长期记忆。
+
+- 入口：[`lib/agent/clarification_resolution_agent/clarification_resolution_agent.dart`](../lib/agent/clarification_resolution_agent/clarification_resolution_agent.dart)
+- Handler：[`lib/data/services/task_handlers/clarification_resolution_handler.dart`](../lib/data/services/task_handlers/clarification_resolution_handler.dart)
+- Prompt：
+  - Agent 内联系统 prompt。
+- Tools：
+  - `append_memories`
+- 输入：
+  - request
+  - answerData
+  - options
+  - evidenceFactIds
+  - existing memory context
+- 关键约束：
+  - 只写稳定事实、偏好、关系、身份、习惯、长期项目上下文。
+  - 不写临时 card-only corrections。
+  - 不把 vague/manual/unknown 选项强行具体化。
+  - LLM 失败时 handler 有 deterministic fallback。
+
+## 5. 宿主型和支撑型 Agent
+
+### 5.1 PersonaAgent
+
+角色设计 Agent。
+
+- 入口：[`lib/agent/persona_agent/persona_agent.dart`](../lib/agent/persona_agent/persona_agent.dart)
+- Prompt：
+  - `_buildSystemPrompt(...)` 内联。
+- Tools：
+  - `LS`
+  - `Glob`
+  - `Grep`
+  - `Read`
+  - `GetCharacterPersona`
+  - `CreateOrUpdateCharacterPersona`
+- 权限：
+  - 文件工具只读 PKM。
+- 职责：
+  - 根据用户 profile/PKM 和现有角色，设计或更新角色 persona。
+
+### 5.2 Custom Agent Hosts
+
+自定义 Agent 的执行宿主。
+
+- 配置服务：[`lib/data/services/custom_agent_config_service.dart`](../lib/data/services/custom_agent_config_service.dart)
+- 执行 handler：[`lib/data/services/task_handlers/custom_agent_task_handler.dart`](../lib/data/services/task_handlers/custom_agent_task_handler.dart)
+- Host 类型：
+  - `PureSkillHostAgent`
+  - `MemexSkillHostAgent`
+- 输入：
+  - SystemEvent 会序列化成 XML。
+  - XML 中的 `fs://...` 图片/音频引用会转成多模态 content part。
+- Tools：
+  - 工作目录内文件工具
+  - `search_workspace_event_logs`
+  - `getCurrentTime`
+  - 文件型 Skills
+  - `FlutterJavaScriptRuntime`
+- 输出：
+  - 创建 chat session。
+  - 创建 system_task timeline card 展示运行结果。
+
+### 5.3 MemexSkillHostAgent
+
+带 Memex 世界观的自定义 skill host。
+
+- 入口：[`lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart`](../lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart)
+- Prompt：[`lib/agent/memex_skill_host_agent/prompts.dart`](../lib/agent/memex_skill_host_agent/prompts.dart)
+- Tools：
+  - `LS`
+  - `Glob`
+  - `Grep`
+  - `Read`
+  - `BatchRead`
+  - `Write`
+  - `Move`
+  - `Remove`
+  - `Edit`
+  - `search_workspace_event_logs`
+  - `getCurrentTime`
+- 不包含：
+  - memory tools
+  - PKM overview tool
+
+### 5.4 PureSkillHostAgent
+
+轻量自定义 skill host。
+
+- 入口：[`lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart`](../lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart)
+- Prompt：
+  - `pureSkillHostAgentSystemPrompt`
+  - 内容非常短：手机上的个人助理，简洁、有帮助、友好。
+- Tools：
+  - 与 MemexSkillHostAgent 基本一致。
+
+### 5.5 FileSystemSkillAgent
+
+实验性 handler。
+
+- 入口：[`lib/data/services/task_handlers/file_system_skill_agent_handler.dart`](../lib/data/services/task_handlers/file_system_skill_agent_handler.dart)
+- 状态：
+  - 当前未在 `MemexRouter._init()` 注册 `file_system_skill_agent_task`。
+- 作用：
+  - 动态创建 `submit_summary` skill。
+  - 让 Agent 读 `SKILL.md`，再用 `RunJavaScript` 执行 `scripts/on_submit.js`。
+
+## 6. 核心工具族
+
+### 6.1 文件系统工具
+
+实现：[`lib/agent/built_in_tools/file_tools.dart`](../lib/agent/built_in_tools/file_tools.dart)
+
+工具：
+
+- `Read`
+- `BatchRead`
+- `Write`
+- `Edit`
+- `Move`
+- `Remove`
+- `LS`
+- `Glob`
+- `Grep`
+
+所有文件操作都经过：
+
+- `FilePermissionManager`
+- `FileOperationService`
+- `FileSystemService`
+
+### 6.2 Event Logs
+
+实现：[`lib/agent/built_in_tools/search_event_logs_tool.dart`](../lib/agent/built_in_tools/search_event_logs_tool.dart)
+
+工具：
+
+- `search_workspace_event_logs`
+
+重要限制：
+
+- 事件日志从 **2026-01-23** 起记录。
+- 更早历史必须查工作区文件。
+
+### 6.3 Memory
+
+实现：[`lib/agent/memory/memory_management.dart`](../lib/agent/memory/memory_management.dart)
+
+用户级工具：
+
+- `append_memories`
+
+角色级工具：
+
+- `MemoryRead`
+- `MemoryWrite`
+- `MemoryEdit`
+- `MemoryRemove`
+- `HistorySearch`
+
+### 6.4 System Action
+
+实现：[`lib/agent/skills/manage_system_action/system_action_skill.dart`](../lib/agent/skills/manage_system_action/system_action_skill.dart)
+
+工具：
+
+- `create_calendar_event`
+- `create_reminder`
+- `get_recent_actions`
+- `cancel_action`
+
+约束：
+
+- 只有明确请求时才创建或取消动作。
+- 取消/修改前必须先查 recent actions。
+
+## 7. 继续深挖 Prompt 和 Tools 的推荐顺序
+
+1. 先读 [`lib/data/repositories/memex_router.dart`](../lib/data/repositories/memex_router.dart)
+   - 看 task handler 注册。
+   - 看 event subscription。
+   - 看 dependsOn、priority、concurrencyPolicy。
+
+2. 再读每个 Agent 的构造函数
+   - 搜 `StatefulAgent(`。
+   - 重点看 `systemPrompts`、`tools`、`skills`、`planMode`、`disableSubAgents`、`systemCallback`。
+
+3. 再读 Skill 文件
+   - `lib/agent/skills/manage_timeline_card/timeline_card_skill.dart`
+   - `lib/agent/skills/manage_pkm/pkm_skill.dart`
+   - `lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart`
+   - `lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart`
+   - `lib/agent/skills/ask_clarification/ask_clarification_skill.dart`
+   - `lib/agent/skills/comment_agent/comment_agent_skill.dart`
+   - `lib/agent/skills/companion_agent/companion_agent_skill.dart`
+
+4. 最后读动态上下文
+   - memory：`lib/agent/memory/`
+   - character context：`lib/agent/context/`
+   - schedule run context：`schedule_aggregator_agent.dart`
+   - insight run context：`knowledge_insight_run_context.dart`
+   - location context：`LocationContextService`
+
+## 8. 改 Prompt 前的检查清单
+
+- 这个行为是不是已有 tool/skill 支持？
+- tool schema 是否允许模型传入需要的字段？
+- Agent 是否真的拥有该 tool？
+- 文件权限是否允许读/写目标路径？
+- 这个 Agent 是自动任务还是聊天场景？
+- 是否会被 `stopFlag` 提前结束？
+- 是否有 handler 级兜底或前置跳过逻辑？
+- 是否需要更新 tests 或 eval？
+- 是否会影响用户长期 memory 污染风险？
+- 是否会破坏 per-user workspace 隔离？
+

--- a/docs/agent_prompt_tools_code_index.md
+++ b/docs/agent_prompt_tools_code_index.md
@@ -1,0 +1,915 @@
+# Memex Agent Prompt / Tools 代码索引
+
+这份索引按“想理解某个 Agent 时应该读哪些代码”的顺序组织。它补充 [agent_overview.md](agent_overview.md)，偏源码入口、类名、函数名和工具名。
+
+## 1. 全局入口
+
+### Agent ID 和设置页
+
+文件：[`lib/domain/models/agent_definitions.dart`](../lib/domain/models/agent_definitions.dart)
+
+关键对象：
+
+```dart
+class AgentDefinitions {
+  static const String analyzeAssets = 'analyze_assets';
+  static const String cardAgent = 'card_agent';
+  static const String pkmAgent = 'pkm_agent';
+  static const String knowledgeInsightAgent = 'knowledge_insight_agent';
+  static const String commentAgent = 'comment_agent';
+  static const String chatAgent = 'chat_agent';
+  static const String companionAgent = 'companion_agent';
+  static const String profileAgent = 'profile_agent';
+  static const String postCardRouterAgent = 'post_card_router_agent';
+  static const String scheduleAggregatorAgent = 'schedule_aggregator_agent';
+  static const String askClarificationAgent = 'ask_clarification_agent';
+  static const String clarificationResolutionAgent =
+      'clarification_resolution_agent';
+}
+```
+
+作用：
+
+- `displayNames` 决定设置页展示。
+- `configurableAgentIds` 决定哪些 Agent 可独立配置模型。
+
+### Task handler 注册
+
+文件：[`lib/data/repositories/memex_router.dart`](../lib/data/repositories/memex_router.dart)
+
+重点读：
+
+- `_init()`
+- `_registerEventSubscriptions()`
+
+核心 handler：
+
+```text
+handle_analyze_assets              -> handleAnalyzeAssetsImpl
+card_agent_task                    -> handleCardAgentImpl
+pkm_agent_task                     -> handlePkmAgentImpl
+comment_agent_task                 -> handleCommentAgentImpl
+process_ai_reply                   -> handleProcessAiReplyImpl
+knowledge_insight_task             -> handleKnowledgeInsight
+schedule_aggregator_task           -> handleScheduleAggregation
+post_card_router_task              -> handlePostCardRouter
+ask_clarification_task             -> handleAskClarificationTask
+clarification_resolution_task      -> handleClarificationResolution
+```
+
+核心订阅：
+
+```text
+userInputSubmitted
+  -> analyze_assets
+  -> card_agent        dependsOn analyze_assets
+  -> pkm_agent         dependsOn analyze_assets, plus previous pkm task
+  -> comment_agent     dependsOn pkm_agent
+  -> post_card_router  dependsOn analyze_assets
+
+cardCommentPosted
+  -> process_ai_reply
+
+knowledgeInsightRefreshRequested
+  -> knowledge_insight_task
+
+scheduleAggregationRequested
+  -> schedule_aggregator_task
+
+clarificationAnswered
+  -> clarification_resolution_task
+```
+
+## 2. Agent 构造函数索引
+
+### CardAgent
+
+文件：
+
+- [`lib/agent/card_agent/card_agent.dart`](../lib/agent/card_agent/card_agent.dart)
+- [`lib/data/services/task_handlers/card_agent_handler.dart`](../lib/data/services/task_handlers/card_agent_handler.dart)
+
+优先读：
+
+1. `processWithCardAgent(...)`
+2. `CardAgent.runWithContent(...)`
+3. `CardAgent._createAgent(...)`
+4. `CardAgent.inspectCardRunCompletion(...)`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'card_agent'
+planMode: PlanMode.none
+tools: []
+skills: [
+  TimelineCardSkill(stopAfterSuccessSaveCard: true, forceActivate: true)
+]
+systemPrompts: [cardAgentSystemPrompt]
+disableSubAgents: true
+systemCallback: createSystemCallback(userId)
+```
+
+Prompt 来源：
+
+- `cardAgentSystemPrompt`
+- `Prompts.cardAgentUserMessagePromptForPublishNewContent(...)`
+- `Prompts.timelineCardSkillSystemPrompt(...)`
+
+Tools 来源：
+
+- `TimelineCardSkill._buildTools(...)`
+
+### PkmAgent
+
+文件：
+
+- [`lib/agent/pkm_agent/pkm_agent.dart`](../lib/agent/pkm_agent/pkm_agent.dart)
+- [`lib/data/services/task_handlers/pkm_agent_handler.dart`](../lib/data/services/task_handlers/pkm_agent_handler.dart)
+
+优先读：
+
+1. `PkmAgent.detectNonPersistentInput(...)`
+2. `processWithPkmAgent(...)`
+3. `PkmAgent.runWithContent(...)`
+4. `PkmAgent.createAgent(...)`
+5. `PkmAgent._getPkmOverview(...)`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'pkm_agent'
+tools: [
+  Read,
+  BatchRead,
+  Write,
+  Edit,
+  Move,
+  Remove,
+  LS,
+  Glob,
+  Grep,
+]
+skills: [
+  PkmSkill(forceActivate: true, workingDirectory: '/')
+]
+systemPrompts: [pkmAgentSystemPrompt]
+disableSubAgents: true
+planMode: PlanMode.none
+```
+
+权限：
+
+```dart
+PermissionRule(
+  rootPath: fileService.getPkmPath(userId),
+  access: FileAccessType.write,
+)
+```
+
+Prompt 来源：
+
+- `pkmAgentSystemPrompt`
+- `Prompts.pkmAgentInstructionForNewPublishedContent(...)`
+- `Prompts.pkmSkillSystemPrompt(...)`
+- dynamic PKM overview
+- read-only user memory reminder
+
+Tools 来源：
+
+- `FileToolFactory`
+- `PkmSkill._buildTools(...)`
+
+### KnowledgeInsightAgent
+
+文件：
+
+- [`lib/agent/insight_agent/knowledge_insight_agent.dart`](../lib/agent/insight_agent/knowledge_insight_agent.dart)
+- [`lib/data/services/task_handlers/knowledge_insight_handler.dart`](../lib/data/services/task_handlers/knowledge_insight_handler.dart)
+- [`lib/agent/insight_agent/knowledge_insight_run_context.dart`](../lib/agent/insight_agent/knowledge_insight_run_context.dart)
+
+优先读：
+
+1. `KnowledgeInsightAgent.updateKnowledgeInsight(...)`
+2. `KnowledgeInsightAgent._createAgent(...)`
+3. `buildKnowledgeInsightRunContext(...)`
+4. `_createInsightSummaryCardIfNeeded(...)`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'knowledge_insight_agent'
+tools: [
+  LS,
+  Glob,
+  Grep,
+  Read,
+  BatchRead,
+  search_workspace_event_logs,
+  getCurrentTime,
+]
+skills: [KnowledgeInsightSkill(forceActivate: true)]
+systemPrompts: [
+  knowledgeInsightAgentSystemPrompt,
+  memoryReadOnlyPrompt,
+]
+disableSubAgents: false
+planMode: PlanMode.auto
+```
+
+权限：
+
+```text
+Workspace/Facts/Cards/PKM: read
+KnowledgeInsights: write
+```
+
+Prompt 来源：
+
+- `knowledgeInsightAgentSystemPrompt`
+- `Prompts.knowledgeInsightAgentKnowledgeInsightSkillPrompt(...)`
+- `MemoryManagement.buildMemoryReadOnlyPrompt()`
+- `buildKnowledgeInsightRunContext(...)`
+
+Tools 来源：
+
+- `FileToolFactory`
+- `buildSearchEventLogsTool()`
+- `getCurrentTimeTool`
+- `KnowledgeInsightSkill`
+
+### CommentAgent
+
+文件：
+
+- [`lib/agent/comment_agent/comment_agent.dart`](../lib/agent/comment_agent/comment_agent.dart)
+- [`lib/data/services/task_handlers/comment_agent_handler.dart`](../lib/data/services/task_handlers/comment_agent_handler.dart)
+- [`lib/agent/context/character_context_assembler.dart`](../lib/agent/context/character_context_assembler.dart)
+
+优先读：
+
+1. `handleCommentAgentImpl(...)`
+2. `handleProcessAiReplyImpl(...)`
+3. `CommentAgent.runWithContent(...)`
+4. `CommentAgent._createAgent(...)`
+5. `CharacterContextAssembler.build(...)`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'comment_agent'
+systemPrompts: [commentAgentSystemPrompt, memoryManagementPrompt]
+tools: withMemoryManagement ? memory tools : []
+skills: [CommentAgentSkill(... forceActivate: true)]
+disableSubAgents: true
+planMode: PlanMode.none
+```
+
+Prompt 来源：
+
+- `commentAgentSystemPrompt`
+- `Prompts.commentAgentInitialCommentPrompt`
+- `Prompts.commentSkillSystemPrompt(...)`
+- character persona
+- character system prompt override
+- style examples
+- character context reminders
+
+Tools 来源：
+
+- `CommentAgentSkill`
+- `CharacterToolsFactory.buildCommentTools(...)`
+- optional `MemoryManagement.buildMemoryManagementTools()`
+
+### SuperAgent / Chat
+
+文件：
+
+- [`lib/data/services/chat_service.dart`](../lib/data/services/chat_service.dart)
+- [`lib/agent/super_agent/super_agent.dart`](../lib/agent/super_agent/super_agent.dart)
+- [`lib/agent/super_agent/prompts.dart`](../lib/agent/super_agent/prompts.dart)
+
+优先读：
+
+1. `ChatService.sendMessage(...)`
+2. `SuperAgent.createAgent(...)`
+3. `ChatService._setupControllerListeners(...)`
+4. `_createSession(...)` / `_addMessageToSession(...)`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: agentName ?? 'memex_agent'
+tools: quickQuery ? readOnlyTools : allTools + memoryTools
+skills: [
+  KnowledgeInsightSkill(),
+  TimelineCardSkill(),
+  PkmSkill(workingDirectory: '/PKM'),
+  SystemActionSkill(),
+  AskClarificationSkill(),
+]
+systemPrompts: [
+  superAgentSystemPrompt,
+  memorySystemPrompt,
+  optionalQuickQueryPrompt,
+  additionalSystemPrompt,
+]
+planMode: PlanMode.auto
+disableSubAgents: true
+```
+
+Prompt 来源：
+
+- `superAgentSystemPrompt`
+- `ChatService` 内联 additional prompt
+- scene context
+- refs context
+- location context
+- current time
+- memory prompt
+
+Quick Query read-only tools：
+
+```text
+LS
+Glob
+Grep
+Read
+BatchRead
+search_event_logs
+getCurrentTime
+get_pkm_overview
+```
+
+### CompanionAgent
+
+文件：
+
+- [`lib/agent/companion_agent/companion_agent.dart`](../lib/agent/companion_agent/companion_agent.dart)
+- [`lib/agent/skills/companion_agent/companion_agent_skill.dart`](../lib/agent/skills/companion_agent/companion_agent_skill.dart)
+- [`lib/agent/context/character_context_assembler.dart`](../lib/agent/context/character_context_assembler.dart)
+
+优先读：
+
+1. `CompanionAgent.chat(...)`
+2. `CompanionAgent._createAgent(...)`
+3. `CompanionAgentSkill._buildSystemPrompt(...)`
+4. `CharacterContextCompressor.compressIfNeeded(...)`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'companion_agent'
+skills: [CompanionAgentSkill(... forceActivate: true)]
+tools: memoryManagement.buildMemoryManagementTools()
+systemPrompts: [memoryManagementPrompt]
+disableSubAgents: true
+planMode: PlanMode.none
+```
+
+Skill tools：
+
+```text
+MemoryRead
+MemoryWrite
+MemoryEdit
+MemoryRemove
+HistorySearch
+SendActionMessage
+```
+
+### MemoryAgent / profile_agent
+
+文件：
+
+- [`lib/agent/memory_agent/memory_agent.dart`](../lib/agent/memory_agent/memory_agent.dart)
+- [`lib/data/services/memory_sync_service.dart`](../lib/data/services/memory_sync_service.dart)
+- [`lib/agent/memory/memory_management.dart`](../lib/agent/memory/memory_management.dart)
+
+优先读：
+
+1. `MemorySyncService.enqueueFact(...)`
+2. `MemorySyncService._processQueue(...)`
+3. `MemorySyncService._processBatch(...)`
+4. `MemoryAgent.run(...)`
+5. `MemoryManagement.buildMemoryManagementTools()`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'memory_agent'
+tools: memoryManagement.buildMemoryManagementTools()
+skills: [AskClarificationSkill()]
+systemPrompts: [systemPrompt]
+disableSubAgents: true
+planMode: PlanMode.none
+```
+
+Prompt 来源：
+
+- `MemoryAgent.run(...)` 内联 Strict Memory Curator prompt
+- existing memory context
+- batch facts
+
+### PostCardRouterAgent
+
+文件：
+
+- [`lib/agent/post_card_router_agent/post_card_router_agent.dart`](../lib/agent/post_card_router_agent/post_card_router_agent.dart)
+- [`lib/data/services/task_handlers/post_card_router_handler.dart`](../lib/data/services/task_handlers/post_card_router_handler.dart)
+
+优先读：
+
+1. `handlePostCardRouter(...)`
+2. `runPostCardRouter(...)`
+3. `PostCardRouterAgent.route(...)`
+4. `_buildActivateTool(...)`
+5. `_enqueueDownstream(...)`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'post_card_router_agent'
+tools: [select_downstream_agents]
+systemPrompts: [postCardRouterSystemPrompt]
+disableSubAgents: true
+planMode: PlanMode.none
+```
+
+可选 downstream：
+
+```text
+schedule_aggregator
+ask_clarification
+```
+
+### ScheduleAggregatorAgent
+
+文件：
+
+- [`lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart`](../lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart)
+- [`lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart`](../lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart)
+- [`lib/data/services/schedule_state_service.dart`](../lib/data/services/schedule_state_service.dart)
+
+优先读：
+
+1. `ScheduleAggregatorAgent.updateScheduleAggregation(...)`
+2. `ScheduleAggregatorAgent._createAgent(...)`
+3. `_buildScheduleRunContext(...)`
+4. `ScheduleAggregationSkill`
+5. `ScheduleStateService`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'schedule_aggregator_agent'
+tools: const []
+skills: [
+  ScheduleAggregationSkill(
+    forceActivate: true,
+    stopAfterSetPresentation: true,
+  )
+]
+systemPrompts: [scheduleAggregatorSystemPrompt]
+disableSubAgents: true
+planMode: PlanMode.none
+```
+
+Skill tools：
+
+```text
+get_schedule_state
+add_pending_item
+update_pending_item
+complete_pending_item
+complete_subtask
+set_presentation
+search_completed
+```
+
+### AskClarificationAgent
+
+文件：
+
+- [`lib/agent/ask_clarification_agent/ask_clarification_agent.dart`](../lib/agent/ask_clarification_agent/ask_clarification_agent.dart)
+- [`lib/agent/skills/ask_clarification/ask_clarification_skill.dart`](../lib/agent/skills/ask_clarification/ask_clarification_skill.dart)
+- [`lib/data/services/clarification_request_service.dart`](../lib/data/services/clarification_request_service.dart)
+
+优先读：
+
+1. `handleAskClarificationTask(...)`
+2. `AskClarificationAgent.run(...)`
+3. `AskClarificationSkill._buildSystemPrompt()`
+4. `AskClarificationSkill._buildTools()`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'ask_clarification_agent'
+tools: const []
+skills: [AskClarificationSkill(forceActivate: true)]
+systemPrompts: [askClarificationAgentSystemPrompt]
+disableSubAgents: true
+planMode: PlanMode.none
+```
+
+Skill tools：
+
+```text
+create_clarification_request
+get_pending_clarification_requests
+get_recent_clarification_requests
+```
+
+### ClarificationResolutionAgent
+
+文件：
+
+- [`lib/agent/clarification_resolution_agent/clarification_resolution_agent.dart`](../lib/agent/clarification_resolution_agent/clarification_resolution_agent.dart)
+- [`lib/data/services/task_handlers/clarification_resolution_handler.dart`](../lib/data/services/task_handlers/clarification_resolution_handler.dart)
+
+优先读：
+
+1. `handleClarificationResolution(...)`
+2. `ClarificationResolutionAgent.run(...)`
+3. `_buildFallbackMemory(...)`
+
+`StatefulAgent` 关键参数：
+
+```dart
+name: 'clarification_resolution_agent'
+tools: memoryManagement.buildMemoryManagementTools()
+systemPrompts: [inline resolution prompt]
+disableSubAgents: true
+planMode: PlanMode.none
+```
+
+关键工具：
+
+```text
+append_memories
+```
+
+## 3. Skill / Tool 代码索引
+
+### TimelineCardSkill
+
+文件：[`lib/agent/skills/manage_timeline_card/timeline_card_skill.dart`](../lib/agent/skills/manage_timeline_card/timeline_card_skill.dart)
+
+Prompt：
+
+- `Prompts.timelineCardSkillSystemPrompt(...)`
+- 模板来源：[`timeline_templates.dart`](../lib/agent/skills/manage_timeline_card/timeline_templates.dart)
+
+Tools：
+
+```text
+get_card_metadata
+save_timeline_card
+```
+
+写入路径：
+
+- `FileSystemService.updateCardFile(...)`
+- `EventBusService.emitEvent(CardDetailUpdatedMessage(...))`
+
+### PkmSkill
+
+文件：[`lib/agent/skills/manage_pkm/pkm_skill.dart`](../lib/agent/skills/manage_pkm/pkm_skill.dart)
+
+Prompt：
+
+- `Prompts.pkmSkillSystemPrompt(...)`
+
+Tools：
+
+```text
+update_timeline_card_insight
+skip_pkm_organization
+```
+
+写入路径：
+
+- `FileSystemService.updateCardFile(...)`
+
+### KnowledgeInsightSkill
+
+文件：[`lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart`](../lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart)
+
+Prompt：
+
+- `Prompts.knowledgeInsightAgentKnowledgeInsightSkillPrompt(...)`
+
+Tools：
+
+```text
+get_exists_knowledge_insight_cards
+save_knowledge_insight_cards
+delete_knowledge_insight_card
+delete_knowledge_insight_tags
+get_available_insight_card_templates
+get_user_activity_stats
+```
+
+模板：
+
+- [`lib/agent/skills/knowledge_insight/native_widgets.dart`](../lib/agent/skills/knowledge_insight/native_widgets.dart)
+
+### ScheduleAggregationSkill
+
+文件：[`lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart`](../lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart)
+
+Prompt：
+
+- `Prompts.scheduleAggregatorSkillPrompt(...)`
+
+Tools：
+
+```text
+get_schedule_state
+add_pending_item
+update_pending_item
+complete_pending_item
+complete_subtask
+set_presentation
+search_completed
+```
+
+服务：
+
+- `ScheduleStateService`
+
+### AskClarificationSkill
+
+文件：[`lib/agent/skills/ask_clarification/ask_clarification_skill.dart`](../lib/agent/skills/ask_clarification/ask_clarification_skill.dart)
+
+Tools：
+
+```text
+create_clarification_request
+get_pending_clarification_requests
+get_recent_clarification_requests
+```
+
+服务：
+
+- `ClarificationRequestService`
+
+### CommentAgentSkill
+
+文件：[`lib/agent/skills/comment_agent/comment_agent_skill.dart`](../lib/agent/skills/comment_agent/comment_agent_skill.dart)
+
+Prompt：
+
+- `Prompts.commentSkillSystemPrompt(...)`
+- character persona
+- character memory
+- style examples
+
+Tools 来源：
+
+- `CharacterToolsFactory.buildCommentTools(...)`
+
+### CompanionAgentSkill
+
+文件：[`lib/agent/skills/companion_agent/companion_agent_skill.dart`](../lib/agent/skills/companion_agent/companion_agent_skill.dart)
+
+Prompt：
+
+- `CompanionAgentSkill._buildSystemPrompt(...)`
+
+Tools 来源：
+
+- `CharacterToolsFactory.buildCompanionTools(...)`
+
+### CharacterToolsFactory
+
+文件：[`lib/agent/skills/character_tools_factory.dart`](../lib/agent/skills/character_tools_factory.dart)
+
+Comment tools：
+
+```text
+Read
+Grep
+SaveComment
+SkipComment
+MemoryRead
+MemoryWrite
+MemoryEdit
+MemoryRemove
+HistorySearch
+```
+
+Companion tools：
+
+```text
+MemoryRead
+MemoryWrite
+MemoryEdit
+MemoryRemove
+HistorySearch
+SendActionMessage
+```
+
+### SystemActionSkill
+
+文件：[`lib/agent/skills/manage_system_action/system_action_skill.dart`](../lib/agent/skills/manage_system_action/system_action_skill.dart)
+
+Tools：
+
+```text
+create_calendar_event
+create_reminder
+get_recent_actions
+cancel_action
+```
+
+服务：
+
+- `SystemActionService`
+
+### FileToolFactory
+
+文件：[`lib/agent/built_in_tools/file_tools.dart`](../lib/agent/built_in_tools/file_tools.dart)
+
+Tools：
+
+```text
+Read
+BatchRead
+Write
+Edit
+Move
+Remove
+LS
+Glob
+Grep
+```
+
+权限：
+
+- `FilePermissionManager.checkPermission(...)`
+- `PermissionRule(rootPath, access)`
+
+### Common Tools
+
+文件：[`lib/agent/common_tools.dart`](../lib/agent/common_tools.dart)
+
+Tools：
+
+```text
+getCurrentTime
+get_pkm_overview
+```
+
+### Event Log Tool
+
+文件：[`lib/agent/built_in_tools/search_event_logs_tool.dart`](../lib/agent/built_in_tools/search_event_logs_tool.dart)
+
+Tool：
+
+```text
+search_workspace_event_logs
+```
+
+注意：
+
+- event logging 从 2026-01-23 开始。
+- 早于该日期的数据必须查文件。
+
+### AssetAnalysisTool
+
+文件：[`lib/agent/built_in_tools/asset_analysis_tool.dart`](../lib/agent/built_in_tools/asset_analysis_tool.dart)
+
+调用者：
+
+- `analyze_assets_handler.dart`
+
+Prompt：
+
+- `Prompts.assetAnalysisPrompt(...)`
+
+## 4. Prompt 文件索引
+
+| 文件 | 主要内容 | 使用者 |
+| --- | --- | --- |
+| [`lib/agent/card_agent/prompts.dart`](../lib/agent/card_agent/prompts.dart) | `cardAgentSystemPrompt` | CardAgent |
+| [`lib/agent/pkm_agent/prompts.dart`](../lib/agent/pkm_agent/prompts.dart) | `pkmAgentSystemPrompt` | PkmAgent |
+| [`lib/agent/comment_agent/prompts.dart`](../lib/agent/comment_agent/prompts.dart) | `commentAgentSystemPrompt` | CommentAgent |
+| [`lib/agent/insight_agent/prompt.dart`](../lib/agent/insight_agent/prompt.dart) | `knowledgeInsightAgentSystemPrompt` | KnowledgeInsightAgent |
+| [`lib/agent/post_card_router_agent/prompt.dart`](../lib/agent/post_card_router_agent/prompt.dart) | `postCardRouterSystemPrompt` | PostCardRouterAgent |
+| [`lib/agent/schedule_aggregator_agent/prompt.dart`](../lib/agent/schedule_aggregator_agent/prompt.dart) | `scheduleAggregatorSystemPrompt` | ScheduleAggregatorAgent |
+| [`lib/agent/ask_clarification_agent/prompt.dart`](../lib/agent/ask_clarification_agent/prompt.dart) | `askClarificationAgentSystemPrompt` | AskClarificationAgent |
+| [`lib/agent/super_agent/prompts.dart`](../lib/agent/super_agent/prompts.dart) | `superAgentSystemPrompt` | Chat / SuperAgent |
+| [`lib/agent/memex_skill_host_agent/prompts.dart`](../lib/agent/memex_skill_host_agent/prompts.dart) | `memexSkillHostAgentSystemPrompt` | MemexSkillHostAgent |
+| [`lib/agent/prompts.dart`](../lib/agent/prompts.dart) | shared skill prompts, tool descriptions, asset prompt, file tool descriptions | 多数 Agent / Skill |
+
+## 5. 常用搜索命令
+
+查所有 StatefulAgent 构造：
+
+```bash
+rg -n "StatefulAgent\\(" lib/agent lib/data/services
+```
+
+查所有 Tool 名：
+
+```bash
+rg -n "Tool\\(|name:\\s*['\\\"]" lib/agent/skills lib/agent/built_in_tools lib/agent/common_tools.dart
+```
+
+查所有 Skill 名：
+
+```bash
+rg -n "class .*Skill|name:\\s*['\\\"]" lib/agent/skills
+```
+
+查所有事件订阅：
+
+```bash
+rg -n "subscribe\\(|subscribeSync|registerHandler" lib/data/repositories/memex_router.dart lib/data/services
+```
+
+查某个 Agent 的模型配置使用：
+
+```bash
+rg -n "AgentDefinitions\\.(cardAgent|pkmAgent|knowledgeInsightAgent|commentAgent|chatAgent|companionAgent|profileAgent|postCardRouterAgent|scheduleAggregatorAgent|askClarificationAgent|clarificationResolutionAgent)" lib
+```
+
+## 6. 读代码时的判断点
+
+读一个 Agent 时，按这个顺序问：
+
+1. 这个 Agent 是自动任务、聊天入口，还是自定义宿主？
+2. 它在哪里获取 LLM resources？
+3. 它的 sessionId 如何构造，是否复用状态？
+4. 它有没有 resume interrupted run？
+5. 它有无 responseId cache？
+6. 它的 system prompts 是静态还是动态拼接？
+7. dynamic reminders 包含哪些数据？
+8. 它拥有哪些 tools？
+9. tools 是否有 stopFlag？
+10. 文件权限 root 是什么？
+11. 写入是通过工具、service，还是直接文件写入？
+12. handler 是否有前置跳过、兜底或 failure handler？
+
+## 7. 高风险修改点
+
+### 修改 `agent/prompts.dart`
+
+影响范围大。这个文件包含：
+
+- Timeline card skill prompt
+- PKM skill prompt
+- File tool descriptions
+- Comment skill prompt
+- Knowledge Insight skill prompt
+- Asset analysis prompt
+- Schedule aggregation skill prompt
+
+改动前先确认调用方。
+
+### 修改 FileToolFactory
+
+影响范围包括：
+
+- PkmAgent
+- SuperAgent
+- KnowledgeInsightAgent
+- Custom Agent Hosts
+- PersonaAgent
+- CommentAgent 的只读文件工具
+
+需要特别小心权限和路径解析。
+
+### 修改 memory tools
+
+影响范围包括：
+
+- SuperAgent
+- CompanionAgent
+- MemoryAgent
+- ClarificationResolutionAgent
+- CommentAgent 回复场景
+
+风险是污染长期用户画像。
+
+### 修改 CharacterToolsFactory
+
+影响范围：
+
+- CommentAgent
+- CompanionAgent
+
+要区分用户级 memory 和角色级 memory。
+
+### 修改 router / schedule
+
+影响范围：
+
+- PostCardRouterAgent 的触发判断。
+- ScheduleAggregatorAgent 的 state mutation。
+- 设备日历/提醒 action 同步。
+
+需要关注重复触发、幂等性和 stopFlag。
+

--- a/docs/core_agent_design.md
+++ b/docs/core_agent_design.md
@@ -1,0 +1,1408 @@
+# Memex 核心 Agent 全量设计
+
+本文档整理当前 Memex 核心 Agent 的设计意图、触发方式、Prompt 结构、Tools、状态管理、数据写入边界和可改进点。
+
+配套文档：
+
+- 能力总览：[agent_overview.md](agent_overview.md)
+- Prompt / Tools 代码索引：[agent_prompt_tools_code_index.md](agent_prompt_tools_code_index.md)
+- HTML 可视化页：[agent_overview.html](agent_overview.html)
+
+## 1. 核心设计目标
+
+Memex 是本地优先的个人生活记录系统。Agent 系统的核心目标是：
+
+1. **记录自动结构化**
+   - 用户只负责输入。
+   - 系统自动完成媒体理解、卡片生成、知识沉淀、评论、日程抽取和长期记忆更新。
+
+2. **每个 Agent 只拥有一个主要职责**
+   - CardAgent 只做卡片。
+   - PkmAgent 只做 PKM 和卡片 insight。
+   - CommentAgent 只做角色评论。
+   - ScheduleAggregatorAgent 只做 schedule state。
+   - KnowledgeInsightAgent 只做 Knowledge Insights。
+
+3. **所有重工作都持久化执行**
+   - 慢任务走 `LocalTaskExecutor`。
+   - 任务可重试、可恢复、可依赖、可按用户串行。
+
+4. **所有数据保持本地边界**
+   - Facts、Cards、PKM、KnowledgeInsights、ChatSessions、Memory 都在本地 workspace。
+   - Agent 文件访问通过 `FilePermissionManager` 限权。
+
+5. **Prompt 不单独决定能力**
+   - 能力由 prompt、tools、skills、handler payload、file permission、runtime reminders 共同决定。
+
+## 2. 核心 Agent 范围
+
+本文档把以下 Agent 作为核心设计对象：
+
+| Agent | 类型 | 核心职责 |
+| --- | --- | --- |
+| Media analysis | 自动任务 | 多模态附件理解 |
+| CardAgent | 自动任务 | 生成 Timeline Card |
+| PkmAgent | 自动任务 | 写 PKM，更新卡片 insight |
+| CommentAgent | 自动任务 / 回复任务 | 角色评论和回复 |
+| PostCardRouterAgent | 自动任务 | 路由后续 Agent |
+| ScheduleAggregatorAgent | 自动任务 / 手动刷新 | 维护 schedule state 和展示 |
+| AskClarificationAgent | 自动任务 | 创建高价值澄清问题 |
+| ClarificationResolutionAgent | 自动任务 | 把澄清答案转成长期记忆 |
+| KnowledgeInsightAgent | 手动/周期刷新 | 生成和维护知识洞察 |
+| MemoryAgent | 后台批处理 | 抽取长期用户记忆 |
+| SuperAgent | 用户聊天 | 中央对话和工具协调 |
+| CompanionAgent | 用户聊天 | 角色私聊和关系记忆 |
+
+扩展对象：
+
+- PersonaAgent
+- PureSkillHostAgent
+- MemexSkillHostAgent
+- Custom Agent runtime
+
+## 3. 全局执行架构
+
+### 3.1 事件驱动
+
+核心入口是：
+
+- [`lib/data/repositories/memex_router.dart`](../lib/data/repositories/memex_router.dart)
+- `MemexRouter._init()`
+- `MemexRouter._registerEventSubscriptions()`
+
+事件流：
+
+```text
+User input
+  -> UserInputSubmitted
+  -> GlobalEventBus
+  -> LocalTaskExecutor
+  -> task handler
+  -> StatefulAgent / tool handler
+  -> FileSystemService / domain services
+  -> EventBusService UI refresh
+```
+
+### 3.2 主输入链路
+
+```text
+userInputSubmitted
+  -> analyze_assets
+  -> card_agent
+  -> pkm_agent
+  -> comment_agent
+  -> post_card_router
+       -> schedule_aggregator
+       -> ask_clarification
+```
+
+关键依赖：
+
+- `card_agent` 依赖 `analyze_assets`
+- `pkm_agent` 依赖 `analyze_assets`
+- `comment_agent` 依赖 `pkm_agent`
+- `post_card_router` 依赖 `analyze_assets`
+- `pkm_agent` 额外依赖上一条 PKM task，保证串行
+
+### 3.3 状态与恢复
+
+绝大多数核心 Agent 使用：
+
+- `loadOrCreateAgentState(...)`
+- `saveAgentState(...)`
+- `AgentController`
+- `addAgentLogger(...)`
+- `addAgentActivityCollector(...)`
+
+设计含义：
+
+- 每个 Agent session 可恢复。
+- LLM 历史可以压缩。
+- Agent 活动可被 UI 展示。
+- 失败任务可通过 `LocalTaskExecutor` 重试。
+
+### 3.4 Prompt 组成
+
+典型 Prompt 不是单一字符串，而是：
+
+```text
+static system prompt
++ skill system prompt
++ user language instruction
++ current time / location reminder
++ memory reminder
++ scene context
++ task-specific payload
++ tool schemas
+```
+
+因此看 Prompt 时必须同时看：
+
+- Agent 构造函数
+- Skill 构造函数
+- Tool schema
+- handler 传入的 user message
+- state.systemReminders
+
+## 4. Media analysis 设计
+
+### 4.1 设计意图
+
+Media analysis 是输入链路的第一阶段。它把附件从“不可读的二进制文件”转成后续 Agent 可消费的文本上下文。
+
+它不是完整 `StatefulAgent`，而是独立 LLM handler，但在设置页作为 `analyze_assets` 配置模型。
+
+### 4.2 触发
+
+入口：
+
+- [`lib/data/services/task_handlers/analyze_assets_handler.dart`](../lib/data/services/task_handlers/analyze_assets_handler.dart)
+
+触发：
+
+```text
+SystemEventTypes.userInputSubmitted
+  -> handle_analyze_assets
+```
+
+### 4.3 输入
+
+```text
+fact_id
+asset_paths
+```
+
+### 4.4 核心能力
+
+- 过滤不支持格式
+- 安全检查
+- 图片 EXIF 提取
+- 图片尺寸和比例
+- GPS 坐标
+- 反向地理编码
+- 用户自定义地点匹配
+- LLM 多模态分析
+- 本地 OCR
+
+### 4.5 Prompt
+
+Prompt 入口：
+
+- `Prompts.assetAnalysisPrompt(...)`
+- 文件：[`lib/agent/prompts.dart`](../lib/agent/prompts.dart)
+
+设计重点：
+
+- 分析结果要是后续 Agent 可引用的客观描述。
+- 系统生成的媒体分析不能被当成用户原话。
+- 图片 metadata 会拼进 prompt。
+
+### 4.6 写入
+
+写入文件：
+
+```text
+Facts/assets/{asset}.analysis.txt
+Facts/assets/{asset}.ocr.txt
+```
+
+### 4.7 风险点
+
+- 媒体分析错误会影响 CardAgent 和 PkmAgent。
+- 纯媒体输入如果分析失败，后续 handler 会按失败处理。
+- OCR 是本地工具，可能和 LLM 分析产生冲突，需要后续 prompt 明确“分析是参考，原图/原音频才是事实源”。
+
+### 4.8 改进方向
+
+- 把 OCR 和 LLM 视觉分析分成两个独立字段，降低混淆。
+- 给图片分析增加“确定性等级”：observed / inferred / uncertain。
+- 对人脸、地点、关系类推断更保守。
+
+## 5. CardAgent 设计
+
+### 5.1 设计意图
+
+CardAgent 把原始输入转成 Timeline Card。它解决的是展示层结构化问题，不负责长期知识组织。
+
+### 5.2 触发
+
+入口：
+
+- [`lib/data/services/task_handlers/card_agent_handler.dart`](../lib/data/services/task_handlers/card_agent_handler.dart)
+- [`lib/agent/card_agent/card_agent.dart`](../lib/agent/card_agent/card_agent.dart)
+
+触发：
+
+```text
+userInputSubmitted
+  -> card_agent_task
+  dependsOn analyze_assets
+```
+
+### 5.3 输入
+
+```text
+fact_id
+combined_text
+markdown_entry
+created_at_ts
+location_context_reminder
+asset_analyses
+```
+
+### 5.4 Prompt 结构
+
+静态 prompt：
+
+- [`lib/agent/card_agent/prompts.dart`](../lib/agent/card_agent/prompts.dart)
+
+动态 prompt：
+
+- `Prompts.cardAgentUserMessagePromptForPublishNewContent(...)`
+- `TimelineCardSkill.getTimelineCardMetadata(...)`
+- 用户语言指令
+- 用户长期 memory reminder
+- 媒体分析
+- location context
+
+### 5.5 Tools / Skills
+
+CardAgent 自身：
+
+```dart
+tools: []
+skills: [
+  TimelineCardSkill(
+    stopAfterSuccessSaveCard: true,
+    forceActivate: true,
+  )
+]
+```
+
+TimelineCardSkill tools：
+
+- `get_card_metadata`
+- `save_timeline_card`
+
+### 5.6 写入
+
+通过 `save_timeline_card` 写 Cards YAML。
+
+核心字段：
+
+- `fact_id`
+- `title`
+- `timestamp`
+- `status`
+- `tags`
+- `ui_configs`
+- `insight`
+- `comments`
+
+### 5.7 完成判定
+
+`CardRunCompletionEvidence` 检查：
+
+- 是否调用成功的 save tool
+- card 文件是否存在
+- `persisted_fact_id` 是否匹配
+- status 是否 completed
+- title 是否存在
+- ui_configs 是否存在
+
+### 5.8 兜底设计
+
+如果 `card_agent` 没有有效 LLM 配置：
+
+- 使用 [`rule_based_card_matcher.dart`](../lib/agent/card_agent/rule_based_card_matcher.dart)
+
+### 5.9 风险点
+
+- CardAgent 容易把“任务/愿望/未来地点”误当成已发生事实。
+- location context 有助于补充当前位置，但也可能污染远程事件或计划。
+- card templates 的 schema 越复杂，越容易生成空 `data` 或错误字段。
+
+### 5.10 改进方向
+
+- 增加 card template 选择的 few-shot。
+- 对 address 增加更强的“actual occurrence only”规则。
+- 对 `ui_configs.data` 做 schema 校验和自动修复。
+
+## 6. PkmAgent 设计
+
+### 6.1 设计意图
+
+PkmAgent 把输入沉淀到 P.A.R.A. 知识库，同时更新对应 Timeline Card 的 insight。
+
+它是自动链路里最重要的知识写入 Agent。
+
+### 6.2 触发
+
+入口：
+
+- [`lib/data/services/task_handlers/pkm_agent_handler.dart`](../lib/data/services/task_handlers/pkm_agent_handler.dart)
+- [`lib/agent/pkm_agent/pkm_agent.dart`](../lib/agent/pkm_agent/pkm_agent.dart)
+
+触发：
+
+```text
+userInputSubmitted
+  -> pkm_agent_task
+  dependsOn analyze_assets
+  dependsOn previous pkm_agent_task
+```
+
+### 6.3 输入
+
+```text
+fact_id
+combined_text
+created_at_ts
+location_context_reminder
+asset_analyses
+PKM overview
+user memory read-only context
+```
+
+### 6.4 Prompt 结构
+
+静态 prompt：
+
+- [`lib/agent/pkm_agent/prompts.dart`](../lib/agent/pkm_agent/prompts.dart)
+
+共享 prompt：
+
+- `Prompts.pkmAgentInstructionForNewPublishedContent(...)`
+- `Prompts.pkmSkillSystemPrompt(...)`
+
+动态上下文：
+
+- PKM directory overview
+- user language instruction
+- user memory reminder
+- media analysis
+- location context
+
+### 6.5 Tools / Skills
+
+文件工具：
+
+- `Read`
+- `BatchRead`
+- `Write`
+- `Edit`
+- `Move`
+- `Remove`
+- `LS`
+- `Glob`
+- `Grep`
+
+Skill：
+
+- `PkmSkill`
+
+Skill tools：
+
+- `update_timeline_card_insight`
+- `skip_pkm_organization`
+
+### 6.6 权限
+
+只写：
+
+```text
+/PKM
+```
+
+不提供 memory 写入工具。
+
+### 6.7 非持久化输入设计
+
+`PkmAgent.detectNonPersistentInput(...)` 会在 LLM 前识别：
+
+- 不要记
+- 别保存
+- 不写长期记忆
+- do not save/store/remember
+
+识别后直接跳过，避免浪费 LLM 和误写 PKM。
+
+### 6.8 P.A.R.A. 维护设计
+
+PkmAgent 的读工具会追加结构提醒：
+
+- 文件太长
+- 目录太碎
+- 文件名含日期
+- 文件被频繁编辑
+
+这些提醒会让 Agent 不仅组织当前输入，也有机会整理结构。
+
+### 6.9 写入结果
+
+写入：
+
+- PKM Markdown files
+- card insight
+
+后续：
+
+- 成功后进入 `MemorySyncService.enqueueFact(...)`
+
+### 6.10 风险点
+
+- PKM 写入是长期结构，错误成本高。
+- 过度积极整理可能破坏用户既有结构。
+- `update_timeline_card_insight` 与文件编辑需要协调，避免 insight 引用未实际写入的内容。
+
+### 6.11 改进方向
+
+- 给 P.A.R.A. maintenance 单独开关或阈值。
+- 给 PKM 文件编辑增加 diff preview / rollback 元信息。
+- 对 related fact ids 做更严格校验。
+
+## 7. CommentAgent 设计
+
+### 7.1 设计意图
+
+CommentAgent 让虚拟角色在用户的私密记录下自然评论，提升表达反馈和陪伴感。
+
+它不是知识分析 Agent，不应该像助理、教练、治疗师或产品界面。
+
+### 7.2 触发
+
+入口：
+
+- [`lib/data/services/task_handlers/comment_agent_handler.dart`](../lib/data/services/task_handlers/comment_agent_handler.dart)
+- [`lib/agent/comment_agent/comment_agent.dart`](../lib/agent/comment_agent/comment_agent.dart)
+
+触发：
+
+```text
+new input
+  -> comment_agent_task
+  dependsOn pkm_agent
+
+cardCommentPosted
+  -> process_ai_reply
+```
+
+### 7.3 角色选择
+
+角色选择路径：
+
+1. payload 显式 `character_id`
+2. 输入里 `@角色`
+3. 单角色模式：`CharacterSelectionService.selectCharacter(...)`
+4. 多角色模式：`selectMultipleCharacters(...)`
+
+### 7.4 Prompt 结构
+
+外层边界：
+
+- [`lib/agent/comment_agent/prompts.dart`](../lib/agent/comment_agent/prompts.dart)
+
+核心 skill prompt：
+
+- `Prompts.commentSkillSystemPrompt(...)`
+- 文件：[`lib/agent/prompts.dart`](../lib/agent/prompts.dart)
+
+动态角色 prompt：
+
+- `CommentAgentSkill._buildSystemPrompt(...)`
+- 文件：[`lib/agent/skills/comment_agent/comment_agent_skill.dart`](../lib/agent/skills/comment_agent/comment_agent_skill.dart)
+
+任务消息：
+
+- `CommentAgent._buildCommentTaskMessage(...)`
+
+### 7.5 动态上下文
+
+来自 `CharacterContextAssembler.build(...)`：
+
+- user profile
+- character memory entries
+- character world
+- compressed interaction history
+- recent cross-scene interactions
+- user knowledge cards
+
+任务消息包含：
+
+- original post
+- initial insight
+- PKM context
+- existing comments
+- reply routing
+- user request
+- current time / location context
+
+### 7.6 Tools / Skills
+
+Skill：
+
+- `CommentAgentSkill`
+
+Tools：
+
+- `Read`
+- `Grep`
+- `SaveComment`
+- `SkipComment`
+- `MemoryRead`
+- `MemoryWrite`
+- `MemoryEdit`
+- `MemoryRemove`
+- `HistorySearch`
+
+用户回复场景可额外启用：
+
+- `append_memories`
+
+### 7.7 完成机制
+
+必须调用一个 completion tool：
+
+- `SaveComment`
+- `SkipComment`
+
+`SaveComment` 和 `SkipComment` 都会返回 `stopFlag: true`。
+
+### 7.8 写入
+
+`SaveComment` 写入：
+
+- Card comments
+- character timeline event
+- event log
+
+### 7.9 风险点
+
+- `character.systemPromptOverride` 当前被放在核心规则前，可能覆盖安全和工具规则。
+- Prompt 里提到 `append_memories`，但普通初始评论不一定拥有这个 tool。
+- 角色记忆和用户长期记忆容易混淆。
+- 多角色评论容易重复或过度热闹。
+
+### 7.10 改进方向
+
+- 把不可覆盖规则放在最高优先级。
+- 把角色 override 限定为“风格/语气”，不能覆盖工具和安全规则。
+- 初始评论和用户回复使用两套 memory prompt。
+- 明确“该不该说”的 policy。
+
+## 8. PostCardRouterAgent 设计
+
+### 8.1 设计意图
+
+PostCardRouterAgent 是轻量 selector。它避免所有后置 Agent 都无脑运行。
+
+### 8.2 触发
+
+入口：
+
+- [`lib/data/services/task_handlers/post_card_router_handler.dart`](../lib/data/services/task_handlers/post_card_router_handler.dart)
+- [`lib/agent/post_card_router_agent/post_card_router_agent.dart`](../lib/agent/post_card_router_agent/post_card_router_agent.dart)
+
+触发：
+
+```text
+userInputSubmitted
+  -> post_card_router_task
+  dependsOn analyze_assets
+```
+
+### 8.3 Prompt
+
+文件：
+
+- [`lib/agent/post_card_router_agent/prompt.dart`](../lib/agent/post_card_router_agent/prompt.dart)
+
+核心规则：
+
+- 保守。
+- 空列表是合法答案。
+- 只调用一次 `select_downstream_agents`。
+- 不执行副作用。
+
+### 8.4 Tool
+
+唯一工具：
+
+- `select_downstream_agents`
+
+可选目标：
+
+- `schedule_aggregator`
+- `ask_clarification`
+
+### 8.5 写入
+
+不直接写业务数据。
+
+只做：
+
+- 发布 `scheduleAggregationRequested`
+- 入队 `ask_clarification_task`
+
+### 8.6 风险点
+
+- 召回不足：漏掉应进入 schedule 的事项。
+- 召回过度：把普通记录误判为 schedule。
+- ask clarification 过度会打扰用户。
+
+### 8.7 改进方向
+
+- 为 schedule 和 clarification 各自增加可解释阈值。
+- 将 router 结果写入 task result，便于调试。
+- 对手动刷新和自动路由做区分。
+
+## 9. ScheduleAggregatorAgent 设计
+
+### 9.1 设计意图
+
+维护用户当前 schedule state，并生成杂志式展示。
+
+### 9.2 触发
+
+入口：
+
+- [`lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart`](../lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart)
+- [`lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart`](../lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart)
+
+触发：
+
+- `scheduleAggregationRequested`
+- 手动刷新
+- PostCardRouterAgent 激活
+
+### 9.3 Prompt
+
+静态 prompt：
+
+- [`lib/agent/schedule_aggregator_agent/prompt.dart`](../lib/agent/schedule_aggregator_agent/prompt.dart)
+
+Skill prompt：
+
+- `Prompts.scheduleAggregatorSkillPrompt(...)`
+
+动态上下文：
+
+- current time
+- schedule state
+- router hint
+- manual recent schedule input
+
+### 9.4 Tools
+
+- `get_schedule_state`
+- `add_pending_item`
+- `update_pending_item`
+- `complete_pending_item`
+- `complete_subtask`
+- `set_presentation`
+- `search_completed`
+
+### 9.5 数据模型
+
+核心服务：
+
+- [`lib/data/services/schedule_state_service.dart`](../lib/data/services/schedule_state_service.dart)
+
+核心状态：
+
+- pending items
+- completed items
+- presentation
+
+### 9.6 完成机制
+
+`set_presentation` 可以 `stopFlag: true`，用于结束 agent loop。
+
+### 9.7 风险点
+
+- 同一事项可能重复 add。
+- todo 和 event 字段容易混用。
+- presentation 可能引用不存在的 item id。
+
+### 9.8 改进方向
+
+- 增加 item merge / duplicate detection tool。
+- 对 event/todo 类型做更强 schema 校验。
+- 将 presentation 生成和 state mutation 分成两阶段。
+
+## 10. AskClarificationAgent 设计
+
+### 10.1 设计意图
+
+只在高价值模糊信息出现时向用户提一个短问题。
+
+### 10.2 触发
+
+入口：
+
+- [`lib/agent/ask_clarification_agent/ask_clarification_agent.dart`](../lib/agent/ask_clarification_agent/ask_clarification_agent.dart)
+- [`lib/agent/skills/ask_clarification/ask_clarification_skill.dart`](../lib/agent/skills/ask_clarification/ask_clarification_skill.dart)
+
+触发：
+
+```text
+PostCardRouterAgent
+  -> ask_clarification_task
+```
+
+### 10.3 Prompt
+
+文件：
+
+- [`lib/agent/ask_clarification_agent/prompt.dart`](../lib/agent/ask_clarification_agent/prompt.dart)
+
+核心规则：
+
+- aggressive skip
+- 一个问题
+- 避免重复
+- 优先 one-tap response
+- 不阻塞其他 Agent
+
+### 10.4 Tools
+
+- `create_clarification_request`
+- `get_pending_clarification_requests`
+- `get_recent_clarification_requests`
+
+### 10.5 写入
+
+写入：
+
+- ClarificationRequestService
+- Timeline 附件卡由服务层生成
+
+### 10.6 风险点
+
+- 问太多会破坏记录体验。
+- dedupe_key 不稳定会重复问。
+- proposed_memory 太具体会诱导 Resolution 写错 memory。
+
+### 10.7 改进方向
+
+- 对 clarification 增加用户打扰预算。
+- 对问题类型建立模板。
+- 对 dedupe_key 做标准化 helper。
+
+## 11. ClarificationResolutionAgent 设计
+
+### 11.1 设计意图
+
+用户回答澄清后，判断答案是否值得写入长期用户 memory。
+
+### 11.2 触发
+
+入口：
+
+- [`lib/agent/clarification_resolution_agent/clarification_resolution_agent.dart`](../lib/agent/clarification_resolution_agent/clarification_resolution_agent.dart)
+- [`lib/data/services/task_handlers/clarification_resolution_handler.dart`](../lib/data/services/task_handlers/clarification_resolution_handler.dart)
+
+触发：
+
+```text
+clarificationAnswered
+  -> clarification_resolution_task
+```
+
+### 11.3 Prompt
+
+内联 prompt，核心规则：
+
+- 只写稳定事实、偏好、关系、身份、习惯、长期项目上下文。
+- 不写临时 card-only corrections。
+- vague/manual/unknown 不具体化。
+- 同语言输出。
+- dedupe against existing memory。
+
+### 11.4 Tools
+
+- `append_memories`
+
+### 11.5 Fallback
+
+LLM 失败时：
+
+- `_buildFallbackMemory(...)`
+- 优先 option memory
+- 再考虑 proposed_memory
+- 模糊选项不写
+
+### 11.6 风险点
+
+- proposed_memory 模板如果设计过度，会写入错误长期事实。
+- multiple choice 需要处理多个 memory 拼接。
+- 自定义输入可能比选项更具体，但当前 fallback 对 custom answer 保守不写。
+
+### 11.7 改进方向
+
+- 给每个 clarification request 存“预期写入类型”。
+- 对 memory 写入加来源 fact id。
+- 记录 resolution 决策理由，便于用户查看。
+
+## 12. KnowledgeInsightAgent 设计
+
+### 12.1 设计意图
+
+从长期数据中挖掘趋势、模式、生活状态和跨记录洞察。
+
+### 12.2 触发
+
+入口：
+
+- [`lib/agent/insight_agent/knowledge_insight_agent.dart`](../lib/agent/insight_agent/knowledge_insight_agent.dart)
+- [`lib/data/services/task_handlers/knowledge_insight_handler.dart`](../lib/data/services/task_handlers/knowledge_insight_handler.dart)
+
+触发：
+
+- 手动更新
+- `knowledgeInsightRefreshRequested`
+
+### 12.3 Prompt
+
+静态 prompt：
+
+- [`lib/agent/insight_agent/prompt.dart`](../lib/agent/insight_agent/prompt.dart)
+
+Skill prompt：
+
+- `Prompts.knowledgeInsightAgentKnowledgeInsightSkillPrompt(...)`
+
+动态上下文：
+
+- current time
+- knowledge insight run context
+- existing insight cards
+- user activity stats
+- memory read-only prompt
+
+### 12.4 Tools
+
+文件读：
+
+- `LS`
+- `Glob`
+- `Grep`
+- `Read`
+- `BatchRead`
+
+通用：
+
+- `search_workspace_event_logs`
+- `getCurrentTime`
+
+Insight skill：
+
+- `get_exists_knowledge_insight_cards`
+- `save_knowledge_insight_cards`
+- `delete_knowledge_insight_card`
+- `delete_knowledge_insight_tags`
+- `get_available_insight_card_templates`
+- `get_user_activity_stats`
+
+### 12.5 权限
+
+```text
+Workspace: read
+Facts: read
+Cards: read
+PKM: read
+KnowledgeInsights: write
+```
+
+### 12.6 子 Agent
+
+`disableSubAgents: false`
+
+设计含义：
+
+- 大范围资料收集可以委托 clone subagent。
+- 主 Agent 负责最终洞察和写入。
+
+### 12.7 风险点
+
+- 全量分析成本高。
+- Insight 容易基于少量样本过度推断。
+- 事件日志从 2026-01-23 才开始，历史必须查文件。
+
+### 12.8 改进方向
+
+- 引入 insight confidence / evidence list。
+- 将首次全量分析和增量分析拆开。
+- 对删除旧 insight 增加更保守策略。
+
+## 13. MemoryAgent 设计
+
+### 13.1 设计意图
+
+把用户输入批量压缩成长期用户画像，不记录流水账。
+
+### 13.2 触发
+
+入口：
+
+- [`lib/data/services/memory_sync_service.dart`](../lib/data/services/memory_sync_service.dart)
+- [`lib/agent/memory_agent/memory_agent.dart`](../lib/agent/memory_agent/memory_agent.dart)
+
+触发：
+
+```text
+PkmAgent success
+  -> MemorySyncService.enqueueFact
+  -> batch threshold 5
+  -> MemoryAgent.run
+```
+
+### 13.3 Prompt
+
+内联 Strict Memory Curator prompt。
+
+核心策略：
+
+- Default deny。
+- 大多数输入不写 memory。
+- 只保留可持续数月/数年的用户属性。
+- 语言和输入一致。
+- 不把系统媒体分析当用户原话。
+
+### 13.4 Tools
+
+- `append_memories`
+- `AskClarificationSkill`
+
+### 13.5 写入
+
+通过 `MemoryManagement` 写用户级 memory。
+
+### 13.6 风险点
+
+- 长期记忆污染。
+- 系统分析内容被误认为用户自述。
+- 批处理上下文过大导致提取粗糙。
+
+### 13.7 改进方向
+
+- memory entry 增加 source fact ids。
+- 用户可审阅/撤销新增 memory。
+- 对 preference、identity、habit 分类型写入。
+
+## 14. SuperAgent / Chat 设计
+
+### 14.1 设计意图
+
+SuperAgent 是用户主动聊天时的中央协调 Agent。它不是单一任务 Agent，而是意图识别和工具协调层。
+
+### 14.2 触发
+
+入口：
+
+- [`lib/data/services/chat_service.dart`](../lib/data/services/chat_service.dart)
+- [`lib/agent/super_agent/super_agent.dart`](../lib/agent/super_agent/super_agent.dart)
+
+触发：
+
+- 普通聊天
+- timeline card detail chat
+- insight card chat
+- quick query
+
+### 14.3 Prompt
+
+静态 prompt：
+
+- [`lib/agent/super_agent/prompts.dart`](../lib/agent/super_agent/prompts.dart)
+
+动态补充：
+
+- 综合纠错原则
+- 交互准则
+- 页面 scene context
+- location context
+- refs context
+- current time
+- memory prompt
+- quick query read-only prompt
+
+### 14.4 Tools
+
+普通模式：
+
+- 文件工具全套
+- `search_workspace_event_logs`
+- `getCurrentTime`
+- `get_pkm_overview`
+- memory tools
+
+Quick Query：
+
+- `LS`
+- `Glob`
+- `Grep`
+- `Read`
+- `BatchRead`
+- `search_event_logs`
+- `getCurrentTime`
+- `get_pkm_overview`
+
+### 14.5 Skills
+
+- `KnowledgeInsightSkill`
+- `TimelineCardSkill`
+- `PkmSkill`
+- `SystemActionSkill`
+- `AskClarificationSkill`
+
+场景强制激活：
+
+- timeline card detail：`manage_timeline_card`、`manage_pkm`
+- insight card chat：`update_knowledge_insight`
+
+### 14.6 风险点
+
+- 普通模式文件写权限大。
+- 多 skill 同时可用时，模型可能过度调用重工具。
+- 聊天纠错可能需要同步修改 Cards、PKM、Asset Analysis，逻辑复杂。
+
+### 14.7 改进方向
+
+- 引入 intent router，先选能力再暴露工具。
+- 对高风险写操作增加 confirmation。
+- 将 quick query 和 full chat 在 UI/Agent 层更彻底隔离。
+
+## 15. CompanionAgent 设计
+
+### 15.1 设计意图
+
+CompanionAgent 是角色私聊 Agent，目标是长期陪伴和关系连续性。
+
+### 15.2 触发
+
+入口：
+
+- [`lib/agent/companion_agent/companion_agent.dart`](../lib/agent/companion_agent/companion_agent.dart)
+- [`lib/agent/skills/companion_agent/companion_agent_skill.dart`](../lib/agent/skills/companion_agent/companion_agent_skill.dart)
+
+触发：
+
+- 角色聊天界面调用 `CompanionAgent.chat(...)`
+
+### 15.3 Prompt
+
+动态 prompt：
+
+- character system prompt override
+- character persona
+- user profile
+- character memory entries
+- style examples
+- behavior rules
+- safety boundary
+- memory update guidance
+
+### 15.4 Tools
+
+角色级：
+
+- `MemoryRead`
+- `MemoryWrite`
+- `MemoryEdit`
+- `MemoryRemove`
+- `HistorySearch`
+- `SendActionMessage`
+
+用户级：
+
+- `append_memories`
+
+### 15.5 上下文
+
+来自 `CharacterContextAssembler`：
+
+- character world
+- compressed checkpoints
+- recent timeline
+- user knowledge cards
+
+### 15.6 压缩
+
+对话后根据 token usage 调用：
+
+- `CharacterContextCompressor.compressIfNeeded(...)`
+
+### 15.7 风险点
+
+- 过度拟人或过度依赖。
+- 角色级 memory 和用户级 memory 混淆。
+- 安全危机下需要保持角色感但不能牺牲现实帮助。
+
+### 15.8 改进方向
+
+- 对角色 memory 写入增加类别。
+- 对 safety escalation 建立统一模板。
+- 对“角色动作消息”和“说话文本”做更明确 UI 区分。
+
+## 16. 扩展 Agent 设计
+
+### 16.1 PersonaAgent
+
+职责：
+
+- 设计或更新虚拟角色 persona。
+
+入口：
+
+- [`lib/agent/persona_agent/persona_agent.dart`](../lib/agent/persona_agent/persona_agent.dart)
+
+Tools：
+
+- PKM read tools
+- `GetCharacterPersona`
+- `CreateOrUpdateCharacterPersona`
+
+设计问题：
+
+- 当前 profileContent 是 TODO。
+- 角色创建直接写 YAML，需要继续评估是否应完全走 CharacterService。
+
+### 16.2 Custom Agent Hosts
+
+职责：
+
+- 让用户自定义事件驱动 Agent。
+
+入口：
+
+- [`lib/data/services/custom_agent_config_service.dart`](../lib/data/services/custom_agent_config_service.dart)
+- [`lib/data/services/task_handlers/custom_agent_task_handler.dart`](../lib/data/services/task_handlers/custom_agent_task_handler.dart)
+- [`lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart`](../lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart)
+- [`lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart`](../lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart)
+
+设计特点：
+
+- 自定义事件订阅。
+- event serializer 把事件转 XML。
+- 支持图片/音频从 XML 中转成 multimodal part。
+- 支持文件型 skills 和 JavaScript runtime。
+- 运行结果创建 chat session 和 system_task card。
+
+风险：
+
+- 自定义 prompt / skill 权限需要严格隔离。
+- workingDirectory 决定可写边界。
+
+## 17. 横向设计：Memory
+
+### 17.1 用户级 memory
+
+用途：
+
+- 用户身份
+- 长期偏好
+- 习惯
+- 资产/环境
+- AI 交互偏好
+
+主要使用者：
+
+- MemoryAgent
+- SuperAgent
+- CompanionAgent
+- ClarificationResolutionAgent
+- CommentAgent 回复场景
+
+核心文件：
+
+- [`lib/agent/memory/memory_management.dart`](../lib/agent/memory/memory_management.dart)
+
+### 17.2 角色级 memory
+
+用途：
+
+- 角色和用户之间的关系动态
+- 支持偏好
+- 风格反馈
+- 情绪模式
+- open threads
+- inside jokes
+
+主要使用者：
+
+- CommentAgent
+- CompanionAgent
+
+核心文件：
+
+- [`lib/agent/memory/character_memory_service.dart`](../lib/agent/memory/character_memory_service.dart)
+- [`lib/agent/skills/comment_agent/tools/memory_tools.dart`](../lib/agent/skills/comment_agent/tools/memory_tools.dart)
+
+### 17.3 设计原则
+
+- 用户级 memory 是跨角色全局事实。
+- 角色级 memory 是某个角色关系上下文。
+- 不要把聊天原文直接存为 memory。
+- 不要把系统媒体分析直接转成 memory。
+
+## 18. 横向设计：File Permissions
+
+核心文件：
+
+- [`lib/agent/security/file_permission_manager.dart`](../lib/agent/security/file_permission_manager.dart)
+- [`lib/agent/built_in_tools/file_tools.dart`](../lib/agent/built_in_tools/file_tools.dart)
+
+典型权限：
+
+| Agent | 权限设计 |
+| --- | --- |
+| PkmAgent | `/PKM` write |
+| KnowledgeInsightAgent | Workspace/Cards/Facts/PKM read, KnowledgeInsights write |
+| SuperAgent | Workspace write；Quick Query read-only |
+| CommentAgent | Workspace read for Read/Grep |
+| PersonaAgent | PKM read |
+| Custom hosts | configured workingDirectory write |
+
+设计原则：
+
+- 不要绕过 FileSystemService。
+- 不要直接操作 workspace 路径。
+- Agent 不应拥有超出职责的写权限。
+
+## 19. 横向设计：LLM 配置
+
+核心入口：
+
+- `UserStorage.getAgentLLMResources(agentId)`
+- `UserStorage.getAgentLLMConfig(agentId)`
+
+设计特点：
+
+- 每个可配置 Agent 可独立选择模型。
+- 未配置时部分 Agent 会跳过或使用规则兜底。
+
+常见兜底：
+
+- CardAgent：rule-based card matcher
+- PkmAgent：跳过
+- PostCardRouter：跳过
+- CommentAgent：跳过
+- AnalyzeAssets：跳过 LLM 分析，保留安全/预处理结果
+
+## 20. 横向设计：Failure / Retry
+
+任务执行：
+
+- `LocalTaskExecutor`
+
+失败处理：
+
+- `handleGenericAgentFailure`
+- `handleCardAgentFailureImpl`
+- `rethrowIfNonRetryable(...)`
+
+设计特点：
+
+- 重任务持久化。
+- Agent 可恢复 state。
+- 部分任务有 by-user concurrency policy。
+
+注意：
+
+- Agent prompt 改动可能影响 retry 行为。
+- Tool stopFlag 改动可能导致 loop detection 或任务不完成。
+
+## 21. 当前最值得优化的设计点
+
+### 21.1 CommentAgent 的 prompt priority
+
+问题：
+
+- character override 目前在核心规则前面。
+
+建议：
+
+- 不可覆盖规则最高优先级。
+- override 只作为角色风格，不允许覆盖 tool/safety。
+
+### 21.2 CommentAgent 的 memory tool mismatch
+
+问题：
+
+- Prompt 提到 `append_memories`，但普通自动评论不一定拥有这个 tool。
+
+建议：
+
+- 初始评论 prompt 不提用户级 memory。
+- 用户回复 prompt 才允许用户级 memory 更新。
+
+### 21.3 SuperAgent 权限过大
+
+问题：
+
+- 普通聊天拥有 workspace write 和多种 skills。
+
+建议：
+
+- 引入 intent router。
+- 默认先只读，写操作需要明确确认或进入具体 skill mode。
+
+### 21.4 KnowledgeInsight 证据链不足
+
+问题：
+
+- 洞察可能缺少 explicit evidence。
+
+建议：
+
+- insight card 增加 evidence facts / pkm refs / confidence。
+
+### 21.5 PKM 自动维护过于隐式
+
+问题：
+
+- PkmAgent 可被 system reminder 触发结构整理，但用户不一定感知。
+
+建议：
+
+- maintenance 输出显式 action summary。
+- 对大范围重构增加 preview 或单独 task。
+
+### 21.6 Clarification 打扰预算
+
+问题：
+
+- 虽然 prompt 要 aggressive skip，但缺少系统级 budget。
+
+建议：
+
+- 按天/周限制未回答澄清数量。
+- 用户 dismiss 后提高同类问题阈值。
+
+## 22. 改 Agent 前的设计 Checklist
+
+改任何核心 Agent 前，至少检查：
+
+1. 是否影响事件触发？
+2. 是否影响任务依赖？
+3. 是否影响 prompt 优先级？
+4. 是否影响 tool 可用性？
+5. 是否影响文件权限？
+6. 是否影响 memory 写入？
+7. 是否影响 stopFlag？
+8. 是否影响 task retry / resume？
+9. 是否需要迁移已有 state？
+10. 是否需要新增测试或 eval？
+
+## 23. 推荐后续拆分
+
+如果要继续系统化优化，建议按下面顺序拆文档或任务：
+
+1. `CommentAgent` 设计重构
+2. `SuperAgent` intent router 设计
+3. `PKM Agent` 写入和维护安全设计
+4. `KnowledgeInsight` evidence schema 设计
+5. `Memory` 用户级 / 角色级边界设计
+6. `Clarification` 打扰预算和 resolution policy 设计
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1852,7 +1852,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
               left: 0,
               right: 0,
               child: Center(
-                child: AgentActivityWidget(navigatorKey: null),
+                child: AgentActivityWidget(),
               ),
             ),
 

--- a/lib/ui/agent_activity/widgets/agent_activity_widget.dart
+++ b/lib/ui/agent_activity/widgets/agent_activity_widget.dart
@@ -1,22 +1,16 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:intl/intl.dart';
-import 'package:memex/data/services/agent_activity_service.dart';
-import 'package:memex/data/services/agent_background_coordinator.dart';
 import 'package:memex/data/services/agent_background_status.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/utils/user_storage.dart';
 
 class AgentActivityWidget extends StatefulWidget {
-  final GlobalKey<NavigatorState>? navigatorKey;
   final bool forceVisible;
   final TaskActivitySnapshot initialTaskSnapshot;
   final Stream<TaskActivitySnapshot>? taskActivitySnapshotStream;
 
   const AgentActivityWidget({
     super.key,
-    this.navigatorKey,
     this.forceVisible = false,
     this.initialTaskSnapshot = const TaskActivitySnapshot.empty(),
     this.taskActivitySnapshotStream,
@@ -27,12 +21,7 @@ class AgentActivityWidget extends StatefulWidget {
 }
 
 class _AgentActivityWidgetState extends State<AgentActivityWidget> {
-  AgentActivityMessageModel? _latestMessage;
-  AgentActivityService? _service;
-  StreamSubscription<AgentActivityMessageModel>? _subscription;
   StreamSubscription<TaskActivitySnapshot>? _taskSubscription;
-  StreamSubscription<void>? _openActivitySubscription;
-  Timer? _historyLoadTimer;
   Timer? _initRetryTimer;
   TaskActivitySnapshot _taskSnapshot = const TaskActivitySnapshot.empty();
 
@@ -42,53 +31,29 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget> {
 
   AgentBackgroundStatus get _status => AgentBackgroundStatus.fromActivity(
         taskSnapshot: _taskSnapshot,
-        latestMessage: _latestMessage,
       );
 
   @override
   void initState() {
     super.initState();
     _taskSnapshot = widget.initialTaskSnapshot;
-
-    try {
-      _service = AgentActivityService.instance;
-      _openActivitySubscription = AgentBackgroundCoordinator
-          .instance.openActivityRequests
-          .listen((_) => _showDetail());
-      _subscribeToService();
-    } catch (_) {
-      _scheduleInitRetry();
-      return;
-    }
+    _subscribeToTaskStream();
   }
 
   void _scheduleInitRetry() {
     _initRetryTimer?.cancel();
-    _initRetryTimer = Timer(const Duration(seconds: 1), () {
-      if (mounted) _initService();
-    });
+    _initRetryTimer = Timer(
+      const Duration(seconds: 1),
+      () {
+        if (mounted) _subscribeToTaskStream();
+      },
+    );
   }
 
-  void _initService() {
-    try {
-      _service = AgentActivityService.instance;
-      _openActivitySubscription ??= AgentBackgroundCoordinator
-          .instance.openActivityRequests
-          .listen((_) => _showDetail());
-      _subscribeToService();
-    } catch (_) {
-      _scheduleInitRetry();
-    }
-  }
-
-  void _subscribeToService() {
+  void _subscribeToTaskStream() {
     _initRetryTimer?.cancel();
     _initRetryTimer = null;
     var needsRetry = false;
-
-    _subscription ??= _service?.messageStream.listen((message) {
-      if (mounted) setState(() => _latestMessage = message);
-    });
 
     try {
       final taskStream = widget.taskActivitySnapshotStream ??
@@ -102,9 +67,6 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget> {
       needsRetry = true;
     }
 
-    _historyLoadTimer ??= Timer(const Duration(seconds: 3), () {
-      if (mounted) _loadLatestFromDb();
-    });
     unawaited(_loadCurrentState());
     if (needsRetry) _scheduleInitRetry();
   }
@@ -121,46 +83,11 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget> {
     } catch (_) {}
   }
 
-  Future<void> _loadLatestFromDb() async {
-    try {
-      if (!_taskSnapshot.hasActiveTasks) return;
-      final history = await _service?.getHistory(limit: 1) ?? [];
-      if (history.isNotEmpty && mounted) {
-        setState(() => _latestMessage = history.first);
-      }
-    } catch (_) {}
-  }
-
   @override
   void dispose() {
-    _subscription?.cancel();
     _taskSubscription?.cancel();
-    _openActivitySubscription?.cancel();
-    _historyLoadTimer?.cancel();
     _initRetryTimer?.cancel();
     super.dispose();
-  }
-
-  bool _isDetailShowing = false;
-
-  Future<void> _showDetail() async {
-    if (_isDetailShowing) return;
-    _isDetailShowing = true;
-    final targetContext = widget.navigatorKey?.currentContext ?? context;
-    try {
-      await showModalBottomSheet(
-        context: targetContext,
-        isScrollControlled: true,
-        backgroundColor: Colors.transparent,
-        builder: (context) => _DetailSheet(
-          initialMessage: _latestMessage,
-          initialTaskSnapshot: _taskSnapshot,
-          taskActivitySnapshotStream: widget.taskActivitySnapshotStream,
-        ),
-      );
-    } finally {
-      if (mounted) _isDetailShowing = false;
-    }
   }
 
   @override
@@ -168,425 +95,60 @@ class _AgentActivityWidgetState extends State<AgentActivityWidget> {
     if (!_isActive) return const SizedBox.shrink();
     final status = _status;
 
-    return GestureDetector(
-      onTap: _showDetail,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(20),
-          color: Colors.white.withValues(alpha: 0.88),
-          border: Border.all(
-            color: Colors.white.withValues(alpha: 0.5),
-            width: 0.5,
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: const Color(0xFF6366F1).withValues(alpha: 0.08),
-              blurRadius: 16,
-              offset: const Offset(0, 4),
-            ),
-          ],
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const _AgentActivityLogo(size: 36),
-            const SizedBox(width: 8),
-            // Text
-            Flexible(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    UserStorage.l10n.agentProcessing,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      color: Color(0xFF1E293B),
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  Text(
-                    status.hasActiveTasks
-                        ? status.taskSummary
-                        : UserStorage.l10n.keepAppOpen,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: const Color(0xFF64748B).withValues(alpha: 0.8),
-                      fontSize: 11,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(width: 6),
-            const Icon(
-              Icons.chevron_right_rounded,
-              size: 16,
-              color: Color(0xFF94A3B8),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _DetailSheet extends StatefulWidget {
-  final AgentActivityMessageModel? initialMessage;
-  final TaskActivitySnapshot initialTaskSnapshot;
-  final Stream<TaskActivitySnapshot>? taskActivitySnapshotStream;
-
-  const _DetailSheet({
-    this.initialMessage,
-    this.initialTaskSnapshot = const TaskActivitySnapshot.empty(),
-    this.taskActivitySnapshotStream,
-  });
-
-  @override
-  State<_DetailSheet> createState() => _DetailSheetState();
-}
-
-class _DetailSheetState extends State<_DetailSheet> {
-  AgentActivityMessageModel? _message;
-  TaskActivitySnapshot _taskSnapshot = const TaskActivitySnapshot.empty();
-  StreamSubscription<AgentActivityMessageModel>? _subscription;
-  StreamSubscription<TaskActivitySnapshot>? _taskSubscription;
-  AgentActivityService? _service;
-
-  @override
-  void initState() {
-    super.initState();
-    _message = widget.initialMessage;
-    _taskSnapshot = widget.initialTaskSnapshot;
-    try {
-      _service = AgentActivityService.instance;
-    } catch (_) {}
-    _loadHistory();
-    _subscription = _service?.messageStream.listen(_handleNewMessage);
-    try {
-      final taskStream = widget.taskActivitySnapshotStream ??
-          LocalTaskExecutor.instance.taskActivitySnapshotStream;
-      _taskSubscription = taskStream.listen(_handleTaskSnapshot);
-    } catch (_) {}
-    unawaited(_loadCurrentState());
-  }
-
-  Future<void> _loadHistory() async {
-    final history = await _service?.getHistory(limit: 1) ?? [];
-    if (mounted && history.isNotEmpty) {
-      if (_message == null || history.first.id >= _message!.id) {
-        setState(() => _message = history.first);
-      }
-    }
-  }
-
-  Future<void> _loadCurrentState() async {
-    try {
-      if (widget.taskActivitySnapshotStream == null) {
-        final snapshot =
-            await LocalTaskExecutor.instance.getTaskActivitySnapshot();
-        if (mounted) {
-          setState(() => _taskSnapshot = snapshot);
-        }
-      }
-    } catch (_) {}
-  }
-
-  void _handleNewMessage(AgentActivityMessageModel newMessage) {
-    if (!mounted) return;
-    setState(() => _message = newMessage);
-  }
-
-  void _handleTaskSnapshot(TaskActivitySnapshot snapshot) {
-    if (!mounted) return;
-    setState(() => _taskSnapshot = snapshot);
-  }
-
-  @override
-  void dispose() {
-    _subscription?.cancel();
-    _taskSubscription?.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return Container(
-      height: MediaQuery.of(context).size.height * 0.7,
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(24),
-          topRight: Radius.circular(24),
-        ),
-      ),
-      child: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 12),
-            child: Container(
-              width: 40,
-              height: 4,
-              decoration: BoxDecoration(
-                color: const Color(0xFFE2E8F0),
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Row(
-                  children: [
-                    const _AgentActivityLogo(size: 38),
-                    const SizedBox(width: 10),
-                    Text(
-                      UserStorage.l10n.activityDetail,
-                      style: const TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                        color: Color(0xFF0F172A),
-                      ),
-                    ),
-                  ],
-                ),
-                IconButton(
-                  icon: const Icon(Icons.close, color: Color(0xFF94A3B8)),
-                  onPressed: () => Navigator.pop(context),
-                ),
-              ],
-            ),
-          ),
-          const Divider(),
-          Expanded(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(24),
-              child: _message == null
-                  ? _buildWaitingState()
-                  : Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            _buildIcon(_message!.type),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    UserStorage.l10n.processingEllipsis,
-                                    style: const TextStyle(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.w600,
-                                      color: Color(0xFF1E293B),
-                                    ),
-                                  ),
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    '${DateFormat('HH:mm:ss').format(_message!.timestamp)} • ${_message!.agentName}',
-                                    style: const TextStyle(
-                                      fontSize: 12,
-                                      color: Color(0xFF64748B),
-                                      fontWeight: FontWeight.w500,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 24),
-                        if (_message!.content != null &&
-                            _message!.content!.isNotEmpty)
-                          Container(
-                            width: double.infinity,
-                            height: 300,
-                            padding: const EdgeInsets.all(16),
-                            decoration: BoxDecoration(
-                              color: const Color(0xFFF7F8FA),
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                color: const Color(0xFFE2E8F0),
-                              ),
-                            ),
-                            child: SingleChildScrollView(
-                              child: MarkdownBody(
-                                data: _message!.content!,
-                                selectable: true,
-                                styleSheet: MarkdownStyleSheet(
-                                  p: const TextStyle(
-                                    fontSize: 14,
-                                    color: Color(0xFF334155),
-                                    height: 1.6,
-                                  ),
-                                  code: const TextStyle(
-                                    fontSize: 13,
-                                    color: Color(0xFF475569),
-                                    backgroundColor: Color(0xFFE2E8F0),
-                                    fontFamily: 'monospace',
-                                  ),
-                                  codeblockDecoration: BoxDecoration(
-                                    color: const Color(0xFF1E293B),
-                                    borderRadius: BorderRadius.circular(8),
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        if (_message!.type != AgentActivityType.agent_stop &&
-                            _message!.type != AgentActivityType.error)
-                          Padding(
-                            padding: const EdgeInsets.only(top: 24),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                    color: Color(0xFF6366F1),
-                                  ),
-                                ),
-                                const SizedBox(width: 8),
-                                Text(
-                                  UserStorage.l10n.keepAppOpen,
-                                  style: const TextStyle(
-                                    fontSize: 14,
-                                    color: Color(0xFF64748B),
-                                    fontStyle: FontStyle.italic,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        _buildTaskSummary(),
-                      ],
-                    ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildWaitingState() {
-    final status = _status;
-    final statusText = status.hasActiveTasks
-        ? status.taskSummary
-        : UserStorage.l10n.noAgentActivityYet;
-
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const SizedBox(
-            width: 22,
-            height: 22,
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              color: Color(0xFF6366F1),
-            ),
-          ),
-          const SizedBox(height: 12),
-          Text(
-            UserStorage.l10n.processingEllipsis,
-            style: const TextStyle(
-              color: Color(0xFF1E293B),
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: 6),
-          Text(
-            statusText,
-            textAlign: TextAlign.center,
-            style: const TextStyle(color: Color(0xFF64748B), fontSize: 14),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTaskSummary() {
-    final status = _status;
-    if (!status.hasActiveTasks) return const SizedBox.shrink();
-    return Padding(
-      padding: const EdgeInsets.only(top: 16),
-      child: Text(
-        status.taskSummary,
-        style: const TextStyle(
-          color: Color(0xFF64748B),
-          fontSize: 13,
-          height: 1.4,
-        ),
-      ),
-    );
-  }
-
-  AgentBackgroundStatus get _status => AgentBackgroundStatus.fromActivity(
-        taskSnapshot: _taskSnapshot,
-        latestMessage: _message,
-      );
-
-  Widget _buildIcon(AgentActivityType type) {
-    IconData iconData;
-    Color color;
-    switch (type) {
-      case AgentActivityType.agent_start:
-        iconData = Icons.rocket_launch;
-        color = const Color(0xFF10B981);
-      case AgentActivityType.agent_stop:
-        iconData = Icons.check_circle;
-        color = const Color(0xFF10B981);
-      case AgentActivityType.tool_call_reqeust:
-        iconData = Icons.build_circle_outlined;
-        color = const Color(0xFF6366F1);
-      case AgentActivityType.tool_call_response:
-        iconData = Icons.task_alt;
-        color = const Color(0xFF10B981);
-      case AgentActivityType.thought:
-      case AgentActivityType.thought_chunk:
-        iconData = Icons.psychology;
-        color = const Color(0xFF8B5CF6);
-      case AgentActivityType.info:
-      case AgentActivityType.output_chunk:
-        iconData = Icons.info_outline;
-        color = const Color(0xFF3B82F6);
-      case AgentActivityType.error:
-        iconData = Icons.error_outline;
-        color = const Color(0xFFEF4444);
-      case AgentActivityType.warn:
-        iconData = Icons.warning_amber_rounded;
-        color = const Color(0xFFF59E0B);
-      case AgentActivityType.plan:
-        iconData = Icons.map_outlined;
-        color = const Color(0xFF10B981);
-    }
-    return Container(
-      width: 48,
-      height: 48,
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
       decoration: BoxDecoration(
-        color: Colors.white,
-        shape: BoxShape.circle,
-        border: Border.all(color: color.withValues(alpha: 0.2), width: 2),
+        borderRadius: BorderRadius.circular(20),
+        color: Colors.white.withValues(alpha: 0.88),
+        border: Border.all(
+          color: Colors.white.withValues(alpha: 0.5),
+          width: 0.5,
+        ),
         boxShadow: [
           BoxShadow(
-            color: color.withValues(alpha: 0.1),
-            blurRadius: 8,
+            color: const Color(0xFF6366F1).withValues(alpha: 0.08),
+            blurRadius: 16,
             offset: const Offset(0, 4),
           ),
         ],
       ),
-      alignment: Alignment.center,
-      child: Icon(iconData, size: 24, color: color),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const _AgentActivityLogo(size: 36),
+          const SizedBox(width: 8),
+          // Text
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  UserStorage.l10n.agentProcessing,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF1E293B),
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                Text(
+                  status.hasActiveTasks
+                      ? status.taskSummary
+                      : UserStorage.l10n.keepAppOpen,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: const Color(0xFF64748B).withValues(alpha: 0.8),
+                    fontSize: 11,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/test/ui/agent_activity/agent_activity_widget_test.dart
+++ b/test/ui/agent_activity/agent_activity_widget_test.dart
@@ -51,22 +51,22 @@ void main() {
     );
   }
 
-  testWidgets('shows tappable processing affordance before task activity', (
+  testWidgets(
+      'shows non-interactive processing affordance before task activity', (
     tester,
   ) async {
     await tester.pumpWidget(buildHost(forceVisible: true));
     await tester.pump();
 
     expect(find.text('AI is processing...'), findsOneWidget);
+    expect(find.byIcon(Icons.chevron_right_rounded), findsNothing);
 
     await tester.tap(find.text('AI is processing...'));
     await tester.pump(const Duration(milliseconds: 350));
 
-    expect(find.text('Activity Detail'), findsOneWidget);
-    expect(find.text('Processing...'), findsOneWidget);
+    expect(find.text('Activity Detail'), findsNothing);
+    expect(find.text('Processing...'), findsNothing);
 
-    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
-    await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
   });
@@ -84,17 +84,16 @@ void main() {
     await tester.tap(find.text('AI is processing...'));
     await tester.pump(const Duration(milliseconds: 350));
 
-    expect(_assetImage('assets/icon.png'), findsNWidgets(2));
+    expect(_assetImage('assets/icon.png'), findsOneWidget);
     expect(_assetImage('assets/icons/processing_1.png'), findsNothing);
     expect(_assetImage('assets/icons/processing_2.png'), findsNothing);
+    expect(find.text('Activity Detail'), findsNothing);
 
-    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
-    await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
   });
 
-  testWidgets('updates background task count while detail sheet is open', (
+  testWidgets('updates background task count while status is visible', (
     tester,
   ) async {
     final taskSnapshots = StreamController<TaskActivitySnapshot>.broadcast();
@@ -124,20 +123,15 @@ void main() {
     );
     expect(find.text(oneTaskMessage), findsOneWidget);
 
-    await tester.tap(find.text('AI is processing...'));
-    await tester.pump(const Duration(milliseconds: 350));
-
-    expect(find.text(oneTaskMessage), findsWidgets);
-
     taskSnapshots.add(
       const TaskActivitySnapshot(pending: 1, processing: 1, retrying: 0),
     );
     await tester.pump();
+    await tester.pump();
 
-    expect(find.text(twoTaskMessage), findsWidgets);
+    expect(find.text(twoTaskMessage), findsOneWidget);
+    expect(find.text('Activity Detail'), findsNothing);
 
-    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
-    await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
     await taskSnapshots.close();
@@ -162,15 +156,14 @@ void main() {
     await tester.tap(find.text('AI is processing...'));
     await tester.pump(const Duration(milliseconds: 350));
 
-    expect(find.text('Running 0, Pending 1, Retry 0'), findsWidgets);
+    expect(find.text('Running 0, Pending 1, Retry 0'), findsOneWidget);
+    expect(find.text('Activity Detail'), findsNothing);
 
-    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
-    await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
   });
 
-  testWidgets('shows active task status after returning from notification', (
+  testWidgets('shows active task status as a static affordance', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -190,11 +183,9 @@ void main() {
     await tester.tap(find.text('AI is processing...'));
     await tester.pump(const Duration(milliseconds: 350));
 
-    expect(find.text('Activity Detail'), findsOneWidget);
-    expect(find.text('Running 0, Pending 4, Retry 0'), findsWidgets);
+    expect(find.text('Activity Detail'), findsNothing);
+    expect(find.text('Running 0, Pending 4, Retry 0'), findsOneWidget);
 
-    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
-    await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
   });
@@ -270,7 +261,7 @@ void main() {
     activity.dispose();
   });
 
-  testWidgets('opens detail sheet from a buffered notification action', (
+  testWidgets('ignores buffered notification activity action', (
     tester,
   ) async {
     final platform = _FakePlatform();
@@ -284,18 +275,16 @@ void main() {
     emitAgentBackgroundOpenActivityForTesting();
     await tester.pump(const Duration(milliseconds: 350));
 
-    expect(find.text('Activity Detail'), findsOneWidget);
-    expect(find.text('No agent activity yet'), findsOneWidget);
+    expect(find.text('Activity Detail'), findsNothing);
+    expect(find.text('No agent activity yet'), findsNothing);
 
-    Navigator.of(tester.element(find.text('Activity Detail'))).pop();
-    await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
     platform.dispose();
   });
 
   testWidgets(
-    'notification action opens detail and renders live background activity',
+    'notification action leaves the static background status unchanged',
     (tester) async {
       final platform = _FakePlatform();
       final coordinator = AgentBackgroundCoordinator(
@@ -322,8 +311,9 @@ void main() {
         retrying: 0,
       );
 
-      expect(find.text('Activity Detail'), findsOneWidget);
-      expect(find.text(taskSummary), findsWidgets);
+      expect(find.text('Activity Detail'), findsNothing);
+      expect(find.text('AI is processing...'), findsOneWidget);
+      expect(find.text(taskSummary), findsOneWidget);
 
       await AgentActivityService.instance.pushMessage(
         type: AgentActivityType.info,
@@ -335,12 +325,10 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text('Live notification body'), findsOneWidget);
-      expect(find.textContaining('Worker Agent'), findsOneWidget);
-      expect(find.text(taskSummary), findsWidgets);
+      expect(find.text('Live notification body'), findsNothing);
+      expect(find.textContaining('Worker Agent'), findsNothing);
+      expect(find.text(taskSummary), findsOneWidget);
 
-      Navigator.of(tester.element(find.text('Activity Detail'))).pop();
-      await tester.pump(const Duration(milliseconds: 350));
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump();
       platform.dispose();


### PR DESCRIPTION
## Summary
- Make the floating agent activity status on timeline a static status indicator instead of a tappable entry point
- Remove the legacy activity detail sheet from AgentActivityWidget
- Update widget tests to cover the non-interactive status behavior

## Test plan
- flutter test test/ui/agent_activity/agent_activity_widget_test.dart
- flutter analyze lib/ui/agent_activity/widgets/agent_activity_widget.dart lib/main.dart test/ui/agent_activity/agent_activity_widget_test.dart
- Built iOS global release and installed on iPhone as Memex 1.0.35 (137) for manual testing