### PR TITLE
Refine subagent prompts and card detail selection

### DIFF
--- a/lib/agent/common_tools.dart
+++ b/lib/agent/common_tools.dart
@@ -39,7 +39,7 @@ final mintRecordFactIdTool = Tool(
       "The system reserves the id (it never collides and is never guessed by "
       "you). Use count when you need ids for multiple new records; the tool "
       "returns one fact_id per line. Pass each returned fact_id into the "
-      "task_brief of every worker for that record (card / PKM / schedule) so "
+      "task_content of every worker for that record (card / PKM / schedule) so "
       "they all link to one identity. Use this only for NEW records — to edit "
       "an existing card, reuse that card's id instead.",
   parameters: {

--- a/lib/agent/prompts.dart
+++ b/lib/agent/prompts.dart
@@ -163,7 +163,7 @@ Examples:
           'insight_text': {
             'type': 'string',
             'description':
-                'User-facing insight text. Synthesize relevant history into a coherent observation; do not dump an evidence inventory.',
+                'User-facing insight text. Do not restate or paraphrase the current record; the card already shows it. Synthesize relevant history into a coherent observation, and do not dump an evidence inventory.',
           },
           'related_fact_ids': {
             'type': 'array',

--- a/lib/agent/super_agent/prompts.dart
+++ b/lib/agent/super_agent/prompts.dart
@@ -52,7 +52,7 @@ The user's long-term profile memory is always readable — relevant pieces are s
 Every record has a `fact_id` (e.g. `2026/01/20.md#ts_5`) that ties its card, PKM entry, insight, and schedule item together. Mint it for new records, reuse the existing one when editing, and never invent or guess one — a guessed id resolves to no card and is rejected. Pass the same id to every worker for that record.
 
 ## The Timeline Card is self-contained
-A card carries everything needed to display and reason about its record, so you rarely need external files to recall one. Its `fact` is the source of truth — a coherent record in the user's own words and speaking/writing style, formed from the user's text and the image/audio content that matters to the record — and its `assets` list the attached media as markdown markers (`![image](fs://…)`, `[audio](fs://…)`); when you hand an attachment to a worker or tool, pass the bare `fs://…` id from inside the marker.
+A card carries everything needed to display and reason about its record, so you rarely need external files to recall one. Its `fact` is the source-of-truth factual record for the card, and its `assets` list the attached media as markdown markers (`![image](fs://…)`, `[audio](fs://…)`); when you hand an attachment to a worker or tool, pass the bare `fs://…` id from inside the marker.
 
 ## Workspace
 Working directory is `/`; always use absolute paths. Read freely everywhere except where noted; to create or modify managed data, use the owning skill/worker, not raw file writes.

--- a/lib/agent/super_agent/subagent/delegate_subagent_tool.dart
+++ b/lib/agent/super_agent/subagent/delegate_subagent_tool.dart
@@ -148,8 +148,10 @@ Tool buildDelegateToSubagentTool() {
                   "record(s) in the user's own words, any fact_id(s) you minted "
                   '(for multiple records, include a clear record -> fact_id '
                   'mapping). Use asset blocks for every attachment the worker '
-                  'should receive. Image asset blocks are passed to the worker '
-                  'as image parts. State the goal, not the steps — do not spell '
+                  'should receive. A child agent can directly see images from '
+                  'image asset blocks, so there is no need to describe image '
+                  'contents in detail in text blocks. State the goal, not the '
+                  'steps — do not spell '
                   'out which template, which PKM file/directory, or how to '
                   'structure the entry (the skill decides that), and do not '
                   'include the current time or location (the runtime gives the '

--- a/lib/agent/super_agent/subagent/super_agent_child.dart
+++ b/lib/agent/super_agent/subagent/super_agent_child.dart
@@ -206,7 +206,7 @@ the user questions, and do not produce user-facing chit-chat. Your final
 message is parsed by the parent runtime.
 
 ## Scope
-- Work only on the task content/brief and context packet provided in this run.
+- Work only on the task content and context packet provided in this run.
 - Follow the active skill instructions for this run.
 - Use ONLY the fact_id, timestamps, assets, and context explicitly provided.
   Never invent or guess record identity.

--- a/lib/agent/super_agent/super_agent_pre_minted_record_hook.dart
+++ b/lib/agent/super_agent/super_agent_pre_minted_record_hook.dart
@@ -105,7 +105,7 @@ class SuperAgentPreMintedRecordHook extends AgentHook {
         final annotated = annotateUserMessageSystemReminder(
           context.state.history.messages,
           userMessageTimestamp: userMessageTimestamp,
-          reminder: 'Pre-minted record fact_id used this turn: $factId.',
+          reminder: 'Newly minted record fact_id was used this turn: $factId.',
         );
         if (!identical(annotated, context.state.history.messages)) {
           context.state.history.messages = annotated;
@@ -183,7 +183,7 @@ List<LLMMessage> annotatePreMintedRecordFactIdReminder(
     return messages;
   }
   final reminder =
-      'Pre-minted record fact_id: $id. You can use it directly; mint more only if needed.';
+      'Newly minted record fact_id: $id. If creating a new record, use this id directly; mint more only if needed.';
   return annotateUserMessageSystemReminder(
     messages,
     userMessageTimestamp: userMessageTimestamp,

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -1110,15 +1110,17 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
                                       padding: const EdgeInsets.only(
                                         bottom: 12,
                                       ),
-                                      child: Text(
-                                        detail.title,
-                                        style: const TextStyle(
-                                          fontFamily: 'PingFang SC',
-                                          fontSize: 24,
-                                          fontWeight: FontWeight.w600,
-                                          color: Color(0xFF334155),
-                                          height: 1.375, // 33/24
-                                          letterSpacing: -0.45,
+                                      child: SelectionArea(
+                                        child: Text(
+                                          detail.title,
+                                          style: const TextStyle(
+                                            fontFamily: 'PingFang SC',
+                                            fontSize: 24,
+                                            fontWeight: FontWeight.w600,
+                                            color: Color(0xFF334155),
+                                            height: 1.375, // 33/24
+                                            letterSpacing: -0.45,
+                                          ),
                                         ),
                                       ),
                                     ),
@@ -2067,40 +2069,42 @@ class TimelineCardDetailBodySection extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    return Text.rich(
-      TextSpan(
-        children: [
-          TextSpan(
-            text: detail.rawContent,
-            style: const TextStyle(
-              fontSize: 16,
-              color: Color(0xFF334155),
-              height: 1.6,
-            ),
-          ),
-          if (detail.rawContent.isNotEmpty && detail.tags.isNotEmpty)
-            const TextSpan(text: ' '),
-          ...detail.tags.map((tag) {
-            return TextSpan(
-              text: '#$tag',
+    return SelectionArea(
+      child: Text.rich(
+        TextSpan(
+          children: [
+            TextSpan(
+              text: detail.rawContent,
               style: const TextStyle(
                 fontSize: 16,
-                color: Color(0xFF6366F1),
-                fontWeight: FontWeight.w400,
-                height: 1.25,
-                letterSpacing: 0,
+                color: Color(0xFF334155),
+                height: 1.6,
               ),
-              recognizer: onTagTap == null
-                  ? null
-                  : (TapGestureRecognizer()..onTap = () => onTagTap!(tag)),
-            );
-          }).expand(
-            (span) => [
-              span,
+            ),
+            if (detail.rawContent.isNotEmpty && detail.tags.isNotEmpty)
               const TextSpan(text: ' '),
-            ],
-          ),
-        ],
+            ...detail.tags.map((tag) {
+              return TextSpan(
+                text: '#$tag',
+                style: const TextStyle(
+                  fontSize: 16,
+                  color: Color(0xFF6366F1),
+                  fontWeight: FontWeight.w400,
+                  height: 1.25,
+                  letterSpacing: 0,
+                ),
+                recognizer: onTagTap == null
+                    ? null
+                    : (TapGestureRecognizer()..onTap = () => onTagTap!(tag)),
+              );
+            }).expand(
+              (span) => [
+                span,
+                const TextSpan(text: ' '),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/test/agent/super_agent_permissions_test.dart
+++ b/test/agent/super_agent_permissions_test.dart
@@ -301,7 +301,7 @@ void main() {
         messages,
         userMessageTimestamp: userMessage.timestamp,
         reminder:
-            'Pre-minted record fact_id used this turn: 2026/06/26.md#ts_1.',
+            'Newly minted record fact_id was used this turn: 2026/06/26.md#ts_1.',
       );
 
       expect(annotated, hasLength(2));
@@ -311,7 +311,7 @@ void main() {
       expect(
         reminder,
         contains(
-            'Pre-minted record fact_id used this turn: 2026/06/26.md#ts_1.'),
+            'Newly minted record fact_id was used this turn: 2026/06/26.md#ts_1.'),
       );
       expect(reminder, contains('</system-reminder>'));
     });

--- a/test/ui/timeline/widgets/timeline_card_detail_body_section_test.dart
+++ b/test/ui/timeline/widgets/timeline_card_detail_body_section_test.dart
@@ -35,6 +35,7 @@ void main() {
     );
     expect(find.textContaining('- 家常菜', findRichText: true), findsOneWidget);
     expect(find.textContaining('#Visual', findRichText: true), findsOneWidget);
+    expect(find.byType(SelectionArea), findsOneWidget);
     expect(find.text('端午的温馨家常晚餐和太顺杨梅'), findsNothing);
     expect(find.text('一家人吃了家常晚餐，还尝到了太顺杨梅。'), findsNothing);
   });
@@ -80,6 +81,31 @@ void main() {
     );
 
     expect(find.text('普通正文'), findsOneWidget);
+  });
+
+  testWidgets('keeps tag taps working when content is selectable',
+      (tester) async {
+    String? tappedTag;
+    final detail = _detail(
+      rawContent: '',
+      uiConfigs: const [],
+      tags: const ['Visual'],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TimelineCardDetailBodySection(
+            detail: detail,
+            onTagTap: (tag) => tappedTag = tag,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.textContaining('#Visual', findRichText: true));
+
+    expect(tappedTag, 'Visual');
   });
 }
 


### PR DESCRIPTION
## Summary
- Refine subagent delegation wording around task_content, image asset blocks, and card fact descriptions.
- Clarify PKM card insight guidance and newly minted fact_id reminders.
- Enable text selection/copy for timeline card detail title and body while preserving tag taps.

## Validation
- flutter test test/agent/super_agent_child_test.dart --reporter compact
- flutter test test/agent/super_agent_permissions_test.dart --reporter compact
- flutter test test/ui/timeline/widgets/timeline_card_detail_body_section_test.dart --reporter compact
- flutter analyze --no-fatal-infos lib/agent/prompts.dart lib/agent/skills/manage_pkm/pkm_skill.dart lib/agent/super_agent/subagent/delegate_subagent_tool.dart lib/agent/super_agent/prompts.dart
- git diff --check