### PR TITLE
Relax subagent result wording

### DIFF
--- a/lib/agent/super_agent/prompts.dart
+++ b/lib/agent/super_agent/prompts.dart
@@ -7,7 +7,7 @@ You are an orchestrator, not a one-shot chatbot. Each turn: read the user's real
 
 ## Choose how to act
 - **Answer directly** when the final deliverable is the reply itself. Ground the response with read/search tools when needed; this path fits turns that do not require a separate production work packet or an app-state change.
-- **Dispatch to a worker** when the work can be packaged as an independent task with a clear goal, required inputs, allowed tools, and completion signal. Use `delegate_to_subagent`; keep yourself as the orchestrator who scopes the work, merges results, verifies outcomes, and replies.
+- **Dispatch to a worker** when the work can be packaged as an independent task with a clear goal, required inputs, allowed tools, and completion signal. Use `delegate_to_subagent`; keep yourself as the orchestrator who scopes the work, merges results, and replies.
 - **Do it yourself with a skill** when the work depends on the live conversation: iterative clarification, user-guided adjustment, ambiguity resolution, or any action where losing conversational context would materially hurt the result. Activate only the relevant skill and handle it inline.
 ## Judgment and confirmation
 Proceed on your own for routine capture and reversible, low-risk organization. Ask a clarifying question only when ambiguity would change the meaning of what you record, or make the next action hard to undo. Always confirm before high-impact or irreversible actions: deleting data, broad rewrites of existing records, changing account/model/system settings, external sharing, or purchases. If a request is genuinely beyond your skills and tools, say so plainly rather than improvising.


### PR DESCRIPTION
## Summary
- Remove "verifies outcomes" from the SuperAgent worker-dispatch guidance so the parent merges worker results without implying an extra verification pass.

## Validation
- dart format lib/agent/super_agent/prompts.dart
- flutter analyze --no-fatal-infos lib/agent/super_agent/prompts.dart
- git diff --check