### PR TITLE
Document Android build flavors

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,11 +1,28 @@
 # Build Guide
 
-Memex ships two flavors: `global` (overseas) and `cn` (China domestic). Currently they only differ by package name; more feature differences will follow.
+Memex uses region flavors (`global`, `cn`) and Android channel flavors
+(`stable`, `early`, `dev`). Android currently defines six Gradle product
+flavors. iOS currently defines two schemes: `global` and `cn`.
 
-| Flavor | Android Package | iOS Bundle ID |
-|--------|----------------|---------------|
-| global | `com.memexlab.memex` | `com.memexlab.memex` |
-| cn | `com.memexlab.memex.cn` | `com.memexlab.memex.cn` |
+## Flavors
+
+### Android
+
+| Flavor | Android Package | Channel | Intended Use |
+|--------|-----------------|---------|--------------|
+| `globalDev` | `com.memexlab.memex.dev` | Dev | Local overseas development; isolated package/data |
+| `cnDev` | `com.memexlab.memex.cn.dev` | Dev | Local China development; isolated package/data |
+| `globalEarly` | `com.memexlab.memex.early` | Early | Overseas early/pre-release Android builds |
+| `cnEarly` | `com.memexlab.memex.cn.early` | Early | China early/pre-release Android builds |
+| `global` | `com.memexlab.memex` | Stable | Overseas stable release; avoid for local dev |
+| `cn` | `com.memexlab.memex.cn` | Stable | China stable release; avoid for local dev |
+
+### iOS
+
+| Flavor | iOS Bundle ID | Intended Use |
+|--------|---------------|--------------|
+| `global` | `com.memexlab.memex` | Overseas builds |
+| `cn` | `com.memexlab.memex.cn` | China domestic builds |
 
 ## Prerequisites
 
@@ -22,11 +39,31 @@ cd ios && pod install && cd ..
 
 ## Run
 
-```bash
-# Overseas
-flutter run --flavor global
+### Android local development
 
-# China
+```bash
+# Overseas dev, isolated package/data
+flutter run --flavor globalDev
+
+# China dev, isolated package/data
+flutter run --flavor cnDev
+```
+
+### Android early or stable channels
+
+```bash
+flutter run --flavor globalEarly
+flutter run --flavor cnEarly
+
+# Stable release flavors; avoid for local development
+flutter run --flavor global
+flutter run --flavor cn
+```
+
+### iOS
+
+```bash
+flutter run --flavor global
 flutter run --flavor cn
 ```
 
@@ -35,13 +72,21 @@ flutter run --flavor cn
 ### Android
 
 ```bash
-# APK
+# Local debug APKs
+flutter build apk --flavor globalDev --debug
+flutter build apk --flavor cnDev --debug
+
+# Release APKs
 flutter build apk --flavor global --release
 flutter build apk --flavor cn --release
+flutter build apk --flavor globalEarly --release
+flutter build apk --flavor cnEarly --release
 
-# App Bundle
+# Release App Bundles
 flutter build appbundle --flavor global --release
 flutter build appbundle --flavor cn --release
+flutter build appbundle --flavor globalEarly --release
+flutter build appbundle --flavor cnEarly --release
 ```
 
 Output path: `build/app/outputs/flutter-apk/memex_<flavor>_<version>_<build>.apk`
@@ -64,17 +109,20 @@ Or use the deploy script:
 
 ### Android
 
-Each flavor uses its own signing key. Config files live under `android/`:
+Release signing configs live under `android/`. Dev flavors use debug signing for
+debug builds and do not define release signing configs.
 
-| Flavor | Properties File | Keystore File |
-|--------|----------------|--------------|
-| global | `android/key-global.properties` | `android/app/memex-global-release.keystore` |
-| cn | `android/key-cn.properties` | `android/app/memex-cn-release.keystore` |
+| Flavor(s) | Properties File | Signing Config |
+|-----------|-----------------|----------------|
+| `global` | `android/key-global.properties` | `globalRelease` |
+| `cn` | `android/key-cn.properties` | `cnRelease` |
+| `globalEarly`, `cnEarly` | `android/key-early.properties` | `earlyRelease` |
+| `globalDev`, `cnDev` | Debug signing only | No release signing config |
 
 Properties file format:
 
 ```properties
-storeFile=memex-<flavor>-release.keystore
+storeFile=<keystore-file>
 storePassword=<your_password>
 keyAlias=<your_alias>
 keyPassword=<your_password>
@@ -84,7 +132,7 @@ Generate a new keystore:
 
 ```bash
 keytool -genkeypair -v \
-  -keystore android/app/memex-<flavor>-release.keystore \
+  -keystore android/app/<keystore-file> \
   -alias <your_alias> \
   -keyalg RSA -keysize 2048 \
   -validity 10000
@@ -93,14 +141,16 @@ keytool -genkeypair -v \
 View signing info (MD5 / SHA1 / SHA256):
 
 ```bash
-keytool -list -v -keystore android/app/memex-<flavor>-release.keystore
+keytool -list -v -keystore android/app/<keystore-file>
 ```
 
 > ⚠️ Keystore and properties files are excluded in `.gitignore`. Never commit them to the repository.
 
 ### iOS
 
-iOS signing is managed through your Apple Developer account. Register the App ID (`com.memexlab.memex.cn`) and create Provisioning Profiles in Xcode or the Apple Developer Portal.
+iOS signing is managed through your Apple Developer account. Register the App
+IDs (`com.memexlab.memex`, `com.memexlab.memex.cn`) and create Provisioning
+Profiles in Xcode or the Apple Developer Portal.
 
 ## Flavor Detection in Dart
 
@@ -111,5 +161,9 @@ import 'package:memex/config/app_flavor.dart';
 
 if (AppFlavor.isCN) {
   // China-specific logic
+}
+
+if (AppFlavor.isDev) {
+  // Development-channel logic
 }
 ```


### PR DESCRIPTION
## Summary
- Update BUILD.md to document all six Android product flavors.
- Clarify Android local development should use globalDev/cnDev with isolated package/data.
- Separate Android flavor guidance from the two existing iOS schemes and refresh signing notes.

## Validation
- git diff --check

Fixes #335