### PR TITLE
Add persistent chat artifacts and JSONL chat storage

### DIFF
--- a/lib/agent/built_in_tools/file_tools.dart
+++ b/lib/agent/built_in_tools/file_tools.dart
@@ -5,6 +5,7 @@ import 'package:memex/agent/prompts.dart';
 import 'package:memex/agent/run_mode/agent_action_approval_service.dart';
 import 'package:memex/agent/security/file_permission_manager.dart';
 import 'package:memex/agent/super_agent/pending_tool_image_buffer.dart';
+import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/services/agent_image_attachment.dart';
 import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/data/services/api_exception.dart';
@@ -21,6 +22,32 @@ typedef ViewImageExifInfoBuilder = Future<String?> Function(
   String userId,
   String imagePath,
 );
+
+Map<String, dynamic> _fileArtifactJson({
+  required String path,
+  required bool updated,
+  required String content,
+}) {
+  final summary =
+      content.length > 160 ? '${content.substring(0, 160)}...' : content;
+  final title = p.basename(path);
+  final isKnowledgeFile =
+      ChatArtifact.knowledgeFilePathFromWorkspacePath(path) != null;
+  final artifact = isKnowledgeFile
+      ? ChatArtifact.knowledgeFile(
+          path: path,
+          title: title,
+          summary: summary,
+          updated: updated,
+        )
+      : ChatArtifact.workspaceFile(
+          path: path,
+          title: title,
+          summary: summary,
+          updated: updated,
+        );
+  return artifact.toJson();
+}
 
 class FileToolFactory {
   final FilePermissionManager permissionManager;
@@ -379,14 +406,11 @@ class FileToolFactory {
         return AgentToolResult(
           content: TextPart(result),
           metadata: {
-            'artifact': {
-              'type': 'file',
-              'path': artifactPath,
-              'updated': artifactIsUpdate,
-              'snippet': content.length > 160
-                  ? '${content.substring(0, 160)}…'
-                  : content,
-            },
+            'artifact': _fileArtifactJson(
+              path: artifactPath,
+              updated: artifactIsUpdate,
+              content: content,
+            ),
           },
         );
       },
@@ -464,14 +488,11 @@ class FileToolFactory {
         return AgentToolResult(
           content: TextPart(result),
           metadata: {
-            'artifact': {
-              'type': 'file',
-              'path': artifactPath,
-              'updated': true,
-              'snippet': new_string.length > 160
-                  ? '${new_string.substring(0, 160)}…'
-                  : new_string,
-            },
+            'artifact': _fileArtifactJson(
+              path: artifactPath,
+              updated: true,
+              content: new_string,
+            ),
           },
         );
       },

--- a/lib/agent/common_tools.dart
+++ b/lib/agent/common_tools.dart
@@ -74,13 +74,6 @@ final mintRecordFactIdTool = Tool(
     getLogger('CommonTools').info('Minted fact_id(s): ${factIds.join(', ')}');
     return AgentToolResult(
       content: TextPart(factIds.join('\n')),
-      metadata: {
-        'artifact': {
-          'type': requestedCount == 1 ? 'fact_id' : 'fact_ids',
-          if (requestedCount == 1) 'id': factIds.single,
-          'ids': factIds,
-        },
-      },
     );
   },
 );

--- a/lib/agent/skills/dynamic_timeline_ui/dynamic_timeline_ui_skill.dart
+++ b/lib/agent/skills/dynamic_timeline_ui/dynamic_timeline_ui_skill.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/agent/run_mode/agent_action_approval_service.dart';
 import 'package:memex/agent/super_agent/pending_tool_image_buffer.dart';
+import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/services/card_renderer.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/webview_snapshot_service.dart';
@@ -651,13 +652,11 @@ Finish by returning a concise result: what template was saved, template_id, use_
     return AgentToolResult(
       content: TextPart(buffer.toString().trimRight()),
       metadata: {
-        'artifact': {
-          'type': 'file',
-          'id': cleanTemplateId,
-          'title': cleanTemplateId,
-          'path': '_UserSettings/Templates/$cleanTemplateId/view.html',
-          'updated': previousMeta != null,
-        },
+        'artifact': ChatArtifact.uiTemplate(
+          templateId: cleanTemplateId,
+          path: '_UserSettings/Templates/$cleanTemplateId/view.html',
+          updated: previousMeta != null,
+        ).toJson(),
       },
     );
   }

--- a/lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart
+++ b/lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart
@@ -5,6 +5,7 @@ import 'package:memex/agent/prompts.dart';
 import 'package:memex/agent/run_mode/agent_action_approval_service.dart';
 import 'package:memex/agent/skills/knowledge_insight/native_widgets.dart';
 
+import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/timeline_card_event_publisher.dart';
@@ -464,8 +465,28 @@ Tool buildSaveKnowledgeInsightCardsTool() {
           logger.warning('Failed to create insight summary timeline card: $e');
         }
 
-        return Prompts.knowledgeInsightToolSuccessUpdate(
-            createdIds.length, createdIds, updatedIds.length, updatedIds);
+        return AgentToolResult(
+          content: TextPart(Prompts.knowledgeInsightToolSuccessUpdate(
+              createdIds.length, createdIds, updatedIds.length, updatedIds)),
+          metadata: {
+            'artifacts': [
+              for (final info in addedSummaryCards)
+                if ((info['id']?.toString().trim() ?? '').isNotEmpty)
+                  ChatArtifact.knowledgeInsight(
+                    insightId: info['id'].toString(),
+                    title: info['title']?.toString(),
+                    updated: false,
+                  ).toJson(),
+              for (final info in updatedSummaryCards)
+                if ((info['id']?.toString().trim() ?? '').isNotEmpty)
+                  ChatArtifact.knowledgeInsight(
+                    insightId: info['id'].toString(),
+                    title: info['title']?.toString(),
+                    updated: true,
+                  ).toJson(),
+            ],
+          },
+        );
       } catch (e) {
         logger.severe('Failed to update knowledge insight cards: $e');
         throw Exception('Failed to update knowledge insight cards: $e');

--- a/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
+++ b/lib/agent/skills/manage_timeline_card/timeline_card_skill.dart
@@ -6,6 +6,7 @@ import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/agent/prompts.dart';
 import 'package:memex/agent/run_mode/agent_action_approval_service.dart';
+import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/services/asset_reference_service.dart';
 import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/data/services/file_system_service.dart';
@@ -19,6 +20,25 @@ import 'package:memex/utils/user_storage.dart';
 final logger = Logger('TimelineCardSkill');
 
 bool _nonEmpty(String? value) => value != null && value.trim().isNotEmpty;
+
+String? _artifactSnippet(String? value) {
+  final text = value?.trim();
+  if (text == null || text.isEmpty) return null;
+  return text.length > 160 ? '${text.substring(0, 160)}…' : text;
+}
+
+List<String> _assetImagePathsForArtifact(List<String> assets) {
+  final paths = <String>[];
+  final imageMarker = RegExp(r'^!\[[^\]]*\]\(fs://([^)]+)\)$');
+  for (final asset in assets) {
+    final match = imageMarker.firstMatch(asset.trim());
+    if (match == null) continue;
+    final fileName = match.group(1)?.trim();
+    if (fileName == null || fileName.isEmpty) continue;
+    paths.add('fs://$fileName');
+  }
+  return paths;
+}
 
 /// Skill for managing Timeline Cards
 class TimelineCardSkill extends Skill {
@@ -583,13 +603,15 @@ class TimelineCardSkill extends Skill {
               stopFlag: stopAfterSuccessSaveCard ||
                   (isSubAgent && _nonEmpty(finish_summary)),
               metadata: {
-                'artifact': {
-                  'type': 'card',
-                  'id': resolvedFactId,
-                  'title': title ?? updatedCardData.title,
-                  'tags': tagNames,
-                  'updated': true,
-                },
+                'artifact': ChatArtifact.timelineCard(
+                  cardId: resolvedFactId,
+                  title: title ?? updatedCardData.title,
+                  summary: _artifactSnippet(updatedCardData.fact),
+                  imagePaths:
+                      _assetImagePathsForArtifact(updatedCardData.assets),
+                  tags: updatedCardData.tags,
+                  updated: !isNewCard,
+                ).toJson(),
                 if (isSubAgent && _nonEmpty(finish_summary))
                   'child_terminal_result': {
                     'status': 'completed',

--- a/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
+++ b/lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:memex/agent/prompts.dart';
+import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/schedule_state_service.dart';
 import 'package:memex/domain/models/schedule_state.dart';
@@ -185,11 +186,20 @@ Tool buildAddPendingItemTool() {
         title: title,
       );
       _emitScheduleAggregationUpdated();
-      return jsonEncode({
+      final result = jsonEncode({
         'status': 'ok',
         'item_id': item?.id,
         'pending': state.pending.length,
       });
+      return AgentToolResult(
+        content: TextPart(result),
+        metadata: {
+          'artifact': _scheduleArtifact(
+            title: title,
+            updated: false,
+          ),
+        },
+      );
     },
   );
 }
@@ -282,7 +292,16 @@ Tool buildUpdatePendingItemTool() {
         clearPriority: clearPriority == true,
       );
       _emitScheduleAggregationUpdated();
-      return 'Pending item updated. pending=${state.pending.length}';
+      return AgentToolResult(
+        content:
+            TextPart('Pending item updated. pending=${state.pending.length}'),
+        metadata: {
+          'artifact': _scheduleArtifact(
+            title: title ?? id,
+            updated: true,
+          ),
+        },
+      );
     },
   );
 }
@@ -309,7 +328,16 @@ Tool buildCompletePendingItemTool() {
         closedAt: _parseScheduleDateTime(closedAt),
       );
       _emitScheduleAggregationUpdated();
-      return 'Pending item completed. completed=${state.completed.length}';
+      return AgentToolResult(
+        content: TextPart(
+            'Pending item completed. completed=${state.completed.length}'),
+        metadata: {
+          'artifact': _scheduleArtifact(
+            title: id,
+            updated: true,
+          ),
+        },
+      );
     },
   );
 }
@@ -345,7 +373,15 @@ Tool buildCompleteSubtaskTool() {
         closedAt: _parseScheduleDateTime(closedAt),
       );
       _emitScheduleAggregationUpdated();
-      return 'Subtask completed. pending=${state.pending.length}';
+      return AgentToolResult(
+        content: TextPart('Subtask completed. pending=${state.pending.length}'),
+        metadata: {
+          'artifact': _scheduleArtifact(
+            title: subtaskTitle,
+            updated: true,
+          ),
+        },
+      );
     },
   );
 }
@@ -399,9 +435,25 @@ Tool buildSetPresentationTool({bool stopAfterSetPresentation = false}) {
           'Presentation updated. pending=${updated.pending.length}',
         ),
         stopFlag: stopAfterSetPresentation,
+        metadata: {
+          'artifact': _scheduleArtifact(
+            title: UserStorage.l10n.scheduleBriefingTitle,
+            updated: true,
+          ),
+        },
       );
     },
   );
+}
+
+Map<String, dynamic> _scheduleArtifact({
+  required String title,
+  required bool updated,
+}) {
+  return ChatArtifact.schedule(
+    title: title,
+    updated: updated,
+  ).toJson();
 }
 
 void _emitScheduleAggregationUpdated() {

--- a/lib/data/model/chat_artifact.dart
+++ b/lib/data/model/chat_artifact.dart
@@ -1,88 +1,628 @@
-/// A user-visible artifact produced by one agent tool call (a saved record,
-/// a Timeline card, a written document, a reminder, ...), extracted from the
-/// tool result metadata so the chat UI can render a preview tile.
+/// A user-visible UI artifact produced by an agent turn.
+///
+/// Tool trace events stay transient. Artifacts are persisted on the completed
+/// assistant message so reopened chats can reconstruct the final app updates.
 class ChatArtifact {
   ChatArtifact({
-    required this.type,
-    this.id,
+    required this.artifactId,
+    required this.kind,
+    required this.operation,
     this.title,
-    this.snippet,
-    this.path,
-    this.kind,
-    this.imagePaths = const [],
-    this.tags = const [],
-    this.updated = false,
-  });
+    this.summary,
+    this.targetUri,
+    this.storageUri,
+    this.sourceRunId,
+    this.sourceToolCallId,
+    DateTime? createdAt,
+    Map<String, dynamic> metadata = const {},
+    this.version = schemaVersion,
+  })  : createdAt = createdAt ?? DateTime.now(),
+        metadata = Map.unmodifiable(metadata);
 
-  static const String typeRecord = 'record';
-  static const String typeHtmlCard = 'html_card';
-  static const String typeCard = 'card';
-  static const String typeFile = 'file';
-  static const String typeSystemAction = 'system_action';
-  static const String typeInsight = 'insight';
+  static const int schemaVersion = 2;
 
-  final String type;
+  static const String kindTimelineCard = 'timeline_card';
+  static const String kindKnowledgeInsight = 'knowledge_insight';
+  static const String kindKnowledgeFile = 'knowledge_file';
+  static const String kindWorkspaceFile = 'workspace_file';
+  static const String kindSchedule = 'schedule';
+  static const String kindSystemAction = 'system_action';
+  static const String kindUiTemplate = 'ui_template';
 
-  /// Fact/card id (e.g. `2026/06/10.md#ts_3`) when the artifact is a record
-  /// or Timeline card — used to deep-link into the card detail page.
-  final String? id;
-  final String? title;
-  final String? snippet;
+  static const String operationCreate = 'create';
+  static const String operationUpdate = 'update';
+  static const String operationSave = 'save';
 
-  /// Workspace-relative file path for [typeFile] artifacts.
-  final String? path;
-
-  /// Sub-kind for [typeSystemAction] artifacts: `calendar` or `reminder`.
-  final String? kind;
-
-  /// Workspace-relative image paths attached to a record.
-  final List<String> imagePaths;
-  final List<String> tags;
-
-  /// True when an existing entity was updated rather than created.
-  final bool updated;
-
-  static const Set<String> _knownTypes = {
-    typeRecord,
-    typeHtmlCard,
-    typeCard,
-    typeFile,
-    typeSystemAction,
-    typeInsight,
+  static const Set<String> _knownKinds = {
+    kindTimelineCard,
+    kindKnowledgeInsight,
+    kindKnowledgeFile,
+    kindWorkspaceFile,
+    kindSchedule,
+    kindSystemAction,
+    kindUiTemplate,
   };
 
-  /// Parses the `artifact` entry of a tool result metadata map. Returns null
-  /// when the metadata carries no recognizable artifact.
+  static const Set<String> _knownOperations = {
+    operationCreate,
+    operationUpdate,
+    operationSave,
+  };
+
+  final String artifactId;
+  final String kind;
+  final String operation;
+  final String? title;
+  final String? summary;
+
+  /// Deep-link destination, e.g. `memex://timeline-card/<id>`,
+  /// `memex://insight/<id>`, `memex://schedule`, or `workspace:///PKM/a.md`.
+  final String? targetUri;
+
+  /// Physical storage location when different from [targetUri].
+  final String? storageUri;
+
+  /// Current chat turn id until a durable AgentRun id exists.
+  final String? sourceRunId;
+  final String? sourceToolCallId;
+  final int version;
+  final DateTime createdAt;
+
+  /// Domain-specific display hints such as tags, image paths, or file excerpts.
+  final Map<String, dynamic> metadata;
+
+  bool get updated => operation == operationUpdate;
+
+  List<String> get imagePaths => _stringList(metadata['image_paths']);
+
+  List<String> get tags => _stringList(metadata['tags']);
+
+  String? get systemActionKind => _nonEmpty(metadata['system_action_kind']);
+
+  String? get timelineCardId => _memexTargetId('timeline-card');
+
+  String? get knowledgeInsightId => _memexTargetId('insight');
+
+  String? get knowledgeFilePath {
+    if (kind != kindKnowledgeFile) return null;
+    return knowledgeFilePathFromWorkspacePath(workspacePath);
+  }
+
+  String? get workspacePath {
+    for (final value in [targetUri, storageUri]) {
+      final uri = _tryParseUri(value);
+      if (uri == null || uri.scheme != 'workspace') continue;
+      if (uri.pathSegments.isEmpty) continue;
+      return uri.pathSegments.join('/');
+    }
+    return null;
+  }
+
+  factory ChatArtifact.timelineCard({
+    required String cardId,
+    String? title,
+    String? summary,
+    List<String> imagePaths = const [],
+    List<String> tags = const [],
+    required bool updated,
+    String? sourceRunId,
+    String? sourceToolCallId,
+    DateTime? createdAt,
+  }) {
+    final targetUri = timelineCardTargetUri(cardId);
+    return ChatArtifact(
+      artifactId: artifactIdFor(kindTimelineCard, targetUri),
+      kind: kindTimelineCard,
+      operation: updated ? operationUpdate : operationCreate,
+      title: _nonEmpty(title),
+      summary: _nonEmpty(summary),
+      targetUri: targetUri,
+      sourceRunId: sourceRunId,
+      sourceToolCallId: sourceToolCallId,
+      createdAt: createdAt,
+      metadata: {
+        if (imagePaths.isNotEmpty) 'image_paths': imagePaths,
+        if (tags.isNotEmpty) 'tags': tags,
+      },
+    );
+  }
+
+  factory ChatArtifact.knowledgeInsight({
+    required String insightId,
+    String? title,
+    String? summary,
+    required bool updated,
+    String? sourceRunId,
+    String? sourceToolCallId,
+    DateTime? createdAt,
+  }) {
+    final targetUri = insightTargetUri(insightId);
+    return ChatArtifact(
+      artifactId: artifactIdFor(kindKnowledgeInsight, targetUri),
+      kind: kindKnowledgeInsight,
+      operation: updated ? operationUpdate : operationCreate,
+      title: _nonEmpty(title),
+      summary: _nonEmpty(summary),
+      targetUri: targetUri,
+      sourceRunId: sourceRunId,
+      sourceToolCallId: sourceToolCallId,
+      createdAt: createdAt,
+    );
+  }
+
+  factory ChatArtifact.knowledgeFile({
+    required String path,
+    String? title,
+    String? summary,
+    required bool updated,
+    String? sourceRunId,
+    String? sourceToolCallId,
+    DateTime? createdAt,
+  }) {
+    final targetUri = workspaceTargetUri(path);
+    return ChatArtifact(
+      artifactId: artifactIdFor(kindKnowledgeFile, targetUri),
+      kind: kindKnowledgeFile,
+      operation: updated ? operationUpdate : operationCreate,
+      title: _nonEmpty(title),
+      summary: _nonEmpty(summary),
+      targetUri: targetUri,
+      storageUri: targetUri,
+      sourceRunId: sourceRunId,
+      sourceToolCallId: sourceToolCallId,
+      createdAt: createdAt,
+    );
+  }
+
+  factory ChatArtifact.workspaceFile({
+    required String path,
+    String? title,
+    String? summary,
+    required bool updated,
+    String? sourceRunId,
+    String? sourceToolCallId,
+    DateTime? createdAt,
+  }) {
+    final targetUri = workspaceTargetUri(path);
+    return ChatArtifact(
+      artifactId: artifactIdFor(kindWorkspaceFile, targetUri),
+      kind: kindWorkspaceFile,
+      operation: updated ? operationUpdate : operationCreate,
+      title: _nonEmpty(title),
+      summary: _nonEmpty(summary),
+      targetUri: targetUri,
+      storageUri: targetUri,
+      sourceRunId: sourceRunId,
+      sourceToolCallId: sourceToolCallId,
+      createdAt: createdAt,
+    );
+  }
+
+  factory ChatArtifact.uiTemplate({
+    required String templateId,
+    required String path,
+    required bool updated,
+    String? sourceRunId,
+    String? sourceToolCallId,
+    DateTime? createdAt,
+  }) {
+    final targetUri = workspaceTargetUri(path);
+    return ChatArtifact(
+      artifactId: artifactIdFor(kindUiTemplate, targetUri),
+      kind: kindUiTemplate,
+      operation: updated ? operationUpdate : operationCreate,
+      title: _nonEmpty(templateId),
+      targetUri: targetUri,
+      storageUri: targetUri,
+      sourceRunId: sourceRunId,
+      sourceToolCallId: sourceToolCallId,
+      createdAt: createdAt,
+    );
+  }
+
+  factory ChatArtifact.schedule({
+    String? title,
+    String? summary,
+    required bool updated,
+    String? sourceRunId,
+    String? sourceToolCallId,
+    DateTime? createdAt,
+  }) {
+    const targetUri = 'memex://schedule';
+    return ChatArtifact(
+      artifactId: artifactIdFor(kindSchedule, targetUri),
+      kind: kindSchedule,
+      operation: updated ? operationUpdate : operationCreate,
+      title: _nonEmpty(title),
+      summary: _nonEmpty(summary),
+      targetUri: targetUri,
+      sourceRunId: sourceRunId,
+      sourceToolCallId: sourceToolCallId,
+      createdAt: createdAt,
+    );
+  }
+
+  factory ChatArtifact.systemAction({
+    required String systemActionKind,
+    String? title,
+    String? summary,
+    required bool updated,
+    String? sourceRunId,
+    String? sourceToolCallId,
+    DateTime? createdAt,
+  }) {
+    final normalizedKind = _nonEmpty(systemActionKind) ?? 'action';
+    final targetUri =
+        'memex://system-action/${Uri.encodeComponent(normalizedKind)}';
+    return ChatArtifact(
+      artifactId: artifactIdFor(kindSystemAction, targetUri),
+      kind: kindSystemAction,
+      operation: updated ? operationUpdate : operationCreate,
+      title: _nonEmpty(title),
+      summary: _nonEmpty(summary),
+      targetUri: targetUri,
+      sourceRunId: sourceRunId,
+      sourceToolCallId: sourceToolCallId,
+      createdAt: createdAt,
+      metadata: {'system_action_kind': normalizedKind},
+    );
+  }
+
   static ChatArtifact? fromToolMetadata(Map<String, dynamic>? metadata) {
     final raw = metadata?['artifact'];
-    if (raw is! Map) return null;
-    final map = Map<String, dynamic>.from(raw);
-    final type = map['type']?.toString();
-    if (type == null || !_knownTypes.contains(type)) return null;
+    if (raw is Map) return fromJson(Map<String, dynamic>.from(raw));
+    return null;
+  }
 
-    List<String> stringList(dynamic value) {
-      if (value is! List) return const [];
-      return value
-          .map((item) => item.toString())
-          .where((item) => item.isNotEmpty)
-          .toList();
+  static List<ChatArtifact> listFromToolMetadata(
+    Map<String, dynamic>? metadata,
+  ) {
+    if (metadata == null) return const [];
+    final artifacts = <ChatArtifact>[];
+    final single = fromToolMetadata(metadata);
+    if (single != null) artifacts.add(single);
+
+    final rawList = metadata['artifacts'];
+    if (rawList is List) {
+      for (final raw in rawList) {
+        if (raw is! Map) continue;
+        final artifact = fromJson(Map<String, dynamic>.from(raw));
+        if (artifact != null) artifacts.add(artifact);
+      }
+    }
+    return artifacts;
+  }
+
+  static ChatArtifact? fromJson(Map<String, dynamic> map) {
+    if (map['version'] != schemaVersion) return null;
+
+    final artifactId = _nonEmpty(map['artifact_id']);
+    final kind = _nonEmpty(map['kind']);
+    final operation = _nonEmpty(map['operation']);
+    if (artifactId == null ||
+        kind == null ||
+        operation == null ||
+        !_knownKinds.contains(kind) ||
+        !_knownOperations.contains(operation)) {
+      return null;
     }
 
-    String? nonEmpty(dynamic value) {
-      final text = value?.toString().trim();
-      return (text == null || text.isEmpty) ? null : text;
-    }
+    final createdAt = DateTime.tryParse(map['created_at']?.toString() ?? '') ??
+        DateTime.now();
+    final rawMetadata = map['metadata'];
 
     return ChatArtifact(
-      type: type,
-      id: nonEmpty(map['id']),
-      title: nonEmpty(map['title']),
-      snippet: nonEmpty(map['snippet']),
-      path: nonEmpty(map['path']),
-      kind: nonEmpty(map['kind']),
-      imagePaths: stringList(map['image_paths']),
-      tags: stringList(map['tags']),
-      updated: map['updated'] == true,
+      artifactId: artifactId,
+      kind: kind,
+      operation: operation,
+      title: _nonEmpty(map['title']),
+      summary: _nonEmpty(map['summary']),
+      targetUri: _nonEmpty(map['target_uri']),
+      storageUri: _nonEmpty(map['storage_uri']),
+      sourceRunId: _nonEmpty(map['source_run_id']),
+      sourceToolCallId: _nonEmpty(map['source_tool_call_id']),
+      createdAt: createdAt,
+      metadata: rawMetadata is Map
+          ? Map<String, dynamic>.from(rawMetadata)
+          : const <String, dynamic>{},
     );
+  }
+
+  ChatArtifact withSource({
+    String? sourceRunId,
+    String? sourceToolCallId,
+    DateTime? createdAt,
+  }) {
+    return ChatArtifact(
+      artifactId: artifactId,
+      kind: kind,
+      operation: operation,
+      title: title,
+      summary: summary,
+      targetUri: targetUri,
+      storageUri: storageUri,
+      sourceRunId: this.sourceRunId ?? _nonEmpty(sourceRunId),
+      sourceToolCallId: this.sourceToolCallId ?? _nonEmpty(sourceToolCallId),
+      createdAt: createdAt ?? this.createdAt,
+      metadata: metadata,
+      version: version,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'artifact_id': artifactId,
+        'kind': kind,
+        'operation': operation,
+        if (title != null) 'title': title,
+        if (summary != null) 'summary': summary,
+        if (targetUri != null) 'target_uri': targetUri,
+        if (storageUri != null) 'storage_uri': storageUri,
+        if (sourceRunId != null) 'source_run_id': sourceRunId,
+        if (sourceToolCallId != null) 'source_tool_call_id': sourceToolCallId,
+        'version': version,
+        'created_at': createdAt.toIso8601String(),
+        if (metadata.isNotEmpty) 'metadata': metadata,
+      };
+
+  String? _memexTargetId(String host) {
+    final uri = _tryParseUri(targetUri);
+    if (uri == null || uri.scheme != 'memex' || uri.host != host) {
+      return null;
+    }
+    if (uri.pathSegments.isEmpty) return null;
+    return uri.pathSegments.first;
+  }
+
+  static String timelineCardTargetUri(String cardId) {
+    return 'memex://timeline-card/${Uri.encodeComponent(cardId)}';
+  }
+
+  static String insightTargetUri(String insightId) {
+    return 'memex://insight/${Uri.encodeComponent(insightId)}';
+  }
+
+  static String workspaceTargetUri(String path) {
+    final normalized = path.trim().replaceAll('\\', '/');
+    final encoded = normalized
+        .split('/')
+        .where((segment) => segment.isNotEmpty)
+        .map(Uri.encodeComponent)
+        .join('/');
+    return 'workspace:///$encoded';
+  }
+
+  static String? knowledgeFilePathFromWorkspacePath(String? path) {
+    final normalized = _normalizeWorkspacePath(path);
+    if (normalized == null || !normalized.endsWith('.md')) return null;
+    if (!normalized.startsWith('PKM/')) return null;
+    final relativePath = normalized.substring('PKM/'.length).trim();
+    return relativePath.isEmpty ? null : relativePath;
+  }
+
+  static String artifactIdFor(String kind, String targetUri) {
+    return '$kind:$targetUri';
+  }
+
+  static Uri? _tryParseUri(String? value) {
+    final text = _nonEmpty(value);
+    if (text == null) return null;
+    return Uri.tryParse(text);
+  }
+
+  static String? _normalizeWorkspacePath(String? value) {
+    final text = _nonEmpty(value)?.replaceAll('\\', '/');
+    if (text == null) return null;
+    final normalized =
+        text.split('/').where((segment) => segment.trim().isNotEmpty).join('/');
+    return normalized.isEmpty ? null : normalized;
+  }
+
+  static String? _nonEmpty(dynamic value) {
+    final text = value?.toString().trim();
+    return (text == null || text.isEmpty) ? null : text;
+  }
+
+  static List<String> _stringList(dynamic value) {
+    if (value is! List) return const [];
+    return value
+        .map((item) => item.toString().trim())
+        .where((item) => item.isNotEmpty)
+        .toList();
+  }
+}
+
+class ChatTurnArtifactCollector {
+  ChatTurnArtifactCollector({required this.sourceRunId});
+
+  final String sourceRunId;
+  final Map<String, ChatArtifact> _artifactsByKey = {};
+
+  List<ChatArtifact> addFromToolResult({
+    required Map<String, dynamic>? metadata,
+    String? sourceToolCallId,
+    DateTime? createdAt,
+  }) {
+    final added = <ChatArtifact>[];
+    for (final artifact in ChatArtifact.listFromToolMetadata(metadata)) {
+      final sourced = artifact.withSource(
+        sourceRunId: sourceRunId,
+        sourceToolCallId: sourceToolCallId,
+        createdAt: createdAt,
+      );
+      final key = _keyFor(sourced);
+      if (!_artifactsByKey.containsKey(key)) {
+        added.add(sourced);
+      }
+      _artifactsByKey[key] = sourced;
+    }
+    return added;
+  }
+
+  List<ChatArtifact> get artifacts => List.unmodifiable(_artifactsByKey.values);
+
+  String _keyFor(ChatArtifact artifact) {
+    return artifact.targetUri ?? artifact.storageUri ?? artifact.artifactId;
+  }
+}
+
+class ChatArtifactSessionMigration {
+  static const String schemaVersionKey = 'artifact_schema_version';
+
+  static bool migrateSessionData(Map<String, dynamic> sessionData) {
+    if (sessionData[schemaVersionKey] == ChatArtifact.schemaVersion) {
+      return false;
+    }
+
+    final rawMessages = sessionData['messages'];
+    if (rawMessages is List) {
+      final messages = <dynamic>[];
+      var messagesChanged = false;
+      for (final rawMessage in rawMessages) {
+        if (rawMessage is! Map) {
+          messages.add(rawMessage);
+          continue;
+        }
+        final message = Map<String, dynamic>.from(rawMessage);
+        final migrated = _migrateMessageArtifacts(message);
+        if (migrated != null) {
+          messages.add(migrated);
+          messagesChanged = true;
+        } else {
+          messages.add(rawMessage);
+        }
+      }
+      if (messagesChanged) {
+        sessionData['messages'] = messages;
+      }
+    }
+
+    sessionData[schemaVersionKey] = ChatArtifact.schemaVersion;
+    return true;
+  }
+
+  static Map<String, dynamic>? _migrateMessageArtifacts(
+    Map<String, dynamic> message,
+  ) {
+    final rawArtifacts = message['artifacts'];
+    if (rawArtifacts is! List) return null;
+
+    final sourceRunId = ChatArtifact._nonEmpty(message['turn_id']);
+    final createdAt = DateTime.tryParse(message['timestamp']?.toString() ?? '');
+    final artifacts = <Map<String, dynamic>>[];
+    var changed = false;
+
+    for (final raw in rawArtifacts) {
+      if (raw is! Map) {
+        changed = true;
+        continue;
+      }
+      final map = Map<String, dynamic>.from(raw);
+      if (map['version'] == ChatArtifact.schemaVersion) {
+        artifacts.add(map);
+        continue;
+      }
+
+      final migrated = _migrateLegacyArtifact(
+        map,
+        sourceRunId: sourceRunId,
+        createdAt: createdAt,
+      );
+      if (migrated != null) artifacts.add(migrated.toJson());
+      changed = true;
+    }
+
+    if (!changed) return null;
+    if (artifacts.isEmpty) {
+      message.remove('artifacts');
+    } else {
+      message['artifacts'] = artifacts;
+    }
+    return message;
+  }
+
+  static ChatArtifact? _migrateLegacyArtifact(
+    Map<String, dynamic> legacy, {
+    required String? sourceRunId,
+    required DateTime? createdAt,
+  }) {
+    final type = ChatArtifact._nonEmpty(legacy['type']);
+    final updated = legacy['updated'] == true;
+    final title = ChatArtifact._nonEmpty(legacy['title']);
+    final summary = ChatArtifact._nonEmpty(legacy['summary']) ??
+        ChatArtifact._nonEmpty(legacy['snippet']);
+
+    switch (type) {
+      case 'record':
+      case 'html_card':
+      case 'card':
+        final id = ChatArtifact._nonEmpty(legacy['id']);
+        if (id == null) return null;
+        return ChatArtifact.timelineCard(
+          cardId: id,
+          title: title,
+          summary: summary,
+          imagePaths: ChatArtifact._stringList(legacy['image_paths']),
+          tags: ChatArtifact._stringList(legacy['tags']),
+          updated: updated,
+          sourceRunId: sourceRunId,
+          createdAt: createdAt,
+        );
+      case 'file':
+        final path = ChatArtifact._nonEmpty(legacy['path']);
+        if (path == null) return null;
+        if (_isKnowledgeArtifactPath(path)) {
+          return ChatArtifact.knowledgeFile(
+            path: path,
+            title: title,
+            summary: summary,
+            updated: updated,
+            sourceRunId: sourceRunId,
+            createdAt: createdAt,
+          );
+        }
+        return ChatArtifact.workspaceFile(
+          path: path,
+          title: title,
+          summary: summary,
+          updated: updated,
+          sourceRunId: sourceRunId,
+          createdAt: createdAt,
+        );
+      case 'insight':
+        final id = ChatArtifact._nonEmpty(legacy['id']);
+        if (id == null) return null;
+        return ChatArtifact.knowledgeInsight(
+          insightId: id,
+          title: title,
+          summary: summary,
+          updated: updated,
+          sourceRunId: sourceRunId,
+          createdAt: createdAt,
+        );
+      case 'schedule':
+        return ChatArtifact.schedule(
+          title: title,
+          summary: summary,
+          updated: updated,
+          sourceRunId: sourceRunId,
+          createdAt: createdAt,
+        );
+      case 'system_action':
+        return ChatArtifact.systemAction(
+          systemActionKind: ChatArtifact._nonEmpty(legacy['kind']) ?? 'action',
+          title: title,
+          summary: summary,
+          updated: updated,
+          sourceRunId: sourceRunId,
+          createdAt: createdAt,
+        );
+      default:
+        return null;
+    }
+  }
+
+  static bool _isKnowledgeArtifactPath(String path) {
+    final normalized = path.trim();
+    return normalized.startsWith('PKM/') && normalized.endsWith('.md');
   }
 }

--- a/lib/data/model/chat_artifact.dart
+++ b/lib/data/model/chat_artifact.dart
@@ -1,7 +1,7 @@
 /// A user-visible UI artifact produced by an agent turn.
 ///
-/// Tool trace events stay transient. Artifacts are persisted on the completed
-/// assistant message so reopened chats can reconstruct the final app updates.
+/// Tool trace events stay transient. Artifacts are persisted as chat artifact
+/// messages so reopened chats can reconstruct the final app updates.
 class ChatArtifact {
   ChatArtifact({
     required this.artifactId,

--- a/lib/data/model/chat_events.dart
+++ b/lib/data/model/chat_events.dart
@@ -3,9 +3,10 @@ import 'chat_artifact.dart';
 abstract class ChatEvent {}
 
 class ChatResponseChunkEvent extends ChatEvent {
+  final String turnId;
   final String text;
   final bool isDone;
-  ChatResponseChunkEvent(this.text, {this.isDone = false});
+  ChatResponseChunkEvent(this.turnId, this.text, {this.isDone = false});
 }
 
 class ChatThoughtChunkEvent extends ChatEvent {
@@ -53,18 +54,26 @@ class ChatTraceCompletedEvent extends ChatEvent {
 }
 
 class ChatErrorEvent extends ChatEvent {
+  final String turnId;
   final String error;
-  ChatErrorEvent(this.error);
+  ChatErrorEvent(this.turnId, this.error);
 }
 
 class ChatArtifactsEvent extends ChatEvent {
+  final String turnId;
   final List<ChatArtifact> artifacts;
-  ChatArtifactsEvent(this.artifacts);
+  ChatArtifactsEvent(this.turnId, this.artifacts);
 }
 
-class ChatAgentStartedEvent extends ChatEvent {}
+class ChatAgentStartedEvent extends ChatEvent {
+  final String turnId;
+  ChatAgentStartedEvent(this.turnId);
+}
 
-class ChatAgentStoppedEvent extends ChatEvent {}
+class ChatAgentStoppedEvent extends ChatEvent {
+  final String turnId;
+  ChatAgentStoppedEvent(this.turnId);
+}
 
 class ChatTokenUsageEvent extends ChatEvent {
   final int promptTokens;

--- a/lib/data/model/chat_events.dart
+++ b/lib/data/model/chat_events.dart
@@ -1,3 +1,5 @@
+import 'chat_artifact.dart';
+
 abstract class ChatEvent {}
 
 class ChatResponseChunkEvent extends ChatEvent {
@@ -53,6 +55,11 @@ class ChatTraceCompletedEvent extends ChatEvent {
 class ChatErrorEvent extends ChatEvent {
   final String error;
   ChatErrorEvent(this.error);
+}
+
+class ChatArtifactsEvent extends ChatEvent {
+  final List<ChatArtifact> artifacts;
+  ChatArtifactsEvent(this.artifacts);
 }
 
 class ChatAgentStartedEvent extends ChatEvent {}

--- a/lib/data/repositories/chat.dart
+++ b/lib/data/repositories/chat.dart
@@ -1,16 +1,11 @@
-import 'dart:io';
-import 'dart:convert';
-import 'dart:math' as math;
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
-import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/chat_session_storage.dart';
 import 'package:memex/data/services/api_exception.dart';
 import 'package:memex/utils/time_context.dart';
-import 'package:path/path.dart' as p;
-import 'package:yaml/yaml.dart';
 
 final _logger = getLogger('ChatEndpoint');
-FileSystemService get _fileSystemService => FileSystemService.instance;
+ChatSessionStorage get _chatStorage => ChatSessionStorage.instance;
 
 /// Get chat session list
 ///
@@ -32,85 +27,18 @@ Future<List<Map<String, dynamic>>> fetchChatSessionsEndpoint({
       throw ApiException('User not logged in, cannot get session list');
     }
 
-    final sessionsPath = _fileSystemService.getChatSessionsPath(userId);
-    final sessionsDir = Directory(sessionsPath);
-
-    if (!await sessionsDir.exists()) {
-      return [];
-    }
-
     final sessions = <Map<String, dynamic>>[];
-    final sessionFiles = <File>[];
-
-    await for (final entity in sessionsDir.list()) {
-      if (entity is File && entity.path.endsWith('.yaml')) {
-        final fileName = p.basenameWithoutExtension(entity.path);
-
-        // If agentName set, filter by filename prefix (no need to read file)
-        if (agentName != null && agentName.isNotEmpty) {
-          if (!fileName.startsWith('${agentName}_')) {
-            continue;
-          }
-        }
-
-        sessionFiles.add(entity);
-      }
-    }
-
-    // Sort by mtime (newest first)
-    sessionFiles.sort((a, b) {
+    final sessionRows = await _chatStorage.listSessionMetadata(userId);
+    for (final sessionData in sessionRows) {
       try {
-        final aStat = a.statSync();
-        final bStat = b.statSync();
-        return bStat.modified.compareTo(aStat.modified);
-      } catch (_) {
-        return 0;
-      }
-    });
-
-    for (final sessionFile in sessionFiles) {
-      try {
-        final content = await sessionFile.readAsString();
-        final doc = loadYaml(content);
-        final sessionData = jsonDecode(jsonEncode(doc)) as Map<String, dynamic>;
-
         final sessionAgentName = sessionData['agent_name'] as String?;
+        final sessionId = sessionData['session_id'] as String?;
+        if (sessionId == null || sessionId.isEmpty) continue;
 
-        // Double check agent_name in file (should match filename prefix, but verify for safety)
         if (agentName != null &&
             agentName.isNotEmpty &&
             sessionAgentName != agentName) {
           continue;
-        }
-
-        final sessionId = sessionData['session_id'] as String? ??
-            p.basenameWithoutExtension(sessionFile.path);
-        final messages = sessionData['messages'] as List<dynamic>? ?? [];
-
-        // Get last message preview
-        String? lastMessagePreview;
-        if (messages.isNotEmpty) {
-          final lastMsg = messages.last as Map<String, dynamic>;
-          final contentList = lastMsg['content'] as List<dynamic>? ?? [];
-          final textParts = <String>[];
-          var imageCount = 0;
-          for (final item in contentList) {
-            if (item is Map<String, dynamic> &&
-                item['type'] == 'text' &&
-                item['text'] != null) {
-              textParts.add(item['text'] as String);
-            } else if (item is Map<String, dynamic> &&
-                item['type'] == 'image_url') {
-              imageCount += 1;
-            }
-          }
-          if (textParts.isNotEmpty) {
-            final preview = textParts.join(' ');
-            lastMessagePreview =
-                preview.length > 100 ? preview.substring(0, 100) : preview;
-          } else if (imageCount > 0) {
-            lastMessagePreview = 'Sent $imageCount image(s)';
-          }
         }
 
         sessions.add({
@@ -131,12 +59,12 @@ Future<List<Map<String, dynamic>>> fetchChatSessionsEndpoint({
               formatLocalDateTimeWithZoneOrNull(sessionData['updated_at']),
           'updated_at_unix_seconds': sessionData['updated_at_unix_seconds'] ??
               unixSecondsFromDateTimeOrNull(sessionData['updated_at']),
-          'message_count': messages.length,
-          'last_message_preview': lastMessagePreview,
+          'last_message_preview':
+              sessionData['last_message_preview'] as String?,
           'is_quick_query': sessionData['is_quick_query'] == true,
         });
       } catch (e) {
-        _logger.warning('Failed to load session from ${sessionFile.path}: $e');
+        _logger.warning('Failed to load chat session row: $e');
         continue;
       }
     }
@@ -163,7 +91,7 @@ Future<List<Map<String, dynamic>>> fetchChatSessionsEndpoint({
 Future<Map<String, dynamic>> fetchChatSessionDetailEndpoint(
   String sessionId, {
   int? messageLimit,
-  int messageOffset = 0,
+  String? messageBeforeCursor,
 }) async {
   _logger.info('fetchChatSessionDetail called: sessionId=$sessionId');
 
@@ -177,26 +105,16 @@ Future<Map<String, dynamic>> fetchChatSessionDetailEndpoint(
       throw ApiException('Session ID cannot be empty');
     }
 
-    final sessionFile = _getSessionFilePath(userId, sessionId);
-    if (!await sessionFile.exists()) {
+    if (!await _chatStorage.sessionExists(userId, sessionId)) {
       throw ApiException('Session not found: $sessionId');
     }
 
-    final content = await sessionFile.readAsString();
-    final doc = loadYaml(content);
-    final sessionData = jsonDecode(jsonEncode(doc)) as Map<String, dynamic>;
-
-    final allMessages = sessionData['messages'] as List<dynamic>? ?? [];
-    final messages = _sliceSessionMessages(
-      allMessages,
+    final sessionData = await _chatStorage.loadMetadata(userId, sessionId);
+    final page = await _chatStorage.loadMessagePage(
+      userId,
+      sessionId,
       limit: messageLimit,
-      offset: messageOffset,
-    );
-    final totalMessages = allMessages.length;
-    final sliceStart = _sessionMessageSliceStart(
-      totalMessages,
-      limit: messageLimit,
-      offset: messageOffset,
+      beforeCursor: messageBeforeCursor,
     );
 
     return {
@@ -217,11 +135,11 @@ Future<Map<String, dynamic>> fetchChatSessionDetailEndpoint(
           formatLocalDateTimeWithZoneOrNull(sessionData['updated_at']),
       'updated_at_unix_seconds': sessionData['updated_at_unix_seconds'] ??
           unixSecondsFromDateTimeOrNull(sessionData['updated_at']),
-      'messages': messages,
-      'message_count': totalMessages,
+      'messages': page.messages.map(_withLocalTimestampFallback).toList(),
       'message_limit': messageLimit,
-      'message_offset': messageOffset,
-      'has_more_messages': sliceStart > 0,
+      'message_before_cursor': messageBeforeCursor,
+      'older_cursor': page.olderCursor,
+      'has_more_messages': page.hasMoreMessages,
       if (sessionData['total_usage'] != null)
         'total_usage': sessionData['total_usage'],
       'is_quick_query': sessionData['is_quick_query'] == true,
@@ -255,14 +173,13 @@ Future<bool> deleteChatSessionEndpoint(String sessionId) async {
       throw ApiException('Session ID cannot be empty');
     }
 
-    final sessionFile = _getSessionFilePath(userId, sessionId);
-    if (!await sessionFile.exists()) {
+    if (!await _chatStorage.sessionExists(userId, sessionId)) {
       _logger.warning('Session file not found: $sessionId');
       return false;
     }
 
-    await sessionFile.delete();
-    _logger.info('Session file physically deleted: $sessionId');
+    await _chatStorage.deleteSession(userId, sessionId);
+    _logger.info('Session physically deleted: $sessionId');
     return true;
   } catch (e) {
     _logger.severe('Failed to delete chat session $sessionId: $e');
@@ -271,48 +188,6 @@ Future<bool> deleteChatSessionEndpoint(String sessionId) async {
 }
 
 // Helper functions
-
-File _getSessionFilePath(String userId, String sessionId) {
-  final sessionsPath = _fileSystemService.getChatSessionsPath(userId);
-  return File(p.join(sessionsPath, '$sessionId.yaml'));
-}
-
-List<Map<String, dynamic>> _sliceSessionMessages(
-  List<dynamic> messages, {
-  int? limit,
-  int offset = 0,
-}) {
-  final total = messages.length;
-  final start = _sessionMessageSliceStart(total, limit: limit, offset: offset);
-  final end = _sessionMessageSliceEnd(total, limit: limit, offset: offset);
-
-  return messages.sublist(start, end).map((msg) {
-    if (msg is Map<String, dynamic>) {
-      return _withLocalTimestampFallback(msg);
-    }
-    return <String, dynamic>{};
-  }).toList();
-}
-
-int _sessionMessageSliceStart(
-  int total, {
-  int? limit,
-  int offset = 0,
-}) {
-  if (limit == null || limit <= 0) return 0;
-  final end = _sessionMessageSliceEnd(total, limit: limit, offset: offset);
-  return math.max(0, end - limit);
-}
-
-int _sessionMessageSliceEnd(
-  int total, {
-  int? limit,
-  int offset = 0,
-}) {
-  if (limit == null || limit <= 0) return total;
-  final safeOffset = math.max(0, offset);
-  return math.max(0, total - safeOffset);
-}
 
 Map<String, dynamic> _withLocalTimestampFallback(Map<String, dynamic> msg) {
   final result = Map<String, dynamic>.from(msg);

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -39,6 +39,7 @@ import 'package:memex/db/app_database.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/data/services/chat_service.dart';
+import 'package:memex/data/services/chat_session_storage.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/data/services/global_event_bus.dart';
@@ -104,6 +105,7 @@ class MemexRouter {
 
       // Use userId to init DB (drift_flutter handles path isolation via name)
       _logger.info('Initializing Local DB for user: $userId');
+      await ChatSessionStorage.instance.ensureMigrated(userId);
       await AppDatabase.init(userId);
 
       _registerTaskHandlers(LocalTaskExecutor.instance);
@@ -248,6 +250,7 @@ class MemexRouter {
   }) async {
     final dataRoot = await UserStorage.resolveDataRoot(userId);
     await FileSystemService.init(dataRoot);
+    await ChatSessionStorage.instance.ensureMigrated(userId);
     await AppDatabase.init(userId);
 
     final taskExecutor = executor ?? LocalTaskExecutor.instance;
@@ -309,6 +312,7 @@ class MemexRouter {
     final dataRoot = await UserStorage.resolveDataRoot(userId);
     await FileSystemService.init(dataRoot);
     if (userId != null && userId.isNotEmpty) {
+      await ChatSessionStorage.instance.ensureMigrated(userId);
       try {
         await FileSystemService.instance.rebuildCardCache(userId);
       } catch (e) {
@@ -1026,7 +1030,7 @@ class MemexRouter {
   Future<Map<String, dynamic>> fetchChatSessionDetail(
     String sessionId, {
     int? messageLimit,
-    int messageOffset = 0,
+    String? messageBeforeCursor,
   }) async {
     await _ensureInitialized();
     _logger.info(
@@ -1037,7 +1041,7 @@ class MemexRouter {
       return await chat_endpoint.fetchChatSessionDetailEndpoint(
         sessionId,
         messageLimit: messageLimit,
-        messageOffset: messageOffset,
+        messageBeforeCursor: messageBeforeCursor,
       );
     } catch (e) {
       _logger.severe('Failed to fetch chat session detail: $e');

--- a/lib/data/repositories/migrate_cards_fact_assets.dart
+++ b/lib/data/repositories/migrate_cards_fact_assets.dart
@@ -1,20 +1,15 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:synchronized/synchronized.dart';
 
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/migration_state_service.dart';
 import 'package:memex/utils/logger.dart';
 
 final _logger = getLogger('MigrateCardsFactAssets');
 
 /// Migration key in `_System/migration_state.json`.
 const _migrationKey = 'cards_fact_assets_created_at_v2';
-
-/// Per-user lock so a migration can't run twice concurrently.
-final Map<String, Lock> _locks = {};
-Lock _lockFor(String userId) => _locks.putIfAbsent(userId, () => Lock());
 
 /// One-time migration of legacy cards to the self-contained card structure.
 ///
@@ -32,79 +27,76 @@ Lock _lockFor(String userId) => _locks.putIfAbsent(userId, () => Lock());
 /// Image-analysis / OCR sidecar text is intentionally not migrated onto the
 /// card; `fact` holds the user's original record only.
 Future<void> migrateCardsToFactAssets(String userId) async {
-  await _lockFor(userId).synchronized(() async {
-    final fs = FileSystemService.instance;
+  await MigrationStateService.instance.runOnce(
+    userId: userId,
+    key: _migrationKey,
+    migrate: () async {
+      final fs = FileSystemService.instance;
+      _logger.info('Migrating cards to fact/assets structure for user $userId');
 
-    final state = await _readMigrationState(userId);
-    if (state[_migrationKey] == true) {
-      return;
-    }
+      var migrated = 0;
+      var scanned = 0;
+      try {
+        final cardFiles = await fs.listAllCardFiles(userId);
+        for (final cardFile in cardFiles) {
+          final factId = fs.factIdFromCardPath(cardFile);
+          if (factId == null) continue;
+          scanned++;
 
-    _logger.info('Migrating cards to fact/assets structure for user $userId');
+          try {
+            final card = await fs.readCardFile(userId, factId);
+            if (card == null || card.deleted == true) continue;
 
-    var migrated = 0;
-    var scanned = 0;
-    try {
-      final cardFiles = await fs.listAllCardFiles(userId);
-      for (final cardFile in cardFiles) {
-        final factId = fs.factIdFromCardPath(cardFile);
-        if (factId == null) continue;
-        scanned++;
-
-        try {
-          final card = await fs.readCardFile(userId, factId);
-          if (card == null || card.deleted == true) continue;
-
-          final needsFactAssets =
-              (card.fact ?? '').trim().isEmpty && card.assets.isEmpty;
-          final needsCreatedAt = card.createdAt == null;
-          if (!needsFactAssets && !needsCreatedAt) {
-            continue;
-          }
-
-          final factInfo =
-              await _extractLegacyFactContentFromFile(fs, userId, factId);
-          if (factInfo == null) continue;
-
-          String? fact;
-          List<String>? assets;
-          if (needsFactAssets) {
-            final split = _splitFactAndAssets(factInfo.content);
-            if (split.$1.isNotEmpty || split.$2.isNotEmpty) {
-              fact = split.$1;
-              assets = split.$2;
+            final needsFactAssets =
+                (card.fact ?? '').trim().isEmpty && card.assets.isEmpty;
+            final needsCreatedAt = card.createdAt == null;
+            if (!needsFactAssets && !needsCreatedAt) {
+              continue;
             }
+
+            final factInfo =
+                await _extractLegacyFactContentFromFile(fs, userId, factId);
+            if (factInfo == null) continue;
+
+            String? fact;
+            List<String>? assets;
+            if (needsFactAssets) {
+              final split = _splitFactAndAssets(factInfo.content);
+              if (split.$1.isNotEmpty || split.$2.isNotEmpty) {
+                fact = split.$1;
+                assets = split.$2;
+              }
+            }
+
+            if (fact == null && assets == null && !needsCreatedAt) continue;
+
+            await fs.updateCardFile(
+              userId,
+              factId,
+              (c) => c.copyWith(
+                fact: fact,
+                assets: assets,
+                createdAt: needsCreatedAt ? factInfo.timestamp : null,
+              ),
+            );
+            migrated++;
+          } catch (e, st) {
+            _logger.warning('Failed to migrate card $factId', e, st);
           }
-
-          if (fact == null && assets == null && !needsCreatedAt) continue;
-
-          await fs.updateCardFile(
-            userId,
-            factId,
-            (c) => c.copyWith(
-              fact: fact,
-              assets: assets,
-              createdAt: needsCreatedAt ? factInfo.timestamp : null,
-            ),
-          );
-          migrated++;
-        } catch (e, st) {
-          _logger.warning('Failed to migrate card $factId', e, st);
         }
+      } catch (e, st) {
+        // A scan failure should not permanently block the app; leave the flag
+        // unset so the migration retries on the next launch.
+        _logger.severe('Card fact/assets migration failed mid-scan', e, st);
+        return false;
       }
-    } catch (e, st) {
-      // A scan failure should not permanently block the app; leave the flag
-      // unset so the migration retries on the next launch.
-      _logger.severe('Card fact/assets migration failed mid-scan', e, st);
-      return;
-    }
 
-    state[_migrationKey] = true;
-    await _writeMigrationState(userId, state);
-    _logger.info(
-      'Card fact/assets migration complete: migrated $migrated of $scanned cards',
-    );
-  });
+      _logger.info(
+        'Card fact/assets migration complete: migrated $migrated of $scanned cards',
+      );
+      return true;
+    },
+  );
 }
 
 /// Split legacy fact-file content into (fact text, asset references).
@@ -215,36 +207,4 @@ String _legacyDailyFactPath(
 String _extractSimpleFactId(String factId) {
   final index = factId.indexOf('#');
   return index == -1 ? factId : factId.substring(index + 1);
-}
-
-String _migrationStatePath(String userId) => p.join(
-      FileSystemService.instance.getSystemPath(userId),
-      'migration_state.json',
-    );
-
-Future<Map<String, dynamic>> _readMigrationState(String userId) async {
-  final file = File(_migrationStatePath(userId));
-  if (!await file.exists()) return <String, dynamic>{};
-  try {
-    final data = jsonDecode(await file.readAsString());
-    if (data is Map) return Map<String, dynamic>.from(data);
-  } catch (e) {
-    _logger.warning('Failed to parse migration_state.json: $e');
-  }
-  return <String, dynamic>{};
-}
-
-Future<void> _writeMigrationState(
-  String userId,
-  Map<String, dynamic> state,
-) async {
-  final path = _migrationStatePath(userId);
-  final dir = Directory(p.dirname(path));
-  if (!await dir.exists()) await dir.create(recursive: true);
-
-  state['updated_at'] = DateTime.now().toIso8601String();
-  const encoder = JsonEncoder.withIndent('  ');
-  final tmpFile = File('$path.tmp');
-  await tmpFile.writeAsString(encoder.convert(state));
-  await tmpFile.rename(path);
 }

--- a/lib/data/services/chat_run_registry.dart
+++ b/lib/data/services/chat_run_registry.dart
@@ -5,11 +5,13 @@ import 'package:memex/data/model/chat_events.dart';
 /// One in-flight agent chat turn, owned by the service layer so it survives
 /// the chat dialog being closed.
 ///
-/// Events are appended to a replay buffer and forwarded to a broadcast
-/// stream. [attach] returns a stream that first replays everything emitted so
-/// far and then continues live — this is what lets a reopened dialog rebuild
-/// the "thinking" UI mid-run. The snapshot+subscribe happens in one
-/// synchronous block, so no event can be dropped or duplicated in between.
+/// Events are usually appended to a replay buffer and forwarded to a broadcast
+/// stream. [attach] returns a stream that first replays buffered events and
+/// then continues live — this is what lets a reopened dialog rebuild the
+/// "thinking" UI mid-run. Persisted events can opt out of replay because the
+/// session history is their source of truth after a dialog reopens. The
+/// snapshot+subscribe happens in one synchronous block, so no event can be
+/// dropped or duplicated in between.
 class ActiveChatRun {
   ActiveChatRun(this.sessionId, {void Function()? onClosed})
       : _onClosed = onClosed;
@@ -24,9 +26,11 @@ class ActiveChatRun {
 
   bool get isClosed => _closed;
 
-  void add(ChatEvent event) {
+  void add(ChatEvent event, {bool replay = true}) {
     if (_closed) return;
-    _replayBuffer.add(event);
+    if (replay) {
+      _replayBuffer.add(event);
+    }
     _live.add(event);
   }
 

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -372,15 +372,15 @@ class ChatService {
       'sendMessage: sessionId=$sessionId, message=$message, refs=${refs?.length}',
     );
 
+    final turnId = _uuid.v4();
     final userId = await UserStorage.getUserId();
     if (userId == null) {
-      yield ChatErrorEvent('User not logged in');
+      yield ChatErrorEvent(turnId, 'User not logged in');
       return;
     }
 
     String finalSessionId = sessionId ?? '';
     final userMessageTime = DateTime.now();
-    final turnId = _uuid.v4();
     final trimmedMessage = message.trim();
     final preparedImages = <AgentImageAttachment>[];
     String agentStateSessionId = '';
@@ -397,12 +397,12 @@ class ChatService {
       }
     } catch (e) {
       _logger.severe('Failed to prepare chat image attachment', e);
-      yield ChatErrorEvent('Failed to prepare image attachment: $e');
+      yield ChatErrorEvent(turnId, 'Failed to prepare image attachment: $e');
       return;
     }
 
     if (trimmedMessage.isEmpty && preparedImages.isEmpty) {
-      yield ChatErrorEvent('Message is empty');
+      yield ChatErrorEvent(turnId, 'Message is empty');
       return;
     }
 
@@ -467,7 +467,7 @@ class ChatService {
       }
     } catch (e) {
       _logger.severe('Failed to manage session', e);
-      yield ChatErrorEvent('Failed to initialize session: $e');
+      yield ChatErrorEvent(turnId, 'Failed to initialize session: $e');
       return;
     }
 
@@ -512,7 +512,7 @@ class ChatService {
       }
     } catch (e, st) {
       _logger.severe('Failed to enqueue chat turn', e, st);
-      run.add(ChatErrorEvent('Failed to enqueue chat turn: $e'));
+      run.add(ChatErrorEvent(turnId, 'Failed to enqueue chat turn: $e'));
       run.close();
     }
 
@@ -728,7 +728,7 @@ class ChatService {
       }
     } catch (e) {
       _logger.severe('Failed to initialize agent', e);
-      run.add(ChatErrorEvent('Failed to initialize agent: $e'));
+      run.add(ChatErrorEvent(turnId, 'Failed to initialize agent: $e'));
       if (await _shouldCloseRunAfterTask(taskId)) {
         run.close();
       }
@@ -756,7 +756,7 @@ class ChatService {
           // Artifact messages are already persisted. Live listeners should see
           // them immediately after the append, but reattached dialogs rebuild
           // them from JSONL history instead of replaying this event.
-          run.add(ChatArtifactsEvent(artifacts), replay: false);
+          run.add(ChatArtifactsEvent(turnId, artifacts), replay: false);
         }
       }).catchError((Object e, StackTrace st) {
         _logger.warning(
@@ -962,7 +962,7 @@ class ChatService {
       } catch (e) {
         _logger.severe('Agent run failed', e);
         if (!run.isClosed) {
-          run.add(ChatErrorEvent(e.toString()));
+          run.add(ChatErrorEvent(turnId, e.toString()));
           if (await _shouldCloseRunAfterTask(taskId)) {
             run.close();
           }
@@ -1050,7 +1050,7 @@ class ChatService {
     // 1. Lifecycle Events
     controller.on((AgentStartedEvent event) {
       _logger.info('Agent started');
-      stream.add(ChatAgentStartedEvent());
+      stream.add(ChatAgentStartedEvent(turnId));
     });
 
     controller.on((AgentStoppedEvent event) async {
@@ -1110,8 +1110,8 @@ class ChatService {
 
       if (event.error != null) {
         if (!stream.isClosed) {
-          stream.add(ChatAgentStoppedEvent());
-          stream.add(ChatErrorEvent(event.error.toString()));
+          stream.add(ChatAgentStoppedEvent(turnId));
+          stream.add(ChatErrorEvent(turnId, event.error.toString()));
           if (await _shouldCloseRunAfterTask(taskId)) {
             stream.close();
           }
@@ -1187,8 +1187,8 @@ class ChatService {
 
       if (!stream.isClosed) {
         // Send a final empty chunk to mark isDone=true without duplicating text
-        stream.add(ChatResponseChunkEvent('', isDone: true));
-        stream.add(ChatAgentStoppedEvent());
+        stream.add(ChatResponseChunkEvent(turnId, '', isDone: true));
+        stream.add(ChatAgentStoppedEvent(turnId));
         if (await _shouldCloseRunAfterTask(taskId)) {
           stream.close();
         }
@@ -1232,7 +1232,7 @@ class ChatService {
 
       if (event.response.textOutput != null &&
           event.response.textOutput!.isNotEmpty) {
-        stream.add(ChatResponseChunkEvent(event.response.textOutput!));
+        stream.add(ChatResponseChunkEvent(turnId, event.response.textOutput!));
       }
     });
 

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
 import 'package:dio/dio.dart' show CancelToken;
@@ -16,20 +15,20 @@ import 'package:memex/data/services/agent_image_attachment.dart';
 import 'package:memex/data/services/agent_foreground_task_tracker.dart';
 import 'package:memex/data/services/chat_run_registry.dart';
 import 'package:memex/data/services/custom_agent_config_service.dart';
+import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/services/location_context_service.dart';
 import 'package:memex/domain/models/custom_agent_config.dart';
 import 'package:memex/domain/models/location_context_config.dart';
 import 'package:memex/domain/models/llm_config.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/chat_session_storage.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/time_context.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/utils/token_usage_utils.dart';
-import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
-import 'package:yaml/yaml.dart';
 
 import 'package:memex/data/model/chat_events.dart';
 
@@ -38,9 +37,15 @@ export 'package:memex/data/model/chat_events.dart';
 // --- Chat Service ---
 
 class _ChatDelegateProgressSink implements DelegateProgressSink {
-  _ChatDelegateProgressSink(this._run);
+  _ChatDelegateProgressSink(
+    this._run,
+    this._artifactCollector,
+    this._onArtifactsProduced,
+  );
 
   final ActiveChatRun _run;
+  final ChatTurnArtifactCollector _artifactCollector;
+  final void Function(List<ChatArtifact> artifacts) _onArtifactsProduced;
   final Map<String, List<String>> _pendingDelegateCallIdsByBrief = {};
   final Map<String, String> _delegateParentIds = {};
   final Map<String, int> _childTraceCounters = {};
@@ -99,11 +104,19 @@ class _ChatDelegateProgressSink implements DelegateProgressSink {
     final childTraceId = _takeChildTraceId(progress.delegateRunId, result.name);
     if (parentId == null || childTraceId == null) return;
     final resultText = _toolResultText(result);
+    final artifacts = result.isError
+        ? const <ChatArtifact>[]
+        : _artifactCollector.addFromToolResult(
+            metadata: result.metadata,
+            sourceToolCallId: result.id,
+          );
     _run.add(ChatTraceCompletedEvent(
       id: childTraceId,
       result: _preview(resultText, 300),
       isError: result.isError,
+      metadata: result.metadata,
     ));
+    _onArtifactsProduced(artifacts);
   }
 
   @override
@@ -240,6 +253,7 @@ class ChatService {
 
   final Logger _logger = getLogger('ChatService');
   FileSystemService get _fileService => FileSystemService.instance;
+  ChatSessionStorage get _chatStorage => ChatSessionStorage.instance;
   final Uuid _uuid = const Uuid();
   static const String _superAgentChatTurnTaskType =
       'super_agent_chat_turn_task';
@@ -310,7 +324,7 @@ class ChatService {
           'Cannot refresh agent state while a chat turn is active');
     }
 
-    final sessionData = await _loadSessionData(userId, sessionId);
+    final sessionData = await _chatStorage.loadMetadata(userId, sessionId);
     final now = DateTime.now();
     final newStateSessionId = '${sessionId}_state_${_uuid.v4()}';
     final state = await loadOrCreateAgentState(newStateSessionId, {
@@ -325,14 +339,16 @@ class ChatService {
     });
     await saveAgentState(state);
 
-    sessionData[_activeAgentStateSessionIdKey] = newStateSessionId;
-    sessionData['agent_state_refreshed_at'] = now.toIso8601String();
-    sessionData['agent_state_refreshed_at_local'] =
-        formatLocalDateTimeWithZone(now);
-    sessionData['agent_state_refreshed_at_unix_seconds'] =
-        unixSecondsFromDateTime(now);
-    sessionData.remove('total_usage');
-    await _saveSessionData(userId, sessionId, sessionData);
+    await _chatStorage.updateMetadata(userId, sessionId, (metadata) {
+      metadata[_activeAgentStateSessionIdKey] = newStateSessionId;
+      metadata['agent_state_refreshed_at'] = now.toIso8601String();
+      metadata['agent_state_refreshed_at_local'] =
+          formatLocalDateTimeWithZone(now);
+      metadata['agent_state_refreshed_at_unix_seconds'] =
+          unixSecondsFromDateTime(now);
+      metadata.remove('total_usage');
+      return metadata;
+    });
     return newStateSessionId;
   }
 
@@ -720,7 +736,44 @@ class ChatService {
     }
 
     // 3. Setup Listeners & Run
-    final progressSink = _ChatDelegateProgressSink(run);
+    final artifactCollector = ChatTurnArtifactCollector(sourceRunId: turnId);
+    var artifactWriteQueue = Future<void>.value();
+
+    void persistAndEmitArtifacts(List<ChatArtifact> artifacts) {
+      if (artifacts.isEmpty) return;
+
+      artifactWriteQueue = artifactWriteQueue.then((_) async {
+        await _addMessageToSession(
+          userId,
+          sessionId,
+          'artifact',
+          const [],
+          artifacts: artifacts.map((artifact) => artifact.toJson()).toList(),
+          timestamp: artifacts.first.createdAt,
+          turnId: turnId,
+        );
+        if (!run.isClosed) {
+          // Artifact messages are already persisted. Live listeners should see
+          // them immediately after the append, but reattached dialogs rebuild
+          // them from JSONL history instead of replaying this event.
+          run.add(ChatArtifactsEvent(artifacts), replay: false);
+        }
+      }).catchError((Object e, StackTrace st) {
+        _logger.warning(
+          'Failed to persist chat artifact message for session $sessionId',
+          e,
+          st,
+        );
+      });
+    }
+
+    Future<void> waitForArtifactWrites() => artifactWriteQueue;
+
+    final progressSink = _ChatDelegateProgressSink(
+      run,
+      artifactCollector,
+      persistAndEmitArtifacts,
+    );
 
     // Forward events from agent controller to the run channel
     _setupControllerListeners(
@@ -731,6 +784,9 @@ class ChatService {
       turnId,
       taskId,
       progressSink,
+      artifactCollector,
+      persistAndEmitArtifacts,
+      waitForArtifactWrites,
     );
 
     // Build scene context reminder
@@ -987,6 +1043,9 @@ class ChatService {
     String turnId,
     String taskId,
     _ChatDelegateProgressSink progressSink,
+    ChatTurnArtifactCollector artifactCollector,
+    void Function(List<ChatArtifact> artifacts) onArtifactsProduced,
+    Future<void> Function() waitForArtifactWrites,
   ) {
     // 1. Lifecycle Events
     controller.on((AgentStartedEvent event) {
@@ -1080,6 +1139,7 @@ class ChatService {
       };
 
       // Save AI response with usage stats
+      await waitForArtifactWrites();
       final responseTime = DateTime.now();
       final sessionTotalUsage =
           await _sessionHasAssistantForTurn(userId, sessionId, turnId)
@@ -1212,6 +1272,12 @@ class ChatService {
       }
 
       final resultPreview = _preview(resultText, 300);
+      final artifacts = event.result.isError
+          ? const <ChatArtifact>[]
+          : artifactCollector.addFromToolResult(
+              metadata: event.result.metadata,
+              sourceToolCallId: event.result.id,
+            );
       stream.add(
         ChatTraceCompletedEvent(
           id: event.result.id,
@@ -1220,6 +1286,7 @@ class ChatService {
           metadata: event.result.metadata,
         ),
       );
+      onArtifactsProduced(artifacts);
     });
   }
 
@@ -1237,7 +1304,7 @@ class ChatService {
     String sessionId,
   ) async {
     try {
-      final sessionData = await _loadSessionData(userId, sessionId);
+      final sessionData = await _chatStorage.loadMetadata(userId, sessionId);
       final activeStateId =
           sessionData[_activeAgentStateSessionIdKey]?.toString().trim();
       if (activeStateId != null && activeStateId.isNotEmpty) {
@@ -1253,33 +1320,10 @@ class ChatService {
     return sessionId;
   }
 
-  Future<Map<String, dynamic>> _loadSessionData(
-    String userId,
-    String sessionId,
-  ) async {
-    final sessionFile = _getSessionFilePath(userId, sessionId);
-    if (!await sessionFile.exists()) {
-      throw StateError('Session not found: $sessionId');
-    }
-
-    final fileContent = await sessionFile.readAsString();
-    final doc = loadYaml(fileContent);
-    return jsonDecode(jsonEncode(doc)) as Map<String, dynamic>;
-  }
-
-  Future<void> _saveSessionData(
-    String userId,
-    String sessionId,
-    Map<String, dynamic> sessionData,
-  ) async {
-    final sessionFile = _getSessionFilePath(userId, sessionId);
-    await _fileService.writeYamlFile(sessionFile.path, sessionData);
-  }
-
   /// Check whether a session file has `is_custom_agent: true`.
   Future<bool> _isCustomAgentSession(String userId, String sessionId) async {
     try {
-      final data = await _loadSessionData(userId, sessionId);
+      final data = await _chatStorage.loadMetadata(userId, sessionId);
       return data['is_custom_agent'] == true;
     } catch (e) {
       _logger.warning('Failed to read session metadata: $e');
@@ -1328,14 +1372,14 @@ class ChatService {
       'updated_at_local': formatLocalDateTimeWithZone(now),
       'updated_at_unix_seconds': unixSecondsFromDateTime(now),
       'is_quick_query': isQuickQuery,
-      'messages': <dynamic>[],
+      ChatArtifactSessionMigration.schemaVersionKey: ChatArtifact.schemaVersion,
     };
 
-    final sessionFile = _getSessionFilePath(userId, sessionId);
-    final parentDir = sessionFile.parent;
-    await parentDir.create(recursive: true);
-
-    await _fileService.writeYamlFile(sessionFile.path, sessionData);
+    await _chatStorage.createSession(
+      userId: userId,
+      sessionId: sessionId,
+      metadata: sessionData,
+    );
     return sessionId;
   }
 
@@ -1345,22 +1389,20 @@ class ChatService {
     String role,
     List<Map<String, dynamic>> content, {
     Map<String, dynamic>? usage,
+    List<Map<String, dynamic>> artifacts = const [],
     List<Map<String, String>>? refs,
     bool? isQuickQuery,
     DateTime? timestamp,
     String? turnId,
   }) async {
-    final sessionFile = _getSessionFilePath(userId, sessionId);
-    if (!await sessionFile.exists()) return null;
-
-    final sessionData = await _loadSessionData(userId, sessionId);
-    _backfillSessionTimeContext(sessionData);
+    if (!await _chatStorage.sessionExists(userId, sessionId)) return null;
 
     final messageTime = timestamp ?? DateTime.now();
     final messageDict = {
       'role': role,
       'content': content,
       if (usage != null) 'usage': usage,
+      if (artifacts.isNotEmpty) 'artifacts': artifacts,
       if (refs != null) 'refs': refs,
       if (turnId != null) 'turn_id': turnId,
       'timestamp': messageTime.toIso8601String(),
@@ -1368,50 +1410,13 @@ class ChatService {
       'unix_seconds': unixSecondsFromDateTime(messageTime),
     };
 
-    final messages = (sessionData['messages'] as List<dynamic>? ?? [])
-        .map(_backfillMessageTimeContext)
-        .toList()
-      ..add(messageDict);
-    sessionData['messages'] = messages;
-
-    // Update cumulative session usage
-    if (usage != null) {
-      final currentTotal =
-          sessionData['total_usage'] as Map<String, dynamic>? ??
-              {
-                'prompt_tokens': 0,
-                'completion_tokens': 0,
-                'cached_tokens': 0,
-                'total_tokens': 0,
-                'total_cost': 0.0,
-              };
-
-      sessionData['total_usage'] = {
-        'prompt_tokens': (currentTotal['prompt_tokens'] as int? ?? 0) +
-            (usage['prompt_tokens'] as int? ?? 0),
-        'completion_tokens': (currentTotal['completion_tokens'] as int? ?? 0) +
-            (usage['completion_tokens'] as int? ?? 0),
-        'cached_tokens': (currentTotal['cached_tokens'] as int? ?? 0) +
-            (usage['cached_tokens'] as int? ?? 0),
-        'total_tokens': (currentTotal['total_tokens'] as int? ?? 0) +
-            (usage['total_tokens'] as int? ?? 0),
-        'total_cost': (currentTotal['total_cost'] as double? ?? 0.0) +
-            (usage['total_cost'] as double? ?? 0.0),
-      };
-    }
-
-    // Update session-level mode flag so history can restore it
-    if (isQuickQuery != null) {
-      sessionData['is_quick_query'] = isQuickQuery;
-    }
-
-    final updatedAt = DateTime.now();
-    sessionData['updated_at'] = updatedAt.toIso8601String();
-    sessionData['updated_at_local'] = formatLocalDateTimeWithZone(updatedAt);
-    sessionData['updated_at_unix_seconds'] = unixSecondsFromDateTime(updatedAt);
-
-    await _saveSessionData(userId, sessionId, sessionData);
-    return sessionData['total_usage'] as Map<String, dynamic>?;
+    return _chatStorage.appendMessage(
+      userId: userId,
+      sessionId: sessionId,
+      message: messageDict,
+      usage: usage,
+      isQuickQuery: isQuickQuery,
+    );
   }
 
   Future<bool> _sessionHasAssistantForTurn(
@@ -1419,61 +1424,7 @@ class ChatService {
     String sessionId,
     String turnId,
   ) async {
-    final sessionFile = _getSessionFilePath(userId, sessionId);
-    if (!await sessionFile.exists()) return false;
-
-    final sessionData = await _loadSessionData(userId, sessionId);
-    final messages = sessionData['messages'] as List<dynamic>? ?? const [];
-    return messages.any((message) {
-      return message is Map &&
-          message['role'] == 'ai' &&
-          message['turn_id'] == turnId;
-    });
-  }
-
-  File _getSessionFilePath(String userId, String sessionId) {
-    final sessionsPath = _fileService.getChatSessionsPath(userId);
-    return File(p.join(sessionsPath, '$sessionId.yaml'));
-  }
-
-  void _backfillSessionTimeContext(Map<String, dynamic> sessionData) {
-    final createdAt = tryParseDateTime(sessionData['created_at']);
-    if (createdAt != null) {
-      sessionData['created_at_local'] ??= formatLocalDateTimeWithZone(
-        createdAt,
-      );
-      sessionData['created_at_unix_seconds'] ??= unixSecondsFromDateTime(
-        createdAt,
-      );
-    }
-
-    final updatedAt = tryParseDateTime(sessionData['updated_at']);
-    if (updatedAt != null) {
-      sessionData['updated_at_local'] ??= formatLocalDateTimeWithZone(
-        updatedAt,
-      );
-      sessionData['updated_at_unix_seconds'] ??= unixSecondsFromDateTime(
-        updatedAt,
-      );
-    }
-  }
-
-  dynamic _backfillMessageTimeContext(dynamic message) {
-    if (message is! Map<String, dynamic>) {
-      return message;
-    }
-
-    final parsed = tryParseDateTime(message['timestamp']);
-    if (parsed == null) {
-      return message;
-    }
-
-    return {
-      ...message,
-      'local_time':
-          message['local_time'] ?? formatLocalDateTimeWithZone(parsed),
-      'unix_seconds':
-          message['unix_seconds'] ?? unixSecondsFromDateTime(parsed),
-    };
+    if (!await _chatStorage.sessionExists(userId, sessionId)) return false;
+    return _chatStorage.hasAssistantMessageForTurn(userId, sessionId, turnId);
   }
 }

--- a/lib/data/services/chat_session_storage.dart
+++ b/lib/data/services/chat_session_storage.dart
@@ -1,0 +1,896 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:memex/data/model/chat_artifact.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/migration_state_service.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:memex/utils/time_context.dart';
+import 'package:path/path.dart' as p;
+import 'package:synchronized/synchronized.dart';
+import 'package:yaml/yaml.dart';
+
+class ChatSessionStorage {
+  ChatSessionStorage._();
+
+  static final ChatSessionStorage instance = ChatSessionStorage._();
+
+  static const int storageSchemaVersion = 1;
+  static const String metadataFileName = 'metadata.json';
+  static const String messagesFileName = 'messages.jsonl';
+  static const String legacyArchiveDirName = '_legacy_yaml';
+  static const String storageSchemaVersionKey = 'storage_schema_version';
+  static const String storageMigrationKey = 'chat_sessions_jsonl_v1';
+
+  final _logger = getLogger('ChatSessionStorage');
+  final Map<String, Future<void>> _migrationFutures = {};
+  final Map<String, Lock> _sessionLocks = {};
+  final Lock _lockMapLock = Lock();
+
+  FileSystemService get _fileService => FileSystemService.instance;
+
+  Future<void> ensureMigrated(String userId) {
+    final rootPath = _sessionsPath(userId);
+    final migrationFutureKey = '$userId:$rootPath';
+    return _migrationFutures.putIfAbsent(
+      migrationFutureKey,
+      () async {
+        var migrationStateSatisfied = false;
+        try {
+          migrationStateSatisfied =
+              await MigrationStateService.instance.runOnce(
+            userId: userId,
+            key: storageMigrationKey,
+            migrate: () => _migrateLegacyYamlSessions(userId),
+          );
+        } finally {
+          if (!migrationStateSatisfied) {
+            _migrationFutures.remove(migrationFutureKey);
+          }
+        }
+      },
+    );
+  }
+
+  Future<bool> sessionExists(String userId, String sessionId) async {
+    await ensureMigrated(userId);
+    _validateSessionId(sessionId);
+    return _metadataFile(userId, sessionId).exists();
+  }
+
+  Future<List<Map<String, dynamic>>> listSessionMetadata(String userId) async {
+    await ensureMigrated(userId);
+    final root = Directory(_sessionsPath(userId));
+    if (!await root.exists()) return const [];
+
+    final result = <Map<String, dynamic>>[];
+    await for (final entity in root.list(followLinks: false)) {
+      if (entity is! Directory) continue;
+      final name = p.basename(entity.path);
+      if (name.startsWith('_')) continue;
+      if (!_isSafeSessionId(name)) continue;
+      final metadataFile = File(p.join(entity.path, metadataFileName));
+      if (!await metadataFile.exists()) continue;
+      try {
+        final metadata = await _readMetadataFile(metadataFile);
+        final sessionId = _stringOrNull(metadata['session_id']) ?? name;
+        if (sessionId != name) {
+          metadata['session_id'] = name;
+        }
+        metadata['last_message_preview'] ??=
+            await lastMessagePreview(userId, name);
+        result.add(metadata);
+      } catch (e, st) {
+        _logger.warning(
+          'Failed to load chat session metadata: ${metadataFile.path}',
+          e,
+          st,
+        );
+      }
+    }
+
+    result.sort((a, b) {
+      final bTime = _sortTime(b);
+      final aTime = _sortTime(a);
+      return bTime.compareTo(aTime);
+    });
+    return result;
+  }
+
+  Future<Map<String, dynamic>> loadMetadata(
+    String userId,
+    String sessionId,
+  ) async {
+    await ensureMigrated(userId);
+    _validateSessionId(sessionId);
+    final file = _metadataFile(userId, sessionId);
+    if (!await file.exists()) {
+      throw StateError('Session not found: $sessionId');
+    }
+    return _readMetadataFile(file);
+  }
+
+  Future<List<Map<String, dynamic>>> loadMessages(
+    String userId,
+    String sessionId,
+  ) async {
+    await ensureMigrated(userId);
+    _validateSessionId(sessionId);
+    return _readMessagesFile(_messagesFile(userId, sessionId));
+  }
+
+  Future<ChatSessionMessagePage> loadMessagePage(
+    String userId,
+    String sessionId, {
+    int? limit,
+    String? beforeCursor,
+  }) async {
+    await ensureMigrated(userId);
+    _validateSessionId(sessionId);
+    final messagesFile = _messagesFile(userId, sessionId);
+
+    if (limit == null || limit <= 0) {
+      final messages = await _readMessagesFile(messagesFile);
+      return ChatSessionMessagePage(
+        messages: messages,
+        olderCursor: null,
+        limit: limit,
+        beforeCursor: beforeCursor,
+      );
+    }
+
+    final linePage = await _readMessageLinesBefore(
+      messagesFile,
+      limit: limit,
+      beforeCursor: beforeCursor,
+    );
+    final messages = <Map<String, dynamic>>[];
+    for (final line in linePage.lines) {
+      try {
+        final decoded = jsonDecode(line.text);
+        if (decoded is Map) {
+          messages.add(Map<String, dynamic>.from(decoded));
+        }
+      } catch (e) {
+        _logger.warning('Failed to parse chat message JSONL page line: $e');
+      }
+    }
+
+    return ChatSessionMessagePage(
+      messages: messages,
+      olderCursor: linePage.olderCursor,
+      limit: limit,
+      beforeCursor: beforeCursor,
+    );
+  }
+
+  Future<Map<String, dynamic>> loadSessionData(
+    String userId,
+    String sessionId,
+  ) async {
+    final metadata = await loadMetadata(userId, sessionId);
+    final messages = await loadMessages(userId, sessionId);
+    return {
+      ...metadata,
+      'messages': messages,
+    };
+  }
+
+  Future<void> createSession({
+    required String userId,
+    required String sessionId,
+    required Map<String, dynamic> metadata,
+    List<Map<String, dynamic>> messages = const [],
+    bool overwrite = false,
+  }) async {
+    await ensureMigrated(userId);
+    _validateSessionId(sessionId);
+    final lock = await _lockFor(userId, sessionId);
+    await lock.synchronized(() async {
+      final dir = _sessionDir(userId, sessionId);
+      final metadataFile = _metadataFile(userId, sessionId);
+      if (!overwrite && await metadataFile.exists()) {
+        throw StateError('Session already exists: $sessionId');
+      }
+
+      await dir.create(recursive: true);
+      final normalizedMessages = messages.map(_normalizeMessage).toList();
+      await _writeMessagesFile(
+        _messagesFile(userId, sessionId),
+        normalizedMessages,
+      );
+      final nextMetadata = _normalizeMetadataForWrite(
+        metadata,
+        sessionId: sessionId,
+        messages: normalizedMessages,
+      );
+      await _writeJsonFile(metadataFile, nextMetadata);
+    });
+  }
+
+  Future<Map<String, dynamic>> updateMetadata(
+    String userId,
+    String sessionId,
+    Map<String, dynamic> Function(Map<String, dynamic> metadata) update,
+  ) async {
+    await ensureMigrated(userId);
+    _validateSessionId(sessionId);
+    final lock = await _lockFor(userId, sessionId);
+    return lock.synchronized(() async {
+      final metadataFile = _metadataFile(userId, sessionId);
+      if (!await metadataFile.exists()) {
+        throw StateError('Session not found: $sessionId');
+      }
+      final current = await _readMetadataFile(metadataFile);
+      final next = _normalizeMetadataForWrite(
+        update(Map<String, dynamic>.from(current)),
+        sessionId: sessionId,
+      );
+      await _writeJsonFile(metadataFile, next);
+      return next;
+    });
+  }
+
+  Future<Map<String, dynamic>?> appendMessage({
+    required String userId,
+    required String sessionId,
+    required Map<String, dynamic> message,
+    Map<String, dynamic>? usage,
+    bool? isQuickQuery,
+  }) async {
+    await ensureMigrated(userId);
+    _validateSessionId(sessionId);
+    final lock = await _lockFor(userId, sessionId);
+    return lock.synchronized(() async {
+      final metadataFile = _metadataFile(userId, sessionId);
+      if (!await metadataFile.exists()) return null;
+
+      final normalizedMessage = _normalizeMessage(message);
+      final messagesFile = _messagesFile(userId, sessionId);
+      await messagesFile.parent.create(recursive: true);
+      await messagesFile.writeAsString(
+        '${jsonEncode(normalizedMessage)}\n',
+        mode: FileMode.append,
+        encoding: utf8,
+        flush: true,
+      );
+
+      final metadata = await _readMetadataFile(metadataFile);
+      metadata['last_message_preview'] = previewForMessage(normalizedMessage);
+      metadata['last_message_role'] = normalizedMessage['role'];
+      metadata['last_message_at'] = normalizedMessage['timestamp'];
+
+      if (usage != null) {
+        final currentTotal = metadata['total_usage'] as Map<String, dynamic>? ??
+            {
+              'prompt_tokens': 0,
+              'completion_tokens': 0,
+              'cached_tokens': 0,
+              'total_tokens': 0,
+              'total_cost': 0.0,
+            };
+        metadata['total_usage'] = {
+          'prompt_tokens': _intValue(currentTotal['prompt_tokens']) +
+              _intValue(usage['prompt_tokens']),
+          'completion_tokens': _intValue(currentTotal['completion_tokens']) +
+              _intValue(usage['completion_tokens']),
+          'cached_tokens': _intValue(currentTotal['cached_tokens']) +
+              _intValue(usage['cached_tokens']),
+          'total_tokens': _intValue(currentTotal['total_tokens']) +
+              _intValue(usage['total_tokens']),
+          'total_cost': _doubleValue(currentTotal['total_cost']) +
+              _doubleValue(usage['total_cost']),
+        };
+      }
+
+      if (isQuickQuery != null) {
+        metadata['is_quick_query'] = isQuickQuery;
+      }
+
+      final updatedAt = DateTime.now();
+      metadata['updated_at'] = updatedAt.toIso8601String();
+      metadata['updated_at_local'] = formatLocalDateTimeWithZone(updatedAt);
+      metadata['updated_at_unix_seconds'] = unixSecondsFromDateTime(updatedAt);
+
+      final nextMetadata = _normalizeMetadataForWrite(
+        metadata,
+        sessionId: sessionId,
+      );
+      await _writeJsonFile(metadataFile, nextMetadata);
+      return nextMetadata['total_usage'] as Map<String, dynamic>?;
+    });
+  }
+
+  Future<bool> hasAssistantMessageForTurn(
+    String userId,
+    String sessionId,
+    String turnId,
+  ) async {
+    await ensureMigrated(userId);
+    _validateSessionId(sessionId);
+    const batchSize = 100;
+    final file = _messagesFile(userId, sessionId);
+    String? cursor;
+
+    while (true) {
+      final page = await _readMessageLinesBefore(
+        file,
+        limit: batchSize,
+        beforeCursor: cursor,
+      );
+      final lines = page.lines;
+      if (lines.isEmpty) return false;
+      for (final line in lines.reversed) {
+        try {
+          final decoded = jsonDecode(line.text);
+          if (decoded is Map &&
+              decoded['role'] == 'ai' &&
+              decoded['turn_id'] == turnId) {
+            return true;
+          }
+        } catch (_) {
+          continue;
+        }
+      }
+      if (!page.hasMore) return false;
+      cursor = page.olderCursor;
+    }
+  }
+
+  Future<String?> lastMessagePreview(String userId, String sessionId) async {
+    _validateSessionId(sessionId);
+    final messagesFile = _messagesFile(userId, sessionId);
+    final page = await _readMessageLinesBefore(messagesFile, limit: 1);
+    if (page.lines.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(page.lines.single.text);
+      if (decoded is Map) {
+        return previewForMessage(Map<String, dynamic>.from(decoded));
+      }
+    } catch (_) {
+      return null;
+    }
+    return null;
+  }
+
+  Future<void> deleteSession(String userId, String sessionId) async {
+    await ensureMigrated(userId);
+    _validateSessionId(sessionId);
+    final dir = _sessionDir(userId, sessionId);
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+  }
+
+  String sessionDirectoryPath(String userId, String sessionId) {
+    _validateSessionId(sessionId);
+    return _sessionDir(userId, sessionId).path;
+  }
+
+  String metadataPath(String userId, String sessionId) {
+    _validateSessionId(sessionId);
+    return _metadataFile(userId, sessionId).path;
+  }
+
+  String messagesPath(String userId, String sessionId) {
+    _validateSessionId(sessionId);
+    return _messagesFile(userId, sessionId).path;
+  }
+
+  String legacyYamlPath(String userId, String sessionId) {
+    _validateSessionId(sessionId);
+    return p.join(_sessionsPath(userId), '$sessionId.yaml');
+  }
+
+  static String? previewForMessage(Map<String, dynamic> message) {
+    final contentList = message['content'] as List<dynamic>? ?? [];
+    final textParts = <String>[];
+    var imageCount = 0;
+    for (final item in contentList) {
+      if (item is Map<String, dynamic> &&
+          item['type'] == 'text' &&
+          item['text'] != null) {
+        textParts.add(item['text'] as String);
+      } else if (item is Map<String, dynamic> && item['type'] == 'image_url') {
+        imageCount += 1;
+      }
+    }
+    if (textParts.isNotEmpty) {
+      final preview = textParts.join(' ');
+      return preview.length > 100 ? preview.substring(0, 100) : preview;
+    }
+    if (imageCount > 0) {
+      return 'Sent $imageCount image(s)';
+    }
+    return null;
+  }
+
+  Future<bool> _migrateLegacyYamlSessions(String userId) async {
+    final root = Directory(_sessionsPath(userId));
+    if (!await root.exists()) {
+      await root.create(recursive: true);
+      return true;
+    }
+
+    var hadFailures = false;
+    await for (final entity in root.list(followLinks: false)) {
+      if (entity is! File || !entity.path.endsWith('.yaml')) continue;
+      try {
+        await _migrateLegacyYamlSessionFile(userId, entity);
+      } catch (e, st) {
+        hadFailures = true;
+        _logger.warning(
+          'Failed to migrate legacy chat session YAML: ${entity.path}',
+          e,
+          st,
+        );
+      }
+    }
+
+    final removedLegacyCounts = await _removeLegacyMessageCounts(userId, root);
+    return !hadFailures && removedLegacyCounts;
+  }
+
+  Future<bool> _removeLegacyMessageCounts(String userId, Directory root) async {
+    var succeeded = true;
+    await for (final entity in root.list(followLinks: false)) {
+      if (entity is! Directory) continue;
+      final sessionId = p.basename(entity.path);
+      if (sessionId.startsWith('_') || !_isSafeSessionId(sessionId)) continue;
+      final metadataFile = File(p.join(entity.path, metadataFileName));
+      if (!await metadataFile.exists()) continue;
+      try {
+        final metadata = await _readMetadataFile(metadataFile);
+        if (!metadata.containsKey('message_count')) continue;
+        metadata.remove('message_count');
+        await _writeJsonFile(
+          metadataFile,
+          _normalizeMetadataForWrite(metadata, sessionId: sessionId),
+        );
+      } catch (e, st) {
+        succeeded = false;
+        _logger.warning(
+          'Failed to remove legacy chat message count for $userId/$sessionId',
+          e,
+          st,
+        );
+      }
+    }
+    return succeeded;
+  }
+
+  Future<void> _migrateLegacyYamlSessionFile(
+    String userId,
+    File legacyFile,
+  ) async {
+    final rawContent = await legacyFile.readAsString();
+    final doc = loadYaml(rawContent);
+    final decoded = jsonDecode(jsonEncode(doc));
+    if (decoded is! Map) {
+      throw const FormatException('Legacy chat session YAML is not a map');
+    }
+
+    final sessionData = Map<String, dynamic>.from(decoded);
+    final fileSessionId = p.basenameWithoutExtension(legacyFile.path);
+    final rawSessionId = _stringOrNull(sessionData['session_id']);
+    final sessionId =
+        _isSafeSessionId(rawSessionId) ? rawSessionId! : fileSessionId;
+    _validateSessionId(sessionId);
+    sessionData['session_id'] = sessionId;
+    ChatArtifactSessionMigration.migrateSessionData(sessionData);
+    _backfillSessionTimeContext(sessionData);
+
+    final rawMessages = sessionData['messages'];
+    final messages = <Map<String, dynamic>>[];
+    if (rawMessages is List) {
+      for (final raw in rawMessages) {
+        if (raw is Map) {
+          messages.add(_normalizeMessage(Map<String, dynamic>.from(raw)));
+        }
+      }
+    }
+
+    final metadata = Map<String, dynamic>.from(sessionData)..remove('messages');
+    final dir = _sessionDir(userId, sessionId);
+    final metadataFile = _metadataFile(userId, sessionId);
+    if (!await metadataFile.exists()) {
+      await dir.create(recursive: true);
+      await _writeMessagesFile(_messagesFile(userId, sessionId), messages);
+      await _writeJsonFile(
+        metadataFile,
+        _normalizeMetadataForWrite(
+          metadata,
+          sessionId: sessionId,
+          messages: messages,
+        ),
+      );
+    }
+
+    await _archiveLegacyYaml(userId, legacyFile);
+  }
+
+  Future<void> _archiveLegacyYaml(String userId, File legacyFile) async {
+    final archiveDir =
+        Directory(p.join(_sessionsPath(userId), legacyArchiveDirName));
+    await archiveDir.create(recursive: true);
+    var target = File(p.join(archiveDir.path, p.basename(legacyFile.path)));
+    if (await target.exists()) {
+      final stamp = DateTime.now().microsecondsSinceEpoch;
+      target = File(p.join(
+        archiveDir.path,
+        '${p.basenameWithoutExtension(legacyFile.path)}.$stamp.yaml',
+      ));
+    }
+    try {
+      await legacyFile.rename(target.path);
+    } catch (_) {
+      await legacyFile.copy(target.path);
+      await legacyFile.delete();
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> _readMessagesFile(File file) async {
+    if (!await file.exists()) return const [];
+    final messages = <Map<String, dynamic>>[];
+    for (final line in await file.readAsLines()) {
+      if (line.trim().isEmpty) continue;
+      try {
+        final decoded = jsonDecode(line);
+        if (decoded is Map) {
+          messages.add(Map<String, dynamic>.from(decoded));
+        }
+      } catch (e) {
+        _logger.warning('Failed to parse chat message JSONL line: $e');
+      }
+    }
+    return messages;
+  }
+
+  Future<_MessageLinePage> _readMessageLinesBefore(
+    File file, {
+    required int limit,
+    String? beforeCursor,
+  }) async {
+    if (limit <= 0 || !await file.exists()) {
+      return const _MessageLinePage(lines: [], olderCursor: null);
+    }
+    final length = await file.length();
+    if (length == 0) {
+      return const _MessageLinePage(lines: [], olderCursor: null);
+    }
+
+    final parsedCursor = int.tryParse(beforeCursor ?? '');
+    var endExclusive = parsedCursor == null
+        ? length
+        : math.max(0, math.min(length, parsedCursor));
+    if (endExclusive <= 0) {
+      return const _MessageLinePage(lines: [], olderCursor: null);
+    }
+
+    const chunkSize = 8192;
+    final chunks = <List<int>>[];
+    var position = endExclusive;
+    var bufferStart = endExclusive;
+    var completeLineCount = 0;
+
+    final raf = await file.open();
+    try {
+      while (position > 0 && completeLineCount <= limit) {
+        final readSize = math.min(chunkSize, position);
+        position -= readSize;
+        bufferStart = position;
+        await raf.setPosition(position);
+        final chunk = await raf.read(readSize);
+        chunks.insert(0, chunk);
+        completeLineCount = _countCompleteLines(
+          chunks,
+          bufferStartsAtFileStart: bufferStart == 0,
+        );
+      }
+    } finally {
+      await raf.close();
+    }
+
+    final bytes = chunks.expand((chunk) => chunk).toList();
+    var localStart = 0;
+    if (bufferStart > 0) {
+      final firstNewline = bytes.indexOf(0x0A);
+      if (firstNewline >= 0) {
+        localStart = firstNewline + 1;
+      } else {
+        return const _MessageLinePage(lines: [], olderCursor: null);
+      }
+    }
+
+    final lineRecords = _decodeLineRecords(
+      bytes.sublist(localStart),
+      absoluteStart: bufferStart + localStart,
+    );
+    if (lineRecords.isEmpty) {
+      return const _MessageLinePage(lines: [], olderCursor: null);
+    }
+
+    final hasMore = lineRecords.length > limit;
+    final returned =
+        hasMore ? lineRecords.sublist(lineRecords.length - limit) : lineRecords;
+    return _MessageLinePage(
+      lines: returned,
+      olderCursor: hasMore ? returned.first.startOffset.toString() : null,
+    );
+  }
+
+  int _countCompleteLines(
+    List<List<int>> chunks, {
+    required bool bufferStartsAtFileStart,
+  }) {
+    final bytes = chunks.expand((chunk) => chunk).toList();
+    if (bytes.isEmpty) return 0;
+    var localStart = 0;
+    if (!bufferStartsAtFileStart) {
+      final firstNewline = bytes.indexOf(0x0A);
+      if (firstNewline < 0) return 0;
+      localStart = firstNewline + 1;
+    }
+    return _decodeLineRecords(
+      bytes.sublist(localStart),
+      absoluteStart: localStart,
+    ).length;
+  }
+
+  List<_MessageLineRecord> _decodeLineRecords(
+    List<int> bytes, {
+    required int absoluteStart,
+  }) {
+    final records = <_MessageLineRecord>[];
+    var localLineStart = 0;
+    for (var i = 0; i < bytes.length; i++) {
+      if (bytes[i] != 0x0A) continue;
+      _addLineRecord(
+        records,
+        bytes,
+        localLineStart,
+        i,
+        absoluteStart,
+      );
+      localLineStart = i + 1;
+    }
+    if (localLineStart < bytes.length) {
+      _addLineRecord(
+        records,
+        bytes,
+        localLineStart,
+        bytes.length,
+        absoluteStart,
+      );
+    }
+    return records;
+  }
+
+  void _addLineRecord(
+    List<_MessageLineRecord> records,
+    List<int> bytes,
+    int localStart,
+    int localEnd,
+    int absoluteStart,
+  ) {
+    var end = localEnd;
+    if (end > localStart && bytes[end - 1] == 0x0D) {
+      end -= 1;
+    }
+    if (end <= localStart) return;
+    final text = utf8.decode(bytes.sublist(localStart, end));
+    if (text.trim().isEmpty) return;
+    records.add(
+      _MessageLineRecord(
+        startOffset: absoluteStart + localStart,
+        text: text,
+      ),
+    );
+  }
+
+  Future<void> _writeMessagesFile(
+    File file,
+    List<Map<String, dynamic>> messages,
+  ) async {
+    await file.parent.create(recursive: true);
+    final content =
+        messages.isEmpty ? '' : '${messages.map(jsonEncode).join('\n')}\n';
+    await file.writeAsString(content, encoding: utf8, flush: true);
+  }
+
+  Future<Map<String, dynamic>> _readMetadataFile(File file) async {
+    final decoded = jsonDecode(await file.readAsString());
+    if (decoded is! Map) {
+      throw FormatException('Chat session metadata is not a map: ${file.path}');
+    }
+    return Map<String, dynamic>.from(decoded);
+  }
+
+  Future<void> _writeJsonFile(File file, Map<String, dynamic> data) async {
+    await file.parent.create(recursive: true);
+    final tempFile = File('${file.path}.tmp');
+    const encoder = JsonEncoder.withIndent('  ');
+    await tempFile.writeAsString(
+      '${encoder.convert(_jsonSafe(data))}\n',
+      encoding: utf8,
+      flush: true,
+    );
+    await tempFile.rename(file.path);
+  }
+
+  Map<String, dynamic> _normalizeMetadataForWrite(
+    Map<String, dynamic> metadata, {
+    required String sessionId,
+    List<Map<String, dynamic>>? messages,
+  }) {
+    final next = Map<String, dynamic>.from(metadata)
+      ..remove('messages')
+      ..remove('message_count')
+      ..['session_id'] = sessionId
+      ..[storageSchemaVersionKey] = storageSchemaVersion
+      ..['messages_file'] = messagesFileName
+      ..[ChatArtifactSessionMigration.schemaVersionKey] =
+          ChatArtifact.schemaVersion;
+
+    final now = DateTime.now().toIso8601String();
+    next['created_at'] ??= now;
+    next['updated_at'] ??= next['created_at'];
+    _backfillSessionTimeContext(next);
+    if (messages != null) {
+      final preview =
+          messages.isEmpty ? null : previewForMessage(messages.last);
+      if (preview == null) {
+        next.remove('last_message_preview');
+      } else {
+        next['last_message_preview'] = preview;
+      }
+      if (messages.isNotEmpty) {
+        next['last_message_role'] = messages.last['role'];
+        next['last_message_at'] = messages.last['timestamp'];
+      }
+    }
+    return Map<String, dynamic>.from(_jsonSafe(next) as Map);
+  }
+
+  static Map<String, dynamic> _normalizeMessage(Map<String, dynamic> message) {
+    final next = Map<String, dynamic>.from(message);
+    final parsed = tryParseDateTime(next['timestamp']);
+    if (parsed != null) {
+      next['local_time'] ??= formatLocalDateTimeWithZone(parsed);
+      next['unix_seconds'] ??= unixSecondsFromDateTime(parsed);
+    }
+    return Map<String, dynamic>.from(_jsonSafe(next) as Map);
+  }
+
+  static void _backfillSessionTimeContext(Map<String, dynamic> sessionData) {
+    final createdAt = tryParseDateTime(sessionData['created_at']);
+    if (createdAt != null) {
+      sessionData['created_at_local'] ??= formatLocalDateTimeWithZone(
+        createdAt,
+      );
+      sessionData['created_at_unix_seconds'] ??= unixSecondsFromDateTime(
+        createdAt,
+      );
+    }
+
+    final updatedAt = tryParseDateTime(sessionData['updated_at']);
+    if (updatedAt != null) {
+      sessionData['updated_at_local'] ??= formatLocalDateTimeWithZone(
+        updatedAt,
+      );
+      sessionData['updated_at_unix_seconds'] ??= unixSecondsFromDateTime(
+        updatedAt,
+      );
+    }
+  }
+
+  Future<Lock> _lockFor(String userId, String sessionId) async {
+    final rootPath = _sessionsPath(userId);
+    return _lockMapLock.synchronized(() {
+      return _sessionLocks.putIfAbsent('$rootPath:$sessionId', () => Lock());
+    });
+  }
+
+  int _sortTime(Map<String, dynamic> metadata) {
+    final unix = metadata['updated_at_unix_seconds'];
+    if (unix is num) return unix.toInt();
+    final parsed = tryParseDateTime(metadata['updated_at']);
+    if (parsed != null) return unixSecondsFromDateTime(parsed);
+    return 0;
+  }
+
+  String _sessionsPath(String userId) =>
+      _fileService.getChatSessionsPath(userId);
+
+  Directory _sessionDir(String userId, String sessionId) {
+    return Directory(p.join(_sessionsPath(userId), sessionId));
+  }
+
+  File _metadataFile(String userId, String sessionId) {
+    return File(p.join(_sessionDir(userId, sessionId).path, metadataFileName));
+  }
+
+  File _messagesFile(String userId, String sessionId) {
+    return File(p.join(_sessionDir(userId, sessionId).path, messagesFileName));
+  }
+
+  static dynamic _jsonSafe(dynamic value) {
+    if (value == null || value is String || value is num || value is bool) {
+      return value;
+    }
+    if (value is DateTime) return value.toIso8601String();
+    if (value is List) return value.map(_jsonSafe).toList();
+    if (value is Map) {
+      return {
+        for (final entry in value.entries)
+          entry.key.toString(): _jsonSafe(entry.value),
+      };
+    }
+    return value.toString();
+  }
+
+  static String? _stringOrNull(dynamic value) {
+    final text = value?.toString().trim();
+    return text == null || text.isEmpty ? null : text;
+  }
+
+  static bool _isSafeSessionId(String? sessionId) {
+    if (sessionId == null || sessionId.isEmpty) return false;
+    if (sessionId.contains('/') || sessionId.contains('\\')) return false;
+    if (sessionId == '.' || sessionId == '..') return false;
+    return true;
+  }
+
+  static void _validateSessionId(String sessionId) {
+    if (!_isSafeSessionId(sessionId)) {
+      throw ArgumentError.value(sessionId, 'sessionId', 'invalid session id');
+    }
+  }
+
+  static int _intValue(dynamic value) {
+    return value is num ? value.toInt() : 0;
+  }
+
+  static double _doubleValue(dynamic value) {
+    return value is num ? value.toDouble() : 0.0;
+  }
+}
+
+class ChatSessionMessagePage {
+  const ChatSessionMessagePage({
+    required this.messages,
+    required this.olderCursor,
+    required this.limit,
+    required this.beforeCursor,
+  });
+
+  final List<Map<String, dynamic>> messages;
+  final String? olderCursor;
+  final int? limit;
+  final String? beforeCursor;
+
+  bool get hasMoreMessages => olderCursor != null;
+}
+
+class _MessageLinePage {
+  const _MessageLinePage({
+    required this.lines,
+    required this.olderCursor,
+  });
+
+  final List<_MessageLineRecord> lines;
+  final String? olderCursor;
+
+  bool get hasMore => olderCursor != null;
+}
+
+class _MessageLineRecord {
+  const _MessageLineRecord({
+    required this.startOffset,
+    required this.text,
+  });
+
+  final int startOffset;
+  final String text;
+}

--- a/lib/data/services/chat_session_storage.dart
+++ b/lib/data/services/chat_session_storage.dart
@@ -140,7 +140,7 @@ class ChatSessionStorage {
       );
     }
 
-    final linePage = await _readMessageLinesBefore(
+    final linePage = await _readMessageTurnGroupsBefore(
       messagesFile,
       limit: limit,
       beforeCursor: beforeCursor,
@@ -314,7 +314,7 @@ class ChatSessionStorage {
     String? cursor;
 
     while (true) {
-      final page = await _readMessageLinesBefore(
+      final page = await _readMessageTurnGroupsBefore(
         file,
         limit: batchSize,
         beforeCursor: cursor,
@@ -341,10 +341,10 @@ class ChatSessionStorage {
   Future<String?> lastMessagePreview(String userId, String sessionId) async {
     _validateSessionId(sessionId);
     final messagesFile = _messagesFile(userId, sessionId);
-    final page = await _readMessageLinesBefore(messagesFile, limit: 1);
+    final page = await _readMessageTurnGroupsBefore(messagesFile, limit: 1);
     if (page.lines.isEmpty) return null;
     try {
-      final decoded = jsonDecode(page.lines.single.text);
+      final decoded = jsonDecode(page.lines.last.text);
       if (decoded is Map) {
         return previewForMessage(Map<String, dynamic>.from(decoded));
       }
@@ -547,7 +547,7 @@ class ChatSessionStorage {
     return messages;
   }
 
-  Future<_MessageLinePage> _readMessageLinesBefore(
+  Future<_MessageLinePage> _readMessageTurnGroupsBefore(
     File file, {
     required int limit,
     String? beforeCursor,
@@ -572,70 +572,101 @@ class ChatSessionStorage {
     final chunks = <List<int>>[];
     var position = endExclusive;
     var bufferStart = endExclusive;
-    var completeLineCount = 0;
 
     final raf = await file.open();
     try {
-      while (position > 0 && completeLineCount <= limit) {
+      while (position > 0) {
         final readSize = math.min(chunkSize, position);
         position -= readSize;
         bufferStart = position;
         await raf.setPosition(position);
         final chunk = await raf.read(readSize);
         chunks.insert(0, chunk);
-        completeLineCount = _countCompleteLines(
+
+        final lineRecords = _lineRecordsFromChunks(
           chunks,
+          bufferStart: bufferStart,
+        );
+        if (lineRecords.isEmpty) continue;
+
+        final page = _selectTurnGroupPage(
+          lineRecords,
+          limit: limit,
           bufferStartsAtFileStart: bufferStart == 0,
         );
+        if (page != null) return page;
       }
     } finally {
       await raf.close();
     }
 
+    return const _MessageLinePage(lines: [], olderCursor: null);
+  }
+
+  List<_MessageLineRecord> _lineRecordsFromChunks(
+    List<List<int>> chunks, {
+    required int bufferStart,
+  }) {
     final bytes = chunks.expand((chunk) => chunk).toList();
     var localStart = 0;
     if (bufferStart > 0) {
       final firstNewline = bytes.indexOf(0x0A);
-      if (firstNewline >= 0) {
-        localStart = firstNewline + 1;
-      } else {
-        return const _MessageLinePage(lines: [], olderCursor: null);
-      }
-    }
-
-    final lineRecords = _decodeLineRecords(
-      bytes.sublist(localStart),
-      absoluteStart: bufferStart + localStart,
-    );
-    if (lineRecords.isEmpty) {
-      return const _MessageLinePage(lines: [], olderCursor: null);
-    }
-
-    final hasMore = lineRecords.length > limit;
-    final returned =
-        hasMore ? lineRecords.sublist(lineRecords.length - limit) : lineRecords;
-    return _MessageLinePage(
-      lines: returned,
-      olderCursor: hasMore ? returned.first.startOffset.toString() : null,
-    );
-  }
-
-  int _countCompleteLines(
-    List<List<int>> chunks, {
-    required bool bufferStartsAtFileStart,
-  }) {
-    final bytes = chunks.expand((chunk) => chunk).toList();
-    if (bytes.isEmpty) return 0;
-    var localStart = 0;
-    if (!bufferStartsAtFileStart) {
-      final firstNewline = bytes.indexOf(0x0A);
-      if (firstNewline < 0) return 0;
+      if (firstNewline < 0) return const [];
       localStart = firstNewline + 1;
     }
     return _decodeLineRecords(
       bytes.sublist(localStart),
-      absoluteStart: localStart,
-    ).length;
+      absoluteStart: bufferStart + localStart,
+    );
+  }
+
+  _MessageLinePage? _selectTurnGroupPage(
+    List<_MessageLineRecord> lineRecords, {
+    required int limit,
+    required bool bufferStartsAtFileStart,
+  }) {
+    if (lineRecords.isEmpty) {
+      return const _MessageLinePage(lines: [], olderCursor: null);
+    }
+
+    var groupCount = 0;
+    var pageStartIndex = 0;
+    String? previousGroupKey;
+    for (var i = lineRecords.length - 1; i >= 0; i--) {
+      final groupKey = _messageTurnGroupKey(lineRecords[i]);
+      if (previousGroupKey != groupKey) {
+        groupCount++;
+        previousGroupKey = groupKey;
+        if (groupCount > limit) {
+          pageStartIndex = i + 1;
+          break;
+        }
+      }
+    }
+
+    if (groupCount <= limit) {
+      if (!bufferStartsAtFileStart) return null;
+      return _MessageLinePage(lines: lineRecords, olderCursor: null);
+    }
+
+    final returned = lineRecords.sublist(pageStartIndex);
+    return _MessageLinePage(
+      lines: returned,
+      olderCursor: returned.first.startOffset.toString(),
+    );
+  }
+
+  String _messageTurnGroupKey(_MessageLineRecord record) {
+    try {
+      final decoded = jsonDecode(record.text);
+      if (decoded is Map) {
+        final turnId = _stringOrNull(decoded['turn_id']);
+        if (turnId != null) return 'turn:$turnId';
+      }
+    } catch (_) {
+      // Invalid JSONL rows are isolated so they cannot merge with neighbors.
+    }
+    return 'line:${record.startOffset}';
   }
 
   List<_MessageLineRecord> _decodeLineRecords(

--- a/lib/data/services/migration_state_service.dart
+++ b/lib/data/services/migration_state_service.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:path/path.dart' as p;
+import 'package:synchronized/synchronized.dart';
+
+class MigrationStateService {
+  MigrationStateService._();
+
+  static final MigrationStateService instance = MigrationStateService._();
+  static const String stateFileName = 'migration_state.json';
+
+  final _logger = getLogger('MigrationStateService');
+  final Map<String, Lock> _locks = {};
+
+  Future<bool> isCompleted(String userId, String key) async {
+    final state = await _readState(userId);
+    return state[key] == true;
+  }
+
+  Future<bool> runOnce({
+    required String userId,
+    required String key,
+    required Future<bool> Function() migrate,
+  }) async {
+    return _lockFor(userId).synchronized(() async {
+      final state = await _readState(userId);
+      if (state[key] == true) return true;
+
+      final completed = await migrate();
+      if (!completed) return false;
+
+      state[key] = true;
+      await _writeState(userId, state);
+      return true;
+    });
+  }
+
+  Future<void> markCompleted(String userId, String key) async {
+    await _lockFor(userId).synchronized(() async {
+      final state = await _readState(userId);
+      state[key] = true;
+      await _writeState(userId, state);
+    });
+  }
+
+  Lock _lockFor(String userId) {
+    return _locks.putIfAbsent(userId, () => Lock());
+  }
+
+  Future<Map<String, dynamic>> _readState(String userId) async {
+    final file = File(_statePath(userId));
+    if (!await file.exists()) return <String, dynamic>{};
+    try {
+      final data = jsonDecode(await file.readAsString());
+      if (data is Map) return Map<String, dynamic>.from(data);
+    } catch (e) {
+      _logger.warning('Failed to parse $stateFileName: $e');
+    }
+    return <String, dynamic>{};
+  }
+
+  Future<void> _writeState(
+    String userId,
+    Map<String, dynamic> state,
+  ) async {
+    final path = _statePath(userId);
+    final dir = Directory(p.dirname(path));
+    if (!await dir.exists()) await dir.create(recursive: true);
+
+    state['updated_at'] = DateTime.now().toIso8601String();
+    const encoder = JsonEncoder.withIndent('  ');
+    final tmpFile = File('$path.tmp');
+    await tmpFile.writeAsString('${encoder.convert(state)}\n');
+    await tmpFile.rename(path);
+  }
+
+  String _statePath(String userId) {
+    return p.join(
+      FileSystemService.instance.getSystemPath(userId),
+      stateFileName,
+    );
+  }
+}

--- a/lib/data/services/task_handlers/custom_agent_task_handler.dart
+++ b/lib/data/services/task_handlers/custom_agent_task_handler.dart
@@ -12,6 +12,7 @@ import 'package:memex/data/services/asset_reference_service.dart';
 import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/data/services/custom_agent_config_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/chat_session_storage.dart';
 import 'package:memex/data/services/llm_image_codec.dart';
 import 'package:memex/domain/models/agent_definitions.dart';
 import 'package:memex/domain/models/custom_agent_config.dart';
@@ -213,7 +214,7 @@ Future<void> _handleCustomAgentTask(
       _logger.info('Custom agent "$agentName" completed, last: $last');
     }
 
-    // Persist a chat session file so AgentChatDialog can load history and
+    // Persist a chat session so AgentChatDialog can load history and
     // continue the conversation in the same session context.
     await _createChatSession(
       userId: userId,
@@ -228,7 +229,7 @@ Future<void> _handleCustomAgentTask(
   }
 }
 
-/// Create a chat session YAML file compatible with ChatService / chat.dart so
+/// Create a chat session compatible with ChatService / chat.dart so
 /// that AgentChatDialog can load the conversation history and continue chatting.
 Future<void> _createChatSession({
   required String userId,
@@ -237,12 +238,10 @@ Future<void> _createChatSession({
   required String userText,
   String? aiResponse,
 }) async {
-  final fs = FileSystemService.instance;
-  final sessionsPath = fs.getChatSessionsPath(userId);
-  final sessionFile = File(p.join(sessionsPath, '$sessionId.yaml'));
+  final storage = ChatSessionStorage.instance;
 
   // Don't overwrite if it already exists (e.g. retry scenario).
-  if (sessionFile.existsSync()) return;
+  if (await storage.sessionExists(userId, sessionId)) return;
 
   final now = DateTime.now();
   final nowIso = now.toIso8601String();
@@ -270,7 +269,7 @@ Future<void> _createChatSession({
       },
   ];
 
-  final sessionData = <String, dynamic>{
+  final metadata = <String, dynamic>{
     'session_id': sessionId,
     'agent_name': agentName,
     'title': agentName,
@@ -285,7 +284,12 @@ Future<void> _createChatSession({
   };
 
   try {
-    await fs.writeYamlFile(sessionFile.path, sessionData);
+    await storage.createSession(
+      userId: userId,
+      sessionId: sessionId,
+      metadata: metadata,
+      messages: messages,
+    );
     _logger.info(
       'Created chat session for custom agent "$agentName": $sessionId',
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -887,7 +887,17 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       initialDraftText: initialDraftText,
       initialImages: initialImages,
       initialImageOriginalFilenames: initialImageOriginalFilenames,
+      onOpenScheduleTab: _openScheduleTabFromArtifact,
     );
+  }
+
+  void _openScheduleTabFromArtifact() {
+    if (!mounted) return;
+    setState(() => _currentTab = 0);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _timelineKey.currentState?.openScheduleTab();
+    });
   }
 
   Map<String, String> _originalFilenamesFromImages(List<XFile> images) {

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -59,13 +59,15 @@ class UserMessageItem extends ChatDisplayItem {
 class AIMessageItem extends ChatDisplayItem {
   String text;
   bool isStreaming;
+  final List<ArtifactItem> artifacts;
   @override
   DateTime? timestamp;
   AIMessageItem(
     this.text, {
     this.isStreaming = false,
+    List<ArtifactItem>? artifacts,
     this.timestamp,
-  });
+  }) : artifacts = artifacts ?? <ArtifactItem>[];
 }
 
 class ThinkingItem extends ChatDisplayItem {
@@ -164,9 +166,11 @@ class ProcessItem extends ChatDisplayItem {
   final DateTime timestamp;
   bool isExpanded;
   bool isFinished;
+  bool needsAttention;
   ProcessItem({
     this.isExpanded = false,
     this.isFinished = false,
+    this.needsAttention = false,
     DateTime? timestamp,
   }) : timestamp = timestamp ?? DateTime.now();
 
@@ -182,6 +186,17 @@ class ProcessItem extends ChatDisplayItem {
   bool get hasRunningTool => toolCalls.any((tool) => tool.hasRunningTrace);
 
   bool get hasToolError => toolCalls.any((tool) => tool.hasTraceError);
+}
+
+enum SuperAgentProcessVisualState { running, needsAttention, done }
+
+@visibleForTesting
+SuperAgentProcessVisualState superAgentProcessVisualState(ProcessItem item) {
+  if (!item.isFinished) return SuperAgentProcessVisualState.running;
+  if (item.needsAttention) {
+    return SuperAgentProcessVisualState.needsAttention;
+  }
+  return SuperAgentProcessVisualState.done;
 }
 
 const double _agentChatSheetHeightFactor = 0.75;
@@ -289,6 +304,17 @@ String formatSuperAgentTokenUsage(ChatTokenUsageEvent item) {
 }
 
 @visibleForTesting
+bool shouldShowSuperAgentThinkingRow({
+  required bool isLoadingAgent,
+  required ChatDisplayItem? primaryItem,
+}) {
+  if (!isLoadingAgent) return false;
+  if (primaryItem is ProcessItem) return false;
+  if (primaryItem is AIMessageItem && primaryItem.isStreaming) return false;
+  return true;
+}
+
+@visibleForTesting
 Duration resolveSuperAgentKeyboardInsetAnimationDuration({
   required double previousInset,
   required double nextInset,
@@ -352,17 +378,6 @@ Key? superAgentDemoPublishTargetKey(DemoStep? currentStep) {
 }
 
 @visibleForTesting
-int superAgentArtifactInsertionIndexBeforeReply(List<ChatDisplayItem> items) {
-  final lastUserIndex = items.lastIndexWhere((item) => item is UserMessageItem);
-  if (lastUserIndex < 0) return items.length;
-
-  for (var i = items.length - 1; i > lastUserIndex; i--) {
-    if (items[i] is AIMessageItem) return i;
-  }
-  return items.length;
-}
-
-@visibleForTesting
 String superAgentUserMessageImageSourceForLocalDisplay(String source) {
   final trimmed = source.trim();
   if (trimmed.isEmpty) return trimmed;
@@ -385,6 +400,10 @@ class AgentChatDialog extends StatefulWidget {
   final VoidCallback? onOpenScheduleTab;
   @visibleForTesting
   final List<ChatDisplayItem> initialItems;
+  @visibleForTesting
+  final bool initialIsLoadingAgent;
+  @visibleForTesting
+  final ChatTokenUsageEvent? initialTokenUsage;
 
   const AgentChatDialog({
     super.key,
@@ -396,6 +415,8 @@ class AgentChatDialog extends StatefulWidget {
     this.initialImageOriginalFilenames = const {},
     this.onOpenScheduleTab,
     this.initialItems = const [],
+    this.initialIsLoadingAgent = false,
+    this.initialTokenUsage,
   });
 
   @override
@@ -447,6 +468,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   double _lastKeyboardBottomOffset = 0;
   final Map<String, Future<String?>> _timelineCardArtifactImageSourceFutures =
       {};
+  final List<ArtifactItem> _pendingReplyArtifacts = [];
 
   late AnimationController _controller;
   late Animation<Offset> _slideAnimation;
@@ -458,6 +480,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     super.initState();
     _currentSessionId = widget.initialSessionId;
     _items = List<ChatDisplayItem>.from(widget.initialItems);
+    _isLoadingAgent = widget.initialIsLoadingAgent;
+    _lastTokenUsage = widget.initialTokenUsage;
     final initialDraftText = widget.initialDraftText;
     if (initialDraftText != null && initialDraftText.isNotEmpty) {
       _messageController.text = initialDraftText;
@@ -641,6 +665,30 @@ class _AgentChatDialogState extends State<AgentChatDialog>
 
   List<ChatDisplayItem> _chatItemsFromSessionMessages(List<dynamic> messages) {
     final historyItems = <ChatDisplayItem>[];
+    final bufferedArtifactsByTurn = <String, List<ArtifactItem>>{};
+    final repliesByTurn = <String, AIMessageItem>{};
+    final orphanArtifacts = <ArtifactItem>[];
+
+    void addArtifactsForMessage(
+      Map<String, dynamic> message,
+      List<ArtifactItem> artifacts,
+    ) {
+      if (artifacts.isEmpty) return;
+      final turnId = message['turn_id']?.toString();
+      if (turnId != null && turnId.isNotEmpty) {
+        final reply = repliesByTurn[turnId];
+        if (reply != null) {
+          reply.artifacts.addAll(artifacts);
+          return;
+        }
+        bufferedArtifactsByTurn
+            .putIfAbsent(turnId, () => <ArtifactItem>[])
+            .addAll(artifacts);
+        return;
+      }
+      orphanArtifacts.addAll(artifacts);
+    }
+
     for (final msg in messages) {
       if (msg is! Map) continue;
       final message = Map<String, dynamic>.from(msg);
@@ -668,6 +716,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           (message['artifacts'] as List).isNotEmpty;
       if (text.isEmpty && imagePaths.isEmpty && !hasArtifacts) continue;
       final timestamp = tryParseDateTime(message['timestamp']);
+      final artifacts =
+          _artifactItemsFromSessionMessage(message, timestamp: timestamp);
       if (role == 'user') {
         List<Map<String, String>>? refs;
         if (message['refs'] != null) {
@@ -686,13 +736,37 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           ),
         );
       } else {
-        historyItems.addAll(
-          _artifactItemsFromSessionMessage(message, timestamp: timestamp),
-        );
+        if (artifacts.isNotEmpty && text.isEmpty && imagePaths.isEmpty) {
+          addArtifactsForMessage(message, artifacts);
+          continue;
+        }
         if (text.isNotEmpty) {
-          historyItems.add(AIMessageItem(text, timestamp: timestamp));
+          final turnId = message['turn_id']?.toString();
+          final itemArtifacts = <ArtifactItem>[
+            if (turnId != null && turnId.isNotEmpty)
+              ...?bufferedArtifactsByTurn.remove(turnId),
+            ...orphanArtifacts,
+            ...artifacts,
+          ];
+          orphanArtifacts.clear();
+          final item = AIMessageItem(
+            text,
+            artifacts: itemArtifacts,
+            timestamp: timestamp,
+          );
+          historyItems.add(item);
+          if (turnId != null && turnId.isNotEmpty) {
+            repliesByTurn[turnId] = item;
+          }
         }
       }
+    }
+    for (final artifacts in bufferedArtifactsByTurn.values) {
+      if (artifacts.isEmpty) continue;
+      historyItems.add(AIMessageItem('', artifacts: artifacts));
+    }
+    if (orphanArtifacts.isNotEmpty) {
+      historyItems.add(AIMessageItem('', artifacts: orphanArtifacts));
     }
     return historyItems;
   }
@@ -1361,16 +1435,16 @@ class _AgentChatDialogState extends State<AgentChatDialog>
 
       if (event is ChatArtifactsEvent) {
         if (event.artifacts.isEmpty) return;
-        final artifactItems = event.artifacts
-            .map(
-              (artifact) => ArtifactItem(
-                artifact,
-                timestamp: DateTime.now(),
-              ),
-            )
-            .toList();
-        final insertIndex = superAgentArtifactInsertionIndexBeforeReply(_items);
-        _items.insertAll(insertIndex, artifactItems);
+        _attachArtifactsToCurrentReply(
+          event.artifacts
+              .map(
+                (artifact) => ArtifactItem(
+                  artifact,
+                  timestamp: DateTime.now(),
+                ),
+              )
+              .toList(),
+        );
         return;
       }
 
@@ -1379,6 +1453,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         final primary = _lastPrimaryItem();
         if (primary is ProcessItem) {
           primary.isFinished = true;
+          primary.needsAttention = false;
           primary.isExpanded = false; // Collapse when answer starts
         }
 
@@ -1386,13 +1461,15 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           primary.text += event.text;
           primary.isStreaming = !event.isDone;
         } else if (shouldCreateAIMessageForResponseChunk(
-          text: event.text,
-          isDone: event.isDone,
-        )) {
+              text: event.text,
+              isDone: event.isDone,
+            ) ||
+            _pendingReplyArtifacts.isNotEmpty) {
           _items.add(
             AIMessageItem(
               event.text,
               isStreaming: !event.isDone,
+              artifacts: _takePendingReplyArtifacts(),
               timestamp: DateTime.now(),
             ),
           );
@@ -1403,10 +1480,33 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           _nextResponseStartsNewMessage = false;
         }
       } else if (event is ChatErrorEvent) {
+        final primary = _lastPrimaryItem();
+        if (primary is ProcessItem) {
+          primary.isFinished = true;
+          primary.needsAttention = true;
+          primary.isExpanded = false;
+        }
         _items.add(ErrorItem(event.error));
       }
     });
     _scrollToBottom();
+  }
+
+  void _attachArtifactsToCurrentReply(List<ArtifactItem> artifacts) {
+    if (artifacts.isEmpty) return;
+    final primary = _lastPrimaryItem();
+    if (primary is AIMessageItem) {
+      primary.artifacts.addAll(artifacts);
+      return;
+    }
+    _pendingReplyArtifacts.addAll(artifacts);
+  }
+
+  List<ArtifactItem> _takePendingReplyArtifacts() {
+    if (_pendingReplyArtifacts.isEmpty) return const <ArtifactItem>[];
+    final artifacts = List<ArtifactItem>.from(_pendingReplyArtifacts);
+    _pendingReplyArtifacts.clear();
+    return artifacts;
   }
 
   /// Auxiliary items (artifacts, approval cards) interleave with the process
@@ -1444,7 +1544,10 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   }
 
   bool get _showAgentThinkingRow {
-    return _isLoadingAgent;
+    return shouldShowSuperAgentThinkingRow(
+      isLoadingAgent: _isLoadingAgent,
+      primaryItem: _lastPrimaryItem(),
+    );
   }
 
   int _agentChatListItemCount() {
@@ -1667,7 +1770,6 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                             ),
                           ),
                         ),
-                        _buildTokenUsageDisplay(),
                         _buildContextIndicator(),
                         _buildInput(),
                       ],
@@ -2406,6 +2508,42 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     );
   }
 
+  String _artifactSectionTitle(int count) {
+    return '${_agentChat.result} · $count';
+  }
+
+  Widget _buildAssistantArtifactSection(List<ArtifactItem> artifacts) {
+    final topPadding = artifacts.length == 1 ? 10.0 : 12.0;
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxWidth: MediaQuery.of(context).size.width * 0.82,
+      ),
+      child: Padding(
+        padding: EdgeInsets.only(top: topPadding),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(left: 2, bottom: 2),
+              child: Text(
+                _artifactSectionTitle(artifacts.length),
+                style: const TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.textTertiary,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+            ...artifacts.map(
+              (artifact) => _buildArtifactItem(artifact, embedded: true),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildMessageImageGrid(List<String> imagePaths) {
     return Wrap(
       spacing: 8,
@@ -2539,65 +2677,68 @@ class _AgentChatDialogState extends State<AgentChatDialog>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Container(
-                    constraints: BoxConstraints(
-                      maxWidth: MediaQuery.of(context).size.width * 0.75,
-                    ),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 14,
-                      vertical: 10,
-                    ),
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(
-                        16,
-                      ).copyWith(topLeft: const Radius.circular(4)),
-                      border: Border.all(color: const Color(0xFFF7F8FA)),
-                    ),
-                    child: MarkdownBody(
-                      data: item.text,
-                      selectable: true,
-                      softLineBreak: true,
-                      styleSheet: MarkdownStyleSheet(
-                        p: const TextStyle(
-                          fontSize: 14,
-                          color: AppColors.textSecondary,
-                          height: 1.5,
-                        ),
-                        strong: const TextStyle(
-                          fontWeight: FontWeight.w700,
-                          color: AppColors.textPrimary,
-                        ),
-                        em: const TextStyle(fontStyle: FontStyle.italic),
-                        listBullet: const TextStyle(color: AppColors.primary),
-                        code: const TextStyle(
-                          fontSize: 13,
-                          color: AppColors.textPrimary,
-                          backgroundColor: Color(0xFFF7F8FA),
-                          fontFamily: 'monospace',
-                        ),
-                        codeblockDecoration: BoxDecoration(
-                          color: const Color(0xFFF7F8FA),
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        blockquote: const TextStyle(
-                          color: AppColors.textSecondary,
-                          fontStyle: FontStyle.italic,
-                        ),
-                        blockquoteDecoration: BoxDecoration(
-                          color: const Color(0xFFF7F8FA),
-                          borderRadius: BorderRadius.circular(8),
-                          border: const Border(
-                            left: BorderSide(
-                              color: AppColors.primary,
-                              width: 3,
+                  if (item.text.trim().isNotEmpty)
+                    Container(
+                      constraints: BoxConstraints(
+                        maxWidth: MediaQuery.of(context).size.width * 0.75,
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 10,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(
+                          16,
+                        ).copyWith(topLeft: const Radius.circular(4)),
+                        border: Border.all(color: const Color(0xFFF7F8FA)),
+                      ),
+                      child: MarkdownBody(
+                        data: item.text,
+                        selectable: true,
+                        softLineBreak: true,
+                        styleSheet: MarkdownStyleSheet(
+                          p: const TextStyle(
+                            fontSize: 14,
+                            color: AppColors.textSecondary,
+                            height: 1.5,
+                          ),
+                          strong: const TextStyle(
+                            fontWeight: FontWeight.w700,
+                            color: AppColors.textPrimary,
+                          ),
+                          em: const TextStyle(fontStyle: FontStyle.italic),
+                          listBullet: const TextStyle(color: AppColors.primary),
+                          code: const TextStyle(
+                            fontSize: 13,
+                            color: AppColors.textPrimary,
+                            backgroundColor: Color(0xFFF7F8FA),
+                            fontFamily: 'monospace',
+                          ),
+                          codeblockDecoration: BoxDecoration(
+                            color: const Color(0xFFF7F8FA),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          blockquote: const TextStyle(
+                            color: AppColors.textSecondary,
+                            fontStyle: FontStyle.italic,
+                          ),
+                          blockquoteDecoration: BoxDecoration(
+                            color: const Color(0xFFF7F8FA),
+                            borderRadius: BorderRadius.circular(8),
+                            border: const Border(
+                              left: BorderSide(
+                                color: AppColors.primary,
+                                width: 3,
+                              ),
                             ),
                           ),
                         ),
                       ),
                     ),
-                  ),
-                  if (!item.isStreaming)
+                  if (item.artifacts.isNotEmpty)
+                    _buildAssistantArtifactSection(item.artifacts),
+                  if (!item.isStreaming && item.text.trim().isNotEmpty)
                     Padding(
                       padding: const EdgeInsets.only(left: 2, top: 6),
                       child: _CopyMessageButton(
@@ -2641,6 +2782,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     InkWell(
+                      key: const ValueKey('agent_chat_process_toggle'),
                       borderRadius: BorderRadius.circular(18),
                       onTap: () {
                         setState(() {
@@ -2698,7 +2840,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                                 ),
                               ],
                             ),
-                            if (item.toolCalls.isNotEmpty) ...[
+                            if (item.toolCalls.isNotEmpty &&
+                                (!item.isFinished || item.isExpanded)) ...[
                               const SizedBox(height: 10),
                               _buildToolSummaryChips(item),
                             ],
@@ -2724,6 +2867,10 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                             ],
                             if (item.toolCalls.isNotEmpty)
                               _buildToolTraceList(item.toolCalls),
+                            if (_lastTokenUsage != null) ...[
+                              const SizedBox(height: 12),
+                              _buildTokenUsageDisplay(),
+                            ],
                           ],
                         ),
                       ),
@@ -3048,6 +3195,16 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           item.artifact.kind == ChatArtifact.kindTimelineCard &&
           item.html != null) {
         allowed.add(item);
+      } else if (item is AIMessageItem) {
+        for (var j = item.artifacts.length - 1;
+            j >= 0 && allowed.length < _maxLiveHtmlPreviews;
+            j--) {
+          final artifactItem = item.artifacts[j];
+          if (artifactItem.artifact.kind == ChatArtifact.kindTimelineCard &&
+              artifactItem.html != null) {
+            allowed.add(artifactItem);
+          }
+        }
       }
     }
     return allowed;
@@ -3096,7 +3253,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     );
   }
 
-  Widget _buildArtifactItem(ArtifactItem item) {
+  Widget _buildArtifactItem(ArtifactItem item, {bool embedded = false}) {
     final artifact = item.artifact;
     final tappable = _artifactIsTappable(artifact);
     final showHtmlPreview =
@@ -3272,20 +3429,27 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       ),
     );
 
+    final wrapped = tappable
+        ? GestureDetector(
+            onTap: () => _openArtifact(artifact),
+            child: content,
+          )
+        : content;
+
+    if (embedded) {
+      return Padding(
+        padding: const EdgeInsets.only(top: 10),
+        child: wrapped,
+      );
+    }
+
     return Padding(
       padding: const EdgeInsets.only(bottom: 16),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const SizedBox(width: 32),
-          Expanded(
-            child: tappable
-                ? GestureDetector(
-                    onTap: () => _openArtifact(artifact),
-                    child: content,
-                  )
-                : content,
-          ),
+          Expanded(child: wrapped),
         ],
       ),
     );
@@ -3295,22 +3459,23 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     if (_lastTokenUsage == null) return const SizedBox.shrink();
     final item = _lastTokenUsage!;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Center(
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          decoration: BoxDecoration(
-            color: const Color(0xFFF7F8FA),
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: Text(
-            formatSuperAgentTokenUsage(item),
-            style: const TextStyle(
-              fontSize: 10,
-              color: AppColors.textSecondary,
-              fontWeight: FontWeight.w500,
-            ),
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        key: const ValueKey('agent_chat_token_usage_debug'),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF7F8FA),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: const Color(0xFFEFF2F6)),
+        ),
+        child: Text(
+          formatSuperAgentTokenUsage(item),
+          style: const TextStyle(
+            fontSize: 10,
+            color: AppColors.textTertiary,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 0,
           ),
         ),
       ),
@@ -3318,11 +3483,12 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   }
 
   Widget _buildProcessStatusGlyph(ProcessItem item) {
-    final color = item.hasToolError
-        ? const Color(0xFFEF4444)
-        : item.hasRunningTool || !item.isFinished
-            ? AppColors.primary
-            : const Color(0xFF10B981);
+    final state = superAgentProcessVisualState(item);
+    final color = switch (state) {
+      SuperAgentProcessVisualState.running => AppColors.primary,
+      SuperAgentProcessVisualState.needsAttention => const Color(0xFFEF4444),
+      SuperAgentProcessVisualState.done => const Color(0xFF10B981),
+    };
     return Container(
       width: 28,
       height: 28,
@@ -3331,7 +3497,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         shape: BoxShape.circle,
       ),
       child: Center(
-        child: item.hasRunningTool || !item.isFinished
+        child: state == SuperAgentProcessVisualState.running
             ? const SizedBox(
                 width: 13,
                 height: 13,
@@ -3341,7 +3507,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                 ),
               )
             : Icon(
-                item.hasToolError
+                state == SuperAgentProcessVisualState.needsAttention
                     ? Icons.error_outline_rounded
                     : Icons.check_rounded,
                 size: 16,
@@ -3352,16 +3518,17 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   }
 
   Widget _buildProcessStatePill(ProcessItem item) {
-    final label = item.hasToolError
-        ? _agentChat.issue
-        : item.hasRunningTool || !item.isFinished
-            ? _agentChat.running
-            : _agentChat.done;
-    final color = item.hasToolError
-        ? const Color(0xFFEF4444)
-        : item.hasRunningTool || !item.isFinished
-            ? AppColors.primary
-            : const Color(0xFF10B981);
+    final state = superAgentProcessVisualState(item);
+    final label = switch (state) {
+      SuperAgentProcessVisualState.running => _agentChat.running,
+      SuperAgentProcessVisualState.needsAttention => _agentChat.issue,
+      SuperAgentProcessVisualState.done => _agentChat.done,
+    };
+    final color = switch (state) {
+      SuperAgentProcessVisualState.running => AppColors.primary,
+      SuperAgentProcessVisualState.needsAttention => const Color(0xFFEF4444),
+      SuperAgentProcessVisualState.done => const Color(0xFF10B981),
+    };
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
@@ -3382,15 +3549,16 @@ class _AgentChatDialogState extends State<AgentChatDialog>
 
   String _processTitle(ProcessItem item) {
     final toolCount = item.allTraceCalls.length;
+    final state = superAgentProcessVisualState(item);
+    if (state == SuperAgentProcessVisualState.needsAttention) {
+      return _agentChat.actionNeedsAttention;
+    }
     if (toolCount == 0) {
-      return item.isFinished
+      return state == SuperAgentProcessVisualState.done
           ? _agentChat.reasoningComplete
           : _agentChat.thinkingThroughRequest;
     }
-    if (item.hasToolError) {
-      return _agentChat.actionNeedsAttention;
-    }
-    if (item.hasRunningTool || !item.isFinished) {
+    if (state == SuperAgentProcessVisualState.running) {
       return _agentChat.workingThroughActions(toolCount);
     }
     return _agentChat.completedActions(toolCount);

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -57,6 +57,7 @@ class UserMessageItem extends ChatDisplayItem {
 }
 
 class AIMessageItem extends ChatDisplayItem {
+  final String? turnId;
   String text;
   bool isStreaming;
   final List<ArtifactItem> artifacts;
@@ -64,6 +65,7 @@ class AIMessageItem extends ChatDisplayItem {
   DateTime? timestamp;
   AIMessageItem(
     this.text, {
+    this.turnId,
     this.isStreaming = false,
     List<ArtifactItem>? artifacts,
     this.timestamp,
@@ -200,7 +202,7 @@ SuperAgentProcessVisualState superAgentProcessVisualState(ProcessItem item) {
 }
 
 const double _agentChatSheetHeightFactor = 0.75;
-const int _agentChatHistoryPageSize = 10;
+const int _agentChatHistoryTurnPageSize = 4;
 const Duration _agentChatKeyboardShowAnimationDuration =
     Duration(milliseconds: 220);
 const Duration _agentChatKeyboardHideAnimationDuration = Duration.zero;
@@ -312,6 +314,14 @@ bool shouldShowSuperAgentThinkingRow({
   if (primaryItem is ProcessItem) return false;
   if (primaryItem is AIMessageItem && primaryItem.isStreaming) return false;
   return true;
+}
+
+@visibleForTesting
+bool shouldAttachArtifactsToAssistantReply({
+  required String turnId,
+  required ChatDisplayItem? primaryItem,
+}) {
+  return primaryItem is AIMessageItem && primaryItem.turnId == turnId;
 }
 
 @visibleForTesting
@@ -468,7 +478,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   double _lastKeyboardBottomOffset = 0;
   final Map<String, Future<String?>> _timelineCardArtifactImageSourceFutures =
       {};
-  final List<ArtifactItem> _pendingReplyArtifacts = [];
+  final Map<String, List<ArtifactItem>> _pendingReplyArtifactsByTurn = {};
 
   late AnimationController _controller;
   late Animation<Offset> _slideAnimation;
@@ -586,7 +596,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       // Since ChatService doesn't expose fetchHistory yet, reusing existing endpoint logic is fine.
       final sessionData = await _router.fetchChatSessionDetail(
         _currentSessionId!,
-        messageLimit: _agentChatHistoryPageSize,
+        messageLimit: _agentChatHistoryTurnPageSize,
       );
       final messagesData = sessionData['messages'] as List<dynamic>? ?? [];
       final historyItems = _chatItemsFromSessionMessages(messagesData);
@@ -642,7 +652,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     try {
       final sessionData = await _router.fetchChatSessionDetail(
         sessionId,
-        messageLimit: _agentChatHistoryPageSize,
+        messageLimit: _agentChatHistoryTurnPageSize,
         messageBeforeCursor: _olderHistoryCursor,
       );
       final messagesData = sessionData['messages'] as List<dynamic>? ?? [];
@@ -751,6 +761,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           orphanArtifacts.clear();
           final item = AIMessageItem(
             text,
+            turnId: turnId,
             artifacts: itemArtifacts,
             timestamp: timestamp,
           );
@@ -761,9 +772,11 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         }
       }
     }
-    for (final artifacts in bufferedArtifactsByTurn.values) {
+    for (final entry in bufferedArtifactsByTurn.entries) {
+      final artifacts = entry.value;
       if (artifacts.isEmpty) continue;
-      historyItems.add(AIMessageItem('', artifacts: artifacts));
+      historyItems
+          .add(AIMessageItem('', turnId: entry.key, artifacts: artifacts));
     }
     if (orphanArtifacts.isNotEmpty) {
       historyItems.add(AIMessageItem('', artifacts: orphanArtifacts));
@@ -1393,6 +1406,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         _isStreaming = true;
         _isLoadingAgent = true;
         _nextResponseStartsNewMessage = true;
+        _discardPendingReplyArtifactsExcept(event.turnId);
         return;
       }
       if (event is ChatAgentStoppedEvent) {
@@ -1436,6 +1450,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       if (event is ChatArtifactsEvent) {
         if (event.artifacts.isEmpty) return;
         _attachArtifactsToCurrentReply(
+          event.turnId,
           event.artifacts
               .map(
                 (artifact) => ArtifactItem(
@@ -1457,19 +1472,25 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           primary.isExpanded = false; // Collapse when answer starts
         }
 
-        if (primary is AIMessageItem && !_nextResponseStartsNewMessage) {
-          primary.text += event.text;
-          primary.isStreaming = !event.isDone;
+        if (shouldAttachArtifactsToAssistantReply(
+              turnId: event.turnId,
+              primaryItem: primary,
+            ) &&
+            !_nextResponseStartsNewMessage) {
+          final reply = primary as AIMessageItem;
+          reply.text += event.text;
+          reply.isStreaming = !event.isDone;
         } else if (shouldCreateAIMessageForResponseChunk(
               text: event.text,
               isDone: event.isDone,
             ) ||
-            _pendingReplyArtifacts.isNotEmpty) {
+            _hasPendingReplyArtifacts(event.turnId)) {
           _items.add(
             AIMessageItem(
               event.text,
+              turnId: event.turnId,
               isStreaming: !event.isDone,
-              artifacts: _takePendingReplyArtifacts(),
+              artifacts: _takePendingReplyArtifacts(event.turnId),
               timestamp: DateTime.now(),
             ),
           );
@@ -1492,21 +1513,39 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     _scrollToBottom();
   }
 
-  void _attachArtifactsToCurrentReply(List<ArtifactItem> artifacts) {
+  void _attachArtifactsToCurrentReply(
+    String turnId,
+    List<ArtifactItem> artifacts,
+  ) {
     if (artifacts.isEmpty) return;
     final primary = _lastPrimaryItem();
-    if (primary is AIMessageItem) {
-      primary.artifacts.addAll(artifacts);
+    if (shouldAttachArtifactsToAssistantReply(
+      turnId: turnId,
+      primaryItem: primary,
+    )) {
+      (primary as AIMessageItem).artifacts.addAll(artifacts);
       return;
     }
-    _pendingReplyArtifacts.addAll(artifacts);
+    _pendingReplyArtifactsByTurn
+        .putIfAbsent(turnId, () => <ArtifactItem>[])
+        .addAll(artifacts);
   }
 
-  List<ArtifactItem> _takePendingReplyArtifacts() {
-    if (_pendingReplyArtifacts.isEmpty) return const <ArtifactItem>[];
-    final artifacts = List<ArtifactItem>.from(_pendingReplyArtifacts);
-    _pendingReplyArtifacts.clear();
+  bool _hasPendingReplyArtifacts(String turnId) {
+    return _pendingReplyArtifactsByTurn[turnId]?.isNotEmpty == true;
+  }
+
+  List<ArtifactItem> _takePendingReplyArtifacts(String turnId) {
+    final pending = _pendingReplyArtifactsByTurn.remove(turnId);
+    if (pending == null || pending.isEmpty) return const <ArtifactItem>[];
+    final artifacts = List<ArtifactItem>.from(pending);
     return artifacts;
+  }
+
+  void _discardPendingReplyArtifactsExcept(String turnId) {
+    _pendingReplyArtifactsByTurn.removeWhere(
+      (pendingTurnId, _) => pendingTurnId != turnId,
+    );
   }
 
   /// Auxiliary items (artifacts, approval cards) interleave with the process

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -23,6 +23,9 @@ import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/input_draft_service.dart';
 import 'package:memex/ui/core/widgets/html_webview_card.dart';
 import 'package:memex/ui/core/widgets/local_image.dart';
+import 'package:memex/ui/insight/widgets/insight_detail_page.dart';
+import 'package:memex/ui/knowledge/widgets/knowledge_file_page.dart';
+import 'package:memex/ui/schedule/widgets/schedule_aggregator_screen.dart';
 import 'package:memex/ui/timeline/widgets/timeline_card_detail_screen.dart';
 import 'package:memex/data/services/photo_suggestion_service.dart';
 import 'package:memex/utils/toast_helper.dart';
@@ -142,8 +145,10 @@ class ArtifactItem extends ChatDisplayItem {
   /// Raw HTML captured from the producing tool call args, for mini previews
   /// of dynamic HTML cards.
   final String? html;
+  @override
+  final DateTime? timestamp;
 
-  ArtifactItem(this.artifact, {this.html});
+  ArtifactItem(this.artifact, {this.html, this.timestamp});
 }
 
 /// Inline ask-first approval card for one pending mutating tool call.
@@ -346,6 +351,29 @@ Key? superAgentDemoPublishTargetKey(DemoStep? currentStep) {
       : null;
 }
 
+@visibleForTesting
+int superAgentArtifactInsertionIndexBeforeReply(List<ChatDisplayItem> items) {
+  final lastUserIndex = items.lastIndexWhere((item) => item is UserMessageItem);
+  if (lastUserIndex < 0) return items.length;
+
+  for (var i = items.length - 1; i > lastUserIndex; i--) {
+    if (items[i] is AIMessageItem) return i;
+  }
+  return items.length;
+}
+
+@visibleForTesting
+String superAgentUserMessageImageSourceForLocalDisplay(String source) {
+  final trimmed = source.trim();
+  if (trimmed.isEmpty) return trimmed;
+  if (trimmed.startsWith('http://') ||
+      trimmed.startsWith('https://') ||
+      trimmed.startsWith('fs://')) {
+    return trimmed;
+  }
+  return FileSystemService.instance.toAbsolutePath(trimmed);
+}
+
 /// Agent Chat Dialog with Real-time Event Streaming
 class AgentChatDialog extends StatefulWidget {
   final String? initialSessionId;
@@ -354,6 +382,9 @@ class AgentChatDialog extends StatefulWidget {
   final String? initialDraftText;
   final List<XFile> initialImages;
   final Map<String, String> initialImageOriginalFilenames;
+  final VoidCallback? onOpenScheduleTab;
+  @visibleForTesting
+  final List<ChatDisplayItem> initialItems;
 
   const AgentChatDialog({
     super.key,
@@ -363,6 +394,8 @@ class AgentChatDialog extends StatefulWidget {
     this.initialDraftText,
     this.initialImages = const [],
     this.initialImageOriginalFilenames = const {},
+    this.onOpenScheduleTab,
+    this.initialItems = const [],
   });
 
   @override
@@ -386,7 +419,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   bool _isLoading = false;
   bool _isLoadingMoreHistory = false;
   bool _hasMoreHistory = false;
-  int _loadedHistoryMessageCount = 0;
+  String? _olderHistoryCursor;
   bool _isStreaming = false;
   bool _isLoadingAgent = false;
   bool _isRefreshingAgentState = false;
@@ -412,6 +445,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   bool _notificationPermissionPromptInFlight = false;
   List<List<EnhancedPhoto>> _photoSuggestionClusters = [];
   double _lastKeyboardBottomOffset = 0;
+  final Map<String, Future<String?>> _timelineCardArtifactImageSourceFutures =
+      {};
 
   late AnimationController _controller;
   late Animation<Offset> _slideAnimation;
@@ -422,6 +457,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   void initState() {
     super.initState();
     _currentSessionId = widget.initialSessionId;
+    _items = List<ChatDisplayItem>.from(widget.initialItems);
     final initialDraftText = widget.initialDraftText;
     if (initialDraftText != null && initialDraftText.isNotEmpty) {
       _messageController.text = initialDraftText;
@@ -552,7 +588,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       setState(() {
         _items = historyItems;
         _lastTokenUsage = restoredUsage;
-        _loadedHistoryMessageCount = messagesData.length;
+        _olderHistoryCursor = sessionData['older_cursor'] as String?;
         _hasMoreHistory =
             sessionData['has_more_messages'] == true && messagesData.isNotEmpty;
         _isLoading = false;
@@ -583,7 +619,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       final sessionData = await _router.fetchChatSessionDetail(
         sessionId,
         messageLimit: _agentChatHistoryPageSize,
-        messageOffset: _loadedHistoryMessageCount,
+        messageBeforeCursor: _olderHistoryCursor,
       );
       final messagesData = sessionData['messages'] as List<dynamic>? ?? [];
       final olderItems = _chatItemsFromSessionMessages(messagesData);
@@ -591,7 +627,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
 
       setState(() {
         _items = [...olderItems, ..._items];
-        _loadedHistoryMessageCount += messagesData.length;
+        _olderHistoryCursor = sessionData['older_cursor'] as String?;
         _hasMoreHistory =
             sessionData['has_more_messages'] == true && messagesData.isNotEmpty;
         _isLoadingMoreHistory = false;
@@ -618,7 +654,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
               if (imageUrl is Map) {
                 final filePath = imageUrl['filePath']?.toString();
                 if (filePath != null && filePath.isNotEmpty) {
-                  imagePaths.add(_resolveDisplayImagePath(filePath));
+                  imagePaths.add(filePath);
                 }
               }
             }
@@ -628,7 +664,9 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           .where((text) => text.isNotEmpty);
       final text = textParts.join(' ');
 
-      if (text.isEmpty && imagePaths.isEmpty) continue;
+      final hasArtifacts = message['artifacts'] is List &&
+          (message['artifacts'] as List).isNotEmpty;
+      if (text.isEmpty && imagePaths.isEmpty && !hasArtifacts) continue;
       final timestamp = tryParseDateTime(message['timestamp']);
       if (role == 'user') {
         List<Map<String, String>>? refs;
@@ -648,17 +686,32 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           ),
         );
       } else {
-        historyItems.add(AIMessageItem(text, timestamp: timestamp));
+        historyItems.addAll(
+          _artifactItemsFromSessionMessage(message, timestamp: timestamp),
+        );
+        if (text.isNotEmpty) {
+          historyItems.add(AIMessageItem(text, timestamp: timestamp));
+        }
       }
     }
     return historyItems;
   }
 
-  String _resolveDisplayImagePath(String filePath) {
-    if (filePath.startsWith('/')) {
-      return filePath;
+  List<ArtifactItem> _artifactItemsFromSessionMessage(
+    Map<String, dynamic> message, {
+    DateTime? timestamp,
+  }) {
+    final rawArtifacts = message['artifacts'];
+    if (rawArtifacts is! List) return const [];
+
+    final items = <ArtifactItem>[];
+    for (final raw in rawArtifacts) {
+      if (raw is! Map) continue;
+      final artifact = ChatArtifact.fromJson(Map<String, dynamic>.from(raw));
+      if (artifact == null) continue;
+      items.add(ArtifactItem(artifact, timestamp: timestamp));
     }
-    return FileSystemService.instance.toAbsolutePath(filePath);
+    return items;
   }
 
   bool get _hasInitialReferenceContext =>
@@ -840,7 +893,6 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           timestamp: sentAt,
         ),
       );
-      _loadedHistoryMessageCount += 1;
       _isStreaming = true;
       _messageController.clear();
       if (images.isNotEmpty) {
@@ -1302,22 +1354,24 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         } else if (event is ChatTraceStartedEvent) {
           _upsertTraceStart(processItem, event);
         } else if (event is ChatTraceCompletedEvent) {
-          final matchedTool = _completeTrace(processItem, event);
-          if (!event.isError) {
-            final artifact = ChatArtifact.fromToolMetadata(event.metadata);
-            if (artifact != null) {
-              _items.add(
-                ArtifactItem(
-                  artifact,
-                  html: artifact.type == ChatArtifact.typeHtmlCard
-                      ? _htmlFromToolArgs(matchedTool)
-                      : null,
-                ),
-              );
-            }
-          }
+          _completeTrace(processItem, event);
         }
         return; // Handled
+      }
+
+      if (event is ChatArtifactsEvent) {
+        if (event.artifacts.isEmpty) return;
+        final artifactItems = event.artifacts
+            .map(
+              (artifact) => ArtifactItem(
+                artifact,
+                timestamp: DateTime.now(),
+              ),
+            )
+            .toList();
+        final insertIndex = superAgentArtifactInsertionIndexBeforeReply(_items);
+        _items.insertAll(insertIndex, artifactItems);
+        return;
       }
 
       // Handle Response (Finish Progress)
@@ -1342,7 +1396,6 @@ class _AgentChatDialogState extends State<AgentChatDialog>
               timestamp: DateTime.now(),
             ),
           );
-          _loadedHistoryMessageCount += 1;
         }
         if (event.isDone) {
           _nextResponseStartsNewMessage = true;
@@ -1376,20 +1429,6 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     final processItem = ProcessItem();
     _items.add(processItem);
     return processItem;
-  }
-
-  String? _htmlFromToolArgs(ToolCallItem? tool) {
-    if (tool == null) return null;
-    try {
-      final decoded = jsonDecode(tool.args);
-      if (decoded is Map && decoded['html'] is String) {
-        final html = (decoded['html'] as String).trim();
-        return html.isEmpty ? null : html;
-      }
-    } catch (_) {
-      // Args are not guaranteed to be valid JSON.
-    }
-    return null;
   }
 
   void _scrollToBottom() {
@@ -2313,6 +2352,60 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     );
   }
 
+  String _userMessageImageSource(String source) {
+    return superAgentUserMessageImageSourceForLocalDisplay(source);
+  }
+
+  Future<String?> _timelineCardArtifactImageSource(String source) {
+    return _timelineCardArtifactImageSourceFutures.putIfAbsent(
+      source,
+      () async {
+        final trimmed = source.trim();
+        if (trimmed.isEmpty) return null;
+        if (!trimmed.startsWith('fs://')) return trimmed;
+
+        final userId = await UserStorage.getUserId();
+        if (userId == null || userId.isEmpty) return null;
+
+        final converted = await FileSystemService.convertFsToLocalHttp(
+          trimmed,
+          userId,
+        );
+        if (converted.isEmpty || converted == trimmed) return null;
+        return converted;
+      },
+    );
+  }
+
+  Widget _buildTimelineCardArtifactImage({
+    required String source,
+    required double width,
+    required double height,
+    required BoxFit fit,
+    required Widget Function() fallbackBuilder,
+  }) {
+    return FutureBuilder<String?>(
+      future: _timelineCardArtifactImageSource(source),
+      builder: (context, snapshot) {
+        final resolvedSource = snapshot.data;
+        if (resolvedSource == null || resolvedSource.isEmpty) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return SizedBox(width: width, height: height);
+          }
+          return fallbackBuilder();
+        }
+
+        return LocalImage(
+          url: resolvedSource,
+          width: width,
+          height: height,
+          fit: fit,
+          errorBuilder: (_, __, ___) => fallbackBuilder(),
+        );
+      },
+    );
+  }
+
   Widget _buildMessageImageGrid(List<String> imagePaths) {
     return Wrap(
       spacing: 8,
@@ -2321,7 +2414,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         return ClipRRect(
           borderRadius: BorderRadius.circular(10),
           child: LocalImage(
-            url: imagePath,
+            url: _userMessageImageSource(imagePath),
             width: 88,
             height: 88,
             fit: BoxFit.cover,
@@ -2820,66 +2913,124 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   // --- Artifact previews ---
 
   String _artifactHeading(ChatArtifact artifact) {
-    switch (artifact.type) {
-      case ChatArtifact.typeRecord:
-        return _agentChat.recordSaved;
-      case ChatArtifact.typeHtmlCard:
+    switch (artifact.kind) {
+      case ChatArtifact.kindTimelineCard:
         return artifact.updated
             ? _agentChat.cardUpdated
             : _agentChat.cardCreated;
-      case ChatArtifact.typeCard:
-        return _agentChat.cardSaved;
-      case ChatArtifact.typeFile:
+      case ChatArtifact.kindKnowledgeFile:
+      case ChatArtifact.kindWorkspaceFile:
+      case ChatArtifact.kindUiTemplate:
         return artifact.updated
             ? _agentChat.documentUpdated
             : _agentChat.documentCreated;
-      case ChatArtifact.typeSystemAction:
-        return artifact.kind == 'calendar'
+      case ChatArtifact.kindSystemAction:
+        return artifact.systemActionKind == 'calendar'
             ? _agentChat.calendarEventCreated
             : _agentChat.reminderCreated;
-      case ChatArtifact.typeInsight:
+      case ChatArtifact.kindKnowledgeInsight:
         return _agentChat.insightSaved;
+      case ChatArtifact.kindSchedule:
+        return UserStorage.l10n.schedule;
       default:
         return _agentChat.done;
     }
   }
 
   IconData _artifactIcon(ChatArtifact artifact) {
-    switch (artifact.type) {
-      case ChatArtifact.typeRecord:
+    switch (artifact.kind) {
+      case ChatArtifact.kindTimelineCard:
         return Icons.bookmark_added_outlined;
-      case ChatArtifact.typeHtmlCard:
-      case ChatArtifact.typeCard:
-        return Icons.auto_awesome_mosaic_outlined;
-      case ChatArtifact.typeFile:
+      case ChatArtifact.kindKnowledgeFile:
+      case ChatArtifact.kindWorkspaceFile:
         return Icons.description_outlined;
-      case ChatArtifact.typeSystemAction:
+      case ChatArtifact.kindUiTemplate:
+        return Icons.auto_awesome_mosaic_outlined;
+      case ChatArtifact.kindSystemAction:
         return Icons.notifications_active_outlined;
-      case ChatArtifact.typeInsight:
+      case ChatArtifact.kindKnowledgeInsight:
         return Icons.insights_outlined;
+      case ChatArtifact.kindSchedule:
+        return Icons.calendar_month_outlined;
       default:
         return Icons.check_circle_outline;
     }
   }
 
   void _openArtifact(ChatArtifact artifact) {
-    final cardId = artifact.id;
-    if (cardId == null || cardId.isEmpty) return;
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => TimelineCardDetailScreen(cardId: cardId),
-      ),
-    );
+    switch (artifact.kind) {
+      case ChatArtifact.kindTimelineCard:
+        final cardId = artifact.timelineCardId;
+        if (cardId == null || cardId.isEmpty) return;
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => TimelineCardDetailScreen(cardId: cardId),
+          ),
+        );
+        return;
+      case ChatArtifact.kindKnowledgeInsight:
+        final insightId = artifact.knowledgeInsightId;
+        if (insightId == null || insightId.isEmpty) return;
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => InsightDetailPage(id: insightId)),
+        );
+        return;
+      case ChatArtifact.kindKnowledgeFile:
+        final path = artifact.knowledgeFilePath;
+        if (path == null || path.isEmpty) return;
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => KnowledgeFilePage(filePath: path),
+          ),
+        );
+        return;
+      case ChatArtifact.kindSchedule:
+        final openSchedule = widget.onOpenScheduleTab;
+        if (openSchedule != null) {
+          openSchedule();
+          unawaited(Navigator.of(context).maybePop());
+        } else {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const ScheduleAggregatorScreen()),
+          );
+        }
+        return;
+      default:
+        return;
+    }
   }
 
   bool _artifactIsTappable(ChatArtifact artifact) {
-    switch (artifact.type) {
-      case ChatArtifact.typeRecord:
-      case ChatArtifact.typeHtmlCard:
-      case ChatArtifact.typeCard:
-        return artifact.id != null && artifact.id!.isNotEmpty;
+    switch (artifact.kind) {
+      case ChatArtifact.kindTimelineCard:
+        return artifact.timelineCardId != null;
+      case ChatArtifact.kindKnowledgeInsight:
+        return artifact.knowledgeInsightId != null;
+      case ChatArtifact.kindKnowledgeFile:
+        return artifact.knowledgeFilePath != null;
+      case ChatArtifact.kindSchedule:
+        return true;
       default:
         return false;
+    }
+  }
+
+  Color _artifactAccentColor(ChatArtifact artifact) {
+    switch (artifact.kind) {
+      case ChatArtifact.kindKnowledgeInsight:
+        return const Color(0xFF7C3AED);
+      case ChatArtifact.kindKnowledgeFile:
+      case ChatArtifact.kindWorkspaceFile:
+      case ChatArtifact.kindUiTemplate:
+        return const Color(0xFF0F766E);
+      case ChatArtifact.kindSchedule:
+        return const Color(0xFFEA580C);
+      case ChatArtifact.kindSystemAction:
+        return const Color(0xFF2563EB);
+      case ChatArtifact.kindTimelineCard:
+        return AppColors.primary;
+      default:
+        return const Color(0xFF10B981);
     }
   }
 
@@ -2894,7 +3045,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         i--) {
       final item = _items[i];
       if (item is ArtifactItem &&
-          item.artifact.type == ChatArtifact.typeHtmlCard &&
+          item.artifact.kind == ChatArtifact.kindTimelineCard &&
           item.html != null) {
         allowed.add(item);
       }
@@ -2902,18 +3053,64 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     return allowed;
   }
 
+  Widget? _buildArtifactMediaSection(ChatArtifact artifact) {
+    switch (artifact.kind) {
+      case ChatArtifact.kindTimelineCard:
+        return _buildTimelineCardArtifactMedia(artifact);
+      default:
+        return null;
+    }
+  }
+
+  Widget? _buildTimelineCardArtifactMedia(ChatArtifact artifact) {
+    if (artifact.imagePaths.isEmpty) return null;
+
+    return SizedBox(
+      height: 64,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: artifact.imagePaths.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 8),
+        itemBuilder: (context, index) {
+          return ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: _buildTimelineCardArtifactImage(
+              source: artifact.imagePaths[index],
+              width: 64,
+              height: 64,
+              fit: BoxFit.cover,
+              fallbackBuilder: () => Container(
+                width: 64,
+                height: 64,
+                color: const Color(0xFFF7F8FA),
+                child: const Icon(
+                  Icons.broken_image_outlined,
+                  size: 18,
+                  color: AppColors.textTertiary,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
   Widget _buildArtifactItem(ArtifactItem item) {
     final artifact = item.artifact;
     final tappable = _artifactIsTappable(artifact);
     final showHtmlPreview =
         item.html != null && _liveHtmlPreviewItems().contains(item);
+    final accentColor = _artifactAccentColor(artifact);
+    final artifactPath = artifact.workspacePath;
+    final artifactMedia = _buildArtifactMediaSection(artifact);
 
     final content = Container(
       padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: const Color(0xFFE6EAF2)),
+        border: Border.all(color: accentColor.withValues(alpha: 0.22)),
         boxShadow: const [
           BoxShadow(
             color: Color(0x0A0F172A),
@@ -2927,12 +3124,20 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         children: [
           Row(
             children: [
-              Icon(
-                _artifactIcon(artifact),
-                size: 15,
-                color: AppColors.primary,
+              Container(
+                width: 24,
+                height: 24,
+                decoration: BoxDecoration(
+                  color: accentColor.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  _artifactIcon(artifact),
+                  size: 15,
+                  color: accentColor,
+                ),
               ),
-              const SizedBox(width: 6),
+              const SizedBox(width: 8),
               Expanded(
                 child: Text(
                   _artifactHeading(artifact),
@@ -2944,10 +3149,28 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                 ),
               ),
               if (tappable)
-                const Icon(
-                  Icons.chevron_right_rounded,
-                  size: 18,
-                  color: AppColors.textTertiary,
+                Container(
+                  padding: const EdgeInsets.only(left: 8),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        UserStorage.l10n.scheduleBriefingOpen,
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w700,
+                          color: accentColor,
+                          height: 1,
+                        ),
+                      ),
+                      const SizedBox(width: 2),
+                      Icon(
+                        Icons.chevron_right_rounded,
+                        size: 18,
+                        color: accentColor,
+                      ),
+                    ],
+                  ),
                 ),
             ],
           ),
@@ -2965,10 +3188,10 @@ class _AgentChatDialogState extends State<AgentChatDialog>
               ),
             ),
           ],
-          if (artifact.path != null) ...[
+          if (artifactPath != null) ...[
             const SizedBox(height: 8),
             Text(
-              artifact.path!,
+              artifactPath,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: const TextStyle(
@@ -2979,10 +3202,10 @@ class _AgentChatDialogState extends State<AgentChatDialog>
               ),
             ),
           ],
-          if (artifact.snippet != null) ...[
+          if (artifact.summary != null) ...[
             const SizedBox(height: 6),
             Text(
-              artifact.snippet!,
+              artifact.summary!,
               maxLines: 3,
               overflow: TextOverflow.ellipsis,
               style: const TextStyle(
@@ -3021,39 +3244,9 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                   .toList(),
             ),
           ],
-          if (artifact.imagePaths.isNotEmpty) ...[
+          if (artifactMedia != null) ...[
             const SizedBox(height: 10),
-            SizedBox(
-              height: 64,
-              child: ListView.separated(
-                scrollDirection: Axis.horizontal,
-                itemCount: artifact.imagePaths.length,
-                separatorBuilder: (_, __) => const SizedBox(width: 8),
-                itemBuilder: (context, index) {
-                  final path =
-                      _resolveDisplayImagePath(artifact.imagePaths[index]);
-                  return ClipRRect(
-                    borderRadius: BorderRadius.circular(10),
-                    child: LocalImage(
-                      url: path,
-                      width: 64,
-                      height: 64,
-                      fit: BoxFit.cover,
-                      errorBuilder: (_, __, ___) => Container(
-                        width: 64,
-                        height: 64,
-                        color: const Color(0xFFF7F8FA),
-                        child: const Icon(
-                          Icons.broken_image_outlined,
-                          size: 18,
-                          color: AppColors.textTertiary,
-                        ),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
+            artifactMedia,
           ],
           if (showHtmlPreview) ...[
             const SizedBox(height: 10),

--- a/lib/ui/chat/widgets/chat_history_screen.dart
+++ b/lib/ui/chat/widgets/chat_history_screen.dart
@@ -168,8 +168,6 @@ class _ChatHistoryScreenState extends State<ChatHistoryScreen> {
                           final lastMessagePreview =
                               session['last_message_preview'] as String? ?? '';
                           final updatedAt = session['updated_at'] as String?;
-                          final messageCount =
-                              session['message_count'] as int? ?? 0;
 
                           return Container(
                             margin: const EdgeInsets.only(bottom: 12),
@@ -232,23 +230,6 @@ class _ChatHistoryScreenState extends State<ChatHistoryScreen> {
                                               children: [
                                                 Text(
                                                   _formatDateTime(updatedAt),
-                                                  style: const TextStyle(
-                                                    fontSize: 12,
-                                                    color:
-                                                        AppColors.textTertiary,
-                                                  ),
-                                                ),
-                                                const Text(
-                                                  '•',
-                                                  style: TextStyle(
-                                                    fontSize: 12,
-                                                    color:
-                                                        AppColors.textTertiary,
-                                                  ),
-                                                ),
-                                                Text(
-                                                  UserStorage.l10n.messageCount(
-                                                      messageCount),
                                                   style: const TextStyle(
                                                     fontSize: 12,
                                                     color:

--- a/lib/ui/chat/widgets/open_super_agent_dialog.dart
+++ b/lib/ui/chat/widgets/open_super_agent_dialog.dart
@@ -43,6 +43,7 @@ void openSuperAgentDialog(
   Map<String, String> initialImageOriginalFilenames = const {},
   String? sceneId,
   List<Map<String, String>>? initialRefs,
+  VoidCallback? onOpenScheduleTab,
 }) {
   final sessionIdFuture = latestSuperAgentSessionId();
   showGeneralDialog(
@@ -59,6 +60,7 @@ void openSuperAgentDialog(
         initialDraftText: initialDraftText,
         initialImages: initialImages,
         initialImageOriginalFilenames: initialImageOriginalFilenames,
+        onOpenScheduleTab: onOpenScheduleTab,
       );
     },
   );
@@ -72,6 +74,7 @@ Widget buildSuperAgentDialogSessionGate({
   Map<String, String> initialImageOriginalFilenames = const {},
   String? sceneId,
   List<Map<String, String>>? initialRefs,
+  VoidCallback? onOpenScheduleTab,
 }) {
   return FutureBuilder<String?>(
     future: sessionIdFuture,
@@ -89,6 +92,7 @@ Widget buildSuperAgentDialogSessionGate({
         initialDraftText: initialDraftText,
         initialImages: initialImages,
         initialImageOriginalFilenames: initialImageOriginalFilenames,
+        onOpenScheduleTab: onOpenScheduleTab,
       );
     },
   );

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -77,6 +77,12 @@ class TimelineScreenState extends State<TimelineScreen> {
     }
   }
 
+  void openScheduleTab() {
+    widget.viewModel.setViewMode(TimelineViewMode.timeline);
+    widget.viewModel.setActiveFilter('schedule');
+    _jumpToPage(2);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -399,23 +405,23 @@ class TimelineScreenState extends State<TimelineScreen> {
                       begin: Alignment.topLeft,
                       end: Alignment.bottomRight,
                       colors: [
-                        Colors.white.withOpacity(0.92),
-                        Colors.white.withOpacity(0.82),
+                        Colors.white.withValues(alpha: 0.92),
+                        Colors.white.withValues(alpha: 0.82),
                       ],
                     ),
                     borderRadius: BorderRadius.circular(16),
                     border: Border.all(
-                      color: Colors.white.withOpacity(0.6),
+                      color: Colors.white.withValues(alpha: 0.6),
                       width: 0.5,
                     ),
                     boxShadow: [
                       BoxShadow(
-                        color: Colors.black.withOpacity(0.06),
+                        color: Colors.black.withValues(alpha: 0.06),
                         blurRadius: 16,
                         offset: const Offset(0, 4),
                       ),
                       BoxShadow(
-                        color: const Color(0xFF10B981).withOpacity(0.08),
+                        color: const Color(0xFF10B981).withValues(alpha: 0.08),
                         blurRadius: 24,
                         offset: const Offset(0, 2),
                       ),
@@ -486,8 +492,8 @@ class TimelineScreenState extends State<TimelineScreen> {
                                 UserStorage.l10n.fitnessBannerMessage,
                                 style: TextStyle(
                                   fontSize: 12,
-                                  color:
-                                      const Color(0xFF64748B).withOpacity(0.9),
+                                  color: const Color(0xFF64748B)
+                                      .withValues(alpha: 0.9),
                                   height: 1.3,
                                 ),
                               ),
@@ -502,7 +508,8 @@ class TimelineScreenState extends State<TimelineScreen> {
                           width: 28,
                           height: 28,
                           decoration: BoxDecoration(
-                            color: const Color(0xFF94A3B8).withOpacity(0.1),
+                            color:
+                                const Color(0xFF94A3B8).withValues(alpha: 0.1),
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: const Icon(Icons.close_rounded,

--- a/test/data/model/chat_artifact_test.dart
+++ b/test/data/model/chat_artifact_test.dart
@@ -2,91 +2,188 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/model/chat_artifact.dart';
 
 void main() {
-  group('ChatArtifact.fromToolMetadata', () {
-    test('parses a record artifact with images', () {
+  group('ChatArtifact schema v2', () {
+    test('parses a timeline card artifact with target uri metadata', () {
       final artifact = ChatArtifact.fromToolMetadata({
-        'artifact': {
-          'type': 'record',
-          'id': '2026/06/10.md#ts_3',
-          'snippet': '今天跑了 5 公里',
-          'image_paths': ['assets/a.jpg', 'assets/b.jpg'],
-        },
+        'artifact': ChatArtifact.timelineCard(
+          cardId: '2026/06/10.md#ts_3',
+          title: '跑步',
+          summary: '今天跑了 5 公里',
+          imagePaths: ['fs://a.jpg', 'fs://b.jpg'],
+          tags: ['Health'],
+          updated: false,
+          createdAt: DateTime.utc(2026, 6, 10),
+        ).toJson(),
       });
 
       expect(artifact, isNotNull);
-      expect(artifact!.type, ChatArtifact.typeRecord);
-      expect(artifact.id, '2026/06/10.md#ts_3');
-      expect(artifact.snippet, '今天跑了 5 公里');
-      expect(artifact.imagePaths, ['assets/a.jpg', 'assets/b.jpg']);
-      expect(artifact.updated, isFalse);
+      expect(artifact!.version, ChatArtifact.schemaVersion);
+      expect(artifact.kind, ChatArtifact.kindTimelineCard);
+      expect(artifact.operation, ChatArtifact.operationCreate);
+      expect(artifact.timelineCardId, '2026/06/10.md#ts_3');
+      expect(artifact.summary, '今天跑了 5 公里');
+      expect(artifact.imagePaths, ['fs://a.jpg', 'fs://b.jpg']);
+      expect(artifact.tags, ['Health']);
     });
 
-    test('parses an html card artifact with tags and updated flag', () {
-      final artifact = ChatArtifact.fromToolMetadata({
-        'artifact': {
-          'type': 'html_card',
-          'id': '2026/06/09.md#ts_1',
-          'title': '本周进度',
-          'tags': ['Project', 'Milestone'],
-          'updated': true,
-        },
+    test('parses multiple artifacts and round-trips json', () {
+      final artifacts = ChatArtifact.listFromToolMetadata({
+        'artifacts': [
+          ChatArtifact.knowledgeInsight(
+            insightId: 'weekly-pattern',
+            title: 'Weekly pattern',
+            updated: false,
+            createdAt: DateTime.utc(2026, 6, 10),
+          ).toJson(),
+          ChatArtifact.schedule(
+            title: 'Schedule presentation',
+            summary: 'Pending schedule items: 3',
+            updated: true,
+            createdAt: DateTime.utc(2026, 6, 10),
+          ).toJson(),
+        ],
       });
 
-      expect(artifact, isNotNull);
-      expect(artifact!.type, ChatArtifact.typeHtmlCard);
-      expect(artifact.title, '本周进度');
-      expect(artifact.tags, ['Project', 'Milestone']);
-      expect(artifact.updated, isTrue);
+      expect(artifacts, hasLength(2));
+      expect(artifacts.first.kind, ChatArtifact.kindKnowledgeInsight);
+      expect(artifacts.last.kind, ChatArtifact.kindSchedule);
+      expect(ChatArtifact.fromJson(artifacts.last.toJson())!.updated, isTrue);
     });
 
-    test('parses a file artifact', () {
-      final artifact = ChatArtifact.fromToolMetadata({
-        'artifact': {
-          'type': 'file',
-          'path': 'PKM/Projects/memex.md',
-          'snippet': '# Memex',
-          'updated': false,
-        },
-      });
+    test('normalizes knowledge file path for knowledge tab navigation', () {
+      final artifact = ChatArtifact.knowledgeFile(
+        path: '/PKM/Projects/memex.md',
+        title: 'memex.md',
+        updated: true,
+      );
 
-      expect(artifact, isNotNull);
-      expect(artifact!.type, ChatArtifact.typeFile);
-      expect(artifact.path, 'PKM/Projects/memex.md');
+      expect(artifact.workspacePath, 'PKM/Projects/memex.md');
+      expect(artifact.knowledgeFilePath, 'Projects/memex.md');
+      expect(
+        ChatArtifact.knowledgeFilePathFromWorkspacePath(
+          r'\PKM\Areas\health.md',
+        ),
+        'Areas/health.md',
+      );
+      expect(
+        ChatArtifact.knowledgeFilePathFromWorkspacePath(
+          'Projects/memex.md',
+        ),
+        isNull,
+      );
     });
 
-    test('returns null for missing, malformed, or unknown artifacts', () {
+    test('rejects missing, malformed, legacy, or unknown artifacts', () {
       expect(ChatArtifact.fromToolMetadata(null), isNull);
       expect(ChatArtifact.fromToolMetadata({}), isNull);
       expect(ChatArtifact.fromToolMetadata({'artifact': 'oops'}), isNull);
       expect(
         ChatArtifact.fromToolMetadata({
-          'artifact': {'type': 'alien'},
+          'artifact': {'type': 'card', 'id': 'legacy'},
         }),
         isNull,
       );
       expect(
         ChatArtifact.fromToolMetadata({
-          'artifact': {'id': 'x'},
+          'artifact': {
+            'version': ChatArtifact.schemaVersion,
+            'artifact_id': 'x',
+            'kind': 'alien',
+            'operation': ChatArtifact.operationCreate,
+          },
         }),
         isNull,
       );
     });
+  });
 
-    test('normalizes empty strings to null and skips empty list entries', () {
-      final artifact = ChatArtifact.fromToolMetadata({
-        'artifact': {
-          'type': 'system_action',
-          'kind': 'reminder',
-          'title': '晚间复盘',
-          'snippet': '',
-          'image_paths': ['', 'assets/x.png'],
+  group('ChatTurnArtifactCollector', () {
+    test('deduplicates by stable UI destination and adds source fields', () {
+      final collector = ChatTurnArtifactCollector(sourceRunId: 'turn-1');
+
+      final firstArtifacts = collector.addFromToolResult(
+        sourceToolCallId: 'tool-1',
+        metadata: {
+          'artifact': ChatArtifact.timelineCard(
+            cardId: '2026/06/10.md#ts_3',
+            title: 'Draft',
+            updated: false,
+          ).toJson(),
         },
-      });
+      );
+      final secondArtifacts = collector.addFromToolResult(
+        sourceToolCallId: 'tool-2',
+        metadata: {
+          'artifact': ChatArtifact.timelineCard(
+            cardId: '2026/06/10.md#ts_3',
+            title: 'Final',
+            updated: true,
+          ).toJson(),
+        },
+      );
 
-      expect(artifact, isNotNull);
-      expect(artifact!.kind, 'reminder');
-      expect(artifact.snippet, isNull);
-      expect(artifact.imagePaths, ['assets/x.png']);
+      expect(firstArtifacts, hasLength(1));
+      expect(secondArtifacts, isEmpty);
+      expect(collector.artifacts, hasLength(1));
+      expect(collector.artifacts.single.title, 'Final');
+      expect(collector.artifacts.single.updated, isTrue);
+      expect(collector.artifacts.single.sourceRunId, 'turn-1');
+      expect(collector.artifacts.single.sourceToolCallId, 'tool-2');
+    });
+  });
+
+  group('ChatArtifactSessionMigration', () {
+    test('rewrites legacy session artifacts to schema v2 once', () {
+      final session = <String, dynamic>{
+        'messages': <dynamic>[
+          {
+            'role': 'ai',
+            'turn_id': 'turn-legacy',
+            'timestamp': '2026-06-10T12:00:00.000Z',
+            'content': [
+              {'type': 'text', 'text': 'done'},
+            ],
+            'artifacts': [
+              {
+                'type': 'file',
+                'path': 'PKM/Projects/memex.md',
+                'snippet': '# Memex',
+                'updated': true,
+              },
+              {
+                'type': 'schedule',
+                'title': 'Schedule presentation',
+                'updated': true,
+              },
+            ],
+          },
+        ],
+      };
+
+      final changed = ChatArtifactSessionMigration.migrateSessionData(session);
+
+      expect(changed, isTrue);
+      expect(
+        session[ChatArtifactSessionMigration.schemaVersionKey],
+        ChatArtifact.schemaVersion,
+      );
+
+      final message =
+          (session['messages'] as List).single as Map<String, dynamic>;
+      final artifacts = message['artifacts'] as List<dynamic>;
+      expect(artifacts, hasLength(2));
+
+      final fileArtifact = ChatArtifact.fromJson(
+        Map<String, dynamic>.from(artifacts.first as Map),
+      )!;
+      expect(fileArtifact.kind, ChatArtifact.kindKnowledgeFile);
+      expect(fileArtifact.workspacePath, 'PKM/Projects/memex.md');
+      expect(fileArtifact.summary, '# Memex');
+      expect(fileArtifact.sourceRunId, 'turn-legacy');
+
+      final secondChanged =
+          ChatArtifactSessionMigration.migrateSessionData(session);
+      expect(secondChanged, isFalse);
     });
   });
 }

--- a/test/data/repositories/chat_session_time_context_test.dart
+++ b/test/data/repositories/chat_session_time_context_test.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/repositories/chat.dart';
+import 'package:memex/data/services/chat_session_storage.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_asset_server.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -115,6 +117,80 @@ void main() {
       expect(message['unix_seconds'], 333);
     });
 
+    test('migrates legacy artifacts in session detail and persists v2',
+        () async {
+      await _writeSession(
+        userId: userId,
+        sessionId: 'legacy-artifact-session',
+        data: {
+          'session_id': 'legacy-artifact-session',
+          'agent_name': 'memex_agent',
+          'title': 'Legacy Artifact Session',
+          'created_at': '2026-04-28T20:00:46.000',
+          'updated_at': '2026-04-28T20:05:00.000',
+          'messages': [
+            {
+              'role': 'ai',
+              'turn_id': 'turn-detail',
+              'content': [
+                {'type': 'text', 'text': 'done'},
+              ],
+              'timestamp': '2026-04-28T20:05:00.000',
+              'artifacts': [
+                {
+                  'type': 'file',
+                  'path': 'PKM/Projects/memex.md',
+                  'snippet': '# Memex',
+                  'updated': true,
+                },
+              ],
+            },
+          ],
+        },
+      );
+
+      final detail =
+          await fetchChatSessionDetailEndpoint('legacy-artifact-session');
+      final message =
+          (detail['messages'] as List<dynamic>).single as Map<String, dynamic>;
+      final artifactMap = Map<String, dynamic>.from(
+        (message['artifacts'] as List).single as Map,
+      );
+      final artifact = ChatArtifact.fromJson(artifactMap)!;
+
+      expect(artifact.kind, ChatArtifact.kindKnowledgeFile);
+      expect(artifact.workspacePath, 'PKM/Projects/memex.md');
+      expect(artifact.sourceRunId, 'turn-detail');
+
+      final storage = ChatSessionStorage.instance;
+      final persisted = await storage.loadSessionData(
+        userId,
+        'legacy-artifact-session',
+      );
+      expect(
+        persisted[ChatArtifactSessionMigration.schemaVersionKey],
+        ChatArtifact.schemaVersion,
+      );
+      final persistedArtifact =
+          (((persisted['messages'] as List).single as Map)['artifacts'] as List)
+              .single as Map;
+      expect(persistedArtifact.containsKey('type'), isFalse);
+      expect(
+        await File(storage.legacyYamlPath(
+          userId,
+          'legacy-artifact-session',
+        )).exists(),
+        isFalse,
+      );
+      expect(
+        await File(storage.messagesPath(
+          userId,
+          'legacy-artifact-session',
+        )).exists(),
+        isTrue,
+      );
+    });
+
     test('paginates session detail messages from newest backwards', () async {
       await _writeSession(
         userId: userId,
@@ -144,26 +220,27 @@ void main() {
       );
       final latestMessages = latest['messages'] as List<dynamic>;
 
-      expect(latest['message_count'], 5);
       expect(latest['has_more_messages'], isTrue);
+      expect(latest['older_cursor'], isNotNull);
       expect(_messageText(latestMessages[0]), 'message 4');
       expect(_messageText(latestMessages[1]), 'message 5');
 
       final older = await fetchChatSessionDetailEndpoint(
         'paged-session',
         messageLimit: 2,
-        messageOffset: 2,
+        messageBeforeCursor: latest['older_cursor'] as String?,
       );
       final olderMessages = older['messages'] as List<dynamic>;
 
       expect(older['has_more_messages'], isTrue);
+      expect(older['older_cursor'], isNotNull);
       expect(_messageText(olderMessages[0]), 'message 2');
       expect(_messageText(olderMessages[1]), 'message 3');
 
       final oldest = await fetchChatSessionDetailEndpoint(
         'paged-session',
         messageLimit: 2,
-        messageOffset: 4,
+        messageBeforeCursor: older['older_cursor'] as String?,
       );
       final oldestMessages = oldest['messages'] as List<dynamic>;
 

--- a/test/data/services/chat_run_registry_test.dart
+++ b/test/data/services/chat_run_registry_test.dart
@@ -8,15 +8,15 @@ void main() {
       final registry = ChatRunRegistry();
       final run = registry.start('s1');
 
-      run.add(ChatResponseChunkEvent('a'));
-      run.add(ChatResponseChunkEvent('b'));
+      run.add(ChatResponseChunkEvent('t1', 'a'));
+      run.add(ChatResponseChunkEvent('t1', 'b'));
 
       final received = <String>[];
       final sub = run.attach().listen((event) {
         received.add((event as ChatResponseChunkEvent).text);
       });
 
-      run.add(ChatResponseChunkEvent('c'));
+      run.add(ChatResponseChunkEvent('t1', 'c'));
       run.close();
       await sub.asFuture<void>();
 
@@ -26,7 +26,7 @@ void main() {
     test('attach after close replays buffer and completes', () async {
       final registry = ChatRunRegistry();
       final run = registry.start('s2');
-      run.add(ChatResponseChunkEvent('x'));
+      run.add(ChatResponseChunkEvent('t2', 'x'));
       run.close();
 
       final events = await run.attach().toList();
@@ -43,7 +43,7 @@ void main() {
       expect(registry.isActive('s3'), isFalse);
       // Closing twice is safe and add() after close is ignored.
       run.close();
-      run.add(ChatResponseChunkEvent('ignored'));
+      run.add(ChatResponseChunkEvent('t3', 'ignored'));
     });
 
     test('getOrStart reuses active run and creates missing run', () {
@@ -63,11 +63,11 @@ void main() {
     test('multiple attachments receive the same events', () async {
       final registry = ChatRunRegistry();
       final run = registry.start('s4');
-      run.add(ChatResponseChunkEvent('1'));
+      run.add(ChatResponseChunkEvent('t4', '1'));
 
       final first = run.attach().toList();
       final second = run.attach().toList();
-      run.add(ChatResponseChunkEvent('2'));
+      run.add(ChatResponseChunkEvent('t4', '2'));
       run.close();
 
       expect((await first).length, 2);
@@ -83,12 +83,12 @@ void main() {
       final liveSub = run.attach().listen(liveReceived.add);
       await pumpEventQueue();
 
-      final liveOnlyEvent = ChatArtifactsEvent(const []);
+      final liveOnlyEvent = ChatArtifactsEvent('t6', const []);
       run.add(liveOnlyEvent, replay: false);
       await pumpEventQueue();
       await liveSub.cancel();
 
-      run.add(ChatResponseChunkEvent('later'));
+      run.add(ChatResponseChunkEvent('t6', 'later'));
       run.close();
 
       final replayed = await run.attach().toList();

--- a/test/data/services/chat_run_registry_test.dart
+++ b/test/data/services/chat_run_registry_test.dart
@@ -73,5 +73,28 @@ void main() {
       expect((await first).length, 2);
       expect((await second).length, 2);
     });
+
+    test('non-replay events are live-only for persisted history events',
+        () async {
+      final registry = ChatRunRegistry();
+      final run = registry.start('s6');
+
+      final liveReceived = <ChatEvent>[];
+      final liveSub = run.attach().listen(liveReceived.add);
+      await pumpEventQueue();
+
+      final liveOnlyEvent = ChatArtifactsEvent(const []);
+      run.add(liveOnlyEvent, replay: false);
+      await pumpEventQueue();
+      await liveSub.cancel();
+
+      run.add(ChatResponseChunkEvent('later'));
+      run.close();
+
+      final replayed = await run.attach().toList();
+      expect(liveReceived, [liveOnlyEvent]);
+      expect(replayed, hasLength(1));
+      expect(replayed.single, isA<ChatResponseChunkEvent>());
+    });
   });
 }

--- a/test/data/services/chat_service_test.dart
+++ b/test/data/services/chat_service_test.dart
@@ -5,15 +5,16 @@ import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/agent/state_util.dart';
+import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/services/agent_foreground_task_tracker.dart';
 import 'package:memex/data/services/chat_service.dart';
+import 'package:memex/data/services/chat_session_storage.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_asset_server.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:yaml/yaml.dart';
 
 void main() {
   group('isActiveChatTurnTaskForSession', () {
@@ -147,6 +148,20 @@ void main() {
       expect(sessionData['active_agent_state_session_id'], newStateId);
       expect(sessionData.containsKey('total_usage'), isFalse);
       expect(sessionData['messages'], hasLength(1));
+      expect(
+        await File(ChatSessionStorage.instance.legacyYamlPath(
+          userId,
+          sessionId,
+        )).exists(),
+        isFalse,
+      );
+      expect(
+        await File(ChatSessionStorage.instance.messagesPath(
+          userId,
+          sessionId,
+        )).exists(),
+        isTrue,
+      );
       expect(await File(p.join(stateDir, '$sessionId.json')).exists(), isTrue);
       expect(await File(p.join(stateDir, '$newStateId.json')).exists(), isTrue);
 
@@ -181,6 +196,51 @@ void main() {
 
       final sessionData = await _readSession(userId, sessionId);
       expect(sessionData.containsKey('active_agent_state_session_id'), isFalse);
+    });
+
+    test('migrates legacy artifacts when loading a session', () async {
+      await _writeSession(
+        userId: userId,
+        sessionId: sessionId,
+        data: _sessionData(messages: [
+          {
+            'role': 'ai',
+            'turn_id': 'turn-legacy',
+            'timestamp': '2026-06-22T12:01:00.000Z',
+            'content': [
+              {'type': 'text', 'text': 'done'},
+            ],
+            'artifacts': [
+              {
+                'type': 'card',
+                'id': '2026/06/22.md#ts_1',
+                'title': 'Legacy card',
+                'snippet': 'legacy summary',
+                'updated': true,
+              },
+            ],
+          },
+        ]),
+      );
+
+      await ChatService.instance.refreshAgentStateForSession(sessionId);
+
+      final sessionData = await _readSession(userId, sessionId);
+      expect(
+        sessionData[ChatArtifactSessionMigration.schemaVersionKey],
+        ChatArtifact.schemaVersion,
+      );
+
+      final messages = sessionData['messages'] as List<dynamic>;
+      final artifacts =
+          (messages.single as Map<String, dynamic>)['artifacts'] as List;
+      final artifactMap = Map<String, dynamic>.from(artifacts.single as Map);
+
+      expect(artifactMap.containsKey('type'), isFalse);
+      final artifact = ChatArtifact.fromJson(artifactMap)!;
+      expect(artifact.kind, ChatArtifact.kindTimelineCard);
+      expect(artifact.timelineCardId, '2026/06/22.md#ts_1');
+      expect(artifact.sourceRunId, 'turn-legacy');
     });
 
     test('freezes the active agent state id into queued chat turn payload',
@@ -250,12 +310,7 @@ Future<void> _writeSession({
 
 Future<Map<String, dynamic>> _readSession(
     String userId, String sessionId) async {
-  final sessionFile = File(p.join(
-    FileSystemService.instance.getChatSessionsPath(userId),
-    '$sessionId.yaml',
-  ));
-  final doc = loadYaml(await sessionFile.readAsString());
-  return jsonDecode(jsonEncode(doc)) as Map<String, dynamic>;
+  return ChatSessionStorage.instance.loadSessionData(userId, sessionId);
 }
 
 Future<Task> _waitForQueuedChatTask(AppDatabase db, String sessionId) async {

--- a/test/data/services/chat_session_storage_test.dart
+++ b/test/data/services/chat_session_storage_test.dart
@@ -1,0 +1,221 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/model/chat_artifact.dart';
+import 'package:memex/data/services/chat_session_storage.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ChatSessionStorage', () {
+    const userId = 'chat-storage-test-user';
+    late Directory tempDir;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await UserStorage.initL10n();
+      await UserStorage.saveUser(userId);
+      tempDir = await Directory.systemTemp.createTemp(
+        'memex_chat_session_storage_test_',
+      );
+      await FileSystemService.init(tempDir.path);
+    });
+
+    tearDown(() async {
+      await LocalAssetServer.stopServer();
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('migrates legacy YAML to metadata JSON and message JSONL', () async {
+      const sessionId = 'memex_agent_legacy_storage';
+      await _writeLegacyYaml(
+        userId: userId,
+        sessionId: sessionId,
+        data: {
+          'session_id': sessionId,
+          'agent_name': 'memex_agent',
+          'title': 'Legacy Storage',
+          'created_at': '2026-06-22T12:00:00.000',
+          'updated_at': '2026-06-22T12:01:00.000',
+          'messages': [
+            {
+              'role': 'ai',
+              'turn_id': 'turn-1',
+              'timestamp': '2026-06-22T12:01:00.000',
+              'content': [
+                {'type': 'text', 'text': 'done'},
+              ],
+              'artifacts': [
+                {
+                  'type': 'card',
+                  'id': '2026/06/22.md#ts_1',
+                  'title': 'Legacy card',
+                },
+              ],
+            },
+          ],
+        },
+      );
+
+      final storage = ChatSessionStorage.instance;
+      await storage.ensureMigrated(userId);
+
+      expect(await File(storage.legacyYamlPath(userId, sessionId)).exists(),
+          isFalse);
+      expect(
+          await File(storage.metadataPath(userId, sessionId)).exists(), isTrue);
+      expect(
+          await File(storage.messagesPath(userId, sessionId)).exists(), isTrue);
+
+      final metadata = jsonDecode(
+        await File(storage.metadataPath(userId, sessionId)).readAsString(),
+      ) as Map<String, dynamic>;
+      expect(metadata.containsKey('messages'), isFalse);
+      expect(metadata.containsKey('message_count'), isFalse);
+      expect(metadata[ChatSessionStorage.storageSchemaVersionKey],
+          ChatSessionStorage.storageSchemaVersion);
+      final migrationState = await _readMigrationState(userId);
+      expect(
+        migrationState[ChatSessionStorage.storageMigrationKey],
+        isTrue,
+      );
+
+      final messages =
+          await File(storage.messagesPath(userId, sessionId)).readAsLines();
+      expect(messages, hasLength(1));
+      final message = jsonDecode(messages.single) as Map<String, dynamic>;
+      final artifact = ChatArtifact.fromJson(
+        Map<String, dynamic>.from((message['artifacts'] as List).single as Map),
+      );
+      expect(artifact?.kind, ChatArtifact.kindTimelineCard);
+    });
+
+    test('appends messages to JSONL and updates metadata only', () async {
+      const sessionId = 'memex_agent_new_storage';
+      final storage = ChatSessionStorage.instance;
+
+      await storage.createSession(
+        userId: userId,
+        sessionId: sessionId,
+        metadata: {
+          'session_id': sessionId,
+          'agent_name': 'memex_agent',
+          'title': 'New Storage',
+          'created_at': '2026-06-22T12:00:00.000',
+          'updated_at': '2026-06-22T12:00:00.000',
+        },
+      );
+
+      await storage.appendMessage(
+        userId: userId,
+        sessionId: sessionId,
+        message: {
+          'role': 'user',
+          'content': [
+            {'type': 'text', 'text': 'hello jsonl'},
+          ],
+          'timestamp': '2026-06-22T12:01:00.000',
+        },
+      );
+
+      final metadata = jsonDecode(
+        await File(storage.metadataPath(userId, sessionId)).readAsString(),
+      ) as Map<String, dynamic>;
+      final lines =
+          await File(storage.messagesPath(userId, sessionId)).readAsLines();
+
+      expect(metadata.containsKey('messages'), isFalse);
+      expect(metadata.containsKey('message_count'), isFalse);
+      expect(metadata['last_message_preview'], 'hello jsonl');
+      expect(lines, hasLength(1));
+      expect(jsonDecode(lines.single)['role'], 'user');
+    });
+
+    test('loads paged messages from newest backwards', () async {
+      const sessionId = 'memex_agent_paged_storage';
+      final storage = ChatSessionStorage.instance;
+
+      await storage.createSession(
+        userId: userId,
+        sessionId: sessionId,
+        metadata: {
+          'session_id': sessionId,
+          'agent_name': 'memex_agent',
+          'title': 'Paged Storage',
+          'created_at': '2026-06-22T12:00:00.000',
+          'updated_at': '2026-06-22T12:00:00.000',
+        },
+        messages: [
+          for (var i = 1; i <= 50; i++)
+            {
+              'role': i.isOdd ? 'user' : 'ai',
+              'content': [
+                {'type': 'text', 'text': 'message $i ${'x' * 600}'},
+              ],
+              'timestamp':
+                  '2026-06-22T12:${(i % 60).toString().padLeft(2, '0')}:00.000',
+            },
+        ],
+      );
+
+      final latest = await storage.loadMessagePage(
+        userId,
+        sessionId,
+        limit: 3,
+      );
+      final older = await storage.loadMessagePage(
+        userId,
+        sessionId,
+        limit: 3,
+        beforeCursor: latest.olderCursor,
+      );
+
+      expect(latest.hasMoreMessages, isTrue);
+      expect(latest.olderCursor, isNotNull);
+      expect(_messageText(latest.messages[0]), startsWith('message 48 '));
+      expect(_messageText(latest.messages[1]), startsWith('message 49 '));
+      expect(_messageText(latest.messages[2]), startsWith('message 50 '));
+      expect(older.hasMoreMessages, isTrue);
+      expect(_messageText(older.messages[0]), startsWith('message 45 '));
+      expect(_messageText(older.messages[1]), startsWith('message 46 '));
+      expect(_messageText(older.messages[2]), startsWith('message 47 '));
+    });
+  });
+}
+
+String _messageText(Map<String, dynamic> message) {
+  final content = message['content'] as List<dynamic>;
+  final textPart = content.single as Map<String, dynamic>;
+  return textPart['text'] as String;
+}
+
+Future<void> _writeLegacyYaml({
+  required String userId,
+  required String sessionId,
+  required Map<String, dynamic> data,
+}) async {
+  final sessionPath = p.join(
+    FileSystemService.instance.getChatSessionsPath(userId),
+    '$sessionId.yaml',
+  );
+  await FileSystemService.instance.writeYamlFile(sessionPath, data);
+}
+
+Future<Map<String, dynamic>> _readMigrationState(String userId) async {
+  final stateFile = File(p.join(
+    FileSystemService.instance.getSystemPath(userId),
+    'migration_state.json',
+  ));
+  if (!await stateFile.exists()) return const {};
+  return Map<String, dynamic>.from(
+    jsonDecode(await stateFile.readAsString()) as Map,
+  );
+}

--- a/test/data/services/chat_session_storage_test.dart
+++ b/test/data/services/chat_session_storage_test.dart
@@ -188,6 +188,93 @@ void main() {
       expect(_messageText(older.messages[1]), startsWith('message 46 '));
       expect(_messageText(older.messages[2]), startsWith('message 47 '));
     });
+
+    test('loads paged messages by complete turn groups', () async {
+      const sessionId = 'memex_agent_turn_paged_storage';
+      final storage = ChatSessionStorage.instance;
+
+      Map<String, dynamic> message(
+        String role,
+        String turnId,
+        String text, {
+        List<Map<String, dynamic>> artifacts = const [],
+      }) {
+        return {
+          'role': role,
+          'turn_id': turnId,
+          'content': [
+            if (text.isNotEmpty) {'type': 'text', 'text': text},
+          ],
+          if (artifacts.isNotEmpty) 'artifacts': artifacts,
+          'timestamp': '2026-06-22T12:00:00.000',
+        };
+      }
+
+      await storage.createSession(
+        userId: userId,
+        sessionId: sessionId,
+        metadata: {
+          'session_id': sessionId,
+          'agent_name': 'memex_agent',
+          'title': 'Turn Paged Storage',
+          'created_at': '2026-06-22T12:00:00.000',
+          'updated_at': '2026-06-22T12:00:00.000',
+        },
+        messages: [
+          message('user', 'turn-1', 'user 1'),
+          message('artifact', 'turn-1', '', artifacts: [
+            {'version': 2, 'kind': 'schedule', 'operation': 'update'},
+          ]),
+          message('ai', 'turn-1', 'ai 1'),
+          message('user', 'turn-2', 'user 2'),
+          message('artifact', 'turn-2', '', artifacts: [
+            {'version': 2, 'kind': 'schedule', 'operation': 'update'},
+          ]),
+          message('ai', 'turn-2', 'ai 2'),
+          message('user', 'turn-3', 'user 3'),
+          message('artifact', 'turn-3', '', artifacts: [
+            {'version': 2, 'kind': 'schedule', 'operation': 'update'},
+          ]),
+          message('ai', 'turn-3', 'ai 3'),
+        ],
+      );
+
+      final latest = await storage.loadMessagePage(
+        userId,
+        sessionId,
+        limit: 2,
+      );
+      final older = await storage.loadMessagePage(
+        userId,
+        sessionId,
+        limit: 2,
+        beforeCursor: latest.olderCursor,
+      );
+
+      expect(latest.messages.map((m) => m['turn_id']), [
+        'turn-2',
+        'turn-2',
+        'turn-2',
+        'turn-3',
+        'turn-3',
+        'turn-3',
+      ]);
+      expect(latest.messages.map((m) => m['role']), [
+        'user',
+        'artifact',
+        'ai',
+        'user',
+        'artifact',
+        'ai',
+      ]);
+      expect(latest.hasMoreMessages, isTrue);
+      expect(older.messages.map((m) => m['turn_id']), [
+        'turn-1',
+        'turn-1',
+        'turn-1',
+      ]);
+      expect(older.hasMoreMessages, isFalse);
+    });
   });
 }
 

--- a/test/data/services/file_system_service_image_source_test.dart
+++ b/test/data/services/file_system_service_image_source_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = Directory.systemTemp.createTempSync('memex_image_source_');
+    await FileSystemService.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    await LocalAssetServer.stopServer();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  test('converts fs asset references to local HTTP asset URLs', () async {
+    final source = await FileSystemService.convertFsToLocalHttp(
+      'fs://nested/img_20260706_ts_0_no_1_1080x1920.jpg',
+      'alice',
+    );
+
+    final uri = Uri.parse(source);
+    expect(uri.scheme, 'http');
+    expect(uri.host, '127.0.0.1');
+    expect(uri.pathSegments, [
+      'assets',
+      'alice',
+      'nested',
+      'img_20260706_ts_0_no_1_1080x1920.jpg',
+    ]);
+    expect(uri.queryParameters['token'], isNotEmpty);
+  });
+}

--- a/test/data/services/migration_state_service_test.dart
+++ b/test/data/services/migration_state_service_test.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/migration_state_service.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('MigrationStateService', () {
+    late Directory tempRoot;
+    late String userId;
+
+    setUp(() async {
+      tempRoot = await Directory.systemTemp.createTemp(
+        'memex_migration_state_test_',
+      );
+      await FileSystemService.init(tempRoot.path);
+      userId = 'migration_state_${DateTime.now().microsecondsSinceEpoch}';
+    });
+
+    tearDown(() async {
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('marks successful migrations and skips later runs', () async {
+      var callCount = 0;
+
+      final firstResult = await MigrationStateService.instance.runOnce(
+        userId: userId,
+        key: 'test_success_v1',
+        migrate: () async {
+          callCount++;
+          return true;
+        },
+      );
+      final secondResult = await MigrationStateService.instance.runOnce(
+        userId: userId,
+        key: 'test_success_v1',
+        migrate: () async {
+          callCount++;
+          return true;
+        },
+      );
+
+      expect(firstResult, isTrue);
+      expect(secondResult, isTrue);
+      expect(callCount, 1);
+      expect(
+        await MigrationStateService.instance.isCompleted(
+          userId,
+          'test_success_v1',
+        ),
+        isTrue,
+      );
+
+      final state = await _readState(userId);
+      expect(state['test_success_v1'], isTrue);
+      expect(state['updated_at'], isA<String>());
+    });
+
+    test('does not mark incomplete migrations', () async {
+      var callCount = 0;
+
+      final incompleteResult = await MigrationStateService.instance.runOnce(
+        userId: userId,
+        key: 'test_retry_v1',
+        migrate: () async {
+          callCount++;
+          return false;
+        },
+      );
+      final retryResult = await MigrationStateService.instance.runOnce(
+        userId: userId,
+        key: 'test_retry_v1',
+        migrate: () async {
+          callCount++;
+          return true;
+        },
+      );
+
+      expect(incompleteResult, isFalse);
+      expect(retryResult, isTrue);
+      expect(callCount, 2);
+      expect(
+        await MigrationStateService.instance.isCompleted(
+          userId,
+          'test_retry_v1',
+        ),
+        isTrue,
+      );
+    });
+  });
+}
+
+Future<Map<String, dynamic>> _readState(String userId) async {
+  final stateFile = File(p.join(
+    FileSystemService.instance.getSystemPath(userId),
+    MigrationStateService.stateFileName,
+  ));
+  if (!await stateFile.exists()) return const {};
+  return Map<String, dynamic>.from(
+    jsonDecode(await stateFile.readAsString()) as Map,
+  );
+}

--- a/test/ui/chat/widgets/agent_chat_dialog_test.dart
+++ b/test/ui/chat/widgets/agent_chat_dialog_test.dart
@@ -182,6 +182,63 @@ void main() {
       expect(text, isNot(contains('0.12345')));
     });
 
+    test('shows standalone thinking only before process or reply appears', () {
+      expect(
+        shouldShowSuperAgentThinkingRow(
+          isLoadingAgent: false,
+          primaryItem: UserMessageItem('hello'),
+        ),
+        isFalse,
+      );
+      expect(
+        shouldShowSuperAgentThinkingRow(
+          isLoadingAgent: true,
+          primaryItem: UserMessageItem('hello'),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldShowSuperAgentThinkingRow(
+          isLoadingAgent: true,
+          primaryItem: ProcessItem(),
+        ),
+        isFalse,
+      );
+      expect(
+        shouldShowSuperAgentThinkingRow(
+          isLoadingAgent: true,
+          primaryItem: AIMessageItem('reply', isStreaming: true),
+        ),
+        isFalse,
+      );
+    });
+
+    test('uses final process state instead of historical tool errors', () {
+      final failedTool = ToolCallItem(
+        'read-1',
+        'read',
+        '{}',
+        result: 'temporary failure',
+        isError: true,
+      );
+      final completedProcess = ProcessItem(isFinished: true)
+        ..children.add(failedTool);
+      final attentionProcess = ProcessItem(
+        isFinished: true,
+        needsAttention: true,
+      )..children.add(failedTool);
+
+      expect(
+        superAgentProcessVisualState(completedProcess),
+        SuperAgentProcessVisualState.done,
+      );
+      expect(
+        superAgentProcessVisualState(attentionProcess),
+        SuperAgentProcessVisualState.needsAttention,
+      );
+      expect(completedProcess.hasToolError, isTrue);
+    });
+
     test('shows the photo suggestion status until suggestions resolve', () {
       expect(
         shouldShowSuperAgentPhotoSuggestionStatus(
@@ -328,33 +385,14 @@ void main() {
       );
     });
 
-    test('places artifacts before the current final assistant reply', () {
-      final currentUser = UserMessageItem('capture this');
-      final currentReply = AIMessageItem('Done');
-      final existingArtifact = ArtifactItem(
-        ChatArtifact.schedule(title: 'Schedule', updated: true),
+    test('keeps artifacts attached to the assistant reply item', () {
+      final artifact = ArtifactItem(
+        ChatArtifact.schedule(title: 'Schedule presentation', updated: true),
       );
+      final reply = AIMessageItem('Done', artifacts: [artifact]);
 
-      expect(
-        superAgentArtifactInsertionIndexBeforeReply([
-          AIMessageItem('Older reply'),
-          currentUser,
-          currentReply,
-        ]),
-        2,
-      );
-      expect(
-        superAgentArtifactInsertionIndexBeforeReply([
-          currentUser,
-          existingArtifact,
-          currentReply,
-        ]),
-        2,
-      );
-      expect(
-        superAgentArtifactInsertionIndexBeforeReply([currentUser]),
-        1,
-      );
+      expect(reply.artifacts, [artifact]);
+      expect(reply.artifacts.single.artifact.title, 'Schedule presentation');
     });
 
     test('toggles demo overlay suspension for routed detail pages', () {
@@ -506,6 +544,75 @@ void main() {
       expect(find.byType(LocalImage), findsOneWidget);
     });
 
+    testWidgets('keeps process thinking and token usage inside details', (
+      tester,
+    ) async {
+      final usage = ChatTokenUsageEvent(
+        promptTokens: 100,
+        completionTokens: 25,
+        cachedTokens: 40,
+        totalTokens: 125,
+        estimatedCost: 0.0,
+        effectivePromptTokens: 100,
+        cachedTokensForRate: 40,
+      );
+      final process = ProcessItem()
+        ..children.add(ThinkingItem('Inspecting the plan'));
+
+      await _pumpDialogFrame(
+        tester,
+        dialog: AgentChatDialog(
+          initialItems: [process],
+          initialIsLoadingAgent: true,
+          initialTokenUsage: usage,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 600));
+
+      final tokenText = formatSuperAgentTokenUsage(usage);
+      expect(find.text(UserStorage.l10n.agentChat.thinking), findsNothing);
+      expect(find.text('Inspecting the plan'), findsNothing);
+      expect(find.text(tokenText), findsNothing);
+
+      await tester.tap(find.byKey(const ValueKey('agent_chat_process_toggle')));
+      await tester.pump();
+
+      expect(find.text(UserStorage.l10n.agentChat.thinking), findsOneWidget);
+      expect(find.text('Inspecting the plan'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('agent_chat_token_usage_debug')),
+        findsOneWidget,
+      );
+      expect(find.text(tokenText), findsOneWidget);
+    });
+
+    testWidgets('shows completed process despite intermediate tool errors', (
+      tester,
+    ) async {
+      final failedTool = ToolCallItem(
+        'read-1',
+        'read',
+        '{}',
+        result: 'temporary failure',
+        isError: true,
+      );
+      final process = ProcessItem(isFinished: true)..children.add(failedTool);
+
+      await _pumpDialogFrame(
+        tester,
+        dialog: AgentChatDialog(initialItems: [process]),
+      );
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(
+        find.text(UserStorage.l10n.agentChat.completedActions(1)),
+        findsOneWidget,
+      );
+      expect(find.text(UserStorage.l10n.agentChat.actionNeedsAttention),
+          findsNothing);
+      expect(find.text(UserStorage.l10n.agentChat.issue), findsNothing);
+    });
+
     test('resolves persisted user image paths as local files', () async {
       final tempDir = Directory.systemTemp.createTempSync(
         'memex_user_message_image_',
@@ -580,18 +687,26 @@ void main() {
         tester,
         dialog: AgentChatDialog(
           initialItems: [
-            ArtifactItem(
-              ChatArtifact.schedule(
-                title: 'Schedule presentation',
-                summary: 'Pending schedule items: 3',
-                updated: true,
-              ),
+            AIMessageItem(
+              'I updated your schedule.',
+              artifacts: [
+                ArtifactItem(
+                  ChatArtifact.schedule(
+                    title: 'Schedule presentation',
+                    summary: 'Pending schedule items: 3',
+                    updated: true,
+                  ),
+                ),
+              ],
             ),
           ],
           onOpenScheduleTab: () => openedSchedule = true,
         ),
       );
 
+      expect(find.text('I updated your schedule.'), findsOneWidget);
+      expect(find.text('${UserStorage.l10n.agentChat.result} · 1'),
+          findsOneWidget);
       expect(find.text(UserStorage.l10n.schedule), findsOneWidget);
       expect(find.text('Schedule presentation'), findsOneWidget);
       expect(find.text('Pending schedule items: 3'), findsOneWidget);
@@ -610,18 +725,26 @@ void main() {
         tester,
         dialog: AgentChatDialog(
           initialItems: [
-            ArtifactItem(
-              ChatArtifact.knowledgeFile(
-                path: 'PKM/Projects/memex.md',
-                title: 'memex.md',
-                summary: '# Memex',
-                updated: true,
-              ),
+            AIMessageItem(
+              'I updated the knowledge file.',
+              artifacts: [
+                ArtifactItem(
+                  ChatArtifact.knowledgeFile(
+                    path: 'PKM/Projects/memex.md',
+                    title: 'memex.md',
+                    summary: '# Memex',
+                    updated: true,
+                  ),
+                ),
+              ],
             ),
           ],
         ),
       );
 
+      expect(find.text('I updated the knowledge file.'), findsOneWidget);
+      expect(find.text('${UserStorage.l10n.agentChat.result} · 1'),
+          findsOneWidget);
       expect(
         find.text(UserStorage.l10n.agentChat.documentUpdated),
         findsOneWidget,

--- a/test/ui/chat/widgets/agent_chat_dialog_test.dart
+++ b/test/ui/chat/widgets/agent_chat_dialog_test.dart
@@ -1,14 +1,21 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/model/chat_events.dart';
 import 'package:memex/data/services/demo_service.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
 import 'package:memex/l10n/app_localizations.dart';
 import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/core/widgets/local_image.dart';
+import 'package:memex/ui/knowledge/widgets/knowledge_file_page.dart';
 import 'package:memex/utils/user_storage.dart';
+import 'package:path/path.dart' as p;
 import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -321,6 +328,35 @@ void main() {
       );
     });
 
+    test('places artifacts before the current final assistant reply', () {
+      final currentUser = UserMessageItem('capture this');
+      final currentReply = AIMessageItem('Done');
+      final existingArtifact = ArtifactItem(
+        ChatArtifact.schedule(title: 'Schedule', updated: true),
+      );
+
+      expect(
+        superAgentArtifactInsertionIndexBeforeReply([
+          AIMessageItem('Older reply'),
+          currentUser,
+          currentReply,
+        ]),
+        2,
+      );
+      expect(
+        superAgentArtifactInsertionIndexBeforeReply([
+          currentUser,
+          existingArtifact,
+          currentReply,
+        ]),
+        2,
+      );
+      expect(
+        superAgentArtifactInsertionIndexBeforeReply([currentUser]),
+        1,
+      );
+    });
+
     test('toggles demo overlay suspension for routed detail pages', () {
       final demo = DemoService.instance;
 
@@ -470,6 +506,32 @@ void main() {
       expect(find.byType(LocalImage), findsOneWidget);
     });
 
+    test('resolves persisted user image paths as local files', () async {
+      final tempDir = Directory.systemTemp.createTempSync(
+        'memex_user_message_image_',
+      );
+      try {
+        await FileSystemService.init(tempDir.path);
+        const relativePath = 'workspace/_alice/Facts/assets/photo.jpg';
+
+        expect(
+          superAgentUserMessageImageSourceForLocalDisplay(relativePath),
+          p.join(tempDir.path, relativePath),
+        );
+        expect(
+          superAgentUserMessageImageSourceForLocalDisplay(
+            'https://example.com/photo.jpg',
+          ),
+          'https://example.com/photo.jpg',
+        );
+      } finally {
+        await LocalAssetServer.stopServer();
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      }
+    });
+
     testWidgets(
       'keeps header actions inside the compact header on narrow screens',
       (tester) async {
@@ -507,6 +569,75 @@ void main() {
         findsOneWidget,
       );
       expect(find.text(UserStorage.l10n.sendLabel), findsOneWidget);
+    });
+
+    testWidgets('renders a completed artifact card and opens schedule tab', (
+      tester,
+    ) async {
+      var openedSchedule = false;
+
+      await _pumpDialog(
+        tester,
+        dialog: AgentChatDialog(
+          initialItems: [
+            ArtifactItem(
+              ChatArtifact.schedule(
+                title: 'Schedule presentation',
+                summary: 'Pending schedule items: 3',
+                updated: true,
+              ),
+            ),
+          ],
+          onOpenScheduleTab: () => openedSchedule = true,
+        ),
+      );
+
+      expect(find.text(UserStorage.l10n.schedule), findsOneWidget);
+      expect(find.text('Schedule presentation'), findsOneWidget);
+      expect(find.text('Pending schedule items: 3'), findsOneWidget);
+      expect(find.text(UserStorage.l10n.scheduleBriefingOpen), findsOneWidget);
+
+      await tester.tap(find.text(UserStorage.l10n.scheduleBriefingOpen));
+      await tester.pump();
+
+      expect(openedSchedule, isTrue);
+    });
+
+    testWidgets('opens knowledge file artifacts with normalized PKM path', (
+      tester,
+    ) async {
+      await _pumpDialog(
+        tester,
+        dialog: AgentChatDialog(
+          initialItems: [
+            ArtifactItem(
+              ChatArtifact.knowledgeFile(
+                path: 'PKM/Projects/memex.md',
+                title: 'memex.md',
+                summary: '# Memex',
+                updated: true,
+              ),
+            ),
+          ],
+        ),
+      );
+
+      expect(
+        find.text(UserStorage.l10n.agentChat.documentUpdated),
+        findsOneWidget,
+      );
+      expect(find.text('memex.md'), findsOneWidget);
+      expect(find.text('PKM/Projects/memex.md'), findsOneWidget);
+      expect(find.text(UserStorage.l10n.scheduleBriefingOpen), findsOneWidget);
+
+      await tester.tap(find.text(UserStorage.l10n.scheduleBriefingOpen));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final page = tester.widget<KnowledgeFilePage>(
+        find.byType(KnowledgeFilePage),
+      );
+      expect(page.filePath, 'Projects/memex.md');
     });
 
     testWidgets('keeps super agent header actions tight to the right edge', (
@@ -555,8 +686,13 @@ void main() {
 Future<void> _pumpDialog(
   WidgetTester tester, {
   Size viewportSize = const Size(390, 800),
+  Widget dialog = const AgentChatDialog(),
 }) async {
-  await _pumpDialogFrame(tester, viewportSize: viewportSize);
+  await _pumpDialogFrame(
+    tester,
+    viewportSize: viewportSize,
+    dialog: dialog,
+  );
   await tester.pumpAndSettle();
 }
 

--- a/test/ui/chat/widgets/agent_chat_dialog_test.dart
+++ b/test/ui/chat/widgets/agent_chat_dialog_test.dart
@@ -389,10 +389,35 @@ void main() {
       final artifact = ArtifactItem(
         ChatArtifact.schedule(title: 'Schedule presentation', updated: true),
       );
-      final reply = AIMessageItem('Done', artifacts: [artifact]);
+      final reply =
+          AIMessageItem('Done', turnId: 'turn-1', artifacts: [artifact]);
 
       expect(reply.artifacts, [artifact]);
       expect(reply.artifacts.single.artifact.title, 'Schedule presentation');
+    });
+
+    test('attaches pending artifacts only to the same assistant turn', () {
+      expect(
+        shouldAttachArtifactsToAssistantReply(
+          turnId: 'turn-1',
+          primaryItem: AIMessageItem('Done', turnId: 'turn-1'),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldAttachArtifactsToAssistantReply(
+          turnId: 'turn-2',
+          primaryItem: AIMessageItem('Done', turnId: 'turn-1'),
+        ),
+        isFalse,
+      );
+      expect(
+        shouldAttachArtifactsToAssistantReply(
+          turnId: 'turn-1',
+          primaryItem: UserMessageItem('next request'),
+        ),
+        isFalse,
+      );
     });
 
     test('toggles demo overlay suspension for routed detail pages', () {


### PR DESCRIPTION
## Summary
- Add ChatArtifact schema v2 with stable target/storage URIs, migration from legacy artifact metadata, and artifact cards that link to timeline cards, knowledge files, insights, and schedule.
- Move chat session storage from YAML to metadata.json + messages.jsonl with one-time migration, cursor pagination, append-only message writes, and centralized migration state.
- Persist and render UI artifacts as soon as producing tools succeed, while keeping final assistant text as a separate message.
- Scope timeline-card artifact image rendering to the timeline-card artifact style and restore persisted user image paths through the existing local image path flow.

## Validation
- flutter test test/data/services/chat_service_test.dart test/data/services/chat_session_storage_test.dart test/data/model/chat_artifact_test.dart test/ui/chat/widgets/agent_chat_dialog_test.dart
- flutter test test/data/services/file_system_service_image_source_test.dart test/ui/core/widgets/local_image_safety_test.dart test/ui/chat/widgets/agent_chat_dialog_test.dart
- dart analyze lib/data/model/chat_artifact.dart lib/data/services/chat_service.dart lib/ui/chat/widgets/agent_chat_dialog.dart test/data/model/chat_artifact_test.dart test/ui/chat/widgets/agent_chat_dialog_test.dart
- git diff --check