### PR TITLE
Use shared image preview cache for local assets

### DIFF
--- a/lib/data/services/image_preview_cache_service.dart
+++ b/lib/data/services/image_preview_cache_service.dart
@@ -1,0 +1,272 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:memex/data/services/asset_safety_service.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:synchronized/synchronized.dart';
+
+typedef TempDirectoryProvider = Future<Directory> Function();
+
+typedef ImageFileCompressor = Future<String?> Function({
+  required String sourcePath,
+  required String targetPath,
+  required int maxWidth,
+  required int maxHeight,
+  required int quality,
+});
+
+class ImagePreviewUnavailable implements Exception {
+  final String reason;
+
+  const ImagePreviewUnavailable(this.reason);
+
+  @override
+  String toString() => reason;
+}
+
+class ImagePreviewFile {
+  final File file;
+  final String contentType;
+  final bool cacheHit;
+
+  const ImagePreviewFile({
+    required this.file,
+    required this.contentType,
+    required this.cacheHit,
+  });
+}
+
+class ImagePreviewCacheService {
+  ImagePreviewCacheService({
+    TempDirectoryProvider? tempDirectoryProvider,
+    ImageFileCompressor? compressor,
+  })  : _tempDirectoryProvider = tempDirectoryProvider ?? getTemporaryDirectory,
+        _compressor = compressor ?? _defaultCompressor;
+
+  static final ImagePreviewCacheService instance = ImagePreviewCacheService();
+
+  static const int maxPreviewSide = 768;
+  static const int previewQuality = 80;
+  static const String cacheDirectoryName = 'image_cache';
+  static const String cacheFileSuffix = '_max768.jpg';
+  static const AssetSafetyConfig previewSourceSafetyConfig = AssetSafetyConfig(
+    maxPixelsForDecode: 48000000,
+  );
+
+  final TempDirectoryProvider _tempDirectoryProvider;
+  final ImageFileCompressor _compressor;
+  final Lock _previewLock = Lock();
+  final Logger _logger = getLogger('ImagePreviewCacheService');
+
+  static Future<String?> _defaultCompressor({
+    required String sourcePath,
+    required String targetPath,
+    required int maxWidth,
+    required int maxHeight,
+    required int quality,
+  }) async {
+    final result = await FlutterImageCompress.compressAndGetFile(
+      sourcePath,
+      targetPath,
+      minWidth: maxWidth,
+      minHeight: maxHeight,
+      quality: quality,
+    );
+    return result?.path;
+  }
+
+  static bool isPreviewableImagePath(String filePath) {
+    final extension = path.extension(filePath).toLowerCase();
+    return AssetSafetyService.imageExtensions.contains(extension);
+  }
+
+  Future<File> cacheFileForSource(String source) async {
+    final cacheDir = await _cacheDirectory();
+    final filenameHash = md5.convert(utf8.encode(source)).toString();
+    return File(path.join(cacheDir.path, '$filenameHash$cacheFileSuffix'));
+  }
+
+  Future<ImagePreviewFile> getOrCreatePreview({
+    required String source,
+    required bool isLocalFile,
+  }) async {
+    if (source.isEmpty) {
+      throw const ImagePreviewUnavailable('image source is empty');
+    }
+
+    if (isLocalFile) {
+      final sourceFile = File(source);
+      if (!await sourceFile.exists()) {
+        throw ImagePreviewUnavailable('source image is missing: $source');
+      }
+
+      final safety = AssetSafetyService.instance.inspectFileSync(
+        source,
+        config: previewSourceSafetyConfig,
+      );
+      if (!safety.safeForPreview) {
+        throw ImagePreviewUnavailable(safety.reason);
+      }
+    }
+
+    final cacheFile = await cacheFileForSource(source);
+    if (await cacheFile.exists()) {
+      return ImagePreviewFile(
+        file: cacheFile,
+        contentType: await detectImageContentType(cacheFile.path),
+        cacheHit: true,
+      );
+    }
+
+    return _previewLock.synchronized(() async {
+      if (await cacheFile.exists()) {
+        return ImagePreviewFile(
+          file: cacheFile,
+          contentType: await detectImageContentType(cacheFile.path),
+          cacheHit: true,
+        );
+      }
+
+      return _createPreviewFile(
+        source: source,
+        isLocalFile: isLocalFile,
+        cacheFile: cacheFile,
+      );
+    });
+  }
+
+  Future<ImagePreviewFile> _createPreviewFile({
+    required String source,
+    required bool isLocalFile,
+    required File cacheFile,
+  }) async {
+    String sourcePath = source;
+    File? tempDownloadFile;
+
+    try {
+      if (!isLocalFile) {
+        _logger.info('Downloading network image preview source: $source');
+        final response = await http.get(Uri.parse(source));
+        if (response.statusCode != 200) {
+          throw ImagePreviewUnavailable(
+            'failed to download image: ${response.statusCode}',
+          );
+        }
+
+        final cacheDir = await _cacheDirectory();
+        tempDownloadFile = File(
+          path.join(
+            cacheDir.path,
+            'temp_${DateTime.now().microsecondsSinceEpoch}',
+          ),
+        );
+        await tempDownloadFile.writeAsBytes(response.bodyBytes);
+        sourcePath = tempDownloadFile.path;
+      }
+
+      final sourceSafety = AssetSafetyService.instance.inspectFileSync(
+        sourcePath,
+        config: previewSourceSafetyConfig,
+      );
+      if (!sourceSafety.safeForPreview) {
+        throw ImagePreviewUnavailable(sourceSafety.reason);
+      }
+
+      final shouldCopyOriginal = sourceSafety.width != null &&
+          sourceSafety.height != null &&
+          sourceSafety.width! <= maxPreviewSide &&
+          sourceSafety.height! <= maxPreviewSide;
+
+      String? resultPath;
+      if (shouldCopyOriginal) {
+        final copiedFile = await File(sourcePath).copy(cacheFile.path);
+        resultPath = copiedFile.path;
+      } else {
+        resultPath = await _compressor(
+          sourcePath: sourcePath,
+          targetPath: cacheFile.path,
+          maxWidth: maxPreviewSide,
+          maxHeight: maxPreviewSide,
+          quality: previewQuality,
+        );
+      }
+
+      if (resultPath == null) {
+        throw const ImagePreviewUnavailable('safe preview generation failed');
+      }
+
+      final resultSafety = AssetSafetyService.instance.inspectFileSync(
+        resultPath,
+      );
+      if (!resultSafety.safeForPreview) {
+        throw ImagePreviewUnavailable(resultSafety.reason);
+      }
+
+      final resultFile = File(resultPath);
+      return ImagePreviewFile(
+        file: resultFile,
+        contentType: await detectImageContentType(resultFile.path),
+        cacheHit: false,
+      );
+    } finally {
+      if (tempDownloadFile != null && await tempDownloadFile.exists()) {
+        await tempDownloadFile.delete();
+      }
+    }
+  }
+
+  Future<Directory> _cacheDirectory() async {
+    final tempDir = await _tempDirectoryProvider();
+    final cacheDir = Directory(path.join(tempDir.path, cacheDirectoryName));
+    if (!await cacheDir.exists()) {
+      await cacheDir.create(recursive: true);
+    }
+    return cacheDir;
+  }
+
+  static Future<String> detectImageContentType(String filePath) async {
+    final file = File(filePath);
+    final stream = file.openRead(0, 16);
+    final chunks = await stream.toList();
+    final bytes = chunks.expand((chunk) => chunk).toList(growable: false);
+
+    if (bytes.length >= 3 &&
+        bytes[0] == 0xff &&
+        bytes[1] == 0xd8 &&
+        bytes[2] == 0xff) {
+      return 'image/jpeg';
+    }
+    if (bytes.length >= 8 &&
+        bytes[0] == 0x89 &&
+        bytes[1] == 0x50 &&
+        bytes[2] == 0x4e &&
+        bytes[3] == 0x47 &&
+        bytes[4] == 0x0d &&
+        bytes[5] == 0x0a &&
+        bytes[6] == 0x1a &&
+        bytes[7] == 0x0a) {
+      return 'image/png';
+    }
+    if (bytes.length >= 6) {
+      final signature = String.fromCharCodes(bytes.take(6));
+      if (signature == 'GIF87a' || signature == 'GIF89a') {
+        return 'image/gif';
+      }
+    }
+    if (bytes.length >= 12) {
+      final riff = String.fromCharCodes(bytes.sublist(0, 4));
+      final webp = String.fromCharCodes(bytes.sublist(8, 12));
+      if (riff == 'RIFF' && webp == 'WEBP') {
+        return 'image/webp';
+      }
+    }
+
+    return 'image/jpeg';
+  }
+}

--- a/lib/data/services/local_asset_server.dart
+++ b/lib/data/services/local_asset_server.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:math';
 import 'package:path/path.dart' as path;
 import 'package:logging/logging.dart';
+import 'package:memex/data/services/image_preview_cache_service.dart';
 import 'package:memex/utils/logger.dart';
 
 /// Local asset server: HTTP server for local file access in client mode.
@@ -230,39 +231,70 @@ class LocalAssetServer {
 
           // Read file (stream to reduce memory)
           try {
-            final fileLength = await file.length();
             final extension = path.extension(filename).toLowerCase();
 
-            // Set Content-Type by extension
+            File responseFile = file;
+            String? previewContentType;
+            if (ImagePreviewCacheService.isPreviewableImagePath(filePath)) {
+              try {
+                final preview =
+                    await ImagePreviewCacheService.instance.getOrCreatePreview(
+                  source: filePath,
+                  isLocalFile: true,
+                );
+                responseFile = preview.file;
+                previewContentType = preview.contentType;
+                _logger.fine(
+                  'Serving image preview for $filePath from ${responseFile.path}',
+                );
+              } on ImagePreviewUnavailable catch (e) {
+                _logger.warning(
+                  'Image preview unavailable for $filePath: ${e.reason}',
+                );
+                request.response
+                  ..statusCode = HttpStatus.unprocessableEntity
+                  ..write('Image preview unavailable: ${e.reason}')
+                  ..close();
+                return;
+              }
+            }
+
+            final fileLength = await responseFile.length();
+
+            // Set Content-Type by extension, or by preview file signature.
             String contentType;
-            switch (extension) {
-              case '.jpg':
-              case '.jpeg':
-                contentType = 'image/jpeg';
-                break;
-              case '.png':
-                contentType = 'image/png';
-                break;
-              case '.gif':
-                contentType = 'image/gif';
-                break;
-              case '.webp':
-                contentType = 'image/webp';
-                break;
-              case '.mp3':
-                contentType = 'audio/mpeg';
-                break;
-              case '.m4a':
-                contentType = 'audio/mp4';
-                break;
-              case '.wav':
-                contentType = 'audio/wav';
-                break;
-              case '.ogg':
-                contentType = 'audio/ogg';
-                break;
-              default:
-                contentType = 'application/octet-stream';
+            if (previewContentType != null) {
+              contentType = previewContentType;
+            } else {
+              switch (extension) {
+                case '.jpg':
+                case '.jpeg':
+                  contentType = 'image/jpeg';
+                  break;
+                case '.png':
+                  contentType = 'image/png';
+                  break;
+                case '.gif':
+                  contentType = 'image/gif';
+                  break;
+                case '.webp':
+                  contentType = 'image/webp';
+                  break;
+                case '.mp3':
+                  contentType = 'audio/mpeg';
+                  break;
+                case '.m4a':
+                  contentType = 'audio/mp4';
+                  break;
+                case '.wav':
+                  contentType = 'audio/wav';
+                  break;
+                case '.ogg':
+                  contentType = 'audio/ogg';
+                  break;
+                default:
+                  contentType = 'application/octet-stream';
+              }
             }
 
             // Stream file content to response
@@ -273,9 +305,11 @@ class LocalAssetServer {
               ..headers.set('Cache-Control', 'public, max-age=31536000');
 
             // Stream file to avoid loading into memory
-            await file.openRead().pipe(request.response);
+            await responseFile.openRead().pipe(request.response);
 
-            _logger.fine('Served file: $filePath (${fileLength} bytes)');
+            _logger.fine(
+              'Served file: ${responseFile.path} ($fileLength bytes)',
+            );
             return;
           } catch (e) {
             _logger.warning('Failed to read file: $filePath, error: $e');

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -594,7 +594,10 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         _loadedHistoryMessageCount += messagesData.length;
         _hasMoreHistory =
             sessionData['has_more_messages'] == true && messagesData.isNotEmpty;
-        _isLoadingMoreHistory = false;
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || sessionId != _currentSessionId) return;
+        setState(() => _isLoadingMoreHistory = false);
       });
     } catch (e, st) {
       _logger.warning('Failed to load older chat history: $e', e, st);

--- a/lib/ui/core/widgets/local_image.dart
+++ b/lib/ui/core/widgets/local_image.dart
@@ -1,16 +1,12 @@
 import 'dart:io';
-import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
-import 'package:flutter_image_compress/flutter_image_compress.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:http/http.dart' as http;
 import 'package:shimmer/shimmer.dart';
-import 'package:crypto/crypto.dart';
 import 'package:memex/data/services/asset_safety_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/image_preview_cache_service.dart';
 import 'package:memex/utils/logger.dart';
 
 final Logger _logger = getLogger('LocalImage');
@@ -90,9 +86,8 @@ final Uint8List _transparentPng = Uint8List.fromList(const [
 /// - If URL does not start with http (local path), use Image.file
 /// - else use Image.network for remote images
 class LocalImage extends StatefulWidget {
-  static const AssetSafetyConfig previewSourceSafetyConfig = AssetSafetyConfig(
-    maxPixelsForDecode: 48000000,
-  );
+  static const AssetSafetyConfig previewSourceSafetyConfig =
+      ImagePreviewCacheService.previewSourceSafetyConfig;
 
   /// Image URL
   final String url;
@@ -306,11 +301,10 @@ class _LocalImageState extends State<LocalImage> {
     final isLocalFile = localFilePath != null || !widget.url.startsWith('http');
 
     String originalPath = '';
-    File? originalFile;
 
     if (isLocalFile) {
       originalPath = localFilePath ?? widget.url;
-      originalFile = File(originalPath);
+      final originalFile = File(originalPath);
 
       if (!originalFile.existsSync()) {
         // original file not found, cannot load
@@ -349,151 +343,28 @@ class _LocalImageState extends State<LocalImage> {
     }
 
     try {
-      // 2. prepare cache directory
-      final tempDir = await getTemporaryDirectory();
-      final cacheDir = Directory(path.join(tempDir.path, 'image_cache'));
-      if (!await cacheDir.exists()) {
-        await cacheDir.create(recursive: true);
-      }
-
-      // 3. generate cache key (MD5 to avoid filename length limit)
-      // Use md5 instead of base64Url: on iOS sim/device full path is very long;
-      // base64 would exceed APFS 255-byte filename limit and cause "Cannot retrieve length of file" error.
-      final cacheKeyBase = originalPath;
-      final filenameHash = md5.convert(utf8.encode(cacheKeyBase)).toString();
-      final cacheFilename = '${filenameHash}_max768.jpg';
-      final cacheFile = File(path.join(cacheDir.path, cacheFilename));
-
-      // 4. check cache
-      if (await cacheFile.exists()) {
-        // cache hit
-        if (mounted) {
-          setState(() {
-            _imageFile = cacheFile;
-            _isLoading = false;
-          });
-        }
-        return;
-      }
-
-      // 5. compress (download first if network image)
-      String sourcePath = originalPath;
-      File? tempDownloadFile;
-
-      if (!isLocalFile) {
-        // download network image to temp file
-        _logger.info('Downloading network image: $originalPath');
-        final response = await http.get(Uri.parse(originalPath));
-        if (response.statusCode == 200) {
-          tempDownloadFile = File(
-            path.join(
-              cacheDir.path,
-              'temp_${DateTime.now().millisecondsSinceEpoch}',
-            ),
-          );
-          await tempDownloadFile.writeAsBytes(response.bodyBytes);
-          sourcePath = tempDownloadFile.path;
-        } else {
-          throw Exception('Failed to download image: ${response.statusCode}');
-        }
-      }
-
-      final previewSafety = AssetSafetyService.instance.inspectFileSync(
-        sourcePath,
-        config: LocalImage.previewSourceSafetyConfig,
+      final preview =
+          await ImagePreviewCacheService.instance.getOrCreatePreview(
+        source: originalPath,
+        isLocalFile: isLocalFile,
       );
-      if (!previewSafety.safeForPreview) {
-        _logger.warning(
-          'Image preview blocked for $originalPath: ${previewSafety.reason}',
-        );
-        if (tempDownloadFile != null && await tempDownloadFile.exists()) {
-          await tempDownloadFile.delete();
-        }
-        if (mounted) {
-          setState(() {
-            _imageFile = null;
-            _isLoading = false;
-            _previewUnavailable = true;
-            _previewUnavailableReason = previewSafety.reason;
-          });
-        }
-        return;
-      }
 
-      // check image size; if already <= 768, copy file to avoid re-compression quality loss
-      String? resultPath;
-      bool needCompress = true;
-
-      try {
-        if (previewSafety.width != null &&
-            previewSafety.height != null &&
-            previewSafety.width! <= 768 &&
-            previewSafety.height! <= 768) {
-          needCompress = false;
-        }
-      } catch (e) {
-        _logger.warning(
-          'Failed to read image metadata to check size for $sourcePath',
-          e,
-        );
-      }
-
-      if (needCompress) {
-        // compress to max side 768
-        final result = await FlutterImageCompress.compressAndGetFile(
-          sourcePath,
-          cacheFile.path,
-          minWidth: 768,
-          minHeight: 768,
-          quality: 80,
-        );
-        resultPath = result?.path;
-      } else {
-        _logger.info(
-          'Image dimensions <= 768, skip compression: $originalPath',
-        );
-        final copiedFile = await File(sourcePath).copy(cacheFile.path);
-        resultPath = copiedFile.path;
-      }
-
-      // delete temp download file if any
-      if (tempDownloadFile != null && await tempDownloadFile.exists()) {
-        await tempDownloadFile.delete();
-      }
-
-      // 6. update status
       if (mounted) {
-        if (resultPath != null) {
-          final resultSafety =
-              AssetSafetyService.instance.inspectFileSync(resultPath);
-          if (!resultSafety.safeForPreview) {
-            _logger.warning(
-              'Generated image preview blocked for $originalPath: ${resultSafety.reason}',
-            );
-            setState(() {
-              _imageFile = null;
-              _isLoading = false;
-              _previewUnavailable = true;
-              _previewUnavailableReason = resultSafety.reason;
-            });
-            return;
-          }
-          _logger.info('Compression/Copy success for image: $originalPath');
-          setState(() {
-            _imageFile = File(resultPath!);
-            _isLoading = false;
-          });
-        } else {
-          _logger.warning(
-            'Compression/Copy failed (null result) for image: $originalPath',
-          );
-          setState(() {
-            _imageFile = null;
-            _isLoading = false;
-            _previewUnavailable = true;
-            _previewUnavailableReason = 'safe preview generation failed';
-          });
-        }
+        _logger.info('Preview ready for image: $originalPath');
+        setState(() {
+          _imageFile = preview.file;
+          _isLoading = false;
+        });
+      }
+    } on ImagePreviewUnavailable catch (e) {
+      _logger.warning('Image preview unavailable for $originalPath: $e');
+      if (mounted) {
+        setState(() {
+          _imageFile = null;
+          _isLoading = false;
+          _previewUnavailable = true;
+          _previewUnavailableReason = e.reason;
+        });
       }
     } catch (e) {
       _logger.severe('LocalImage processing error for image: $originalPath', e);

--- a/test/data/services/image_preview_cache_service_test.dart
+++ b/test/data/services/image_preview_cache_service_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/image_preview_cache_service.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('memex_preview_cache_');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  test('copies small images into the shared max768 cache path', () async {
+    final image = File('${tempDir.path}/small.png');
+    image.writeAsBytesSync(_pngHeader(width: 320, height: 240));
+
+    var compressorCalled = false;
+    final service = ImagePreviewCacheService(
+      tempDirectoryProvider: () async => tempDir,
+      compressor: ({
+        required sourcePath,
+        required targetPath,
+        required maxWidth,
+        required maxHeight,
+        required quality,
+      }) async {
+        compressorCalled = true;
+        return null;
+      },
+    );
+
+    final preview = await service.getOrCreatePreview(
+      source: image.path,
+      isLocalFile: true,
+    );
+    final cachedAgain = await service.getOrCreatePreview(
+      source: image.path,
+      isLocalFile: true,
+    );
+
+    expect(compressorCalled, isFalse);
+    expect(
+        preview.file.path, endsWith(ImagePreviewCacheService.cacheFileSuffix));
+    expect(preview.file.path, cachedAgain.file.path);
+    expect(preview.contentType, 'image/png');
+    expect(cachedAgain.cacheHit, isTrue);
+  });
+
+  test('compresses large images into the shared max768 cache path', () async {
+    final image = File('${tempDir.path}/large.png');
+    image.writeAsBytesSync(_pngHeader(width: 1200, height: 900));
+
+    var compressorCalls = 0;
+    final service = ImagePreviewCacheService(
+      tempDirectoryProvider: () async => tempDir,
+      compressor: ({
+        required sourcePath,
+        required targetPath,
+        required maxWidth,
+        required maxHeight,
+        required quality,
+      }) async {
+        compressorCalls++;
+        expect(sourcePath, image.path);
+        expect(maxWidth, ImagePreviewCacheService.maxPreviewSide);
+        expect(maxHeight, ImagePreviewCacheService.maxPreviewSide);
+        expect(quality, ImagePreviewCacheService.previewQuality);
+        await File(targetPath).writeAsBytes(_jpegHeader());
+        return targetPath;
+      },
+    );
+
+    final preview = await service.getOrCreatePreview(
+      source: image.path,
+      isLocalFile: true,
+    );
+    final cachedAgain = await service.getOrCreatePreview(
+      source: image.path,
+      isLocalFile: true,
+    );
+
+    expect(compressorCalls, 1);
+    expect(
+        preview.file.path, endsWith(ImagePreviewCacheService.cacheFileSuffix));
+    expect(preview.file.path, cachedAgain.file.path);
+    expect(preview.contentType, 'image/jpeg');
+    expect(cachedAgain.cacheHit, isTrue);
+  });
+}
+
+List<int> _pngHeader({required int width, required int height}) {
+  final bytes = Uint8List(33);
+  bytes.setAll(0, const [
+    0x89,
+    0x50,
+    0x4e,
+    0x47,
+    0x0d,
+    0x0a,
+    0x1a,
+    0x0a,
+    0x00,
+    0x00,
+    0x00,
+    0x0d,
+    0x49,
+    0x48,
+    0x44,
+    0x52,
+  ]);
+  _writeUint32Be(bytes, 16, width);
+  _writeUint32Be(bytes, 20, height);
+  bytes.setAll(24, const [
+    0x08,
+    0x02,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+  ]);
+  return bytes;
+}
+
+List<int> _jpegHeader() => const [0xff, 0xd8, 0xff, 0xd9];
+
+void _writeUint32Be(Uint8List bytes, int offset, int value) {
+  bytes[offset] = (value >> 24) & 0xff;
+  bytes[offset + 1] = (value >> 16) & 0xff;
+  bytes[offset + 2] = (value >> 8) & 0xff;
+  bytes[offset + 3] = value & 0xff;
+}

--- a/test/data/services/local_asset_server_image_preview_test.dart
+++ b/test/data/services/local_asset_server_image_preview_test.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart' show MethodChannel;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/image_preview_cache_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+import 'package:path/path.dart' as path;
+
+const _pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  File? cacheFile;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync(
+      'memex_local_asset_preview_',
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_pathProviderChannel, (call) async {
+      if (call.method == 'getTemporaryDirectory') return tempDir.path;
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    await LocalAssetServer.stopServer();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_pathProviderChannel, null);
+    if (cacheFile != null && await cacheFile!.exists()) {
+      await cacheFile!.delete();
+    }
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  test('serves shared max768 image cache for asset HTTP requests', () async {
+    const userId = 'alice';
+    final assetsDir = Directory(
+      path.join(tempDir.path, 'workspace', '_$userId', 'Facts', 'assets'),
+    );
+    await assetsDir.create(recursive: true);
+
+    final sourceImage = File(path.join(assetsDir.path, 'safe.png'));
+    await sourceImage.writeAsBytes(_pngHeader(width: 320, height: 240));
+
+    cacheFile = await ImagePreviewCacheService.instance.cacheFileForSource(
+      sourceImage.path,
+    );
+    const cachedPreviewBytes = [0xff, 0xd8, 0xff, 0xd9];
+    await cacheFile!.writeAsBytes(cachedPreviewBytes);
+
+    final port = await LocalAssetServer.startServer(dataRoot: tempDir.path);
+    final response = await _rawHttpGet(
+      port,
+      '/assets/$userId/safe.png?token=${LocalAssetServer.accessToken!}',
+    );
+
+    expect(response.headers.toLowerCase(), contains('http/1.1 200 ok'));
+    expect(
+        response.headers.toLowerCase(), contains('content-type: image/jpeg'));
+    expect(response.body, cachedPreviewBytes);
+  });
+}
+
+Future<_RawHttpResponse> _rawHttpGet(int port, String requestPath) async {
+  final socket = await Socket.connect(InternetAddress.loopbackIPv4, port);
+  socket.write(
+    'GET $requestPath HTTP/1.1\r\n'
+    'Host: 127.0.0.1:$port\r\n'
+    'Connection: close\r\n'
+    '\r\n',
+  );
+
+  final bytes = <int>[];
+  await for (final chunk in socket) {
+    bytes.addAll(chunk);
+  }
+
+  final separator = ascii.encode('\r\n\r\n');
+  final separatorIndex = _indexOfBytes(bytes, separator);
+  expect(separatorIndex, isNonNegative);
+
+  return _RawHttpResponse(
+    headers: ascii.decode(bytes.sublist(0, separatorIndex)),
+    body: bytes.sublist(separatorIndex + separator.length),
+  );
+}
+
+int _indexOfBytes(List<int> bytes, List<int> pattern) {
+  for (var i = 0; i <= bytes.length - pattern.length; i++) {
+    var matches = true;
+    for (var j = 0; j < pattern.length; j++) {
+      if (bytes[i + j] != pattern[j]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return i;
+  }
+  return -1;
+}
+
+class _RawHttpResponse {
+  final String headers;
+  final List<int> body;
+
+  const _RawHttpResponse({
+    required this.headers,
+    required this.body,
+  });
+}
+
+List<int> _pngHeader({required int width, required int height}) {
+  final bytes = Uint8List(33);
+  bytes.setAll(0, const [
+    0x89,
+    0x50,
+    0x4e,
+    0x47,
+    0x0d,
+    0x0a,
+    0x1a,
+    0x0a,
+    0x00,
+    0x00,
+    0x00,
+    0x0d,
+    0x49,
+    0x48,
+    0x44,
+    0x52,
+  ]);
+  _writeUint32Be(bytes, 16, width);
+  _writeUint32Be(bytes, 20, height);
+  bytes.setAll(24, const [
+    0x08,
+    0x02,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+  ]);
+  return bytes;
+}
+
+void _writeUint32Be(Uint8List bytes, int offset, int value) {
+  bytes[offset] = (value >> 24) & 0xff;
+  bytes[offset + 1] = (value >> 16) & 0xff;
+  bytes[offset + 2] = (value >> 8) & 0xff;
+  bytes[offset + 3] = value & 0xff;
+}


### PR DESCRIPTION
## Summary
- Add a shared max768 image preview cache service used by both LocalImage and LocalAssetServer.
- Serve HTML/local asset HTTP image requests from the same cached preview path instead of streaming original images.
- Defer chat history pagination loading reset to the post-frame phase to avoid duplicate pagination triggers.

## Validation
- flutter test test/data/services/image_preview_cache_service_test.dart test/data/services/local_asset_server_image_preview_test.dart test/ui/core/widgets/local_image_safety_test.dart
- flutter test test/ui/chat/widgets/agent_chat_dialog_test.dart
- dart analyze lib/data/services/local_asset_server.dart lib/data/services/image_preview_cache_service.dart lib/ui/core/widgets/local_image.dart lib/ui/chat/widgets/agent_chat_dialog.dart test/data/services/image_preview_cache_service_test.dart test/data/services/local_asset_server_image_preview_test.dart