### PR TITLE
Generate star history on a dedicated branch

### DIFF
--- a/.github/scripts/generate_star_history.py
+++ b/.github/scripts/generate_star_history.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Generate a deterministic SVG chart from a repository's current stargazers."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from collections import Counter
+from html import escape
+from pathlib import Path
+
+
+API_VERSION = "2026-03-10"
+LINK_PATTERN = re.compile(r'<([^>]+)>;\s*rel="([^"]+)"')
+
+
+def fetch_star_dates(repository: str, token: str) -> list[dt.date]:
+    url = f"https://api.github.com/repos/{repository}/stargazers?per_page=100"
+    dates: list[dt.date] = []
+
+    while url:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github.star+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": f"{repository}-star-history-workflow",
+                "X-GitHub-Api-Version": API_VERSION,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.load(response)
+                links = {
+                    relation: target
+                    for target, relation in LINK_PATTERN.findall(
+                        response.headers.get("Link", "")
+                    )
+                }
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"GitHub stargazers API returned HTTP {error.code}: {body}"
+            ) from error
+
+        for item in payload:
+            starred_at = item.get("starred_at")
+            if not starred_at:
+                raise RuntimeError(
+                    "GitHub did not return starred_at timestamps; check the Accept header "
+                    "and token permissions."
+                )
+            dates.append(dt.datetime.fromisoformat(starred_at.replace("Z", "+00:00")).date())
+
+        url = links.get("next", "")
+
+    return sorted(dates)
+
+
+def cumulative_points(dates: list[dt.date]) -> list[tuple[dt.date, int]]:
+    counts = Counter(dates)
+    total = 0
+    points: list[tuple[dt.date, int]] = []
+    for date in sorted(counts):
+        total += counts[date]
+        points.append((date, total))
+    return points
+
+
+def render_svg(repository: str, dates: list[dt.date]) -> str:
+    width, height = 900, 500
+    left, right, top, bottom = 82, 32, 72, 68
+    plot_width = width - left - right
+    plot_height = height - top - bottom
+    points = cumulative_points(dates)
+    total = len(dates)
+
+    if points:
+        start_date = points[0][0]
+        end_date = points[-1][0]
+    else:
+        start_date = end_date = dt.date.today()
+
+    span_days = max((end_date - start_date).days, 1)
+    y_max = max(total, 1)
+
+    def x_position(date: dt.date) -> float:
+        return left + ((date - start_date).days / span_days) * plot_width
+
+    def y_position(value: int) -> float:
+        return top + plot_height - (value / y_max) * plot_height
+
+    chart_points = [(start_date, 0), *points]
+    path = " ".join(
+        f"{'M' if index == 0 else 'L'} {x_position(date):.2f} {y_position(value):.2f}"
+        for index, (date, value) in enumerate(chart_points)
+    )
+
+    grid_lines: list[str] = []
+    y_labels: list[str] = []
+    for index in range(6):
+        value = round(y_max * index / 5)
+        y = y_position(value)
+        grid_lines.append(
+            f'<line x1="{left}" y1="{y:.2f}" x2="{width - right}" y2="{y:.2f}" />'
+        )
+        y_labels.append(
+            f'<text x="{left - 14}" y="{y + 5:.2f}" text-anchor="end">{value}</text>'
+        )
+
+    x_labels: list[str] = []
+    for index in range(6):
+        offset = round(span_days * index / 5)
+        date = start_date + dt.timedelta(days=offset)
+        x = x_position(date)
+        x_labels.append(
+            f'<text x="{x:.2f}" y="{height - 30}" text-anchor="middle">{date.isoformat()}</text>'
+        )
+
+    title = escape(repository)
+    empty_message = ""
+    if not points:
+        empty_message = (
+            f'<text class="empty" x="{width / 2}" y="{top + plot_height / 2}" '
+            'text-anchor="middle">No stars yet</text>'
+        )
+
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title description">
+  <title id="title">Star history for {title}</title>
+  <desc id="description">{total} current stargazers, grouped by the date each star was added.</desc>
+  <style>
+    text {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #64748b; font-size: 12px; }}
+    .heading {{ fill: #334155; font-size: 22px; font-weight: 600; }}
+    .total {{ fill: #64748b; font-size: 14px; }}
+    .grid {{ stroke: #94a3b8; stroke-opacity: .32; stroke-width: 1; }}
+    .axis {{ stroke: #64748b; stroke-opacity: .55; stroke-width: 1; }}
+    .history {{ fill: none; stroke: #f59e0b; stroke-linecap: round; stroke-linejoin: round; stroke-width: 3; }}
+    .empty {{ font-size: 16px; }}
+    @media (prefers-color-scheme: dark) {{
+      text, .total {{ fill: #94a3b8; }}
+      .heading {{ fill: #e2e8f0; }}
+      .grid {{ stroke: #64748b; }}
+      .axis {{ stroke: #94a3b8; }}
+    }}
+  </style>
+  <text class="heading" x="{left}" y="36">{title} Star History</text>
+  <text class="total" x="{left}" y="58">{total} current stars</text>
+  <g class="grid">{''.join(grid_lines)}</g>
+  <line class="axis" x1="{left}" y1="{top}" x2="{left}" y2="{top + plot_height}" />
+  <line class="axis" x1="{left}" y1="{top + plot_height}" x2="{width - right}" y2="{top + plot_height}" />
+  <g>{''.join(y_labels)}</g>
+  <g>{''.join(x_labels)}</g>
+  <path class="history" d="{path}" />
+  {empty_message}
+</svg>
+'''
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.repository:
+        raise SystemExit("--repository or GITHUB_REPOSITORY is required")
+    if not args.token:
+        raise SystemExit("--token or GITHUB_TOKEN is required")
+
+    dates = fetch_star_dates(args.repository, args.token)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_svg(args.repository, dates), encoding="utf-8")
+    print(f"Generated {args.output} from {len(dates)} current stargazers")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_generate_star_history.py
+++ b/.github/scripts/test_generate_star_history.py
@@ -1,0 +1,44 @@
+import datetime as dt
+import importlib.util
+import unittest
+import xml.etree.ElementTree as element_tree
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("generate_star_history.py")
+SPEC = importlib.util.spec_from_file_location("generate_star_history", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+GENERATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GENERATOR)
+
+
+class GenerateStarHistoryTest(unittest.TestCase):
+    def test_cumulative_points_groups_stars_by_date(self) -> None:
+        dates = [
+            dt.date(2025, 2, 1),
+            dt.date(2025, 1, 1),
+            dt.date(2025, 1, 1),
+        ]
+
+        self.assertEqual(
+            GENERATOR.cumulative_points(dates),
+            [(dt.date(2025, 1, 1), 2), (dt.date(2025, 2, 1), 3)],
+        )
+
+    def test_svg_is_deterministic_and_contains_summary(self) -> None:
+        dates = [dt.date(2025, 1, 1), dt.date(2025, 2, 1)]
+
+        first = GENERATOR.render_svg("memex-lab/memex", dates)
+        second = GENERATOR.render_svg("memex-lab/memex", list(reversed(dates)))
+
+        self.assertEqual(first, second)
+        self.assertIn("2 current stars", first)
+        self.assertIn("memex-lab/memex Star History", first)
+        self.assertEqual(
+            element_tree.fromstring(first).tag,
+            "{http://www.w3.org/2000/svg}svg",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -1,0 +1,63 @@
+name: Update Star History
+
+on:
+  schedule:
+    # 03:17 Asia/Shanghai. Scheduled workflows run on the default branch.
+    - cron: "17 19 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-star-history
+  cancel-in-progress: true
+
+jobs:
+  update-star-history:
+    name: Generate and publish chart
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Test chart generator
+        run: python3 .github/scripts/test_generate_star_history.py
+
+      - name: Generate star history SVG
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/generate_star_history.py \
+            --output /tmp/star-history.svg
+
+      - name: Publish to star-history branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code origin refs/heads/star-history >/dev/null 2>&1; then
+            git fetch --depth=1 origin star-history
+            git switch --force-create star-history origin/star-history
+          else
+            git switch --orphan star-history
+          fi
+
+          cp /tmp/star-history.svg star-history.svg
+          touch .nojekyll
+          printf '%s\n' \
+            '# Memex Star History' \
+            '' \
+            'This branch is maintained automatically by the Update Star History workflow.' \
+            > README.md
+
+          git add .nojekyll README.md star-history.svg
+          if git diff --cached --quiet; then
+            echo "Star history is unchanged; nothing to publish."
+            exit 0
+          fi
+
+          git commit -m "chore: update star history [skip ci]"
+          git push origin HEAD:star-history

--- a/README.md
+++ b/README.md
@@ -302,17 +302,7 @@ Contributions are welcome. Please open an issue first to discuss what you would 
 ## Star History
 
 <div align="center">
-  <picture>
-    <source
-      media="(prefers-color-scheme: dark)"
-      srcset="https://api.star-history.com/svg?repos=memex-lab/memex&type=Date&theme=dark"
-    />
-    <source
-      media="(prefers-color-scheme: light)"
-      srcset="https://api.star-history.com/svg?repos=memex-lab/memex&type=Date"
-    />
-    <img src="https://api.star-history.com/svg?repos=memex-lab/memex&type=Date" alt="Star History Chart" />
-  </picture>
+  <img src="https://raw.githubusercontent.com/memex-lab/memex/star-history/star-history.svg" alt="Memex Star History Chart" />
 </div>
 
 ## License

--- a/README_CN.md
+++ b/README_CN.md
@@ -302,17 +302,7 @@ Memex Agent 编排
 ## Star History
 
 <div align="center">
-  <picture>
-    <source
-      media="(prefers-color-scheme: dark)"
-      srcset="https://api.star-history.com/svg?repos=memex-lab/memex&type=Date&theme=dark"
-    />
-    <source
-      media="(prefers-color-scheme: light)"
-      srcset="https://api.star-history.com/svg?repos=memex-lab/memex&type=Date"
-    />
-    <img src="https://api.star-history.com/svg?repos=memex-lab/memex&type=Date" alt="Star History Chart" />
-  </picture>
+  <img src="https://raw.githubusercontent.com/memex-lab/memex/star-history/star-history.svg" alt="Memex Star History Chart" />
 </div>
 
 ## 许可证


### PR DESCRIPTION
## Summary
- replace the broken public Star History embed with a repository-hosted SVG
- add a scheduled and manually-triggered workflow using the built-in GITHUB_TOKEN
- publish chart updates to an isolated star-history branch only when star data changes
- add deterministic SVG generator tests

## Test plan
- PYTHONDONTWRITEBYTECODE=1 python3 .github/scripts/test_generate_star_history.py
- parse .github/workflows/update-star-history.yml with Ruby YAML
- git diff --check

Flutter tests were not run because this changes only repository automation and README configuration.