### PR TITLE
Fix Super Agent session recovery after reinstall

### DIFF
--- a/lib/data/repositories/chat.dart
+++ b/lib/data/repositories/chat.dart
@@ -81,6 +81,18 @@ Future<List<Map<String, dynamic>>> fetchChatSessionsEndpoint({
   }
 }
 
+/// Check one chat session path without scanning or reading session content.
+Future<bool> chatSessionExistsEndpoint(String sessionId) async {
+  final userId = await UserStorage.getUserId();
+  if (userId == null) {
+    throw ApiException('User not logged in, cannot check session');
+  }
+  if (sessionId.isEmpty) {
+    throw ApiException('Session ID cannot be empty');
+  }
+  return _chatStorage.sessionExists(userId, sessionId);
+}
+
 /// Get session detail
 ///
 /// Args:

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -1027,6 +1027,16 @@ class MemexRouter {
     });
   }
 
+  Future<Result<bool>> chatSessionExists(String sessionId) {
+    return runResult(() async {
+      await _ensureInitialized();
+      _logger.info(
+        'LocalMode: chatSessionExists called: sessionId=$sessionId',
+      );
+      return chat_endpoint.chatSessionExistsEndpoint(sessionId);
+    });
+  }
+
   Future<Map<String, dynamic>> fetchChatSessionDetail(
     String sessionId, {
     int? messageLimit,

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -413,7 +413,15 @@ class ChatService {
 
     // 1. Session Management
     try {
-      if (finalSessionId.isEmpty) {
+      final sessionExists = finalSessionId.isNotEmpty &&
+          await _chatStorage.sessionExists(userId, finalSessionId);
+      if (!sessionExists) {
+        if (finalSessionId.isNotEmpty) {
+          _logger.warning(
+            'Chat session $finalSessionId no longer exists; creating a new '
+            'session so this turn remains persistent',
+          );
+        }
         finalSessionId = await _createSession(
           userId,
           agentName,

--- a/lib/ui/chat/widgets/open_super_agent_dialog.dart
+++ b/lib/ui/chat/widgets/open_super_agent_dialog.dart
@@ -5,25 +5,65 @@ import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
 import 'package:memex/utils/result.dart';
 import 'package:memex/utils/user_storage.dart';
 
-Future<String?> latestSuperAgentSessionId() async {
+typedef SuperAgentSessionFetcher = Future<Result<List<Map<String, dynamic>>>>
+    Function();
+
+@visibleForTesting
+String? resolveLatestSuperAgentSessionId({
+  required String? cachedSessionId,
+  required List<Map<String, dynamic>> sessions,
+}) {
+  bool isHomeCompatible(Map<String, dynamic> session) {
+    final scene = session['scene']?.toString().trim();
+    return scene == null ||
+        scene.isEmpty ||
+        scene == 'assistant' ||
+        scene == 'super_agent_home';
+  }
+
+  final normalizedCachedSessionId = cachedSessionId?.trim();
+  if (normalizedCachedSessionId != null &&
+      normalizedCachedSessionId.isNotEmpty) {
+    for (final session in sessions) {
+      if (session['session_id']?.toString() == normalizedCachedSessionId &&
+          isHomeCompatible(session)) {
+        return normalizedCachedSessionId;
+      }
+    }
+  }
+
+  for (final session in sessions) {
+    if (session['scene'] == 'super_agent_home') {
+      return session['session_id']?.toString();
+    }
+  }
+
+  // Sessions created before the unified Super Agent entry used the default
+  // assistant scene. They remain valid home conversations after reinstall.
+  for (final session in sessions) {
+    if (isHomeCompatible(session)) {
+      return session['session_id']?.toString();
+    }
+  }
+  return null;
+}
+
+Future<String?> latestSuperAgentSessionId({
+  SuperAgentSessionFetcher? fetchSessions,
+}) async {
   final cachedSessionId = await UserStorage.getLatestSuperAgentHomeSessionId();
-  if (cachedSessionId != null) return cachedSessionId;
 
   try {
-    final result = await MemexRouter().fetchChatSessions(
-      agentName: 'memex_agent',
-      limit: 30,
-    );
+    final result = await (fetchSessions?.call() ??
+        MemexRouter().fetchChatSessions(agentName: 'memex_agent'));
     final sessionId = result.when(
-      onOk: (sessions) {
-        for (final session in sessions) {
-          if (session['scene'] == 'super_agent_home') {
-            return session['session_id']?.toString();
-          }
-        }
-        return null;
-      },
-      onError: (_, __) => null,
+      onOk: (sessions) => resolveLatestSuperAgentSessionId(
+        cachedSessionId: cachedSessionId,
+        sessions: sessions,
+      ),
+      // A transient storage error should not discard a potentially valid
+      // pointer. ChatService validates it again before writing a new turn.
+      onError: (_, __) => cachedSessionId,
     );
     if (sessionId == null || sessionId.isEmpty) {
       await UserStorage.clearLatestSuperAgentHomeSessionId();

--- a/lib/ui/chat/widgets/open_super_agent_dialog.dart
+++ b/lib/ui/chat/widgets/open_super_agent_dialog.dart
@@ -7,26 +7,29 @@ import 'package:memex/utils/user_storage.dart';
 
 typedef SuperAgentSessionFetcher = Future<Result<List<Map<String, dynamic>>>>
     Function();
+typedef SuperAgentSessionExistsChecker = Future<Result<bool>> Function(
+  String sessionId,
+);
+
+bool _isHomeCompatible(Map<String, dynamic> session) {
+  final scene = session['scene']?.toString().trim();
+  return scene == null ||
+      scene.isEmpty ||
+      scene == 'assistant' ||
+      scene == 'super_agent_home';
+}
 
 @visibleForTesting
 String? resolveLatestSuperAgentSessionId({
   required String? cachedSessionId,
   required List<Map<String, dynamic>> sessions,
 }) {
-  bool isHomeCompatible(Map<String, dynamic> session) {
-    final scene = session['scene']?.toString().trim();
-    return scene == null ||
-        scene.isEmpty ||
-        scene == 'assistant' ||
-        scene == 'super_agent_home';
-  }
-
   final normalizedCachedSessionId = cachedSessionId?.trim();
   if (normalizedCachedSessionId != null &&
       normalizedCachedSessionId.isNotEmpty) {
     for (final session in sessions) {
       if (session['session_id']?.toString() == normalizedCachedSessionId &&
-          isHomeCompatible(session)) {
+          _isHomeCompatible(session)) {
         return normalizedCachedSessionId;
       }
     }
@@ -41,7 +44,7 @@ String? resolveLatestSuperAgentSessionId({
   // Sessions created before the unified Super Agent entry used the default
   // assistant scene. They remain valid home conversations after reinstall.
   for (final session in sessions) {
-    if (isHomeCompatible(session)) {
+    if (_isHomeCompatible(session)) {
       return session['session_id']?.toString();
     }
   }
@@ -50,8 +53,27 @@ String? resolveLatestSuperAgentSessionId({
 
 Future<String?> latestSuperAgentSessionId({
   SuperAgentSessionFetcher? fetchSessions,
+  SuperAgentSessionExistsChecker? sessionExists,
 }) async {
   final cachedSessionId = await UserStorage.getLatestSuperAgentHomeSessionId();
+
+  if (cachedSessionId != null) {
+    try {
+      final existsResult = await (sessionExists?.call(cachedSessionId) ??
+          MemexRouter().chatSessionExists(cachedSessionId));
+      final cacheStatus = existsResult.when<bool?>(
+        onOk: (exists) => exists,
+        // A transient path check error is not evidence that the cached session
+        // is stale. Keep the pointer and let ChatService validate before writes.
+        onError: (_, __) => null,
+      );
+      if (cacheStatus == true || cacheStatus == null) {
+        return cachedSessionId;
+      }
+    } catch (_) {
+      return cachedSessionId;
+    }
+  }
 
   try {
     final result = await (fetchSessions?.call() ??

--- a/test/data/repositories/chat_session_time_context_test.dart
+++ b/test/data/repositories/chat_session_time_context_test.dart
@@ -280,6 +280,24 @@ void main() {
       expect(sessions.single['updated_at_local'], contains('2026-04-28'));
       expect(sessions.single['last_message_preview'], 'preview text');
     });
+
+    test('checks one session path without loading session content', () async {
+      await ChatSessionStorage.instance.createSession(
+        userId: userId,
+        sessionId: 'exists-session',
+        metadata: {
+          'session_id': 'exists-session',
+          'agent_name': 'memex_agent',
+          'scene': 'super_agent_home',
+          'title': 'Exists session',
+          'created_at': '2026-04-28T20:00:46.000',
+          'updated_at': '2026-04-28T20:05:00.000',
+        },
+      );
+
+      expect(await chatSessionExistsEndpoint('exists-session'), isTrue);
+      expect(await chatSessionExistsEndpoint('missing-session'), isFalse);
+    });
   });
 }
 

--- a/test/data/services/chat_service_test.dart
+++ b/test/data/services/chat_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -273,6 +274,43 @@ void main() {
         expect(payload['session_id'], queuedSessionId);
         expect(payload['agent_state_session_id'], activeStateId);
         expect(foregroundSnapshot.activeTaskIds, contains(task.id));
+      } finally {
+        await subscription.cancel();
+      }
+    });
+
+    test('replaces a missing session id and persists the new turn', () async {
+      const missingSessionId = 'memex_agent_missing_session';
+      final createdSession = Completer<String>();
+      final subscription = ChatService.instance
+          .sendMessage(
+        'recover this turn',
+        sessionId: missingSessionId,
+        agentName: 'memex_agent',
+        scene: 'super_agent_home',
+      )
+          .listen((event) {
+        if (event is ChatSessionCreatedEvent && !createdSession.isCompleted) {
+          createdSession.complete(event.sessionId);
+        }
+      });
+
+      try {
+        final newSessionId = await createdSession.future.timeout(
+          const Duration(seconds: 3),
+        );
+        expect(newSessionId, isNot(missingSessionId));
+
+        await _waitForQueuedChatTask(db, newSessionId);
+        final sessionData = await _readSession(userId, newSessionId);
+        final messages = sessionData['messages'] as List<dynamic>;
+
+        expect(messages, hasLength(1));
+        expect(messages.single['role'], 'user');
+        expect(
+          messages.single['content'].single['text'],
+          'recover this turn',
+        );
       } finally {
         await subscription.cancel();
       }

--- a/test/ui/chat/widgets/open_super_agent_dialog_test.dart
+++ b/test/ui/chat/widgets/open_super_agent_dialog_test.dart
@@ -23,23 +23,26 @@ void main() {
   test('returns cached latest Super Agent home session id', () async {
     await UserStorage.setLatestSuperAgentHomeSessionId('cached-session');
 
+    var scannedSessions = false;
+
     await expectLater(
       latestSuperAgentSessionId(
-        fetchSessions: () async => const Ok([
-          {
-            'session_id': 'cached-session',
-            'scene': 'super_agent_home',
-          },
-        ]),
+        sessionExists: (_) async => const Ok(true),
+        fetchSessions: () async {
+          scannedSessions = true;
+          return const Ok([]);
+        },
       ),
       completion('cached-session'),
     );
+    expect(scannedSessions, isFalse);
   });
 
   test('replaces a stale cached id with the latest home session', () async {
     await UserStorage.setLatestSuperAgentHomeSessionId('missing-session');
 
     final sessionId = await latestSuperAgentSessionId(
+      sessionExists: (_) async => const Ok(false),
       fetchSessions: () async => const Ok([
         {
           'session_id': 'timeline-detail',
@@ -57,6 +60,23 @@ void main() {
       await UserStorage.getLatestSuperAgentHomeSessionId(),
       'restored-home',
     );
+  });
+
+  test('keeps the cached id when targeted validation temporarily fails',
+      () async {
+    await UserStorage.setLatestSuperAgentHomeSessionId('cached-session');
+
+    var scannedSessions = false;
+    final sessionId = await latestSuperAgentSessionId(
+      sessionExists: (_) async => Error(Exception('temporary failure')),
+      fetchSessions: () async {
+        scannedSessions = true;
+        return const Ok([]);
+      },
+    );
+
+    expect(sessionId, 'cached-session');
+    expect(scannedSessions, isFalse);
   });
 
   test('restores a legacy assistant session after app preferences are lost',

--- a/test/ui/chat/widgets/open_super_agent_dialog_test.dart
+++ b/test/ui/chat/widgets/open_super_agent_dialog_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/l10n/app_localizations.dart';
 import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
 import 'package:memex/ui/chat/widgets/open_super_agent_dialog.dart';
+import 'package:memex/utils/result.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -23,7 +24,57 @@ void main() {
     await UserStorage.setLatestSuperAgentHomeSessionId('cached-session');
 
     await expectLater(
-        latestSuperAgentSessionId(), completion('cached-session'));
+      latestSuperAgentSessionId(
+        fetchSessions: () async => const Ok([
+          {
+            'session_id': 'cached-session',
+            'scene': 'super_agent_home',
+          },
+        ]),
+      ),
+      completion('cached-session'),
+    );
+  });
+
+  test('replaces a stale cached id with the latest home session', () async {
+    await UserStorage.setLatestSuperAgentHomeSessionId('missing-session');
+
+    final sessionId = await latestSuperAgentSessionId(
+      fetchSessions: () async => const Ok([
+        {
+          'session_id': 'timeline-detail',
+          'scene': 'assistant_timeline_card_detail',
+        },
+        {
+          'session_id': 'restored-home',
+          'scene': 'super_agent_home',
+        },
+      ]),
+    );
+
+    expect(sessionId, 'restored-home');
+    expect(
+      await UserStorage.getLatestSuperAgentHomeSessionId(),
+      'restored-home',
+    );
+  });
+
+  test('restores a legacy assistant session after app preferences are lost',
+      () async {
+    final sessionId = await latestSuperAgentSessionId(
+      fetchSessions: () async => const Ok([
+        {
+          'session_id': 'card-detail',
+          'scene': 'assistant_timeline_card_detail',
+        },
+        {
+          'session_id': 'legacy-home',
+          'scene': 'assistant',
+        },
+      ]),
+    );
+
+    expect(sessionId, 'legacy-home');
   });
 
   testWidgets('waits for session lookup before building chat dialog', (


### PR DESCRIPTION
## Summary

- validate the cached Super Agent home session with a targeted path lookup instead of scanning every session on each open
- search all persisted sessions when the cache is missing or stale, and recover legacy assistant-scene conversations after app preferences are cleared
- exclude timeline-detail and other contextual sessions during fallback recovery
- create a fresh persisted session when a caller supplies a session ID that no longer exists

## Scope

This restores sessions that still exist in the selected workspace, including iCloud workspaces. It cannot recover chat files that were physically removed with an app-local container.

## Test plan

- flutter test test/ui/chat/widgets/open_super_agent_dialog_test.dart test/data/services/chat_service_test.dart test/data/services/chat_session_storage_test.dart test/data/repositories/chat_session_time_context_test.dart
- flutter analyze lib/data/repositories/chat.dart lib/data/repositories/memex_router.dart lib/data/services/chat_service.dart lib/ui/chat/widgets/open_super_agent_dialog.dart test/data/repositories/chat_session_time_context_test.dart test/data/services/chat_service_test.dart test/ui/chat/widgets/open_super_agent_dialog_test.dart
- Latest branch result: 22 targeted tests passed; targeted analyze reported no issues
- Full flutter test on the first commit: 793 passed, 5 skipped, 12 failures in unmodified settings/agent/task-test areas
- Full flutter analyze on the first commit: 174 pre-existing info-level findings; no findings in changed files