### PR TITLE
fix(image cache): add HTTP timeout to network image preview download

### DIFF
--- a/lib/data/services/image_preview_cache_service.dart
+++ b/lib/data/services/image_preview_cache_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -152,7 +153,14 @@ class ImagePreviewCacheService {
     try {
       if (!isLocalFile) {
         _logger.info('Downloading network image preview source: $source');
-        final response = await http.get(Uri.parse(source));
+        final http.Response response;
+        try {
+          response = await http
+              .get(Uri.parse(source))
+              .timeout(const Duration(seconds: 20));
+        } on TimeoutException {
+          throw const ImagePreviewUnavailable('image download timed out');
+        }
         if (response.statusCode != 200) {
           throw ImagePreviewUnavailable(
             'failed to download image: ${response.statusCode}',


### PR DESCRIPTION
## What changed

Add a 20 s timeout on the `http.get` in `ImagePreviewCacheService._createPreviewFile` and surface a `TimeoutException` as `ImagePreviewUnavailable`.

## Why

`ImagePreviewCacheService` is a process-wide singleton with a single `Lock _previewLock` held around the whole download+compress. The `http.get` used the default IO client with **no timeout**. A hung or blackholed remote image URL therefore held the lock indefinitely and blocked every other preview call — including local-file previews and the requests served over `LocalAssetServer` that back the WebView.

Adding a bounded timeout is the smallest safe change. The broader design question of sharding the lock per cache key (so unrelated in-flight fetches cannot block each other at all) is intentionally out of scope for this PR and worth its own discussion.

Closes #344

## Type of change

- [x] Bug fix

## Risk areas

- [x] None of the above

## Screenshots or recordings

No visual change.

## Test plan

- [ ] Added/updated unit tests for changed non-UI behavior, or explained why not:  
      Not added. The service uses the top-level `http.get` (not an injected client), so exercising the timeout branch requires an http-client injection refactor. That refactor is out of scope for this narrow fix.
- [ ] Exact test files: n/a
- [ ] `flutter test`
- [ ] `flutter analyze`
- [ ] Manual iOS check
- [ ] Manual Android check
- [x] Not run; reason: no Flutter toolchain on the audit machine. Please run the CI checks before merging.

## Contributor checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I kept this PR focused on one change.
- [x] I did not edit generated `*.g.dart` files manually.
- [x] I did not add telemetry, hidden network calls, secrets, or signing keys.
- [x] I updated docs or localization when needed. _(No docs or strings touched.)_
