### PR TITLE
Persist persona chat in the character workspace

### DIFF
--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -50,6 +50,7 @@ import 'package:memex/data/services/character_initiative_service.dart';
 import 'package:memex/data/services/character_history_acquaintance_service.dart';
 import 'package:memex/data/services/character_service.dart';
 import 'package:memex/data/repositories/persona_chat_repository.dart';
+import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/data/repositories/character_editor_repository.dart';
 import 'package:memex/data/services/task_handlers/reprocess_comments_handler.dart';
 import 'package:memex/data/services/task_handlers/custom_agent_task_handler.dart';
@@ -116,6 +117,8 @@ class MemexRouter {
       _logger.info('Initializing Local DB for user: $userId');
       await ChatSessionStorage.instance.ensureMigrated(userId);
       await AppDatabase.init(userId);
+      PersonaChatService.instance.bindUser(userId);
+      await PersonaChatService.instance.reconcileFromWorkspace(userId);
 
       _registerTaskHandlers(LocalTaskExecutor.instance);
       await LocalTaskExecutor.instance.start(userId: userId);
@@ -295,6 +298,8 @@ class MemexRouter {
     await FileSystemService.init(dataRoot);
     await ChatSessionStorage.instance.ensureMigrated(userId);
     await AppDatabase.init(userId);
+    PersonaChatService.instance.bindUser(userId);
+    await PersonaChatService.instance.reconcileFromWorkspace(userId);
 
     final taskExecutor = executor ?? LocalTaskExecutor.instance;
     AgentActivityService.setInstance(LocalAgentActivityService.instance);
@@ -1148,8 +1153,11 @@ class MemexRouter {
   }) {
     return runResult(() async {
       await _ensureInitialized();
+      final userId = await UserStorage.getUserId();
+      if (userId == null) throw StateError('No active user.');
       return _personaChatRepository.getMessages(
         characterId,
+        userId: userId,
         limit: limit,
         offset: offset,
       );
@@ -1175,7 +1183,12 @@ class MemexRouter {
   Future<Result<int>> markPersonaChatRead(String characterId) {
     return runResult(() async {
       await _ensureInitialized();
-      final count = await _personaChatRepository.markAllRead(characterId);
+      final userId = await UserStorage.getUserId();
+      if (userId == null) throw StateError('No active user.');
+      final count = await _personaChatRepository.markAllRead(
+        characterId,
+        userId: userId,
+      );
       EventBusService.instance.emitEvent(
         PersonaChatUnreadChangedMessage(characterId: characterId),
       );

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -117,8 +117,8 @@ class MemexRouter {
       _logger.info('Initializing Local DB for user: $userId');
       await ChatSessionStorage.instance.ensureMigrated(userId);
       await AppDatabase.init(userId);
-      PersonaChatService.instance.bindUser(userId);
-      await PersonaChatService.instance.reconcileFromWorkspace(userId);
+      await PersonaChatService.instance
+          .initialize(userId, AppDatabase.instance);
 
       _registerTaskHandlers(LocalTaskExecutor.instance);
       await LocalTaskExecutor.instance.start(userId: userId);
@@ -298,8 +298,7 @@ class MemexRouter {
     await FileSystemService.init(dataRoot);
     await ChatSessionStorage.instance.ensureMigrated(userId);
     await AppDatabase.init(userId);
-    PersonaChatService.instance.bindUser(userId);
-    await PersonaChatService.instance.reconcileFromWorkspace(userId);
+    await PersonaChatService.instance.initialize(userId, AppDatabase.instance);
 
     final taskExecutor = executor ?? LocalTaskExecutor.instance;
     AgentActivityService.setInstance(LocalAgentActivityService.instance);

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -122,6 +122,9 @@ class MemexRouter {
 
       _registerTaskHandlers(LocalTaskExecutor.instance);
       await LocalTaskExecutor.instance.start(userId: userId);
+      await CharacterConversationService.instance.reconcilePendingReplies(
+        userId: userId,
+      );
 
       // Start table change notifier (binlog-style listener for Drift tables)
       TableChangeNotifier.instance.init();
@@ -1145,20 +1148,36 @@ class MemexRouter {
     });
   }
 
-  Future<Result<List<PersonaChatMessageModel>>> fetchPersonaChatMessages(
+  Future<Result<PersonaChatMessagePageModel>> fetchPersonaChatMessagePage(
     String characterId, {
     required int limit,
-    int offset = 0,
+    int? beforeCursor,
   }) {
     return runResult(() async {
       await _ensureInitialized();
       final userId = await UserStorage.getUserId();
       if (userId == null) throw StateError('No active user.');
-      return _personaChatRepository.getMessages(
+      return _personaChatRepository.getMessagePage(
         characterId,
         userId: userId,
         limit: limit,
-        offset: offset,
+        beforeCursor: beforeCursor,
+      );
+    });
+  }
+
+  Future<Result<PersonaChatMessagePageModel>> fetchNewPersonaChatMessages(
+    String characterId, {
+    required int afterCursor,
+  }) {
+    return runResult(() async {
+      await _ensureInitialized();
+      final userId = await UserStorage.getUserId();
+      if (userId == null) throw StateError('No active user.');
+      return _personaChatRepository.getMessagesAfter(
+        characterId,
+        userId: userId,
+        afterCursor: afterCursor,
       );
     });
   }

--- a/lib/data/repositories/persona_chat_repository.dart
+++ b/lib/data/repositories/persona_chat_repository.dart
@@ -50,13 +50,15 @@ class PersonaChatRepository {
         character: character,
       );
     }
-    var messages = await _chatService.getMessages(
+    var page = await _chatService.getMessagePage(
       characterId,
       limit: limit,
       userId: userId,
     );
     final firstMessage = character.firstMessage?.trim();
-    if (messages.isEmpty && firstMessage != null && firstMessage.isNotEmpty) {
+    if (page.messages.isEmpty &&
+        firstMessage != null &&
+        firstMessage.isNotEmpty) {
       await _chatService.addCharacterMessage(
         characterId,
         TavernMacro.resolve(
@@ -68,7 +70,7 @@ class PersonaChatRepository {
         contactEpisodeId: 'greeting:first_message',
         userId: userId,
       );
-      messages = await _chatService.getMessages(
+      page = await _chatService.getMessagePage(
         characterId,
         limit: limit,
         userId: userId,
@@ -78,23 +80,38 @@ class PersonaChatRepository {
       character: character,
       userId: userId,
       userAvatar: userAvatar,
-      messages: messages.map(_toDomain).toList(growable: false),
+      messages: page.messages.map(_toDomain).toList(growable: false),
+      olderCursor: page.olderCursor,
+      newestCursor: page.newestCursor,
     );
   }
 
-  Future<List<PersonaChatMessageModel>> getMessages(
+  Future<PersonaChatMessagePageModel> getMessagePage(
     String characterId, {
     required int limit,
-    int offset = 0,
+    int? beforeCursor,
     String? userId,
   }) async {
-    final rows = await _chatService.getMessages(
+    final page = await _chatService.getMessagePage(
       characterId,
       limit: limit,
-      offset: offset,
+      beforeCursor: beforeCursor,
       userId: userId,
     );
-    return rows.map(_toDomain).toList(growable: false);
+    return _toPage(page);
+  }
+
+  Future<PersonaChatMessagePageModel> getMessagesAfter(
+    String characterId, {
+    required int afterCursor,
+    String? userId,
+  }) async {
+    final page = await _chatService.getMessagesAfter(
+      characterId,
+      afterCursor: afterCursor,
+      userId: userId,
+    );
+    return _toPage(page);
   }
 
   Future<int> sendMessage({
@@ -135,7 +152,15 @@ class PersonaChatRepository {
       timestamp: row.timestamp,
       messageType: row.messageType,
       origin: row.origin,
-      episodeId: row.contactEpisodeId,
+      turnId: row.contactEpisodeId,
+    );
+  }
+
+  static PersonaChatMessagePageModel _toPage(PersonaChatMessagePage page) {
+    return PersonaChatMessagePageModel(
+      messages: page.messages.map(_toDomain).toList(growable: false),
+      olderCursor: page.olderCursor,
+      newestCursor: page.newestCursor,
     );
   }
 }

--- a/lib/data/repositories/persona_chat_repository.dart
+++ b/lib/data/repositories/persona_chat_repository.dart
@@ -27,7 +27,7 @@ class PersonaChatRepository {
 
   Future<PersonaAvatarSummary> loadAvatarSummary(String userId) async {
     final characterFuture = _characterService.getPrimaryCompanion(userId);
-    final unreadCountFuture = _chatService.getTotalUnreadCount();
+    final unreadCountFuture = _chatService.getTotalUnreadCount(userId: userId);
     return PersonaAvatarSummary(
       character: await characterFuture,
       unreadCount: await unreadCountFuture,
@@ -50,7 +50,11 @@ class PersonaChatRepository {
         character: character,
       );
     }
-    var messages = await _chatService.getMessages(characterId, limit: limit);
+    var messages = await _chatService.getMessages(
+      characterId,
+      limit: limit,
+      userId: userId,
+    );
     final firstMessage = character.firstMessage?.trim();
     if (messages.isEmpty && firstMessage != null && firstMessage.isNotEmpty) {
       await _chatService.addCharacterMessage(
@@ -61,8 +65,14 @@ class PersonaChatRepository {
           charName: character.name,
         ),
         isRead: true,
+        contactEpisodeId: 'greeting:first_message',
+        userId: userId,
       );
-      messages = await _chatService.getMessages(characterId, limit: limit);
+      messages = await _chatService.getMessages(
+        characterId,
+        limit: limit,
+        userId: userId,
+      );
     }
     return PersonaChatThreadModel(
       character: character,
@@ -76,11 +86,13 @@ class PersonaChatRepository {
     String characterId, {
     required int limit,
     int offset = 0,
+    String? userId,
   }) async {
     final rows = await _chatService.getMessages(
       characterId,
       limit: limit,
       offset: offset,
+      userId: userId,
     );
     return rows.map(_toDomain).toList(growable: false);
   }
@@ -99,8 +111,8 @@ class PersonaChatRepository {
     );
   }
 
-  Future<int> markAllRead(String characterId) {
-    return _chatService.markAllRead(characterId);
+  Future<int> markAllRead(String characterId, {String? userId}) {
+    return _chatService.markAllRead(characterId, userId: userId);
   }
 
   Future<List<CharacterModel>> getEnabledCharacters(String userId) async {

--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -410,8 +410,10 @@ class BackupService {
 
       // Re-init DB
       await AppDatabase.init(restoredUserId);
-      PersonaChatService.instance.bindUser(restoredUserId);
-      await PersonaChatService.instance.reconcileFromWorkspace(restoredUserId);
+      await PersonaChatService.instance.initialize(
+        restoredUserId,
+        AppDatabase.instance,
+      );
       databaseClosedForRestore = false;
 
       // 4. Rebuild card cache

--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import 'package:memex/config/app_flavor.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -409,6 +410,8 @@ class BackupService {
 
       // Re-init DB
       await AppDatabase.init(restoredUserId);
+      PersonaChatService.instance.bindUser(restoredUserId);
+      await PersonaChatService.instance.reconcileFromWorkspace(restoredUserId);
       databaseClosedForRestore = false;
 
       // 4. Rebuild card cache

--- a/lib/data/services/character_conversation_service.dart
+++ b/lib/data/services/character_conversation_service.dart
@@ -113,4 +113,20 @@ class CharacterConversationService {
       maxRetries: 3,
     );
   }
+
+  /// Rebuilds missing durable tasks from workspace-authoritative inbox state.
+  ///
+  /// This closes the crash window between appending a user message and
+  /// enqueueing its SQLite task, and also restores work after the task cache is
+  /// recreated.
+  Future<void> reconcilePendingReplies({required String userId}) async {
+    final characterIds =
+        await _chatService.getCharactersWithPendingUserMessages(userId: userId);
+    for (final characterId in characterIds) {
+      await ensurePendingReplyScheduled(
+        userId: userId,
+        characterId: characterId,
+      );
+    }
+  }
 }

--- a/lib/data/services/character_conversation_service.dart
+++ b/lib/data/services/character_conversation_service.dart
@@ -61,6 +61,7 @@ class CharacterConversationService {
       characterId,
       text,
       timestamp: sentAt,
+      userId: userId,
     );
     await schedulePendingReply(
       userId: userId,

--- a/lib/data/services/character_workspace_service.dart
+++ b/lib/data/services/character_workspace_service.dart
@@ -460,6 +460,9 @@ class CharacterWorkspaceService {
         .create(recursive: true);
     await Directory(_fileSystem.getCharacterJournalPath(userId, character.id))
         .create(recursive: true);
+    await Directory(
+      _fileSystem.getCharacterConversationPath(userId, character.id),
+    ).create(recursive: true);
 
     await _migrateLegacyConfiguredMemoryUnlocked(userId, character.id);
 

--- a/lib/data/services/character_workspace_service.dart
+++ b/lib/data/services/character_workspace_service.dart
@@ -741,11 +741,6 @@ class CharacterWorkspaceService {
   }
 
   void _validateCharacterId(String characterId) {
-    if (characterId.trim().isEmpty ||
-        characterId == '.' ||
-        characterId == '..' ||
-        p.basename(characterId) != characterId) {
-      throw ArgumentError.value(characterId, 'characterId');
-    }
+    FileSystemService.validateCharacterId(characterId);
   }
 }

--- a/lib/data/services/chat_session_storage.dart
+++ b/lib/data/services/chat_session_storage.dart
@@ -13,7 +13,21 @@ import 'package:synchronized/synchronized.dart';
 import 'package:yaml/yaml.dart';
 
 class ChatSessionStorage {
-  ChatSessionStorage._();
+  ChatSessionStorage._({
+    FileSystemService? fileService,
+    JsonlFileStore? jsonl,
+  })  : _injectedFileService = fileService,
+        _jsonl = jsonl ?? JsonlFileStore(loggerName: 'ChatSessionJsonl');
+
+  factory ChatSessionStorage.forTesting({
+    required FileSystemService fileService,
+    JsonlFileStore? jsonl,
+  }) {
+    return ChatSessionStorage._(
+      fileService: fileService,
+      jsonl: jsonl,
+    );
+  }
 
   static final ChatSessionStorage instance = ChatSessionStorage._();
 
@@ -25,13 +39,15 @@ class ChatSessionStorage {
   static const String storageMigrationKey = 'chat_sessions_jsonl_v1';
 
   final _logger = getLogger('ChatSessionStorage');
-  final _jsonl = JsonlFileStore(loggerName: 'ChatSessionJsonl');
+  final FileSystemService? _injectedFileService;
+  final JsonlFileStore _jsonl;
   final Map<String, Future<void>> _migrationFutures = {};
   final Map<String, Lock> _sessionLocks = {};
   final Map<String, Lock> _legacyMigrationLocks = {};
   final Lock _lockMapLock = Lock();
 
-  FileSystemService get _fileService => FileSystemService.instance;
+  FileSystemService get _fileService =>
+      _injectedFileService ?? FileSystemService.instance;
 
   Future<void> ensureMigrated(String userId) {
     final rootPath = _sessionsPath(userId);
@@ -124,7 +140,10 @@ class ChatSessionStorage {
   ) async {
     await ensureMigrated(userId);
     _validateSessionId(sessionId);
-    return _readMessagesFile(_messagesFile(userId, sessionId));
+    final lock = await _lockFor(userId, sessionId);
+    return lock.synchronized(
+      () => _readMessagesFile(_messagesFile(userId, sessionId)),
+    );
   }
 
   Future<ChatSessionMessagePage> loadMessagePage(
@@ -135,41 +154,44 @@ class ChatSessionStorage {
   }) async {
     await ensureMigrated(userId);
     _validateSessionId(sessionId);
-    final messagesFile = _messagesFile(userId, sessionId);
+    final lock = await _lockFor(userId, sessionId);
+    return lock.synchronized(() async {
+      final messagesFile = _messagesFile(userId, sessionId);
 
-    if (limit == null || limit <= 0) {
-      final messages = await _readMessagesFile(messagesFile);
-      return ChatSessionMessagePage(
-        messages: messages,
-        olderCursor: null,
+      if (limit == null || limit <= 0) {
+        final messages = await _readMessagesFile(messagesFile);
+        return ChatSessionMessagePage(
+          messages: messages,
+          olderCursor: null,
+          limit: limit,
+          beforeCursor: beforeCursor,
+        );
+      }
+
+      final linePage = await _readMessageTurnGroupsBefore(
+        messagesFile,
         limit: limit,
         beforeCursor: beforeCursor,
       );
-    }
-
-    final linePage = await _readMessageTurnGroupsBefore(
-      messagesFile,
-      limit: limit,
-      beforeCursor: beforeCursor,
-    );
-    final messages = <Map<String, dynamic>>[];
-    for (final line in linePage.lines) {
-      try {
-        final decoded = jsonDecode(line.text);
-        if (decoded is Map) {
-          messages.add(Map<String, dynamic>.from(decoded));
+      final messages = <Map<String, dynamic>>[];
+      for (final line in linePage.lines) {
+        try {
+          final decoded = jsonDecode(line.text);
+          if (decoded is Map) {
+            messages.add(Map<String, dynamic>.from(decoded));
+          }
+        } catch (e) {
+          _logger.warning('Failed to parse chat message JSONL page line: $e');
         }
-      } catch (e) {
-        _logger.warning('Failed to parse chat message JSONL page line: $e');
       }
-    }
 
-    return ChatSessionMessagePage(
-      messages: messages,
-      olderCursor: linePage.olderCursor,
-      limit: limit,
-      beforeCursor: beforeCursor,
-    );
+      return ChatSessionMessagePage(
+        messages: messages,
+        olderCursor: linePage.olderCursor,
+        limit: limit,
+        beforeCursor: beforeCursor,
+      );
+    });
   }
 
   Future<Map<String, dynamic>> loadSessionData(
@@ -310,49 +332,55 @@ class ChatSessionStorage {
   ) async {
     await ensureMigrated(userId);
     _validateSessionId(sessionId);
-    const batchSize = 100;
-    final file = _messagesFile(userId, sessionId);
-    String? cursor;
+    final lock = await _lockFor(userId, sessionId);
+    return lock.synchronized(() async {
+      const batchSize = 100;
+      final file = _messagesFile(userId, sessionId);
+      String? cursor;
 
-    while (true) {
-      final page = await _readMessageTurnGroupsBefore(
-        file,
-        limit: batchSize,
-        beforeCursor: cursor,
-      );
-      final lines = page.lines;
-      if (lines.isEmpty) return false;
-      for (final line in lines.reversed) {
-        try {
-          final decoded = jsonDecode(line.text);
-          if (decoded is Map &&
-              decoded['role'] == 'ai' &&
-              decoded['turn_id'] == turnId) {
-            return true;
+      while (true) {
+        final page = await _readMessageTurnGroupsBefore(
+          file,
+          limit: batchSize,
+          beforeCursor: cursor,
+        );
+        final lines = page.lines;
+        if (lines.isEmpty) return false;
+        for (final line in lines.reversed) {
+          try {
+            final decoded = jsonDecode(line.text);
+            if (decoded is Map &&
+                decoded['role'] == 'ai' &&
+                decoded['turn_id'] == turnId) {
+              return true;
+            }
+          } catch (_) {
+            continue;
           }
-        } catch (_) {
-          continue;
         }
+        if (!page.hasMore) return false;
+        cursor = page.olderCursor;
       }
-      if (!page.hasMore) return false;
-      cursor = page.olderCursor;
-    }
+    });
   }
 
   Future<String?> lastMessagePreview(String userId, String sessionId) async {
     _validateSessionId(sessionId);
-    final messagesFile = _messagesFile(userId, sessionId);
-    final page = await _readMessageTurnGroupsBefore(messagesFile, limit: 1);
-    if (page.lines.isEmpty) return null;
-    try {
-      final decoded = jsonDecode(page.lines.last.text);
-      if (decoded is Map) {
-        return previewForMessage(Map<String, dynamic>.from(decoded));
+    final lock = await _lockFor(userId, sessionId);
+    return lock.synchronized(() async {
+      final messagesFile = _messagesFile(userId, sessionId);
+      final page = await _readMessageTurnGroupsBefore(messagesFile, limit: 1);
+      if (page.lines.isEmpty) return null;
+      try {
+        final decoded = jsonDecode(page.lines.last.text);
+        if (decoded is Map) {
+          return previewForMessage(Map<String, dynamic>.from(decoded));
+        }
+      } catch (_) {
+        return null;
       }
-    } catch (_) {
       return null;
-    }
-    return null;
+    });
   }
 
   Future<void> deleteSession(String userId, String sessionId) async {
@@ -557,6 +585,8 @@ class ChatSessionStorage {
   }
 
   Future<List<Map<String, dynamic>>> _readMessagesFile(File file) async {
+    // Tail recovery may truncate an interrupted append. Public callers hold
+    // the session lock so a live append can never be mistaken for crash debris.
     return _jsonl.readAllRecoveringTail(file);
   }
 

--- a/lib/data/services/chat_session_storage.dart
+++ b/lib/data/services/chat_session_storage.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/jsonl_file_store.dart';
 import 'package:memex/data/services/migration_state_service.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/time_context.dart';
@@ -24,6 +25,7 @@ class ChatSessionStorage {
   static const String storageMigrationKey = 'chat_sessions_jsonl_v1';
 
   final _logger = getLogger('ChatSessionStorage');
+  final _jsonl = JsonlFileStore(loggerName: 'ChatSessionJsonl');
   final Map<String, Future<void>> _migrationFutures = {};
   final Map<String, Lock> _sessionLocks = {};
   final Map<String, Lock> _legacyMigrationLocks = {};
@@ -253,13 +255,7 @@ class ChatSessionStorage {
 
       final normalizedMessage = _normalizeMessage(message);
       final messagesFile = _messagesFile(userId, sessionId);
-      await messagesFile.parent.create(recursive: true);
-      await messagesFile.writeAsString(
-        '${jsonEncode(normalizedMessage)}\n',
-        mode: FileMode.append,
-        encoding: utf8,
-        flush: true,
-      );
+      await _jsonl.append(messagesFile, [normalizedMessage]);
 
       final metadata = await _readMetadataFile(metadataFile);
       metadata['last_message_preview'] = previewForMessage(normalizedMessage);
@@ -561,20 +557,7 @@ class ChatSessionStorage {
   }
 
   Future<List<Map<String, dynamic>>> _readMessagesFile(File file) async {
-    if (!await file.exists()) return const [];
-    final messages = <Map<String, dynamic>>[];
-    for (final line in await file.readAsLines()) {
-      if (line.trim().isEmpty) continue;
-      try {
-        final decoded = jsonDecode(line);
-        if (decoded is Map) {
-          messages.add(Map<String, dynamic>.from(decoded));
-        }
-      } catch (e) {
-        _logger.warning('Failed to parse chat message JSONL line: $e');
-      }
-    }
-    return messages;
+    return _jsonl.readAllRecoveringTail(file);
   }
 
   Future<_MessageLinePage> _readMessageTurnGroupsBefore(

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -1367,7 +1367,18 @@ class FileSystemService {
     return path.join(getSystemPath(userId), 'character_workspaces');
   }
 
+  /// Ensures a character identifier is safe to use as one path component.
+  static void validateCharacterId(String characterId) {
+    if (characterId.trim().isEmpty ||
+        characterId == '.' ||
+        characterId == '..' ||
+        path.basename(characterId) != characterId) {
+      throw ArgumentError.value(characterId, 'characterId');
+    }
+  }
+
   String getCharacterWorkspacePath(String userId, String characterId) {
+    validateCharacterId(characterId);
     return path.join(getCharacterWorkspacesPath(userId), characterId);
   }
 

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -1508,6 +1508,33 @@ class FileSystemService {
     );
   }
 
+  String getCharacterConversationPath(String userId, String characterId) {
+    return path.join(
+      getCharacterWorkspacePath(userId, characterId),
+      'Conversation',
+    );
+  }
+
+  String getCharacterConversationMessagesPath(
+    String userId,
+    String characterId,
+  ) {
+    return path.join(
+      getCharacterConversationPath(userId, characterId),
+      'messages.jsonl',
+    );
+  }
+
+  String getCharacterConversationStatePath(
+    String userId,
+    String characterId,
+  ) {
+    return path.join(
+      getCharacterConversationPath(userId, characterId),
+      'state.json',
+    );
+  }
+
   /// Unified media pool directory — all user-uploaded images/audio/etc.
   /// land here with a canonical filename (see [MediaService]).
   String getMediaPath(String userId) {

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -1536,13 +1536,44 @@ class FileSystemService {
     );
   }
 
-  String getCharacterConversationStatePath(
+  String getCharacterConversationMetadataPath(
     String userId,
     String characterId,
   ) {
     return path.join(
       getCharacterConversationPath(userId, characterId),
-      'state.json',
+      'metadata.json',
+    );
+  }
+
+  String getCharacterConversationEpisodeReceiptsPath(
+    String userId,
+    String characterId,
+  ) {
+    return path.join(
+      getCharacterConversationPath(userId, characterId),
+      '_episodes',
+    );
+  }
+
+  String getCharacterConversationEpisodeReceiptPath(
+    String userId,
+    String characterId,
+    String receiptName,
+  ) {
+    return path.join(
+      getCharacterConversationEpisodeReceiptsPath(userId, characterId),
+      '$receiptName.json',
+    );
+  }
+
+  String getCharacterConversationWriteLockPath(
+    String userId,
+    String characterId,
+  ) {
+    return path.join(
+      getCharacterConversationPath(userId, characterId),
+      '.write.lock',
     );
   }
 

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -1546,24 +1546,13 @@ class FileSystemService {
     );
   }
 
-  String getCharacterConversationEpisodeReceiptsPath(
+  String getCharacterConversationPendingCommitPath(
     String userId,
     String characterId,
   ) {
     return path.join(
       getCharacterConversationPath(userId, characterId),
-      '_episodes',
-    );
-  }
-
-  String getCharacterConversationEpisodeReceiptPath(
-    String userId,
-    String characterId,
-    String receiptName,
-  ) {
-    return path.join(
-      getCharacterConversationEpisodeReceiptsPath(userId, characterId),
-      '$receiptName.json',
+      '.pending_commit.json',
     );
   }
 

--- a/lib/data/services/jsonl_conversation_journal.dart
+++ b/lib/data/services/jsonl_conversation_journal.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:memex/data/services/jsonl_file_store.dart';
+
+enum JsonlConversationCommitPhase {
+  pendingWritten,
+  messagesAppended,
+  metadataWritten,
+}
+
+typedef JsonlConversationCommitObserver = Future<void> Function(
+  JsonlConversationCommitPhase phase,
+);
+
+/// Crash-recoverable commits spanning an append-only JSONL file and metadata.
+///
+/// The journal is deliberately schema-agnostic. Feature stores own message and
+/// metadata validation while this service owns the physical write protocol.
+/// Only one pending commit may exist because callers serialize access to a
+/// conversation before invoking this service.
+class JsonlConversationJournal {
+  JsonlConversationJournal({
+    JsonlFileStore? jsonl,
+    JsonlConversationCommitObserver? observer,
+  })  : _jsonl = jsonl ?? JsonlFileStore(),
+        _observer = observer;
+
+  static const int pendingSchemaVersion = 1;
+
+  final JsonlFileStore _jsonl;
+  final JsonlConversationCommitObserver? _observer;
+
+  Future<void> commit({
+    required File messagesFile,
+    required File metadataFile,
+    required File pendingFile,
+    required int baseOffset,
+    required List<Map<String, dynamic>> messages,
+    required Map<String, dynamic> targetMetadata,
+    bool truncateBeforeAppend = false,
+  }) async {
+    await writeJsonFile(pendingFile, {
+      'journal_schema_version': pendingSchemaVersion,
+      'base_offset': baseOffset,
+      'messages': messages,
+      'target_metadata': targetMetadata,
+    });
+    await _observer?.call(JsonlConversationCommitPhase.pendingWritten);
+
+    if (truncateBeforeAppend) {
+      await _truncate(messagesFile, baseOffset);
+    } else {
+      final currentLength =
+          await messagesFile.exists() ? await messagesFile.length() : 0;
+      if (currentLength != baseOffset) {
+        await pendingFile.delete();
+        throw StateError(
+          'JSONL log changed while preparing a conversation commit.',
+        );
+      }
+    }
+    await _jsonl.append(messagesFile, messages);
+    await _observer?.call(JsonlConversationCommitPhase.messagesAppended);
+
+    await writeJsonFile(metadataFile, targetMetadata);
+    await _observer?.call(JsonlConversationCommitPhase.metadataWritten);
+    if (await pendingFile.exists()) await pendingFile.delete();
+  }
+
+  /// Completes a pending commit by replaying it from its original byte offset.
+  ///
+  /// Callers must validate [targetMetadata] before it replaces feature state.
+  /// Replaying from [baseOffset] makes recovery correct whether no message,
+  /// part of a batch, or the complete batch reached disk before interruption.
+  Future<bool> recover({
+    required File messagesFile,
+    required File metadataFile,
+    required File pendingFile,
+    required bool Function(Map<String, dynamic> targetMetadata)
+        validateMetadata,
+  }) async {
+    if (!await pendingFile.exists()) return false;
+    final decoded = jsonDecode(await pendingFile.readAsString());
+    if (decoded is! Map ||
+        decoded['journal_schema_version'] != pendingSchemaVersion) {
+      throw const FormatException('Invalid JSONL conversation commit.');
+    }
+    final baseOffset = decoded['base_offset'];
+    final rawMessages = decoded['messages'];
+    final rawMetadata = decoded['target_metadata'];
+    if (baseOffset is! num ||
+        baseOffset.toInt() < 0 ||
+        rawMessages is! List ||
+        rawMetadata is! Map) {
+      throw const FormatException('Incomplete JSONL conversation commit.');
+    }
+    if (rawMessages.any((row) => row is! Map)) {
+      throw const FormatException('Invalid JSONL conversation rows.');
+    }
+    final messages = rawMessages
+        .whereType<Map>()
+        .map((row) => Map<String, dynamic>.from(row))
+        .toList(growable: false);
+    final targetMetadata = Map<String, dynamic>.from(rawMetadata);
+    if (!validateMetadata(targetMetadata)) {
+      throw const FormatException('Invalid pending conversation metadata.');
+    }
+
+    await messagesFile.parent.create(recursive: true);
+    if (!await messagesFile.exists()) {
+      await messagesFile.writeAsString('', flush: true);
+    }
+    final currentLength = await messagesFile.length();
+    if (currentLength < baseOffset.toInt()) {
+      throw StateError('JSONL log is shorter than its pending commit.');
+    }
+    await _truncate(messagesFile, baseOffset.toInt());
+    await _jsonl.append(messagesFile, messages);
+    await writeJsonFile(metadataFile, targetMetadata);
+    await pendingFile.delete();
+    return true;
+  }
+
+  Future<void> _truncate(File file, int length) async {
+    await file.parent.create(recursive: true);
+    if (!await file.exists()) await file.writeAsString('', flush: true);
+    final handle = await file.open(mode: FileMode.append);
+    try {
+      await handle.truncate(length);
+      await handle.flush();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  Future<void> writeJsonFile(
+    File file,
+    Map<String, dynamic> value,
+  ) {
+    const encoder = JsonEncoder.withIndent('  ');
+    return replaceFile(file, '${encoder.convert(value)}\n');
+  }
+
+  Future<void> replaceFile(File file, String content) async {
+    await file.parent.create(recursive: true);
+    final temporary = File('${file.path}.tmp');
+    await temporary.writeAsString(content, encoding: utf8, flush: true);
+    try {
+      await temporary.rename(file.path);
+    } on FileSystemException {
+      if (await file.exists()) await file.delete();
+      await temporary.rename(file.path);
+    }
+  }
+}

--- a/lib/data/services/jsonl_file_store.dart
+++ b/lib/data/services/jsonl_file_store.dart
@@ -1,0 +1,291 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:logging/logging.dart';
+import 'package:memex/utils/logger.dart';
+
+/// Low-level primitives for append-only JSONL stores.
+///
+/// Writers always append complete UTF-8 lines. Readers tolerate a process
+/// dying during the final append by truncating only the unterminated tail.
+/// Higher-level stores remain responsible for schema validation and locking.
+class JsonlFileStore {
+  JsonlFileStore({String loggerName = 'JsonlFileStore'})
+      : _logger = getLogger(loggerName);
+
+  final Logger _logger;
+
+  Future<JsonlAppendResult> append(
+    File file,
+    List<Map<String, dynamic>> objects,
+  ) async {
+    if (objects.isEmpty) {
+      final length = await file.exists() ? await file.length() : 0;
+      return JsonlAppendResult(startOffset: length, endOffset: length);
+    }
+    await file.parent.create(recursive: true);
+    final startOffset = await file.exists() ? await file.length() : 0;
+    final bytes = utf8.encode('${objects.map(jsonEncode).join('\n')}\n');
+    await file.writeAsBytes(bytes, mode: FileMode.append, flush: true);
+    return JsonlAppendResult(
+      startOffset: startOffset,
+      endOffset: startOffset + bytes.length,
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> readAllRecoveringTail(File file) async {
+    if (!await file.exists()) return const [];
+    final bytes = await file.readAsBytes();
+    if (bytes.isEmpty) return const [];
+
+    final result = <Map<String, dynamic>>[];
+    var lineStart = 0;
+    var lastValidOffset = 0;
+
+    Future<void> decodeLine(int lineEnd, {required bool terminated}) async {
+      final endOffset = terminated ? lineEnd + 1 : lineEnd;
+      try {
+        final text = utf8.decode(bytes.sublist(lineStart, lineEnd));
+        if (text.trim().isEmpty) {
+          lastValidOffset = endOffset;
+          return;
+        }
+        final decoded = jsonDecode(text);
+        if (decoded is! Map) {
+          throw const FormatException('JSONL row is not an object');
+        }
+        result.add(Map<String, dynamic>.from(decoded));
+        lastValidOffset = endOffset;
+      } catch (error) {
+        if (!terminated) {
+          _logger.warning('Truncating incomplete JSONL tail in ${file.path}');
+          await file.writeAsBytes(
+            bytes.sublist(0, lastValidOffset),
+            flush: true,
+          );
+          return;
+        }
+        _logger.warning('Skipping malformed JSONL row in ${file.path}: $error');
+        lastValidOffset = endOffset;
+      }
+    }
+
+    for (var index = 0; index < bytes.length; index++) {
+      if (bytes[index] != 0x0A) continue;
+      await decodeLine(index, terminated: true);
+      lineStart = index + 1;
+    }
+    if (lineStart < bytes.length) {
+      await decodeLine(bytes.length, terminated: false);
+    }
+    return result;
+  }
+
+  /// Reads the committed JSON object beginning at [startOffset].
+  ///
+  /// This is intended for small derived indexes that point into the JSONL
+  /// file. The row remains authoritative: a stale or invalid pointer returns
+  /// `null` instead of supplying a second copy of the object.
+  Future<Map<String, dynamic>?> readObjectAt(
+    File file,
+    int startOffset,
+  ) async {
+    if (startOffset < 0 || !await file.exists()) return null;
+    final length = await file.length();
+    if (startOffset >= length) return null;
+
+    final handle = await file.open();
+    final bytes = <int>[];
+    var terminated = false;
+    try {
+      await handle.setPosition(startOffset);
+      while (startOffset + bytes.length < length) {
+        final chunk = await handle.read(
+          math.min(8192, length - startOffset - bytes.length),
+        );
+        if (chunk.isEmpty) break;
+        final newline = chunk.indexOf(0x0A);
+        if (newline >= 0) {
+          bytes.addAll(chunk.sublist(0, newline));
+          terminated = true;
+          break;
+        }
+        bytes.addAll(chunk);
+      }
+    } finally {
+      await handle.close();
+    }
+    return terminated ? _decodeObject(bytes) : null;
+  }
+
+  /// Finds the last committed row matching [predicate].
+  ///
+  /// This scans the file and is reserved for recovery after a process dies
+  /// between appending a row and updating its derived index.
+  Future<JsonlLocatedObject?> findLastObject(
+    File file,
+    bool Function(Map<String, dynamic> object) predicate,
+  ) async {
+    if (!await file.exists()) return null;
+    final bytes = await file.readAsBytes();
+    JsonlLocatedObject? match;
+    var lineStart = 0;
+    for (var index = 0; index < bytes.length; index++) {
+      if (bytes[index] != 0x0A) continue;
+      final object = _decodeObject(bytes.sublist(lineStart, index));
+      if (object != null && predicate(object)) {
+        match = JsonlLocatedObject(
+          startOffset: lineStart,
+          value: object,
+        );
+      }
+      lineStart = index + 1;
+    }
+    return match;
+  }
+
+  Map<String, dynamic>? _decodeObject(List<int> bytes) {
+    if (bytes.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(utf8.decode(bytes));
+      return decoded is Map ? Map<String, dynamic>.from(decoded) : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Reads at most [limit] JSONL rows backwards from [beforeOffset].
+  ///
+  /// The cursor is a UTF-8 byte offset and therefore remains independent of
+  /// Dart string length and multi-byte characters.
+  Future<JsonlPage> readPageBefore(
+    File file, {
+    required int limit,
+    int? beforeOffset,
+  }) async {
+    if (limit <= 0 || !await file.exists()) return JsonlPage.empty;
+    final length = await file.length();
+    var endExclusive = beforeOffset == null
+        ? length
+        : math.max(0, math.min(length, beforeOffset));
+    if (endExclusive == 0) return JsonlPage.empty;
+
+    const chunkSize = 8192;
+    final chunks = <List<int>>[];
+    var position = endExclusive;
+    var bufferStart = endExclusive;
+    final handle = await file.open();
+    try {
+      while (position > 0) {
+        final readSize = math.min(chunkSize, position);
+        position -= readSize;
+        bufferStart = position;
+        await handle.setPosition(position);
+        chunks.insert(0, await handle.read(readSize));
+
+        final bytes = chunks.expand((chunk) => chunk).toList(growable: false);
+        var localStart = 0;
+        if (bufferStart > 0) {
+          final newline = bytes.indexOf(0x0A);
+          if (newline < 0) continue;
+          localStart = newline + 1;
+        }
+        final lines = _decodeCompleteLines(
+          bytes.sublist(localStart),
+          absoluteStart: bufferStart + localStart,
+          reachesFileEnd: endExclusive == length,
+        );
+        if (lines.length <= limit && bufferStart > 0) continue;
+
+        final selected =
+            lines.length <= limit ? lines : lines.sublist(lines.length - limit);
+        return JsonlPage(
+          rows: selected.map((line) => line.value).toList(growable: false),
+          olderOffset: selected.isEmpty || selected.first.startOffset == 0
+              ? null
+              : selected.first.startOffset,
+        );
+      }
+    } finally {
+      await handle.close();
+    }
+    return JsonlPage.empty;
+  }
+
+  List<_DecodedLine> _decodeCompleteLines(
+    List<int> bytes, {
+    required int absoluteStart,
+    required bool reachesFileEnd,
+  }) {
+    final result = <_DecodedLine>[];
+    var start = 0;
+    for (var index = 0; index < bytes.length; index++) {
+      if (bytes[index] != 0x0A) continue;
+      _decodePageLine(result, bytes, start, index, absoluteStart);
+      start = index + 1;
+    }
+    // Writers terminate every committed row with a newline. Ignore an
+    // incomplete final row here; readAllRecoveringTail owns physical repair.
+    if (!reachesFileEnd && start < bytes.length) {
+      _decodePageLine(result, bytes, start, bytes.length, absoluteStart);
+    }
+    return result;
+  }
+
+  void _decodePageLine(
+    List<_DecodedLine> output,
+    List<int> bytes,
+    int start,
+    int end,
+    int absoluteStart,
+  ) {
+    if (end <= start) return;
+    try {
+      final decoded = jsonDecode(utf8.decode(bytes.sublist(start, end)));
+      if (decoded is Map) {
+        output.add(
+          _DecodedLine(
+            startOffset: absoluteStart + start,
+            value: Map<String, dynamic>.from(decoded),
+          ),
+        );
+      }
+    } catch (error) {
+      _logger.warning('Skipping malformed JSONL page row: $error');
+    }
+  }
+}
+
+class JsonlAppendResult {
+  const JsonlAppendResult({
+    required this.startOffset,
+    required this.endOffset,
+  });
+
+  final int startOffset;
+  final int endOffset;
+}
+
+class JsonlPage {
+  const JsonlPage({required this.rows, required this.olderOffset});
+
+  static const empty = JsonlPage(rows: [], olderOffset: null);
+
+  final List<Map<String, dynamic>> rows;
+  final int? olderOffset;
+}
+
+class JsonlLocatedObject {
+  const JsonlLocatedObject({required this.startOffset, required this.value});
+
+  final int startOffset;
+  final Map<String, dynamic> value;
+}
+
+class _DecodedLine {
+  const _DecodedLine({required this.startOffset, required this.value});
+
+  final int startOffset;
+  final Map<String, dynamic> value;
+}

--- a/lib/data/services/persona_chat_conversation_storage.dart
+++ b/lib/data/services/persona_chat_conversation_storage.dart
@@ -1,0 +1,780 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/migration_state_service.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/character_message.dart';
+import 'package:memex/utils/logger.dart';
+import 'package:path/path.dart' as p;
+import 'package:synchronized/synchronized.dart';
+import 'package:uuid/uuid.dart';
+
+class PersonaChatConversationRecord {
+  const PersonaChatConversationRecord({
+    required this.id,
+    required this.seq,
+    required this.characterId,
+    required this.isFromCharacter,
+    required this.content,
+    required this.isRead,
+    required this.timestamp,
+    required this.messageType,
+    required this.origin,
+    this.factId,
+    this.contactEpisodeId,
+  });
+
+  final String id;
+  final int seq;
+  final String characterId;
+  final bool isFromCharacter;
+  final String content;
+  final String? factId;
+  final bool isRead;
+  final DateTime timestamp;
+  final String messageType;
+  final String origin;
+  final String? contactEpisodeId;
+
+  String get speaker => isFromCharacter ? 'character' : 'user';
+
+  PersonaChatConversationRecord copyWith({
+    bool? isRead,
+  }) {
+    return PersonaChatConversationRecord(
+      id: id,
+      seq: seq,
+      characterId: characterId,
+      isFromCharacter: isFromCharacter,
+      content: content,
+      factId: factId,
+      isRead: isRead ?? this.isRead,
+      timestamp: timestamp,
+      messageType: messageType,
+      origin: origin,
+      contactEpisodeId: contactEpisodeId,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'seq': seq,
+      'character_id': characterId,
+      'speaker': speaker,
+      'is_from_character': isFromCharacter,
+      'content': content,
+      if (factId != null) 'fact_id': factId,
+      'is_read': isRead,
+      'timestamp': timestamp.toIso8601String(),
+      'unix_seconds': timestamp.millisecondsSinceEpoch ~/ 1000,
+      'type': messageType,
+      'message_type': messageType,
+      'origin': origin,
+      if (contactEpisodeId != null) 'contact_episode_id': contactEpisodeId,
+    };
+  }
+
+  static PersonaChatConversationRecord? fromJson(Map<String, dynamic> json) {
+    final id = json['id']?.toString();
+    final characterId = json['character_id']?.toString();
+    final content = json['content']?.toString();
+    if (id == null ||
+        id.isEmpty ||
+        characterId == null ||
+        characterId.isEmpty ||
+        content == null) {
+      return null;
+    }
+    final speaker = json['speaker']?.toString();
+    final isFromCharacter =
+        json['is_from_character'] == true || speaker == 'character';
+    final timestampRaw = json['timestamp']?.toString();
+    final unixSeconds = json['unix_seconds'];
+    DateTime timestamp;
+    if (timestampRaw != null) {
+      timestamp = DateTime.tryParse(timestampRaw) ?? DateTime.now();
+    } else if (unixSeconds is num) {
+      timestamp = DateTime.fromMillisecondsSinceEpoch(
+        unixSeconds.toInt() * 1000,
+      );
+    } else {
+      timestamp = DateTime.now();
+    }
+    final type = (json['message_type'] ?? json['type'])?.toString() ??
+        PersonaChatMessageTypes.text;
+    return PersonaChatConversationRecord(
+      id: id,
+      seq: json['seq'] is num ? (json['seq'] as num).toInt() : 0,
+      characterId: characterId,
+      isFromCharacter: isFromCharacter,
+      content: content,
+      factId: json['fact_id']?.toString(),
+      isRead: json['is_read'] == true,
+      timestamp: timestamp,
+      messageType: type == 'text' ? PersonaChatMessageTypes.text : type,
+      origin: json['origin']?.toString() ?? 'conversation',
+      contactEpisodeId: json['contact_episode_id']?.toString(),
+    );
+  }
+}
+
+class PersonaChatConversationState {
+  const PersonaChatConversationState({
+    required this.schemaVersion,
+    required this.nextSeq,
+    this.consumedThroughMessageId,
+    this.updatedAt,
+    this.clearedAt,
+  });
+
+  final int schemaVersion;
+  final int nextSeq;
+  final String? consumedThroughMessageId;
+  final DateTime? updatedAt;
+  final DateTime? clearedAt;
+
+  factory PersonaChatConversationState.initial() {
+    return const PersonaChatConversationState(
+      schemaVersion: PersonaChatConversationStorage.schemaVersion,
+      nextSeq: 1,
+    );
+  }
+
+  PersonaChatConversationState copyWith({
+    int? schemaVersion,
+    int? nextSeq,
+    String? consumedThroughMessageId,
+    bool clearConsumedThroughMessageId = false,
+    DateTime? updatedAt,
+    DateTime? clearedAt,
+    bool clearClearedAt = false,
+  }) {
+    return PersonaChatConversationState(
+      schemaVersion: schemaVersion ?? this.schemaVersion,
+      nextSeq: nextSeq ?? this.nextSeq,
+      consumedThroughMessageId: clearConsumedThroughMessageId
+          ? null
+          : (consumedThroughMessageId ?? this.consumedThroughMessageId),
+      updatedAt: updatedAt ?? this.updatedAt,
+      clearedAt: clearClearedAt ? null : (clearedAt ?? this.clearedAt),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'schema_version': schemaVersion,
+      'next_message_seq': nextSeq,
+      'consumed_through_message_id': consumedThroughMessageId,
+      if (updatedAt != null) 'updated_at': updatedAt!.toIso8601String(),
+      if (clearedAt != null) 'cleared_at': clearedAt!.toIso8601String(),
+    };
+  }
+
+  static PersonaChatConversationState fromJson(Map<String, dynamic> json) {
+    return PersonaChatConversationState(
+      schemaVersion: json['schema_version'] is num
+          ? (json['schema_version'] as num).toInt()
+          : PersonaChatConversationStorage.schemaVersion,
+      nextSeq: json['next_message_seq'] is num
+          ? (json['next_message_seq'] as num).toInt()
+          : 1,
+      consumedThroughMessageId: json['consumed_through_message_id']?.toString(),
+      updatedAt: json['updated_at'] is String
+          ? DateTime.tryParse(json['updated_at'] as String)
+          : null,
+      clearedAt: json['cleared_at'] is String
+          ? DateTime.tryParse(json['cleared_at'] as String)
+          : null,
+    );
+  }
+}
+
+/// Durable character-conversation store. Workspace files are the source of
+/// truth; SQLite is a rebuildable projection.
+class PersonaChatConversationStorage {
+  PersonaChatConversationStorage({
+    FileSystemService? fileSystem,
+    MigrationStateService? migrationState,
+    Uuid? uuid,
+  })  : _injectedFileSystem = fileSystem,
+        _migrationState = migrationState ?? MigrationStateService.instance,
+        _uuid = uuid ?? const Uuid();
+
+  static final PersonaChatConversationStorage instance =
+      PersonaChatConversationStorage();
+
+  static const int schemaVersion = 1;
+  static const String storageMigrationKey = 'persona_chat_workspace_v1';
+
+  final FileSystemService? _injectedFileSystem;
+  final MigrationStateService _migrationState;
+  final Uuid _uuid;
+  final _logger = getLogger('PersonaChatConversationStorage');
+  final Map<String, Lock> _locks = {};
+
+  FileSystemService get _fileSystem =>
+      _injectedFileSystem ?? FileSystemService.instance;
+
+  Lock _lockFor(String userId, String characterId) {
+    return _locks.putIfAbsent('$userId:$characterId', Lock.new);
+  }
+
+  Future<void> ensureLayout(String userId, String characterId) {
+    return _lockFor(userId, characterId).synchronized(
+      () => _ensureLayoutUnlocked(userId, characterId),
+    );
+  }
+
+  Future<void> ensureMigrated({
+    required String userId,
+    required AppDatabase db,
+  }) {
+    return _migrationState.runOnce(
+      userId: userId,
+      key: storageMigrationKey,
+      migrate: () => _exportSqliteToWorkspace(userId, db),
+    );
+  }
+
+  Future<PersonaChatConversationRecord> appendMessage({
+    required String userId,
+    required String characterId,
+    required bool isFromCharacter,
+    required String content,
+    required DateTime timestamp,
+    required String messageType,
+    required String origin,
+    String? factId,
+    bool isRead = false,
+    String? contactEpisodeId,
+    String? stableId,
+  }) {
+    return _lockFor(userId, characterId).synchronized(() async {
+      await _ensureLayoutUnlocked(userId, characterId);
+      var state = await _readStateUnlocked(userId, characterId);
+      final record = PersonaChatConversationRecord(
+        id: stableId ?? _uuid.v4(),
+        seq: state.nextSeq,
+        characterId: characterId,
+        isFromCharacter: isFromCharacter,
+        content: content,
+        factId: factId,
+        isRead: isRead,
+        timestamp: timestamp,
+        messageType: messageType,
+        origin: origin,
+        contactEpisodeId: contactEpisodeId,
+      );
+      await _appendLineUnlocked(userId, characterId, record);
+      await _writeStateUnlocked(
+        userId,
+        characterId,
+        state.copyWith(
+          nextSeq: state.nextSeq + 1,
+          updatedAt: DateTime.now(),
+          clearClearedAt: true,
+        ),
+      );
+      return record;
+    });
+  }
+
+  Future<List<PersonaChatConversationRecord>> appendEpisode({
+    required String userId,
+    required String characterId,
+    required List<PersonaChatConversationRecord> Function(int nextSeq) records,
+    required String contactEpisodeId,
+  }) {
+    return _lockFor(userId, characterId).synchronized(() async {
+      await _ensureLayoutUnlocked(userId, characterId);
+      final existing = await _readRecordsUnlocked(userId, characterId);
+      final already = existing
+          .where((record) => record.contactEpisodeId == contactEpisodeId)
+          .toList(growable: false);
+      if (already.isNotEmpty) return already;
+
+      var state = await _readStateUnlocked(userId, characterId);
+      final toWrite = records(state.nextSeq);
+      for (final record in toWrite) {
+        await _appendLineUnlocked(userId, characterId, record);
+      }
+      await _writeStateUnlocked(
+        userId,
+        characterId,
+        state.copyWith(
+          nextSeq: state.nextSeq + toWrite.length,
+          updatedAt: DateTime.now(),
+          clearClearedAt: true,
+        ),
+      );
+      return toWrite;
+    });
+  }
+
+  Future<List<PersonaChatConversationRecord>> loadMessages({
+    required String userId,
+    required String characterId,
+  }) {
+    return _lockFor(userId, characterId).synchronized(
+      () => _readRecordsUnlocked(userId, characterId),
+    );
+  }
+
+  Future<PersonaChatConversationState> loadState({
+    required String userId,
+    required String characterId,
+  }) {
+    return _lockFor(userId, characterId).synchronized(() async {
+      await _ensureLayoutUnlocked(userId, characterId);
+      return _readStateUnlocked(userId, characterId);
+    });
+  }
+
+  Future<void> advanceCursor({
+    required String userId,
+    required String characterId,
+    required String consumedThroughMessageId,
+  }) {
+    return _lockFor(userId, characterId).synchronized(() async {
+      await _ensureLayoutUnlocked(userId, characterId);
+      final records = await _readRecordsUnlocked(userId, characterId);
+      final current = await _readStateUnlocked(userId, characterId);
+      if (!_cursorIsAhead(
+        records: records,
+        currentId: current.consumedThroughMessageId,
+        nextId: consumedThroughMessageId,
+      )) {
+        return;
+      }
+      await _writeStateUnlocked(
+        userId,
+        characterId,
+        current.copyWith(
+          consumedThroughMessageId: consumedThroughMessageId,
+          updatedAt: DateTime.now(),
+        ),
+      );
+    });
+  }
+
+  Future<void> clearConversation({
+    required String userId,
+    required String characterId,
+    required DateTime clearedAt,
+  }) {
+    return _lockFor(userId, characterId).synchronized(() async {
+      await _ensureLayoutUnlocked(userId, characterId);
+      await _writeMessagesFile(
+        File(_fileSystem.getCharacterConversationMessagesPath(
+          userId,
+          characterId,
+        )),
+        const [],
+      );
+      await _writeStateUnlocked(
+        userId,
+        characterId,
+        PersonaChatConversationState(
+          schemaVersion: schemaVersion,
+          nextSeq: 1,
+          clearedAt: clearedAt,
+          updatedAt: clearedAt,
+        ),
+      );
+    });
+  }
+
+  Future<void> markAllRead({
+    required String userId,
+    required String characterId,
+  }) {
+    return _lockFor(userId, characterId).synchronized(() async {
+      await _ensureLayoutUnlocked(userId, characterId);
+      final records = await _readRecordsUnlocked(userId, characterId);
+      final updated = records
+          .map(
+            (record) =>
+                record.isFromCharacter ? record.copyWith(isRead: true) : record,
+          )
+          .toList(growable: false);
+      await _writeMessagesFile(
+        File(_fileSystem.getCharacterConversationMessagesPath(
+          userId,
+          characterId,
+        )),
+        updated,
+      );
+    });
+  }
+
+  Future<void> rebuildSqliteProjection({
+    required String userId,
+    required String characterId,
+    required AppDatabase db,
+  }) {
+    return _lockFor(userId, characterId).synchronized(() async {
+      await _ensureLayoutUnlocked(userId, characterId);
+      await _rebuildSqliteUnlocked(
+        userId: userId,
+        characterId: characterId,
+        db: db,
+      );
+    });
+  }
+
+  Future<void> reconcileAll({
+    required String userId,
+    required AppDatabase db,
+  }) async {
+    final characterIds = await _characterIds(userId, db);
+    for (final characterId in characterIds) {
+      await rebuildSqliteProjection(
+        userId: userId,
+        characterId: characterId,
+        db: db,
+      );
+    }
+  }
+
+  Future<void> _ensureLayoutUnlocked(String userId, String characterId) async {
+    final directory = Directory(
+      _fileSystem.getCharacterConversationPath(userId, characterId),
+    );
+    await directory.create(recursive: true);
+    final messages = File(
+      _fileSystem.getCharacterConversationMessagesPath(userId, characterId),
+    );
+    if (!await messages.exists()) {
+      await messages.writeAsString('', flush: true);
+    }
+    final stateFile = File(
+      _fileSystem.getCharacterConversationStatePath(userId, characterId),
+    );
+    if (!await stateFile.exists()) {
+      await _writeJsonFile(
+        stateFile,
+        PersonaChatConversationState.initial().toJson(),
+      );
+    }
+  }
+
+  Future<bool> _exportSqliteToWorkspace(String userId, AppDatabase db) async {
+    final characterIds = await _characterIdsFromSqlite(db);
+    for (final characterId in characterIds) {
+      await _lockFor(userId, characterId).synchronized(() async {
+        await _ensureLayoutUnlocked(userId, characterId);
+        final existing = await _readRecordsUnlocked(userId, characterId);
+        if (existing.isNotEmpty) return;
+
+        final rows = await (db.select(db.personaChatMessages)
+              ..where((row) => row.characterId.equals(characterId))
+              ..orderBy([
+                (row) => OrderingTerm.asc(row.timestamp),
+                (row) => OrderingTerm.asc(row.id),
+              ]))
+            .get();
+        if (rows.isEmpty) return;
+
+        var seq = 1;
+        final records = <PersonaChatConversationRecord>[];
+        for (final row in rows) {
+          final stableId = (row.stableId != null && row.stableId!.isNotEmpty)
+              ? row.stableId!
+              : 'legacy-${row.id}';
+          records.add(
+            PersonaChatConversationRecord(
+              id: stableId,
+              seq: seq++,
+              characterId: characterId,
+              isFromCharacter: row.isFromCharacter,
+              content: row.content,
+              factId: row.factId,
+              isRead: row.isRead,
+              timestamp: row.timestamp,
+              messageType: row.messageType,
+              origin: row.origin,
+              contactEpisodeId: row.contactEpisodeId,
+            ),
+          );
+        }
+        await _writeMessagesFile(
+          File(_fileSystem.getCharacterConversationMessagesPath(
+            userId,
+            characterId,
+          )),
+          records,
+        );
+
+        final cursor = await (db.select(db.personaChatReplyCursors)
+              ..where((row) => row.characterId.equals(characterId)))
+            .getSingleOrNull();
+        String? consumedStableId;
+        if (cursor != null && cursor.consumedThroughMessageId > 0) {
+          PersonaChatMessage? consumedRow;
+          for (final row in rows) {
+            if (row.id == cursor.consumedThroughMessageId) {
+              consumedRow = row;
+              break;
+            }
+          }
+          if (consumedRow != null) {
+            consumedStableId = (consumedRow.stableId != null &&
+                    consumedRow.stableId!.isNotEmpty)
+                ? consumedRow.stableId
+                : 'legacy-${consumedRow.id}';
+          } else {
+            consumedStableId = 'legacy-${cursor.consumedThroughMessageId}';
+          }
+        }
+        await _writeStateUnlocked(
+          userId,
+          characterId,
+          PersonaChatConversationState(
+            schemaVersion: schemaVersion,
+            nextSeq: seq,
+            consumedThroughMessageId: consumedStableId,
+            updatedAt: DateTime.now(),
+          ),
+        );
+      });
+    }
+    return true;
+  }
+
+  Future<void> _rebuildSqliteUnlocked({
+    required String userId,
+    required String characterId,
+    required AppDatabase db,
+  }) async {
+    final records = await _readRecordsUnlocked(userId, characterId);
+    final state = await _readStateUnlocked(userId, characterId);
+    await db.transaction(() async {
+      await (db.delete(db.personaChatMessages)
+            ..where((row) => row.characterId.equals(characterId)))
+          .go();
+      await (db.delete(db.personaChatReplyCursors)
+            ..where((row) => row.characterId.equals(characterId)))
+          .go();
+      final idByStable = <String, int>{};
+      for (final record in records) {
+        final id = await db.into(db.personaChatMessages).insert(
+              PersonaChatMessagesCompanion.insert(
+                characterId: record.characterId,
+                isFromCharacter: record.isFromCharacter,
+                content: record.content,
+                factId: Value(record.factId),
+                isRead: Value(record.isRead),
+                timestamp: record.timestamp,
+                messageType: Value(record.messageType),
+                origin: Value(record.origin),
+                contactEpisodeId: Value(record.contactEpisodeId),
+                stableId: Value(record.id),
+              ),
+            );
+        idByStable[record.id] = id;
+      }
+      final consumedStableId = state.consumedThroughMessageId;
+      if (consumedStableId != null &&
+          consumedStableId.isNotEmpty &&
+          idByStable.containsKey(consumedStableId)) {
+        await db.into(db.personaChatReplyCursors).insert(
+              PersonaChatReplyCursorsCompanion.insert(
+                characterId: characterId,
+                consumedThroughMessageId: Value(idByStable[consumedStableId]!),
+                updatedAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              ),
+            );
+      }
+    });
+  }
+
+  Future<List<PersonaChatConversationRecord>> _readRecordsUnlocked(
+    String userId,
+    String characterId,
+  ) async {
+    final file = File(
+      _fileSystem.getCharacterConversationMessagesPath(userId, characterId),
+    );
+    if (!await file.exists()) return const [];
+    final bytes = await file.readAsBytes();
+    if (bytes.isEmpty) return const [];
+    final text = utf8.decode(bytes);
+    final records = <PersonaChatConversationRecord>[];
+    var lastValidOffset = 0;
+    var offset = 0;
+    final lines = text.split('\n');
+    for (var index = 0; index < lines.length; index++) {
+      final line = lines[index];
+      final hasTrailingNewline = index < lines.length - 1;
+      offset += line.length + (hasTrailingNewline ? 1 : 0);
+      if (line.trim().isEmpty) {
+        lastValidOffset = offset;
+        continue;
+      }
+      try {
+        final decoded = jsonDecode(line);
+        if (decoded is! Map) {
+          throw const FormatException(
+              'Conversation JSONL row is not an object');
+        }
+        final record = PersonaChatConversationRecord.fromJson(
+          Map<String, dynamic>.from(decoded),
+        );
+        if (record == null) {
+          throw const FormatException('Conversation JSONL row is incomplete');
+        }
+        records.add(record);
+        lastValidOffset = offset;
+      } catch (error) {
+        final truncatedTail = !hasTrailingNewline && !text.endsWith('\n');
+        if (truncatedTail) {
+          _logger.warning(
+            'Truncating incomplete conversation JSONL tail in ${file.path}',
+          );
+          await file.writeAsBytes(
+            bytes.sublist(0, lastValidOffset),
+            flush: true,
+          );
+          break;
+        }
+        _logger.warning(
+          'Skipping malformed conversation JSONL row in ${file.path}: $error',
+        );
+        lastValidOffset = offset;
+      }
+    }
+    return records;
+  }
+
+  Future<PersonaChatConversationState> _readStateUnlocked(
+    String userId,
+    String characterId,
+  ) async {
+    final file = File(
+      _fileSystem.getCharacterConversationStatePath(userId, characterId),
+    );
+    if (!await file.exists()) {
+      return PersonaChatConversationState.initial();
+    }
+    try {
+      final decoded = jsonDecode(await file.readAsString());
+      if (decoded is Map) {
+        return PersonaChatConversationState.fromJson(
+          Map<String, dynamic>.from(decoded),
+        );
+      }
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Failed to parse conversation state ${file.path}',
+        error,
+        stackTrace,
+      );
+    }
+    return PersonaChatConversationState.initial();
+  }
+
+  Future<void> _appendLineUnlocked(
+    String userId,
+    String characterId,
+    PersonaChatConversationRecord record,
+  ) async {
+    final file = File(
+      _fileSystem.getCharacterConversationMessagesPath(userId, characterId),
+    );
+    await file.parent.create(recursive: true);
+    await file.writeAsString(
+      '${jsonEncode(record.toJson())}\n',
+      mode: FileMode.append,
+      flush: true,
+    );
+  }
+
+  Future<void> _writeStateUnlocked(
+    String userId,
+    String characterId,
+    PersonaChatConversationState state,
+  ) {
+    return _writeJsonFile(
+      File(_fileSystem.getCharacterConversationStatePath(userId, characterId)),
+      state.toJson(),
+    );
+  }
+
+  Future<void> _writeMessagesFile(
+    File file,
+    List<PersonaChatConversationRecord> records,
+  ) async {
+    await file.parent.create(recursive: true);
+    final content = records.isEmpty
+        ? ''
+        : '${records.map((record) => jsonEncode(record.toJson())).join('\n')}\n';
+    final temporary = File('${file.path}.tmp');
+    await temporary.writeAsString(content, flush: true);
+    try {
+      await temporary.rename(file.path);
+    } on FileSystemException {
+      if (await file.exists()) await file.delete();
+      await temporary.rename(file.path);
+    }
+  }
+
+  Future<void> _writeJsonFile(File file, Map<String, dynamic> data) async {
+    await file.parent.create(recursive: true);
+    final temporary = File('${file.path}.tmp');
+    const encoder = JsonEncoder.withIndent('  ');
+    await temporary.writeAsString(
+      '${encoder.convert(data)}\n',
+      flush: true,
+    );
+    try {
+      await temporary.rename(file.path);
+    } on FileSystemException {
+      if (await file.exists()) await file.delete();
+      await temporary.rename(file.path);
+    }
+  }
+
+  bool _cursorIsAhead({
+    required List<PersonaChatConversationRecord> records,
+    required String? currentId,
+    required String nextId,
+  }) {
+    if (currentId == null || currentId.isEmpty) return true;
+    if (currentId == nextId) return false;
+    final currentIndex = records.indexWhere((record) => record.id == currentId);
+    final nextIndex = records.indexWhere((record) => record.id == nextId);
+    if (nextIndex < 0) return false;
+    if (currentIndex < 0) return true;
+    return nextIndex > currentIndex;
+  }
+
+  Future<Set<String>> _characterIds(String userId, AppDatabase db) async {
+    final ids = await _characterIdsFromSqlite(db);
+    final root = Directory(_fileSystem.getCharacterWorkspacesPath(userId));
+    if (await root.exists()) {
+      await for (final entity in root.list(followLinks: false)) {
+        if (entity is! Directory) continue;
+        final name = p.basename(entity.path);
+        if (name.startsWith('.')) continue;
+        ids.add(name);
+      }
+    }
+    return ids;
+  }
+
+  Future<Set<String>> _characterIdsFromSqlite(AppDatabase db) async {
+    final rows = await db
+        .customSelect(
+          'SELECT DISTINCT character_id FROM persona_chat_messages',
+        )
+        .get();
+    return rows
+        .map((row) => row.data['character_id']?.toString())
+        .whereType<String>()
+        .where((id) => id.isNotEmpty)
+        .toSet();
+  }
+}

--- a/lib/data/services/persona_chat_conversation_storage.dart
+++ b/lib/data/services/persona_chat_conversation_storage.dart
@@ -1,12 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:drift/drift.dart';
+import 'package:crypto/crypto.dart';
 import 'package:memex/data/services/file_system_service.dart';
-import 'package:memex/data/services/migration_state_service.dart';
-import 'package:memex/db/app_database.dart';
+import 'package:memex/data/services/jsonl_file_store.dart';
 import 'package:memex/domain/models/character_message.dart';
-import 'package:memex/utils/logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:synchronized/synchronized.dart';
 import 'package:uuid/uuid.dart';
@@ -38,11 +36,7 @@ class PersonaChatConversationRecord {
   final String origin;
   final String? contactEpisodeId;
 
-  String get speaker => isFromCharacter ? 'character' : 'user';
-
-  PersonaChatConversationRecord copyWith({
-    bool? isRead,
-  }) {
+  PersonaChatConversationRecord copyWith({bool? isRead}) {
     return PersonaChatConversationRecord(
       id: id,
       seq: seq,
@@ -58,191 +52,204 @@ class PersonaChatConversationRecord {
     );
   }
 
-  Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'seq': seq,
-      'character_id': characterId,
-      'speaker': speaker,
-      'is_from_character': isFromCharacter,
-      'content': content,
-      if (factId != null) 'fact_id': factId,
-      'is_read': isRead,
-      'timestamp': timestamp.toIso8601String(),
-      'unix_seconds': timestamp.millisecondsSinceEpoch ~/ 1000,
-      'type': messageType,
-      'message_type': messageType,
-      'origin': origin,
-      if (contactEpisodeId != null) 'contact_episode_id': contactEpisodeId,
-    };
-  }
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'seq': seq,
+        'character_id': characterId,
+        'speaker': isFromCharacter ? 'character' : 'user',
+        'content': content,
+        if (factId != null) 'fact_id': factId,
+        'is_read': isRead,
+        'timestamp': timestamp.toIso8601String(),
+        'unix_seconds': timestamp.millisecondsSinceEpoch ~/ 1000,
+        'message_type': messageType,
+        'origin': origin,
+        if (contactEpisodeId != null) 'contact_episode_id': contactEpisodeId,
+      };
 
   static PersonaChatConversationRecord? fromJson(Map<String, dynamic> json) {
     final id = json['id']?.toString();
     final characterId = json['character_id']?.toString();
     final content = json['content']?.toString();
+    final seq = json['seq'];
     if (id == null ||
         id.isEmpty ||
         characterId == null ||
         characterId.isEmpty ||
-        content == null) {
+        content == null ||
+        seq is! num ||
+        seq.toInt() <= 0) {
       return null;
     }
-    final speaker = json['speaker']?.toString();
-    final isFromCharacter =
-        json['is_from_character'] == true || speaker == 'character';
-    final timestampRaw = json['timestamp']?.toString();
+    final timestampText = json['timestamp']?.toString();
     final unixSeconds = json['unix_seconds'];
-    DateTime timestamp;
-    if (timestampRaw != null) {
-      timestamp = DateTime.tryParse(timestampRaw) ?? DateTime.now();
-    } else if (unixSeconds is num) {
-      timestamp = DateTime.fromMillisecondsSinceEpoch(
-        unixSeconds.toInt() * 1000,
-      );
-    } else {
-      timestamp = DateTime.now();
-    }
-    final type = (json['message_type'] ?? json['type'])?.toString() ??
-        PersonaChatMessageTypes.text;
+    final timestamp = timestampText == null
+        ? unixSeconds is num
+            ? DateTime.fromMillisecondsSinceEpoch(unixSeconds.toInt() * 1000)
+            : DateTime.fromMillisecondsSinceEpoch(0)
+        : DateTime.tryParse(timestampText) ??
+            DateTime.fromMillisecondsSinceEpoch(0);
     return PersonaChatConversationRecord(
       id: id,
-      seq: json['seq'] is num ? (json['seq'] as num).toInt() : 0,
+      seq: seq.toInt(),
       characterId: characterId,
-      isFromCharacter: isFromCharacter,
+      isFromCharacter:
+          json['speaker'] == 'character' || json['is_from_character'] == true,
       content: content,
       factId: json['fact_id']?.toString(),
       isRead: json['is_read'] == true,
       timestamp: timestamp,
-      messageType: type == 'text' ? PersonaChatMessageTypes.text : type,
+      messageType: (json['message_type'] ?? json['type'])?.toString() ??
+          PersonaChatMessageTypes.text,
       origin: json['origin']?.toString() ?? 'conversation',
       contactEpisodeId: json['contact_episode_id']?.toString(),
     );
   }
 }
 
-class PersonaChatConversationState {
-  const PersonaChatConversationState({
+class PersonaChatConversationMetadata {
+  const PersonaChatConversationMetadata({
     required this.schemaVersion,
     required this.nextSeq,
-    this.consumedThroughMessageId,
+    required this.messageCount,
+    required this.unreadCount,
+    required this.messagesByteLength,
+    required this.readThroughSeq,
+    this.consumedThroughSeq,
+    this.lastMessage,
     this.updatedAt,
     this.clearedAt,
   });
 
-  final int schemaVersion;
-  final int nextSeq;
-  final String? consumedThroughMessageId;
-  final DateTime? updatedAt;
-  final DateTime? clearedAt;
-
-  factory PersonaChatConversationState.initial() {
-    return const PersonaChatConversationState(
+  factory PersonaChatConversationMetadata.initial() {
+    return const PersonaChatConversationMetadata(
       schemaVersion: PersonaChatConversationStorage.schemaVersion,
       nextSeq: 1,
+      messageCount: 0,
+      unreadCount: 0,
+      messagesByteLength: 0,
+      readThroughSeq: 0,
     );
   }
 
-  PersonaChatConversationState copyWith({
-    int? schemaVersion,
+  final int schemaVersion;
+  final int nextSeq;
+  final int messageCount;
+  final int unreadCount;
+  final int messagesByteLength;
+  final int readThroughSeq;
+  final int? consumedThroughSeq;
+  final PersonaChatConversationRecord? lastMessage;
+  final DateTime? updatedAt;
+  final DateTime? clearedAt;
+
+  PersonaChatConversationMetadata copyWith({
     int? nextSeq,
-    String? consumedThroughMessageId,
-    bool clearConsumedThroughMessageId = false,
+    int? messageCount,
+    int? unreadCount,
+    int? messagesByteLength,
+    int? readThroughSeq,
+    int? consumedThroughSeq,
+    bool clearConsumedThroughSeq = false,
+    PersonaChatConversationRecord? lastMessage,
+    bool clearLastMessage = false,
     DateTime? updatedAt,
     DateTime? clearedAt,
     bool clearClearedAt = false,
   }) {
-    return PersonaChatConversationState(
-      schemaVersion: schemaVersion ?? this.schemaVersion,
+    return PersonaChatConversationMetadata(
+      schemaVersion: schemaVersion,
       nextSeq: nextSeq ?? this.nextSeq,
-      consumedThroughMessageId: clearConsumedThroughMessageId
+      messageCount: messageCount ?? this.messageCount,
+      unreadCount: unreadCount ?? this.unreadCount,
+      messagesByteLength: messagesByteLength ?? this.messagesByteLength,
+      readThroughSeq: readThroughSeq ?? this.readThroughSeq,
+      consumedThroughSeq: clearConsumedThroughSeq
           ? null
-          : (consumedThroughMessageId ?? this.consumedThroughMessageId),
+          : consumedThroughSeq ?? this.consumedThroughSeq,
+      lastMessage: clearLastMessage ? null : lastMessage ?? this.lastMessage,
       updatedAt: updatedAt ?? this.updatedAt,
-      clearedAt: clearClearedAt ? null : (clearedAt ?? this.clearedAt),
+      clearedAt: clearClearedAt ? null : clearedAt ?? this.clearedAt,
     );
   }
 
-  Map<String, dynamic> toJson() {
-    return {
-      'schema_version': schemaVersion,
-      'next_message_seq': nextSeq,
-      'consumed_through_message_id': consumedThroughMessageId,
-      if (updatedAt != null) 'updated_at': updatedAt!.toIso8601String(),
-      if (clearedAt != null) 'cleared_at': clearedAt!.toIso8601String(),
-    };
-  }
+  Map<String, dynamic> toJson() => {
+        'schema_version': schemaVersion,
+        'next_message_seq': nextSeq,
+        'message_count': messageCount,
+        'unread_count': unreadCount,
+        'messages_byte_length': messagesByteLength,
+        'read_through_seq': readThroughSeq,
+        if (consumedThroughSeq != null)
+          'consumed_through_seq': consumedThroughSeq,
+        if (lastMessage != null) 'last_message': lastMessage!.toJson(),
+        if (updatedAt != null) 'updated_at': updatedAt!.toIso8601String(),
+        if (clearedAt != null) 'cleared_at': clearedAt!.toIso8601String(),
+      };
 
-  static PersonaChatConversationState fromJson(Map<String, dynamic> json) {
-    return PersonaChatConversationState(
-      schemaVersion: json['schema_version'] is num
-          ? (json['schema_version'] as num).toInt()
-          : PersonaChatConversationStorage.schemaVersion,
-      nextSeq: json['next_message_seq'] is num
-          ? (json['next_message_seq'] as num).toInt()
-          : 1,
-      consumedThroughMessageId: json['consumed_through_message_id']?.toString(),
-      updatedAt: json['updated_at'] is String
-          ? DateTime.tryParse(json['updated_at'] as String)
+  static PersonaChatConversationMetadata? fromJson(Map<String, dynamic> json) {
+    if (json['schema_version'] !=
+        PersonaChatConversationStorage.schemaVersion) {
+      return null;
+    }
+    final lastRaw = json['last_message'];
+    return PersonaChatConversationMetadata(
+      schemaVersion: PersonaChatConversationStorage.schemaVersion,
+      nextSeq: _positiveInt(json['next_message_seq'], fallback: 1),
+      messageCount: _nonNegativeInt(json['message_count']),
+      unreadCount: _nonNegativeInt(json['unread_count']),
+      messagesByteLength: _nonNegativeInt(json['messages_byte_length']),
+      readThroughSeq: _nonNegativeInt(json['read_through_seq']),
+      consumedThroughSeq: json['consumed_through_seq'] is num
+          ? (json['consumed_through_seq'] as num).toInt()
           : null,
-      clearedAt: json['cleared_at'] is String
-          ? DateTime.tryParse(json['cleared_at'] as String)
+      lastMessage: lastRaw is Map
+          ? PersonaChatConversationRecord.fromJson(
+              Map<String, dynamic>.from(lastRaw),
+            )
           : null,
+      updatedAt: DateTime.tryParse(json['updated_at']?.toString() ?? ''),
+      clearedAt: DateTime.tryParse(json['cleared_at']?.toString() ?? ''),
     );
   }
+
+  static int _nonNegativeInt(dynamic value) =>
+      value is num && value >= 0 ? value.toInt() : 0;
+
+  static int _positiveInt(dynamic value, {required int fallback}) =>
+      value is num && value > 0 ? value.toInt() : fallback;
 }
 
-/// Durable character-conversation store. Workspace files are the source of
-/// truth; SQLite is a rebuildable projection.
+/// File-only persona conversation store.
 ///
-/// Single-message appends may leave only an invalid final JSONL row after a
-/// crash, which [_readRecordsUnlocked] removes at a UTF-8 byte boundary.
-/// Multi-record episodes replace the JSONL file once so they become visible
-/// together; a count mismatch on retry replaces an incomplete episode.
+/// `messages.jsonl` is the sole durable message history. `metadata.json` is a
+/// rebuildable summary used for O(1) unread/cursor/last-message queries. An
+/// episode is one JSONL envelope, so all bubbles become visible together.
 class PersonaChatConversationStorage {
   PersonaChatConversationStorage({
     FileSystemService? fileSystem,
-    MigrationStateService? migrationState,
+    JsonlFileStore? jsonl,
     Uuid? uuid,
   })  : _injectedFileSystem = fileSystem,
-        _migrationState = migrationState ?? MigrationStateService.instance,
+        _jsonl = jsonl ?? JsonlFileStore(loggerName: 'PersonaChatJsonl'),
         _uuid = uuid ?? const Uuid();
 
   static final PersonaChatConversationStorage instance =
       PersonaChatConversationStorage();
 
-  static const int schemaVersion = 1;
-  static const String storageMigrationKey = 'persona_chat_workspace_v1';
+  static const int schemaVersion = 2;
+  static const String storageMigrationKey = 'persona_chat_workspace_v2';
+  static const String _episodeRecordType = 'episode';
+  static const String _readBoundaryRecordType = 'read_boundary';
+  static const String _replyCursorRecordType = 'reply_cursor';
+  static final Map<String, Lock> _processLocks = {};
 
   final FileSystemService? _injectedFileSystem;
-  final MigrationStateService _migrationState;
+  final JsonlFileStore _jsonl;
   final Uuid _uuid;
-  final _logger = getLogger('PersonaChatConversationStorage');
-  final Map<String, Lock> _locks = {};
 
   FileSystemService get _fileSystem =>
       _injectedFileSystem ?? FileSystemService.instance;
-
-  Lock _lockFor(String userId, String characterId) {
-    return _locks.putIfAbsent('$userId:$characterId', Lock.new);
-  }
-
-  Future<void> ensureLayout(String userId, String characterId) {
-    return _lockFor(userId, characterId).synchronized(
-      () => _ensureLayoutUnlocked(userId, characterId),
-    );
-  }
-
-  Future<void> ensureMigrated({
-    required String userId,
-    required AppDatabase db,
-  }) {
-    return _migrationState.runOnce(
-      userId: userId,
-      key: storageMigrationKey,
-      migrate: () => _exportSqliteToWorkspace(userId, db),
-    );
-  }
 
   Future<PersonaChatConversationRecord> appendMessage({
     required String userId,
@@ -255,14 +262,15 @@ class PersonaChatConversationStorage {
     String? factId,
     bool isRead = false,
     String? contactEpisodeId,
-    String? stableId,
   }) {
-    return _lockFor(userId, characterId).synchronized(() async {
-      await _ensureLayoutUnlocked(userId, characterId);
-      var state = await _readStateUnlocked(userId, characterId);
+    return _synchronized(userId, characterId, () async {
+      final metadata = await _readMetadataRepairingIfNeeded(
+        userId,
+        characterId,
+      );
       final record = PersonaChatConversationRecord(
-        id: stableId ?? _uuid.v4(),
-        seq: state.nextSeq,
+        id: _uuid.v4(),
+        seq: metadata.nextSeq,
         characterId: characterId,
         isFromCharacter: isFromCharacter,
         content: content,
@@ -273,15 +281,12 @@ class PersonaChatConversationStorage {
         origin: origin,
         contactEpisodeId: contactEpisodeId,
       );
-      await _appendLineUnlocked(userId, characterId, record);
-      await _writeStateUnlocked(
-        userId,
-        characterId,
-        state.copyWith(
-          nextSeq: state.nextSeq + 1,
-          updatedAt: DateTime.now(),
-          clearClearedAt: true,
-        ),
+      await _appendRecords(
+        userId: userId,
+        characterId: characterId,
+        metadata: metadata,
+        records: [record],
+        jsonRow: record.toJson(),
       );
       return record;
     });
@@ -293,521 +298,844 @@ class PersonaChatConversationStorage {
     required List<PersonaChatConversationRecord> Function(int nextSeq) records,
     required String contactEpisodeId,
     required int expectedRecordCount,
+    int? consumedThroughSeq,
   }) {
-    if (contactEpisodeId.trim().isEmpty) {
-      throw ArgumentError.value(contactEpisodeId, 'contactEpisodeId');
-    }
-    if (expectedRecordCount <= 0) {
-      throw ArgumentError.value(expectedRecordCount, 'expectedRecordCount');
-    }
-    return _lockFor(userId, characterId).synchronized(() async {
-      await _ensureLayoutUnlocked(userId, characterId);
-      final existing = await _readRecordsUnlocked(userId, characterId);
-      final state = await _readStateUnlocked(userId, characterId);
-      final already = existing
-          .where((record) => record.contactEpisodeId == contactEpisodeId)
-          .toList(growable: false);
-      if (already.length == expectedRecordCount && already.isNotEmpty) {
-        await _repairNextSeqIfNeeded(
-          userId: userId,
-          characterId: characterId,
-          state: state,
-          records: existing,
-        );
-        return already;
-      }
-      final nextSeq = _nextSeq(state, existing);
-      final toWrite = records(nextSeq);
-      if (toWrite.length != expectedRecordCount) {
-        throw StateError(
-          'Episode $contactEpisodeId produced ${toWrite.length} records; '
-          'expected $expectedRecordCount.',
-        );
-      }
-      for (var index = 0; index < toWrite.length; index++) {
-        final record = toWrite[index];
-        if (record.characterId != characterId ||
-            record.contactEpisodeId != contactEpisodeId ||
-            record.seq != nextSeq + index) {
-          throw StateError(
-            'Episode $contactEpisodeId produced an invalid record at $index.',
-          );
-        }
-      }
-
-      var retained = existing;
-      if (already.isNotEmpty) {
-        _logger.warning(
-          'Replacing incomplete conversation episode $contactEpisodeId for '
-          '$characterId (${already.length}/${toWrite.length} records)',
-        );
-        retained = existing
-            .where((record) => record.contactEpisodeId != contactEpisodeId)
-            .toList(growable: false);
-      }
-      final updated = [...retained, ...toWrite];
-      final stableIds = <String>{};
-      if (updated.any((record) => !stableIds.add(record.id))) {
-        throw StateError(
-          'Conversation $characterId contains duplicate stable message IDs.',
-        );
-      }
-      await _writeMessagesFile(
-        File(_fileSystem.getCharacterConversationMessagesPath(
-          userId,
-          characterId,
-        )),
-        updated,
-      );
-      await _writeStateUnlocked(
+    _validateEpisode(contactEpisodeId, expectedRecordCount);
+    return _synchronized(userId, characterId, () async {
+      var metadata = await _readMetadataRepairingIfNeeded(userId, characterId);
+      final receiptFile = _episodeReceiptFile(
         userId,
         characterId,
-        state.copyWith(
-          nextSeq: _nextSeq(state, updated),
-          updatedAt: DateTime.now(),
-          clearClearedAt: true,
-        ),
+        contactEpisodeId,
+      );
+      final receipt = await _readEpisodeReceipt(
+        receiptFile,
+        contactEpisodeId,
+      );
+      final persisted = await _loadEpisodeFromReceiptOrLog(
+        userId: userId,
+        characterId: characterId,
+        episodeId: contactEpisodeId,
+        receiptFile: receiptFile,
+        receipt: receipt,
+      );
+      if (persisted != null) {
+        _verifyEpisodeCount(persisted, expectedRecordCount);
+        if (consumedThroughSeq != null) {
+          await _advanceCursorUnlocked(
+            userId,
+            characterId,
+            metadata,
+            consumedThroughSeq,
+          );
+        }
+        return persisted;
+      }
+
+      if (receipt == null) {
+        await _writeEpisodeReceipt(
+          receiptFile,
+          contactEpisodeId,
+        );
+      }
+
+      final toWrite = records(metadata.nextSeq);
+      _verifyNewEpisode(
+        characterId,
+        contactEpisodeId,
+        metadata.nextSeq,
+        expectedRecordCount,
+        toWrite,
+      );
+      final lineOffset = metadata.messagesByteLength;
+      metadata = await _appendRecords(
+        userId: userId,
+        characterId: characterId,
+        metadata: metadata,
+        records: toWrite,
+        jsonRow: {
+          'record_type': _episodeRecordType,
+          'episode_id': contactEpisodeId,
+          'messages': toWrite.map((record) => record.toJson()).toList(),
+        },
+        consumedThroughSeq: consumedThroughSeq,
+      );
+      await _writeEpisodeReceipt(
+        receiptFile,
+        contactEpisodeId,
+        lineOffset: lineOffset,
       );
       return toWrite;
+    });
+  }
+
+  Future<bool> tryAppendInitiativeEpisode({
+    required String userId,
+    required String characterId,
+    required List<PersonaChatConversationRecord> Function(int nextSeq) records,
+    required String contactEpisodeId,
+    required int expectedRecordCount,
+  }) {
+    _validateEpisode(contactEpisodeId, expectedRecordCount);
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      final receipt = await _readEpisodeReceipt(
+        _episodeReceiptFile(userId, characterId, contactEpisodeId),
+        contactEpisodeId,
+      );
+      if (receipt != null &&
+          await _loadEpisodeFromReceiptOrLog(
+                userId: userId,
+                characterId: characterId,
+                episodeId: contactEpisodeId,
+                receiptFile: _episodeReceiptFile(
+                  userId,
+                  characterId,
+                  contactEpisodeId,
+                ),
+                receipt: receipt,
+              ) !=
+              null) {
+        return true;
+      }
+      final pending = await _loadPendingUserMessagesUnlocked(
+        userId,
+        characterId,
+        metadata.consumedThroughSeq ?? 0,
+        limit: 1,
+      );
+      if (pending.isNotEmpty) return false;
+      await _appendEpisodeUnlocked(
+        userId: userId,
+        characterId: characterId,
+        metadata: metadata,
+        records: records,
+        contactEpisodeId: contactEpisodeId,
+        expectedRecordCount: expectedRecordCount,
+      );
+      return true;
     });
   }
 
   Future<List<PersonaChatConversationRecord>> loadMessages({
     required String userId,
     required String characterId,
+    int? limit,
+    int offset = 0,
   }) {
-    return _lockFor(userId, characterId).synchronized(
-      () => _readRecordsUnlocked(userId, characterId),
-    );
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      if (limit == null || limit <= 0) {
+        final records = await _readAllRecords(userId, characterId);
+        return _applyReadState(records.reversed, metadata).toList();
+      }
+      final records = await _readNewestRecords(
+        userId,
+        characterId,
+        limit + offset,
+      );
+      return _applyReadState(records, metadata)
+          .skip(offset)
+          .take(limit)
+          .toList(growable: false);
+    });
   }
 
-  Future<PersonaChatConversationState> loadState({
+  Future<List<PersonaChatConversationRecord>> loadMessagesBefore({
+    required String userId,
+    required String characterId,
+    required int beforeSeq,
+    int limit = 50,
+  }) {
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      final records = await _scanBackwards(
+        userId,
+        characterId,
+        stop: (collected, record) =>
+            record.seq < beforeSeq && collected.length >= limit,
+        include: (record) => record.seq < beforeSeq,
+      );
+      return _applyReadState(records.take(limit), metadata)
+          .toList(growable: false);
+    });
+  }
+
+  Future<List<PersonaChatConversationRecord>> loadPendingUserMessages({
+    required String userId,
+    required String characterId,
+    int limit = 50,
+  }) {
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      return _loadPendingUserMessagesUnlocked(
+        userId,
+        characterId,
+        metadata.consumedThroughSeq ?? 0,
+        limit: limit,
+      );
+    });
+  }
+
+  Future<int> getReplyCursor({
     required String userId,
     required String characterId,
   }) {
-    return _lockFor(userId, characterId).synchronized(() async {
-      await _ensureLayoutUnlocked(userId, characterId);
-      return _readStateUnlocked(userId, characterId);
+    return _synchronized(userId, characterId, () async {
+      return (await _readMetadataRepairingIfNeeded(userId, characterId))
+              .consumedThroughSeq ??
+          0;
     });
+  }
+
+  Future<PersonaChatConversationMetadata> loadMetadata({
+    required String userId,
+    required String characterId,
+  }) {
+    return _synchronized(
+      userId,
+      characterId,
+      () => _readMetadataRepairingIfNeeded(userId, characterId),
+    );
   }
 
   Future<void> advanceCursor({
     required String userId,
     required String characterId,
-    required String consumedThroughMessageId,
+    required int consumedThroughSeq,
   }) {
-    return _lockFor(userId, characterId).synchronized(() async {
-      await _ensureLayoutUnlocked(userId, characterId);
-      final records = await _readRecordsUnlocked(userId, characterId);
-      final current = await _readStateUnlocked(userId, characterId);
-      if (!_cursorIsAhead(
-        records: records,
-        currentId: current.consumedThroughMessageId,
-        nextId: consumedThroughMessageId,
-      )) {
-        return;
-      }
-      await _writeStateUnlocked(
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      await _advanceCursorUnlocked(
         userId,
         characterId,
-        current.copyWith(
-          consumedThroughMessageId: consumedThroughMessageId,
-          updatedAt: DateTime.now(),
-        ),
+        metadata,
+        consumedThroughSeq,
       );
     });
   }
 
-  Future<void> clearConversation({
+  Future<int> unreadCount({
+    required String userId,
+    required String characterId,
+  }) {
+    return _synchronized(userId, characterId, () async {
+      return (await _readMetadataRepairingIfNeeded(userId, characterId))
+          .unreadCount;
+    });
+  }
+
+  Future<int> totalUnreadCount(String userId) async {
+    var total = 0;
+    for (final characterId in await characterIds(userId)) {
+      total += await unreadCount(userId: userId, characterId: characterId);
+    }
+    return total;
+  }
+
+  Future<int> markAllRead({
+    required String userId,
+    required String characterId,
+  }) {
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      final changed = metadata.unreadCount;
+      if (changed == 0) return 0;
+      final readThroughSeq = metadata.nextSeq - 1;
+      final append = await _jsonl.append(
+        _messagesFile(userId, characterId),
+        [
+          {
+            'record_type': _readBoundaryRecordType,
+            'read_through_seq': readThroughSeq,
+          },
+        ],
+      );
+      await _writeMetadata(
+        userId,
+        characterId,
+        metadata.copyWith(
+          unreadCount: 0,
+          readThroughSeq: readThroughSeq,
+          messagesByteLength: append.endOffset,
+          updatedAt: DateTime.now(),
+        ),
+      );
+      return changed;
+    });
+  }
+
+  Future<PersonaChatConversationRecord?> lastMessage({
+    required String userId,
+    required String characterId,
+  }) {
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      final last = metadata.lastMessage;
+      return last == null ? null : _withEffectiveRead(last, metadata);
+    });
+  }
+
+  Future<int> latestMessageSeq({
+    required String userId,
+    required String characterId,
+  }) {
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      return metadata.nextSeq - 1;
+    });
+  }
+
+  Future<int> clearConversation({
     required String userId,
     required String characterId,
     required DateTime clearedAt,
   }) {
-    return _lockFor(userId, characterId).synchronized(() async {
-      await _ensureLayoutUnlocked(userId, characterId);
-      await _writeMessagesFile(
-        File(_fileSystem.getCharacterConversationMessagesPath(
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      await _replaceFile(_messagesFile(userId, characterId), '');
+      final receipts = Directory(
+        _fileSystem.getCharacterConversationEpisodeReceiptsPath(
           userId,
           characterId,
-        )),
-        const [],
+        ),
       );
-      await _writeStateUnlocked(
+      if (await receipts.exists()) await receipts.delete(recursive: true);
+      await _writeMetadata(
         userId,
         characterId,
-        PersonaChatConversationState(
-          schemaVersion: schemaVersion,
-          nextSeq: 1,
+        PersonaChatConversationMetadata.initial().copyWith(
           clearedAt: clearedAt,
           updatedAt: clearedAt,
         ),
       );
+      return metadata.messageCount;
     });
   }
 
-  Future<void> markAllRead({
+  /// Imports a legacy snapshot only when the new conversation log is empty.
+  Future<bool> importLegacySnapshot({
     required String userId,
     required String characterId,
+    required List<PersonaChatConversationRecord> records,
+    int? consumedThroughSeq,
   }) {
-    return _lockFor(userId, characterId).synchronized(() async {
-      await _ensureLayoutUnlocked(userId, characterId);
-      final records = await _readRecordsUnlocked(userId, characterId);
-      final updated = records
-          .map(
-            (record) =>
-                record.isFromCharacter ? record.copyWith(isRead: true) : record,
-          )
-          .toList(growable: false);
-      await _writeMessagesFile(
-        File(_fileSystem.getCharacterConversationMessagesPath(
-          userId,
-          characterId,
-        )),
-        updated,
+    return _synchronized(userId, characterId, () async {
+      final metadata =
+          await _readMetadataRepairingIfNeeded(userId, characterId);
+      if (metadata.messageCount > 0 || records.isEmpty) return false;
+      _verifyContiguousRecords(characterId, records);
+      final file = _messagesFile(userId, characterId);
+      final rows = <Map<String, dynamic>>[
+        ...records.map((record) => record.toJson()),
+        if (consumedThroughSeq != null)
+          {
+            'record_type': _replyCursorRecordType,
+            'consumed_through_seq': consumedThroughSeq,
+          },
+      ];
+      await _replaceFile(
+        file,
+        '${rows.map(jsonEncode).join('\n')}\n',
       );
+      await _writeMetadata(
+        userId,
+        characterId,
+        _metadataFromRecords(
+          records,
+          messagesByteLength: await file.length(),
+          consumedThroughSeq: consumedThroughSeq,
+        ),
+      );
+      return true;
     });
   }
 
-  Future<void> rebuildSqliteProjection({
+  Future<Set<String>> characterIds(String userId) async {
+    final root = Directory(_fileSystem.getCharacterWorkspacesPath(userId));
+    if (!await root.exists()) return <String>{};
+    final ids = <String>{};
+    await for (final entity in root.list(followLinks: false)) {
+      if (entity is! Directory) continue;
+      final id = p.basename(entity.path);
+      if (id.startsWith('.')) continue;
+      if (await _messagesFile(userId, id).exists() ||
+          await _metadataFile(userId, id).exists()) {
+        ids.add(id);
+      }
+    }
+    return ids;
+  }
+
+  Future<List<PersonaChatConversationRecord>> _appendEpisodeUnlocked({
     required String userId,
     required String characterId,
-    required AppDatabase db,
-  }) {
-    return _lockFor(userId, characterId).synchronized(() async {
-      await _ensureLayoutUnlocked(userId, characterId);
-      await _rebuildSqliteUnlocked(
-        userId: userId,
-        characterId: characterId,
-        db: db,
-      );
-    });
-  }
-
-  Future<void> reconcileAll({
-    required String userId,
-    required AppDatabase db,
+    required PersonaChatConversationMetadata metadata,
+    required List<PersonaChatConversationRecord> Function(int nextSeq) records,
+    required String contactEpisodeId,
+    required int expectedRecordCount,
   }) async {
-    final characterIds = await _characterIds(userId, db);
-    for (final characterId in characterIds) {
-      await rebuildSqliteProjection(
-        userId: userId,
-        characterId: characterId,
-        db: db,
+    final receiptFile = _episodeReceiptFile(
+      userId,
+      characterId,
+      contactEpisodeId,
+    );
+    final existing = await _readEpisodeReceipt(receiptFile, contactEpisodeId);
+    final persisted = await _loadEpisodeFromReceiptOrLog(
+      userId: userId,
+      characterId: characterId,
+      episodeId: contactEpisodeId,
+      receiptFile: receiptFile,
+      receipt: existing,
+    );
+    if (persisted != null) {
+      _verifyEpisodeCount(persisted, expectedRecordCount);
+      return persisted;
+    }
+    if (existing == null) {
+      await _writeEpisodeReceipt(receiptFile, contactEpisodeId);
+    }
+    final toWrite = records(metadata.nextSeq);
+    _verifyNewEpisode(
+      characterId,
+      contactEpisodeId,
+      metadata.nextSeq,
+      expectedRecordCount,
+      toWrite,
+    );
+    final lineOffset = metadata.messagesByteLength;
+    await _appendRecords(
+      userId: userId,
+      characterId: characterId,
+      metadata: metadata,
+      records: toWrite,
+      jsonRow: {
+        'record_type': _episodeRecordType,
+        'episode_id': contactEpisodeId,
+        'messages': toWrite.map((record) => record.toJson()).toList(),
+      },
+    );
+    await _writeEpisodeReceipt(
+      receiptFile,
+      contactEpisodeId,
+      lineOffset: lineOffset,
+    );
+    return toWrite;
+  }
+
+  Future<List<PersonaChatConversationRecord>?> _loadEpisodeFromReceiptOrLog({
+    required String userId,
+    required String characterId,
+    required String episodeId,
+    required File receiptFile,
+    required _EpisodeReceipt? receipt,
+  }) async {
+    Map<String, dynamic>? row;
+    var lineOffset = receipt?.lineOffset;
+    if (receipt?.isComplete == true && lineOffset != null) {
+      row = await _jsonl.readObjectAt(
+        _messagesFile(userId, characterId),
+        lineOffset,
       );
+      if (!_isEpisodeRow(row, episodeId)) row = null;
+    }
+    if (row == null && receipt != null) {
+      final located = await _jsonl.findLastObject(
+        _messagesFile(userId, characterId),
+        (candidate) => _isEpisodeRow(candidate, episodeId),
+      );
+      if (located != null) {
+        row = located.value;
+        lineOffset = located.startOffset;
+        await _writeEpisodeReceipt(
+          receiptFile,
+          episodeId,
+          lineOffset: lineOffset,
+        );
+      }
+    }
+    if (row == null) return null;
+    final records = _recordsFromRow(row).toList(growable: false);
+    return records.isEmpty ? null : records;
+  }
+
+  bool _isEpisodeRow(Map<String, dynamic>? row, String episodeId) =>
+      row?['record_type'] == _episodeRecordType &&
+      row?['episode_id'] == episodeId;
+
+  Future<PersonaChatConversationMetadata> _appendRecords({
+    required String userId,
+    required String characterId,
+    required PersonaChatConversationMetadata metadata,
+    required List<PersonaChatConversationRecord> records,
+    required Map<String, dynamic> jsonRow,
+    int? consumedThroughSeq,
+  }) async {
+    final append = await _jsonl.append(
+      _messagesFile(userId, characterId),
+      [
+        {
+          ...jsonRow,
+          if (consumedThroughSeq != null)
+            'consumed_through_seq': consumedThroughSeq,
+        },
+      ],
+    );
+    final unreadAdded = records
+        .where((record) => record.isFromCharacter && !record.isRead)
+        .length;
+    final next = metadata.copyWith(
+      nextSeq: records.last.seq + 1,
+      messageCount: metadata.messageCount + records.length,
+      unreadCount: metadata.unreadCount + unreadAdded,
+      messagesByteLength: append.endOffset,
+      consumedThroughSeq: consumedThroughSeq,
+      lastMessage: records.last,
+      updatedAt: DateTime.now(),
+      clearClearedAt: true,
+    );
+    await _writeMetadata(userId, characterId, next);
+    return next;
+  }
+
+  Future<List<PersonaChatConversationRecord>> _readAllRecords(
+    String userId,
+    String characterId,
+  ) async {
+    return (await _readSnapshot(userId, characterId)).records;
+  }
+
+  Future<List<PersonaChatConversationRecord>> _readNewestRecords(
+    String userId,
+    String characterId,
+    int count,
+  ) async {
+    if (count <= 0) return const [];
+    return _scanBackwards(
+      userId,
+      characterId,
+      include: (_) => true,
+      stop: (collected, _) => collected.length >= count,
+    );
+  }
+
+  Future<_ConversationSnapshot> _readSnapshot(
+    String userId,
+    String characterId,
+  ) async {
+    final rows = await _jsonl.readAllRecoveringTail(
+      _messagesFile(userId, characterId),
+    );
+    final records = <PersonaChatConversationRecord>[];
+    var readThroughSeq = 0;
+    int? consumedThroughSeq;
+    for (final row in rows) {
+      records.addAll(_recordsFromRow(row));
+      final rowReadThrough = row['read_through_seq'];
+      if (rowReadThrough is num && rowReadThrough > readThroughSeq) {
+        readThroughSeq = rowReadThrough.toInt();
+      }
+      final rowConsumedThrough = row['consumed_through_seq'];
+      if (rowConsumedThrough is num &&
+          rowConsumedThrough > (consumedThroughSeq ?? 0)) {
+        consumedThroughSeq = rowConsumedThrough.toInt();
+      }
+    }
+    return _ConversationSnapshot(
+      records: records,
+      readThroughSeq: readThroughSeq,
+      consumedThroughSeq: consumedThroughSeq,
+    );
+  }
+
+  Future<List<PersonaChatConversationRecord>> _scanBackwards(
+    String userId,
+    String characterId, {
+    required bool Function(
+      List<PersonaChatConversationRecord> collected,
+      PersonaChatConversationRecord record,
+    ) stop,
+    required bool Function(PersonaChatConversationRecord record) include,
+  }) async {
+    const pageSize = 64;
+    int? cursor;
+    final collected = <PersonaChatConversationRecord>[];
+    while (true) {
+      final page = await _jsonl.readPageBefore(
+        _messagesFile(userId, characterId),
+        limit: pageSize,
+        beforeOffset: cursor,
+      );
+      if (page.rows.isEmpty) return collected;
+      final records =
+          page.rows.expand(_recordsFromRow).toList(growable: false).reversed;
+      for (final record in records) {
+        if (include(record)) collected.add(record);
+        if (stop(collected, record)) return collected;
+      }
+      cursor = page.olderOffset;
+      if (cursor == null) return collected;
     }
   }
 
-  Future<void> _ensureLayoutUnlocked(String userId, String characterId) async {
+  Future<List<PersonaChatConversationRecord>> _loadPendingUserMessagesUnlocked(
+    String userId,
+    String characterId,
+    int cursorSeq, {
+    required int limit,
+  }) async {
+    final newestFirst = await _scanBackwards(
+      userId,
+      characterId,
+      include: (record) => record.seq > cursorSeq && !record.isFromCharacter,
+      stop: (_, record) => record.seq <= cursorSeq,
+    );
+    return newestFirst.reversed.take(limit).toList(growable: false);
+  }
+
+  Iterable<PersonaChatConversationRecord> _recordsFromRow(
+    Map<String, dynamic> row,
+  ) sync* {
+    if (row['record_type'] == _episodeRecordType) {
+      final messages = row['messages'];
+      if (messages is! List) return;
+      for (final raw in messages) {
+        if (raw is! Map) continue;
+        final record = PersonaChatConversationRecord.fromJson(
+          Map<String, dynamic>.from(raw),
+        );
+        if (record != null) yield record;
+      }
+      return;
+    }
+    final record = PersonaChatConversationRecord.fromJson(row);
+    if (record != null) yield record;
+  }
+
+  Future<PersonaChatConversationMetadata> _readMetadataRepairingIfNeeded(
+    String userId,
+    String characterId,
+  ) async {
+    await _ensureLayout(userId, characterId);
+    final file = _metadataFile(userId, characterId);
+    PersonaChatConversationMetadata? metadata;
+    try {
+      final decoded = jsonDecode(await file.readAsString());
+      if (decoded is Map) {
+        metadata = PersonaChatConversationMetadata.fromJson(
+          Map<String, dynamic>.from(decoded),
+        );
+      }
+    } catch (_) {
+      metadata = null;
+    }
+    final messagesLength = await _messagesFile(userId, characterId).length();
+    if (metadata != null && metadata.messagesByteLength == messagesLength) {
+      return metadata;
+    }
+    final snapshot = await _readSnapshot(userId, characterId);
+    final repaired = _metadataFromRecords(
+      snapshot.records,
+      messagesByteLength: await _messagesFile(userId, characterId).length(),
+      readThroughSeq: snapshot.readThroughSeq,
+      consumedThroughSeq: snapshot.consumedThroughSeq,
+      clearedAt: metadata?.clearedAt,
+    );
+    await _writeMetadata(userId, characterId, repaired);
+    return repaired;
+  }
+
+  PersonaChatConversationMetadata _metadataFromRecords(
+    List<PersonaChatConversationRecord> records, {
+    required int messagesByteLength,
+    int readThroughSeq = 0,
+    int? consumedThroughSeq,
+    DateTime? clearedAt,
+  }) {
+    final unread = records
+        .where(
+          (record) =>
+              record.isFromCharacter &&
+              !record.isRead &&
+              record.seq > readThroughSeq,
+        )
+        .length;
+    return PersonaChatConversationMetadata(
+      schemaVersion: schemaVersion,
+      nextSeq: records.isEmpty ? 1 : records.last.seq + 1,
+      messageCount: records.length,
+      unreadCount: unread,
+      messagesByteLength: messagesByteLength,
+      readThroughSeq: readThroughSeq,
+      consumedThroughSeq: consumedThroughSeq,
+      lastMessage: records.isEmpty ? null : records.last,
+      updatedAt: DateTime.now(),
+      clearedAt: records.isEmpty ? clearedAt : null,
+    );
+  }
+
+  Future<PersonaChatConversationMetadata> _advanceCursorUnlocked(
+    String userId,
+    String characterId,
+    PersonaChatConversationMetadata metadata,
+    int nextSeq,
+  ) async {
+    if (nextSeq <= 0 || nextSeq >= metadata.nextSeq) {
+      throw ArgumentError.value(nextSeq, 'consumedThroughSeq');
+    }
+    if ((metadata.consumedThroughSeq ?? 0) >= nextSeq) return metadata;
+    final append = await _jsonl.append(
+      _messagesFile(userId, characterId),
+      [
+        {
+          'record_type': _replyCursorRecordType,
+          'consumed_through_seq': nextSeq,
+        },
+      ],
+    );
+    final next = metadata.copyWith(
+      consumedThroughSeq: nextSeq,
+      messagesByteLength: append.endOffset,
+      updatedAt: DateTime.now(),
+    );
+    await _writeMetadata(userId, characterId, next);
+    return next;
+  }
+
+  Iterable<PersonaChatConversationRecord> _applyReadState(
+    Iterable<PersonaChatConversationRecord> records,
+    PersonaChatConversationMetadata metadata,
+  ) =>
+      records.map((record) => _withEffectiveRead(record, metadata));
+
+  PersonaChatConversationRecord _withEffectiveRead(
+    PersonaChatConversationRecord record,
+    PersonaChatConversationMetadata metadata,
+  ) {
+    if (!record.isFromCharacter ||
+        record.isRead ||
+        record.seq > metadata.readThroughSeq) {
+      return record;
+    }
+    return record.copyWith(isRead: true);
+  }
+
+  Future<void> _ensureLayout(String userId, String characterId) async {
     final directory = Directory(
       _fileSystem.getCharacterConversationPath(userId, characterId),
     );
     await directory.create(recursive: true);
-    final messages = File(
-      _fileSystem.getCharacterConversationMessagesPath(userId, characterId),
-    );
-    if (!await messages.exists()) {
-      await messages.writeAsString('', flush: true);
-    }
-    final stateFile = File(
-      _fileSystem.getCharacterConversationStatePath(userId, characterId),
-    );
-    if (!await stateFile.exists()) {
-      await _writeJsonFile(
-        stateFile,
-        PersonaChatConversationState.initial().toJson(),
+    final messages = _messagesFile(userId, characterId);
+    if (!await messages.exists()) await messages.writeAsString('', flush: true);
+    final metadata = _metadataFile(userId, characterId);
+    if (!await metadata.exists()) {
+      await _writeMetadata(
+        userId,
+        characterId,
+        PersonaChatConversationMetadata.initial(),
       );
     }
   }
 
-  Future<bool> _exportSqliteToWorkspace(String userId, AppDatabase db) async {
-    final characterIds = await _characterIdsFromSqlite(db);
-    for (final characterId in characterIds) {
-      await _lockFor(userId, characterId).synchronized(() async {
-        await _ensureLayoutUnlocked(userId, characterId);
-        final existing = await _readRecordsUnlocked(userId, characterId);
-        if (existing.isNotEmpty) return;
-
-        final rows = await (db.select(db.personaChatMessages)
-              ..where((row) => row.characterId.equals(characterId))
-              ..orderBy([
-                (row) => OrderingTerm.asc(row.timestamp),
-                (row) => OrderingTerm.asc(row.id),
-              ]))
-            .get();
-        if (rows.isEmpty) return;
-
-        var seq = 1;
-        final records = <PersonaChatConversationRecord>[];
-        for (final row in rows) {
-          final stableId = (row.stableId != null && row.stableId!.isNotEmpty)
-              ? row.stableId!
-              : 'legacy-${row.id}';
-          records.add(
-            PersonaChatConversationRecord(
-              id: stableId,
-              seq: seq++,
-              characterId: characterId,
-              isFromCharacter: row.isFromCharacter,
-              content: row.content,
-              factId: row.factId,
-              isRead: row.isRead,
-              timestamp: row.timestamp,
-              messageType: row.messageType,
-              origin: row.origin,
-              contactEpisodeId: row.contactEpisodeId,
-            ),
-          );
-        }
-        await _writeMessagesFile(
-          File(_fileSystem.getCharacterConversationMessagesPath(
-            userId,
-            characterId,
-          )),
-          records,
-        );
-
-        final cursor = await (db.select(db.personaChatReplyCursors)
-              ..where((row) => row.characterId.equals(characterId)))
-            .getSingleOrNull();
-        String? consumedStableId;
-        if (cursor != null && cursor.consumedThroughMessageId > 0) {
-          PersonaChatMessage? consumedRow;
-          for (final row in rows) {
-            if (row.id == cursor.consumedThroughMessageId) {
-              consumedRow = row;
-              break;
-            }
-          }
-          if (consumedRow != null) {
-            consumedStableId = (consumedRow.stableId != null &&
-                    consumedRow.stableId!.isNotEmpty)
-                ? consumedRow.stableId
-                : 'legacy-${consumedRow.id}';
-          } else {
-            consumedStableId = 'legacy-${cursor.consumedThroughMessageId}';
-          }
-        }
-        await _writeStateUnlocked(
-          userId,
-          characterId,
-          PersonaChatConversationState(
-            schemaVersion: schemaVersion,
-            nextSeq: seq,
-            consumedThroughMessageId: consumedStableId,
-            updatedAt: DateTime.now(),
-          ),
-        );
-      });
-    }
-    return true;
-  }
-
-  Future<void> _rebuildSqliteUnlocked({
-    required String userId,
-    required String characterId,
-    required AppDatabase db,
-  }) async {
-    final records = await _readRecordsUnlocked(userId, characterId);
-    final state = await _readStateUnlocked(userId, characterId);
-    await db.transaction(() async {
-      await (db.delete(db.personaChatMessages)
-            ..where((row) => row.characterId.equals(characterId)))
-          .go();
-      await (db.delete(db.personaChatReplyCursors)
-            ..where((row) => row.characterId.equals(characterId)))
-          .go();
-      final idByStable = <String, int>{};
-      for (final record in records) {
-        final id = await db.into(db.personaChatMessages).insert(
-              PersonaChatMessagesCompanion.insert(
-                characterId: record.characterId,
-                isFromCharacter: record.isFromCharacter,
-                content: record.content,
-                factId: Value(record.factId),
-                isRead: Value(record.isRead),
-                timestamp: record.timestamp,
-                messageType: Value(record.messageType),
-                origin: Value(record.origin),
-                contactEpisodeId: Value(record.contactEpisodeId),
-                stableId: Value(record.id),
-              ),
-            );
-        idByStable[record.id] = id;
-      }
-      final consumedStableId = state.consumedThroughMessageId;
-      if (consumedStableId != null &&
-          consumedStableId.isNotEmpty &&
-          idByStable.containsKey(consumedStableId)) {
-        await db.into(db.personaChatReplyCursors).insert(
-              PersonaChatReplyCursorsCompanion.insert(
-                characterId: characterId,
-                consumedThroughMessageId: Value(idByStable[consumedStableId]!),
-                updatedAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-              ),
-            );
+  Future<T> _synchronized<T>(
+    String userId,
+    String characterId,
+    Future<T> Function() action,
+  ) {
+    final lockPath = _fileSystem.getCharacterConversationWriteLockPath(
+      userId,
+      characterId,
+    );
+    return _processLocks.putIfAbsent(lockPath, Lock.new).synchronized(() async {
+      await Directory(
+        _fileSystem.getCharacterConversationPath(userId, characterId),
+      ).create(recursive: true);
+      final lockFile = File(lockPath);
+      final handle = await lockFile.open(mode: FileMode.append);
+      await handle.lock(FileLock.exclusive);
+      try {
+        return await action();
+      } finally {
+        await handle.unlock();
+        await handle.close();
       }
     });
   }
 
-  Future<List<PersonaChatConversationRecord>> _readRecordsUnlocked(
+  File _messagesFile(String userId, String characterId) => File(
+        _fileSystem.getCharacterConversationMessagesPath(userId, characterId),
+      );
+
+  File _metadataFile(String userId, String characterId) => File(
+        _fileSystem.getCharacterConversationMetadataPath(userId, characterId),
+      );
+
+  File _episodeReceiptFile(
     String userId,
     String characterId,
-  ) async {
-    final file = File(
-      _fileSystem.getCharacterConversationMessagesPath(userId, characterId),
-    );
-    if (!await file.exists()) return const [];
-    final bytes = await file.readAsBytes();
-    if (bytes.isEmpty) return const [];
-    final records = <PersonaChatConversationRecord>[];
-    var lastValidOffset = 0;
-    var lineStart = 0;
-
-    Future<void> readLine(int lineEnd, {required bool terminated}) async {
-      final endOffset = terminated ? lineEnd + 1 : lineEnd;
-      try {
-        final line = utf8.decode(bytes.sublist(lineStart, lineEnd));
-        if (line.trim().isEmpty) {
-          lastValidOffset = endOffset;
-          return;
-        }
-        final decoded = jsonDecode(line);
-        if (decoded is! Map) {
-          throw const FormatException(
-              'Conversation JSONL row is not an object');
-        }
-        final record = PersonaChatConversationRecord.fromJson(
-          Map<String, dynamic>.from(decoded),
-        );
-        if (record == null) {
-          throw const FormatException('Conversation JSONL row is incomplete');
-        }
-        records.add(record);
-        lastValidOffset = endOffset;
-        return;
-      } catch (error) {
-        if (!terminated) {
-          _logger.warning(
-            'Truncating incomplete conversation JSONL tail in ${file.path}',
-          );
-          await file.writeAsBytes(
-            bytes.sublist(0, lastValidOffset),
-            flush: true,
-          );
-          return;
-        }
-        _logger.warning(
-          'Skipping malformed conversation JSONL row in ${file.path}: $error',
-        );
-        lastValidOffset = endOffset;
-      }
-    }
-
-    for (var index = 0; index < bytes.length; index++) {
-      if (bytes[index] != 0x0A) continue;
-      await readLine(index, terminated: true);
-      lineStart = index + 1;
-    }
-    if (lineStart < bytes.length) {
-      await readLine(bytes.length, terminated: false);
-    }
-    return records;
-  }
-
-  int _nextSeq(
-    PersonaChatConversationState state,
-    List<PersonaChatConversationRecord> records,
+    String episodeId,
   ) {
-    var nextSeq = state.nextSeq;
-    for (final record in records) {
-      if (record.seq >= nextSeq) nextSeq = record.seq + 1;
-    }
-    return nextSeq;
-  }
-
-  Future<void> _repairNextSeqIfNeeded({
-    required String userId,
-    required String characterId,
-    required PersonaChatConversationState state,
-    required List<PersonaChatConversationRecord> records,
-  }) async {
-    final nextSeq = _nextSeq(state, records);
-    if (nextSeq == state.nextSeq) return;
-    await _writeStateUnlocked(
-      userId,
-      characterId,
-      state.copyWith(nextSeq: nextSeq, updatedAt: DateTime.now()),
+    final name = sha256.convert(utf8.encode(episodeId)).toString();
+    return File(
+      _fileSystem.getCharacterConversationEpisodeReceiptPath(
+        userId,
+        characterId,
+        name,
+      ),
     );
   }
 
-  Future<PersonaChatConversationState> _readStateUnlocked(
-    String userId,
-    String characterId,
+  Future<_EpisodeReceipt?> _readEpisodeReceipt(
+    File file,
+    String expectedEpisodeId,
   ) async {
-    final file = File(
-      _fileSystem.getCharacterConversationStatePath(userId, characterId),
-    );
-    if (!await file.exists()) {
-      return PersonaChatConversationState.initial();
-    }
+    if (!await file.exists()) return null;
     try {
       final decoded = jsonDecode(await file.readAsString());
-      if (decoded is Map) {
-        return PersonaChatConversationState.fromJson(
-          Map<String, dynamic>.from(decoded),
-        );
+      if (decoded is! Map || decoded['episode_id'] != expectedEpisodeId) {
+        throw const FormatException('Episode receipt identity mismatch');
       }
-    } catch (error, stackTrace) {
-      _logger.warning(
-        'Failed to parse conversation state ${file.path}',
-        error,
-        stackTrace,
+      return _EpisodeReceipt(
+        isComplete: decoded['status'] == 'complete',
+        lineOffset: decoded['line_offset'] is num
+            ? (decoded['line_offset'] as num).toInt()
+            : null,
       );
+    } catch (_) {
+      return const _EpisodeReceipt(isComplete: false);
     }
-    return PersonaChatConversationState.initial();
   }
 
-  Future<void> _appendLineUnlocked(
-    String userId,
-    String characterId,
-    PersonaChatConversationRecord record,
-  ) async {
-    final file = File(
-      _fileSystem.getCharacterConversationMessagesPath(userId, characterId),
-    );
-    await file.parent.create(recursive: true);
-    await file.writeAsString(
-      '${jsonEncode(record.toJson())}\n',
-      mode: FileMode.append,
-      flush: true,
-    );
+  Future<void> _writeEpisodeReceipt(File file, String episodeId,
+      {int? lineOffset}) {
+    return _writeJsonFile(file, {
+      'episode_id': episodeId,
+      'status': lineOffset == null ? 'pending' : 'complete',
+      if (lineOffset != null) 'line_offset': lineOffset,
+    });
   }
 
-  Future<void> _writeStateUnlocked(
+  Future<void> _writeMetadata(
     String userId,
     String characterId,
-    PersonaChatConversationState state,
+    PersonaChatConversationMetadata metadata,
   ) {
     return _writeJsonFile(
-      File(_fileSystem.getCharacterConversationStatePath(userId, characterId)),
-      state.toJson(),
-    );
+        _metadataFile(userId, characterId), metadata.toJson());
   }
 
-  Future<void> _writeMessagesFile(
-    File file,
-    List<PersonaChatConversationRecord> records,
-  ) async {
-    await file.parent.create(recursive: true);
-    final content = records.isEmpty
-        ? ''
-        : '${records.map((record) => jsonEncode(record.toJson())).join('\n')}\n';
-    await _replaceFile(file, content);
-  }
-
-  Future<void> _writeJsonFile(File file, Map<String, dynamic> data) async {
+  Future<void> _writeJsonFile(File file, Map<String, dynamic> value) {
     const encoder = JsonEncoder.withIndent('  ');
-    await _replaceFile(file, '${encoder.convert(data)}\n');
+    return _replaceFile(file, '${encoder.convert(value)}\n');
   }
 
   Future<void> _replaceFile(File file, String content) async {
@@ -822,44 +1150,74 @@ class PersonaChatConversationStorage {
     }
   }
 
-  bool _cursorIsAhead({
-    required List<PersonaChatConversationRecord> records,
-    required String? currentId,
-    required String nextId,
-  }) {
-    if (currentId == null || currentId.isEmpty) return true;
-    if (currentId == nextId) return false;
-    final currentIndex = records.indexWhere((record) => record.id == currentId);
-    final nextIndex = records.indexWhere((record) => record.id == nextId);
-    if (nextIndex < 0) return false;
-    if (currentIndex < 0) return true;
-    return nextIndex > currentIndex;
+  void _validateEpisode(String episodeId, int expectedCount) {
+    if (episodeId.trim().isEmpty) {
+      throw ArgumentError.value(episodeId, 'contactEpisodeId');
+    }
+    if (expectedCount <= 0) {
+      throw ArgumentError.value(expectedCount, 'expectedRecordCount');
+    }
   }
 
-  Future<Set<String>> _characterIds(String userId, AppDatabase db) async {
-    final ids = await _characterIdsFromSqlite(db);
-    final root = Directory(_fileSystem.getCharacterWorkspacesPath(userId));
-    if (await root.exists()) {
-      await for (final entity in root.list(followLinks: false)) {
-        if (entity is! Directory) continue;
-        final name = p.basename(entity.path);
-        if (name.startsWith('.')) continue;
-        ids.add(name);
+  void _verifyEpisodeCount(
+    List<PersonaChatConversationRecord> records,
+    int expectedCount,
+  ) {
+    if (records.length != expectedCount) {
+      throw StateError(
+        'Persisted episode contains ${records.length} messages; '
+        'expected $expectedCount.',
+      );
+    }
+  }
+
+  void _verifyNewEpisode(
+    String characterId,
+    String episodeId,
+    int nextSeq,
+    int expectedCount,
+    List<PersonaChatConversationRecord> records,
+  ) {
+    _verifyEpisodeCount(records, expectedCount);
+    for (var index = 0; index < records.length; index++) {
+      final record = records[index];
+      if (record.characterId != characterId ||
+          record.contactEpisodeId != episodeId ||
+          record.seq != nextSeq + index) {
+        throw StateError(
+            'Episode $episodeId has an invalid message at $index.');
       }
     }
-    return ids;
   }
 
-  Future<Set<String>> _characterIdsFromSqlite(AppDatabase db) async {
-    final rows = await db
-        .customSelect(
-          'SELECT DISTINCT character_id FROM persona_chat_messages',
-        )
-        .get();
-    return rows
-        .map((row) => row.data['character_id']?.toString())
-        .whereType<String>()
-        .where((id) => id.isNotEmpty)
-        .toSet();
+  void _verifyContiguousRecords(
+    String characterId,
+    List<PersonaChatConversationRecord> records,
+  ) {
+    for (var index = 0; index < records.length; index++) {
+      if (records[index].characterId != characterId ||
+          records[index].seq != index + 1) {
+        throw StateError('Legacy conversation snapshot is not contiguous.');
+      }
+    }
   }
+}
+
+class _EpisodeReceipt {
+  const _EpisodeReceipt({required this.isComplete, this.lineOffset});
+
+  final bool isComplete;
+  final int? lineOffset;
+}
+
+class _ConversationSnapshot {
+  const _ConversationSnapshot({
+    required this.records,
+    required this.readThroughSeq,
+    this.consumedThroughSeq,
+  });
+
+  final List<PersonaChatConversationRecord> records;
+  final int readThroughSeq;
+  final int? consumedThroughSeq;
 }

--- a/lib/data/services/persona_chat_conversation_storage.dart
+++ b/lib/data/services/persona_chat_conversation_storage.dart
@@ -194,6 +194,11 @@ class PersonaChatConversationState {
 
 /// Durable character-conversation store. Workspace files are the source of
 /// truth; SQLite is a rebuildable projection.
+///
+/// Single-message appends may leave only an invalid final JSONL row after a
+/// crash, which [_readRecordsUnlocked] removes at a UTF-8 byte boundary.
+/// Multi-record episodes replace the JSONL file once so they become visible
+/// together; a count mismatch on retry replaces an incomplete episode.
 class PersonaChatConversationStorage {
   PersonaChatConversationStorage({
     FileSystemService? fileSystem,
@@ -287,25 +292,78 @@ class PersonaChatConversationStorage {
     required String characterId,
     required List<PersonaChatConversationRecord> Function(int nextSeq) records,
     required String contactEpisodeId,
+    required int expectedRecordCount,
   }) {
+    if (contactEpisodeId.trim().isEmpty) {
+      throw ArgumentError.value(contactEpisodeId, 'contactEpisodeId');
+    }
+    if (expectedRecordCount <= 0) {
+      throw ArgumentError.value(expectedRecordCount, 'expectedRecordCount');
+    }
     return _lockFor(userId, characterId).synchronized(() async {
       await _ensureLayoutUnlocked(userId, characterId);
       final existing = await _readRecordsUnlocked(userId, characterId);
+      final state = await _readStateUnlocked(userId, characterId);
       final already = existing
           .where((record) => record.contactEpisodeId == contactEpisodeId)
           .toList(growable: false);
-      if (already.isNotEmpty) return already;
-
-      var state = await _readStateUnlocked(userId, characterId);
-      final toWrite = records(state.nextSeq);
-      for (final record in toWrite) {
-        await _appendLineUnlocked(userId, characterId, record);
+      if (already.length == expectedRecordCount && already.isNotEmpty) {
+        await _repairNextSeqIfNeeded(
+          userId: userId,
+          characterId: characterId,
+          state: state,
+          records: existing,
+        );
+        return already;
       }
+      final nextSeq = _nextSeq(state, existing);
+      final toWrite = records(nextSeq);
+      if (toWrite.length != expectedRecordCount) {
+        throw StateError(
+          'Episode $contactEpisodeId produced ${toWrite.length} records; '
+          'expected $expectedRecordCount.',
+        );
+      }
+      for (var index = 0; index < toWrite.length; index++) {
+        final record = toWrite[index];
+        if (record.characterId != characterId ||
+            record.contactEpisodeId != contactEpisodeId ||
+            record.seq != nextSeq + index) {
+          throw StateError(
+            'Episode $contactEpisodeId produced an invalid record at $index.',
+          );
+        }
+      }
+
+      var retained = existing;
+      if (already.isNotEmpty) {
+        _logger.warning(
+          'Replacing incomplete conversation episode $contactEpisodeId for '
+          '$characterId (${already.length}/${toWrite.length} records)',
+        );
+        retained = existing
+            .where((record) => record.contactEpisodeId != contactEpisodeId)
+            .toList(growable: false);
+      }
+      final updated = [...retained, ...toWrite];
+      final stableIds = <String>{};
+      if (updated.any((record) => !stableIds.add(record.id))) {
+        throw StateError(
+          'Conversation $characterId contains duplicate stable message IDs.',
+        );
+      }
+      await _writeMessagesFile(
+        File(_fileSystem.getCharacterConversationMessagesPath(
+          userId,
+          characterId,
+        )),
+        updated,
+      );
       await _writeStateUnlocked(
         userId,
         characterId,
         state.copyWith(
-          nextSeq: state.nextSeq + toWrite.length,
+          nextSeq: _nextSeq(state, updated),
           updatedAt: DateTime.now(),
           clearClearedAt: true,
         ),
@@ -601,20 +659,18 @@ class PersonaChatConversationStorage {
     if (!await file.exists()) return const [];
     final bytes = await file.readAsBytes();
     if (bytes.isEmpty) return const [];
-    final text = utf8.decode(bytes);
     final records = <PersonaChatConversationRecord>[];
     var lastValidOffset = 0;
-    var offset = 0;
-    final lines = text.split('\n');
-    for (var index = 0; index < lines.length; index++) {
-      final line = lines[index];
-      final hasTrailingNewline = index < lines.length - 1;
-      offset += line.length + (hasTrailingNewline ? 1 : 0);
-      if (line.trim().isEmpty) {
-        lastValidOffset = offset;
-        continue;
-      }
+    var lineStart = 0;
+
+    Future<void> readLine(int lineEnd, {required bool terminated}) async {
+      final endOffset = terminated ? lineEnd + 1 : lineEnd;
       try {
+        final line = utf8.decode(bytes.sublist(lineStart, lineEnd));
+        if (line.trim().isEmpty) {
+          lastValidOffset = endOffset;
+          return;
+        }
         final decoded = jsonDecode(line);
         if (decoded is! Map) {
           throw const FormatException(
@@ -627,10 +683,10 @@ class PersonaChatConversationStorage {
           throw const FormatException('Conversation JSONL row is incomplete');
         }
         records.add(record);
-        lastValidOffset = offset;
+        lastValidOffset = endOffset;
+        return;
       } catch (error) {
-        final truncatedTail = !hasTrailingNewline && !text.endsWith('\n');
-        if (truncatedTail) {
+        if (!terminated) {
           _logger.warning(
             'Truncating incomplete conversation JSONL tail in ${file.path}',
           );
@@ -638,15 +694,50 @@ class PersonaChatConversationStorage {
             bytes.sublist(0, lastValidOffset),
             flush: true,
           );
-          break;
+          return;
         }
         _logger.warning(
           'Skipping malformed conversation JSONL row in ${file.path}: $error',
         );
-        lastValidOffset = offset;
+        lastValidOffset = endOffset;
       }
     }
+
+    for (var index = 0; index < bytes.length; index++) {
+      if (bytes[index] != 0x0A) continue;
+      await readLine(index, terminated: true);
+      lineStart = index + 1;
+    }
+    if (lineStart < bytes.length) {
+      await readLine(bytes.length, terminated: false);
+    }
     return records;
+  }
+
+  int _nextSeq(
+    PersonaChatConversationState state,
+    List<PersonaChatConversationRecord> records,
+  ) {
+    var nextSeq = state.nextSeq;
+    for (final record in records) {
+      if (record.seq >= nextSeq) nextSeq = record.seq + 1;
+    }
+    return nextSeq;
+  }
+
+  Future<void> _repairNextSeqIfNeeded({
+    required String userId,
+    required String characterId,
+    required PersonaChatConversationState state,
+    required List<PersonaChatConversationRecord> records,
+  }) async {
+    final nextSeq = _nextSeq(state, records);
+    if (nextSeq == state.nextSeq) return;
+    await _writeStateUnlocked(
+      userId,
+      characterId,
+      state.copyWith(nextSeq: nextSeq, updatedAt: DateTime.now()),
+    );
   }
 
   Future<PersonaChatConversationState> _readStateUnlocked(
@@ -711,24 +802,18 @@ class PersonaChatConversationStorage {
     final content = records.isEmpty
         ? ''
         : '${records.map((record) => jsonEncode(record.toJson())).join('\n')}\n';
-    final temporary = File('${file.path}.tmp');
-    await temporary.writeAsString(content, flush: true);
-    try {
-      await temporary.rename(file.path);
-    } on FileSystemException {
-      if (await file.exists()) await file.delete();
-      await temporary.rename(file.path);
-    }
+    await _replaceFile(file, content);
   }
 
   Future<void> _writeJsonFile(File file, Map<String, dynamic> data) async {
+    const encoder = JsonEncoder.withIndent('  ');
+    await _replaceFile(file, '${encoder.convert(data)}\n');
+  }
+
+  Future<void> _replaceFile(File file, String content) async {
     await file.parent.create(recursive: true);
     final temporary = File('${file.path}.tmp');
-    const encoder = JsonEncoder.withIndent('  ');
-    await temporary.writeAsString(
-      '${encoder.convert(data)}\n',
-      flush: true,
-    );
+    await temporary.writeAsString(content, encoding: utf8, flush: true);
     try {
       await temporary.rename(file.path);
     } on FileSystemException {

--- a/lib/data/services/persona_chat_conversation_storage.dart
+++ b/lib/data/services/persona_chat_conversation_storage.dart
@@ -1,18 +1,16 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:crypto/crypto.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/jsonl_conversation_journal.dart';
 import 'package:memex/data/services/jsonl_file_store.dart';
 import 'package:memex/domain/models/character_message.dart';
 import 'package:path/path.dart' as p;
 import 'package:synchronized/synchronized.dart';
-import 'package:uuid/uuid.dart';
 
 class PersonaChatConversationRecord {
   const PersonaChatConversationRecord({
     required this.id,
-    required this.seq,
     required this.characterId,
     required this.isFromCharacter,
     required this.content,
@@ -21,11 +19,10 @@ class PersonaChatConversationRecord {
     required this.messageType,
     required this.origin,
     this.factId,
-    this.contactEpisodeId,
+    this.turnId,
   });
 
-  final String id;
-  final int seq;
+  final int id;
   final String characterId;
   final bool isFromCharacter;
   final String content;
@@ -34,12 +31,11 @@ class PersonaChatConversationRecord {
   final DateTime timestamp;
   final String messageType;
   final String origin;
-  final String? contactEpisodeId;
+  final String? turnId;
 
   PersonaChatConversationRecord copyWith({bool? isRead}) {
     return PersonaChatConversationRecord(
       id: id,
-      seq: seq,
       characterId: characterId,
       isFromCharacter: isFromCharacter,
       content: content,
@@ -48,40 +44,54 @@ class PersonaChatConversationRecord {
       timestamp: timestamp,
       messageType: messageType,
       origin: origin,
-      contactEpisodeId: contactEpisodeId,
+      turnId: turnId,
     );
   }
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'seq': seq,
-        'character_id': characterId,
-        'speaker': isFromCharacter ? 'character' : 'user',
-        'content': content,
+        'role': isFromCharacter ? 'assistant' : 'user',
+        'content': [
+          {
+            'type': messageType == PersonaChatMessageTypes.text
+                ? 'text'
+                : messageType,
+            'text': content,
+          },
+        ],
         if (factId != null) 'fact_id': factId,
-        'is_read': isRead,
-        'timestamp': timestamp.toIso8601String(),
+        'created_at': timestamp.toIso8601String(),
         'unix_seconds': timestamp.millisecondsSinceEpoch ~/ 1000,
-        'message_type': messageType,
         'origin': origin,
-        if (contactEpisodeId != null) 'contact_episode_id': contactEpisodeId,
+        if (turnId != null) 'turn_id': turnId,
       };
 
-  static PersonaChatConversationRecord? fromJson(Map<String, dynamic> json) {
-    final id = json['id']?.toString();
-    final characterId = json['character_id']?.toString();
-    final content = json['content']?.toString();
-    final seq = json['seq'];
-    if (id == null ||
-        id.isEmpty ||
-        characterId == null ||
-        characterId.isEmpty ||
-        content == null ||
-        seq is! num ||
-        seq.toInt() <= 0) {
+  static PersonaChatConversationRecord? fromJson(
+    Map<String, dynamic> json, {
+    required String characterId,
+  }) {
+    final id = json['id'];
+    final role = json['role']?.toString();
+    final contentBlocks = json['content'];
+    if (id is! num ||
+        id.toInt() <= 0 ||
+        (role != 'user' && role != 'assistant') ||
+        contentBlocks is! List) {
       return null;
     }
-    final timestampText = json['timestamp']?.toString();
+
+    Map<String, dynamic>? block;
+    for (final candidate in contentBlocks) {
+      if (candidate is Map && candidate['text'] != null) {
+        block = Map<String, dynamic>.from(candidate);
+        break;
+      }
+    }
+    if (block == null) return null;
+    final content = block['text']?.toString();
+    if (content == null) return null;
+
+    final timestampText = json['created_at']?.toString();
     final unixSeconds = json['unix_seconds'];
     final timestamp = timestampText == null
         ? unixSeconds is num
@@ -89,20 +99,19 @@ class PersonaChatConversationRecord {
             : DateTime.fromMillisecondsSinceEpoch(0)
         : DateTime.tryParse(timestampText) ??
             DateTime.fromMillisecondsSinceEpoch(0);
+    final blockType = block['type']?.toString() ?? 'text';
     return PersonaChatConversationRecord(
-      id: id,
-      seq: seq.toInt(),
+      id: id.toInt(),
       characterId: characterId,
-      isFromCharacter:
-          json['speaker'] == 'character' || json['is_from_character'] == true,
+      isFromCharacter: role == 'assistant',
       content: content,
       factId: json['fact_id']?.toString(),
-      isRead: json['is_read'] == true,
+      isRead: false,
       timestamp: timestamp,
-      messageType: (json['message_type'] ?? json['type'])?.toString() ??
-          PersonaChatMessageTypes.text,
+      messageType:
+          blockType == 'text' ? PersonaChatMessageTypes.text : blockType,
       origin: json['origin']?.toString() ?? 'conversation',
-      contactEpisodeId: json['contact_episode_id']?.toString(),
+      turnId: json['turn_id']?.toString(),
     );
   }
 }
@@ -110,13 +119,18 @@ class PersonaChatConversationRecord {
 class PersonaChatConversationMetadata {
   const PersonaChatConversationMetadata({
     required this.schemaVersion,
-    required this.nextSeq,
+    required this.generation,
+    required this.nextMessageId,
     required this.messageCount,
     required this.unreadCount,
     required this.messagesByteLength,
-    required this.readThroughSeq,
-    this.consumedThroughSeq,
-    this.lastMessage,
+    required this.readThroughMessageId,
+    required this.agentProcessedThroughUserMessageId,
+    required this.lastMessageId,
+    required this.latestUserMessageId,
+    this.lastTurnId,
+    this.lastTurnFirstMessageId,
+    this.lastTurnLastMessageId,
     this.updatedAt,
     this.clearedAt,
   });
@@ -124,50 +138,71 @@ class PersonaChatConversationMetadata {
   factory PersonaChatConversationMetadata.initial() {
     return const PersonaChatConversationMetadata(
       schemaVersion: PersonaChatConversationStorage.schemaVersion,
-      nextSeq: 1,
+      generation: 1,
+      nextMessageId: 1,
       messageCount: 0,
       unreadCount: 0,
       messagesByteLength: 0,
-      readThroughSeq: 0,
+      readThroughMessageId: 0,
+      agentProcessedThroughUserMessageId: 0,
+      lastMessageId: 0,
+      latestUserMessageId: 0,
     );
   }
 
   final int schemaVersion;
-  final int nextSeq;
+  final int generation;
+  final int nextMessageId;
   final int messageCount;
   final int unreadCount;
   final int messagesByteLength;
-  final int readThroughSeq;
-  final int? consumedThroughSeq;
-  final PersonaChatConversationRecord? lastMessage;
+  final int readThroughMessageId;
+  final int agentProcessedThroughUserMessageId;
+  final int lastMessageId;
+  final int latestUserMessageId;
+  final String? lastTurnId;
+  final int? lastTurnFirstMessageId;
+  final int? lastTurnLastMessageId;
   final DateTime? updatedAt;
   final DateTime? clearedAt;
 
   PersonaChatConversationMetadata copyWith({
-    int? nextSeq,
+    int? generation,
+    int? nextMessageId,
     int? messageCount,
     int? unreadCount,
     int? messagesByteLength,
-    int? readThroughSeq,
-    int? consumedThroughSeq,
-    bool clearConsumedThroughSeq = false,
-    PersonaChatConversationRecord? lastMessage,
-    bool clearLastMessage = false,
+    int? readThroughMessageId,
+    int? agentProcessedThroughUserMessageId,
+    int? lastMessageId,
+    int? latestUserMessageId,
+    String? lastTurnId,
+    bool clearLastTurn = false,
+    int? lastTurnFirstMessageId,
+    int? lastTurnLastMessageId,
     DateTime? updatedAt,
     DateTime? clearedAt,
     bool clearClearedAt = false,
   }) {
     return PersonaChatConversationMetadata(
       schemaVersion: schemaVersion,
-      nextSeq: nextSeq ?? this.nextSeq,
+      generation: generation ?? this.generation,
+      nextMessageId: nextMessageId ?? this.nextMessageId,
       messageCount: messageCount ?? this.messageCount,
       unreadCount: unreadCount ?? this.unreadCount,
       messagesByteLength: messagesByteLength ?? this.messagesByteLength,
-      readThroughSeq: readThroughSeq ?? this.readThroughSeq,
-      consumedThroughSeq: clearConsumedThroughSeq
+      readThroughMessageId: readThroughMessageId ?? this.readThroughMessageId,
+      agentProcessedThroughUserMessageId: agentProcessedThroughUserMessageId ??
+          this.agentProcessedThroughUserMessageId,
+      lastMessageId: lastMessageId ?? this.lastMessageId,
+      latestUserMessageId: latestUserMessageId ?? this.latestUserMessageId,
+      lastTurnId: clearLastTurn ? null : lastTurnId ?? this.lastTurnId,
+      lastTurnFirstMessageId: clearLastTurn
           ? null
-          : consumedThroughSeq ?? this.consumedThroughSeq,
-      lastMessage: clearLastMessage ? null : lastMessage ?? this.lastMessage,
+          : lastTurnFirstMessageId ?? this.lastTurnFirstMessageId,
+      lastTurnLastMessageId: clearLastTurn
+          ? null
+          : lastTurnLastMessageId ?? this.lastTurnLastMessageId,
       updatedAt: updatedAt ?? this.updatedAt,
       clearedAt: clearClearedAt ? null : clearedAt ?? this.clearedAt,
     );
@@ -175,39 +210,54 @@ class PersonaChatConversationMetadata {
 
   Map<String, dynamic> toJson() => {
         'schema_version': schemaVersion,
-        'next_message_seq': nextSeq,
-        'message_count': messageCount,
-        'unread_count': unreadCount,
-        'messages_byte_length': messagesByteLength,
-        'read_through_seq': readThroughSeq,
-        if (consumedThroughSeq != null)
-          'consumed_through_seq': consumedThroughSeq,
-        if (lastMessage != null) 'last_message': lastMessage!.toJson(),
+        'generation': generation,
+        'next_message_id': nextMessageId,
+        'read_through_message_id': readThroughMessageId,
+        'agent_processed_through_user_message_id':
+            agentProcessedThroughUserMessageId,
+        'summary': {
+          'message_count': messageCount,
+          'unread_count': unreadCount,
+          'messages_byte_length': messagesByteLength,
+          'last_message_id': lastMessageId,
+          'latest_user_message_id': latestUserMessageId,
+        },
+        if (lastTurnId != null)
+          'last_committed_turn': {
+            'id': lastTurnId,
+            'first_message_id': lastTurnFirstMessageId,
+            'last_message_id': lastTurnLastMessageId,
+          },
         if (updatedAt != null) 'updated_at': updatedAt!.toIso8601String(),
         if (clearedAt != null) 'cleared_at': clearedAt!.toIso8601String(),
       };
 
-  static PersonaChatConversationMetadata? fromJson(Map<String, dynamic> json) {
+  static PersonaChatConversationMetadata? fromJson(
+    Map<String, dynamic> json,
+  ) {
     if (json['schema_version'] !=
         PersonaChatConversationStorage.schemaVersion) {
       return null;
     }
-    final lastRaw = json['last_message'];
+    final summary = json['summary'];
+    if (summary is! Map) return null;
+    final turn = json['last_committed_turn'];
+    final turnMap = turn is Map ? Map<String, dynamic>.from(turn) : null;
     return PersonaChatConversationMetadata(
       schemaVersion: PersonaChatConversationStorage.schemaVersion,
-      nextSeq: _positiveInt(json['next_message_seq'], fallback: 1),
-      messageCount: _nonNegativeInt(json['message_count']),
-      unreadCount: _nonNegativeInt(json['unread_count']),
-      messagesByteLength: _nonNegativeInt(json['messages_byte_length']),
-      readThroughSeq: _nonNegativeInt(json['read_through_seq']),
-      consumedThroughSeq: json['consumed_through_seq'] is num
-          ? (json['consumed_through_seq'] as num).toInt()
-          : null,
-      lastMessage: lastRaw is Map
-          ? PersonaChatConversationRecord.fromJson(
-              Map<String, dynamic>.from(lastRaw),
-            )
-          : null,
+      generation: _positiveInt(json['generation'], fallback: 1),
+      nextMessageId: _positiveInt(json['next_message_id'], fallback: 1),
+      messageCount: _nonNegativeInt(summary['message_count']),
+      unreadCount: _nonNegativeInt(summary['unread_count']),
+      messagesByteLength: _nonNegativeInt(summary['messages_byte_length']),
+      readThroughMessageId: _nonNegativeInt(json['read_through_message_id']),
+      agentProcessedThroughUserMessageId:
+          _nonNegativeInt(json['agent_processed_through_user_message_id']),
+      lastMessageId: _nonNegativeInt(summary['last_message_id']),
+      latestUserMessageId: _nonNegativeInt(summary['latest_user_message_id']),
+      lastTurnId: turnMap?['id']?.toString(),
+      lastTurnFirstMessageId: _positiveIntOrNull(turnMap?['first_message_id']),
+      lastTurnLastMessageId: _positiveIntOrNull(turnMap?['last_message_id']),
       updatedAt: DateTime.tryParse(json['updated_at']?.toString() ?? ''),
       clearedAt: DateTime.tryParse(json['cleared_at']?.toString() ?? ''),
     );
@@ -218,35 +268,59 @@ class PersonaChatConversationMetadata {
 
   static int _positiveInt(dynamic value, {required int fallback}) =>
       value is num && value > 0 ? value.toInt() : fallback;
+
+  static int? _positiveIntOrNull(dynamic value) =>
+      value is num && value > 0 ? value.toInt() : null;
 }
 
-/// File-only persona conversation store.
+class PersonaChatConversationPage {
+  const PersonaChatConversationPage({
+    required this.records,
+    required this.olderCursor,
+    required this.newestCursor,
+  });
+
+  final List<PersonaChatConversationRecord> records;
+  final int? olderCursor;
+  final int newestCursor;
+}
+
+typedef PersonaChatCommitPhase = JsonlConversationCommitPhase;
+typedef PersonaChatCommitObserver = JsonlConversationCommitObserver;
+
+/// Workspace-authoritative persona conversation storage.
 ///
-/// `messages.jsonl` is the sole durable message history. `metadata.json` is a
-/// rebuildable summary used for O(1) unread/cursor/last-message queries. An
-/// episode is one JSONL envelope, so all bubbles become visible together.
+/// Every line in `messages.jsonl` is one immutable message. Mutable read and
+/// agent-processing boundaries live in `metadata.json`. Agent-produced turns
+/// are committed with a single transient write-ahead file so multiple bubbles
+/// and their state transition recover together after a process interruption.
 class PersonaChatConversationStorage {
   PersonaChatConversationStorage({
     FileSystemService? fileSystem,
     JsonlFileStore? jsonl,
-    Uuid? uuid,
+    PersonaChatCommitObserver? commitObserver,
   })  : _injectedFileSystem = fileSystem,
-        _jsonl = jsonl ?? JsonlFileStore(loggerName: 'PersonaChatJsonl'),
-        _uuid = uuid ?? const Uuid();
+        _jsonl = jsonl ?? JsonlFileStore(loggerName: 'PersonaChatJsonl') {
+    _journal = JsonlConversationJournal(
+      jsonl: _jsonl,
+      observer: commitObserver,
+    );
+  }
 
   static final PersonaChatConversationStorage instance =
       PersonaChatConversationStorage();
 
-  static const int schemaVersion = 2;
-  static const String storageMigrationKey = 'persona_chat_workspace_v2';
-  static const String _episodeRecordType = 'episode';
-  static const String _readBoundaryRecordType = 'read_boundary';
-  static const String _replyCursorRecordType = 'reply_cursor';
+  // This is the first released workspace format. The episode-based format
+  // existed only inside the unmerged pull request and is intentionally not a
+  // migration source.
+  static const int schemaVersion = 1;
+  static const String storageMigrationKey = 'persona_chat_workspace_v1';
+  static const int _scanPageSize = 64;
   static final Map<String, Lock> _processLocks = {};
 
   final FileSystemService? _injectedFileSystem;
   final JsonlFileStore _jsonl;
-  final Uuid _uuid;
+  late final JsonlConversationJournal _journal;
 
   FileSystemService get _fileSystem =>
       _injectedFileSystem ?? FileSystemService.instance;
@@ -261,160 +335,274 @@ class PersonaChatConversationStorage {
     required String origin,
     String? factId,
     bool isRead = false,
-    String? contactEpisodeId,
+    String? turnId,
   }) {
     return _synchronized(userId, characterId, () async {
-      final metadata = await _readMetadataRepairingIfNeeded(
-        userId,
-        characterId,
-      );
+      final metadata = await _prepareUnlocked(userId, characterId);
       final record = PersonaChatConversationRecord(
-        id: _uuid.v4(),
-        seq: metadata.nextSeq,
+        id: metadata.nextMessageId,
         characterId: characterId,
         isFromCharacter: isFromCharacter,
         content: content,
         factId: factId,
-        isRead: isRead,
+        isRead: isRead || !isFromCharacter,
         timestamp: timestamp,
         messageType: messageType,
         origin: origin,
-        contactEpisodeId: contactEpisodeId,
+        turnId: turnId,
       );
-      await _appendRecords(
-        userId: userId,
-        characterId: characterId,
-        metadata: metadata,
-        records: [record],
-        jsonRow: record.toJson(),
+      final append = await _jsonl.append(
+        _messagesFile(userId, characterId),
+        [record.toJson()],
       );
-      return record;
+      final next = _metadataAfterAppend(
+        metadata,
+        [record],
+        messagesByteLength: append.endOffset,
+        readThroughMessageId: isFromCharacter && isRead ? record.id : null,
+        lastTurnId: turnId,
+      );
+      await _writeMetadata(userId, characterId, next);
+      return _withEffectiveRead(record, next);
     });
   }
 
-  Future<List<PersonaChatConversationRecord>> appendEpisode({
+  Future<List<PersonaChatConversationRecord>> appendTurn({
     required String userId,
     required String characterId,
-    required List<PersonaChatConversationRecord> Function(int nextSeq) records,
-    required String contactEpisodeId,
+    required List<PersonaChatConversationRecord> Function(int firstMessageId)
+        records,
+    required String turnId,
     required int expectedRecordCount,
-    int? consumedThroughSeq,
+    int? agentProcessedThroughUserMessageId,
+    int? expectedGeneration,
   }) {
-    _validateEpisode(contactEpisodeId, expectedRecordCount);
+    _validateTurn(turnId, expectedRecordCount);
     return _synchronized(userId, characterId, () async {
-      var metadata = await _readMetadataRepairingIfNeeded(userId, characterId);
-      final receiptFile = _episodeReceiptFile(
+      final metadata = await _prepareUnlocked(userId, characterId);
+      if (expectedGeneration != null &&
+          metadata.generation != expectedGeneration) {
+        throw StateError(
+          'Persona conversation changed while the reply was generated.',
+        );
+      }
+      final alreadyProcessed = agentProcessedThroughUserMessageId != null &&
+          metadata.agentProcessedThroughUserMessageId >=
+              agentProcessedThroughUserMessageId;
+      final existing = await _loadCommittedTurn(
         userId,
         characterId,
-        contactEpisodeId,
+        metadata,
+        turnId,
+        searchHistory: alreadyProcessed,
       );
-      final receipt = await _readEpisodeReceipt(
-        receiptFile,
-        contactEpisodeId,
-      );
-      final persisted = await _loadEpisodeFromReceiptOrLog(
-        userId: userId,
-        characterId: characterId,
-        episodeId: contactEpisodeId,
-        receiptFile: receiptFile,
-        receipt: receipt,
-      );
-      if (persisted != null) {
-        _verifyEpisodeCount(persisted, expectedRecordCount);
-        if (consumedThroughSeq != null) {
-          await _advanceCursorUnlocked(
-            userId,
-            characterId,
-            metadata,
-            consumedThroughSeq,
+      if (existing != null) {
+        _verifyTurnCount(existing, expectedRecordCount);
+        if (agentProcessedThroughUserMessageId != null &&
+            metadata.agentProcessedThroughUserMessageId <
+                agentProcessedThroughUserMessageId) {
+          await _commitUnlocked(
+            userId: userId,
+            characterId: characterId,
+            metadata: metadata,
+            records: const [],
+            nextMetadata: metadata.copyWith(
+              agentProcessedThroughUserMessageId:
+                  agentProcessedThroughUserMessageId,
+              updatedAt: DateTime.now(),
+            ),
           );
         }
-        return persisted;
+        return existing
+            .map((record) => _withEffectiveRead(record, metadata))
+            .toList(growable: false);
       }
-
-      if (receipt == null) {
-        await _writeEpisodeReceipt(
-          receiptFile,
-          contactEpisodeId,
+      if (alreadyProcessed) {
+        throw StateError(
+          'Conversation input was already finalized without turn $turnId.',
         );
       }
 
-      final toWrite = records(metadata.nextSeq);
-      _verifyNewEpisode(
+      if (agentProcessedThroughUserMessageId != null) {
+        _validateProcessedBoundary(
+          metadata,
+          agentProcessedThroughUserMessageId,
+        );
+      }
+      final toWrite = records(metadata.nextMessageId);
+      _verifyNewTurn(
         characterId,
-        contactEpisodeId,
-        metadata.nextSeq,
+        turnId,
+        metadata.nextMessageId,
         expectedRecordCount,
         toWrite,
       );
-      final lineOffset = metadata.messagesByteLength;
-      metadata = await _appendRecords(
+      final next = _metadataAfterAppend(
+        metadata,
+        toWrite,
+        messagesByteLength: metadata.messagesByteLength +
+            _encodedRowsLength(toWrite.map((record) => record.toJson())),
+        readThroughMessageId: _readBoundaryFromRecords(toWrite),
+        agentProcessedThroughUserMessageId: agentProcessedThroughUserMessageId,
+        lastTurnId: turnId,
+      );
+      await _commitUnlocked(
         userId: userId,
         characterId: characterId,
         metadata: metadata,
         records: toWrite,
-        jsonRow: {
-          'record_type': _episodeRecordType,
-          'episode_id': contactEpisodeId,
-          'messages': toWrite.map((record) => record.toJson()).toList(),
-        },
-        consumedThroughSeq: consumedThroughSeq,
+        nextMetadata: next,
       );
-      await _writeEpisodeReceipt(
-        receiptFile,
-        contactEpisodeId,
-        lineOffset: lineOffset,
-      );
-      return toWrite;
+      return toWrite.map((record) => _withEffectiveRead(record, next)).toList();
     });
   }
 
-  Future<bool> tryAppendInitiativeEpisode({
+  Future<bool> tryAppendInitiativeTurn({
     required String userId,
     required String characterId,
-    required List<PersonaChatConversationRecord> Function(int nextSeq) records,
-    required String contactEpisodeId,
+    required List<PersonaChatConversationRecord> Function(int firstMessageId)
+        records,
+    required String turnId,
     required int expectedRecordCount,
+    int? expectedGeneration,
   }) {
-    _validateEpisode(contactEpisodeId, expectedRecordCount);
+    _validateTurn(turnId, expectedRecordCount);
     return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
-      final receipt = await _readEpisodeReceipt(
-        _episodeReceiptFile(userId, characterId, contactEpisodeId),
-        contactEpisodeId,
-      );
-      if (receipt != null &&
-          await _loadEpisodeFromReceiptOrLog(
-                userId: userId,
-                characterId: characterId,
-                episodeId: contactEpisodeId,
-                receiptFile: _episodeReceiptFile(
-                  userId,
-                  characterId,
-                  contactEpisodeId,
-                ),
-                receipt: receipt,
-              ) !=
-              null) {
-        return true;
+      final metadata = await _prepareUnlocked(userId, characterId);
+      if (expectedGeneration != null &&
+          metadata.generation != expectedGeneration) {
+        return false;
       }
-      final pending = await _loadPendingUserMessagesUnlocked(
+      final existing = await _loadCommittedTurn(
         userId,
         characterId,
-        metadata.consumedThroughSeq ?? 0,
-        limit: 1,
+        metadata,
+        turnId,
+        // Initiative is infrequent and has no processing cursor. Scanning on
+        // a cache miss keeps messages.jsonl as the only idempotency fact.
+        searchHistory: true,
       );
-      if (pending.isNotEmpty) return false;
-      await _appendEpisodeUnlocked(
+      if (existing != null) {
+        _verifyTurnCount(existing, expectedRecordCount);
+        return true;
+      }
+      if (metadata.latestUserMessageId >
+          metadata.agentProcessedThroughUserMessageId) {
+        return false;
+      }
+
+      final toWrite = records(metadata.nextMessageId);
+      _verifyNewTurn(
+        characterId,
+        turnId,
+        metadata.nextMessageId,
+        expectedRecordCount,
+        toWrite,
+      );
+      final next = _metadataAfterAppend(
+        metadata,
+        toWrite,
+        messagesByteLength: metadata.messagesByteLength +
+            _encodedRowsLength(toWrite.map((record) => record.toJson())),
+        readThroughMessageId: _readBoundaryFromRecords(toWrite),
+        lastTurnId: turnId,
+      );
+      await _commitUnlocked(
         userId: userId,
         characterId: characterId,
         metadata: metadata,
-        records: records,
-        contactEpisodeId: contactEpisodeId,
-        expectedRecordCount: expectedRecordCount,
+        records: toWrite,
+        nextMetadata: next,
       );
       return true;
+    });
+  }
+
+  Future<PersonaChatConversationPage> loadMessagePage({
+    required String userId,
+    required String characterId,
+    required int limit,
+    int? beforeCursor,
+  }) {
+    return _synchronized(userId, characterId, () async {
+      final metadata = await _prepareUnlocked(userId, characterId);
+      if (limit <= 0) {
+        return PersonaChatConversationPage(
+          records: const [],
+          olderCursor: null,
+          newestCursor: metadata.messagesByteLength,
+        );
+      }
+      final page = await _jsonl.readPageBefore(
+        _messagesFile(userId, characterId),
+        limit: limit,
+        beforeOffset: beforeCursor,
+      );
+      final records = page.rows
+          .map(
+            (row) => PersonaChatConversationRecord.fromJson(
+              row,
+              characterId: characterId,
+            ),
+          )
+          .whereType<PersonaChatConversationRecord>()
+          .toList(growable: false)
+          .reversed
+          .map((record) => _withEffectiveRead(record, metadata))
+          .toList(growable: false);
+      return PersonaChatConversationPage(
+        records: records,
+        olderCursor: page.olderOffset,
+        newestCursor: metadata.messagesByteLength,
+      );
+    });
+  }
+
+  Future<PersonaChatConversationPage> loadMessagesAfter({
+    required String userId,
+    required String characterId,
+    required int afterCursor,
+  }) {
+    return _synchronized(userId, characterId, () async {
+      final metadata = await _prepareUnlocked(userId, characterId);
+      final file = _messagesFile(userId, characterId);
+      final safeCursor =
+          afterCursor.clamp(0, metadata.messagesByteLength).toInt();
+      if (safeCursor == metadata.messagesByteLength) {
+        return PersonaChatConversationPage(
+          records: const [],
+          olderCursor: null,
+          newestCursor: metadata.messagesByteLength,
+        );
+      }
+      final handle = await file.open();
+      late List<int> bytes;
+      try {
+        await handle.setPosition(safeCursor);
+        bytes = await handle.read(metadata.messagesByteLength - safeCursor);
+      } finally {
+        await handle.close();
+      }
+      final records = <PersonaChatConversationRecord>[];
+      for (final line in utf8.decode(bytes).split('\n')) {
+        if (line.trim().isEmpty) continue;
+        try {
+          final decoded = jsonDecode(line);
+          if (decoded is! Map) continue;
+          final record = PersonaChatConversationRecord.fromJson(
+            Map<String, dynamic>.from(decoded),
+            characterId: characterId,
+          );
+          if (record != null) records.add(_withEffectiveRead(record, metadata));
+        } catch (_) {
+          continue;
+        }
+      }
+      return PersonaChatConversationPage(
+        records: records.reversed.toList(growable: false),
+        olderCursor: null,
+        newestCursor: metadata.messagesByteLength,
+      );
     });
   }
 
@@ -423,43 +611,42 @@ class PersonaChatConversationStorage {
     required String characterId,
     int? limit,
     int offset = 0,
-  }) {
-    return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
-      if (limit == null || limit <= 0) {
-        final records = await _readAllRecords(userId, characterId);
-        return _applyReadState(records.reversed, metadata).toList();
-      }
-      final records = await _readNewestRecords(
-        userId,
-        characterId,
-        limit + offset,
-      );
-      return _applyReadState(records, metadata)
-          .skip(offset)
-          .take(limit)
-          .toList(growable: false);
-    });
+  }) async {
+    if (limit == null || limit <= 0) {
+      return _synchronized(userId, characterId, () async {
+        final metadata = await _prepareUnlocked(userId, characterId);
+        return (await _readAllRecords(userId, characterId))
+            .reversed
+            .map((record) => _withEffectiveRead(record, metadata))
+            .toList(growable: false);
+      });
+    }
+    final page = await loadMessagePage(
+      userId: userId,
+      characterId: characterId,
+      limit: limit + offset,
+    );
+    return page.records.skip(offset).take(limit).toList(growable: false);
   }
 
   Future<List<PersonaChatConversationRecord>> loadMessagesBefore({
     required String userId,
     required String characterId,
-    required int beforeSeq,
+    required int beforeMessageId,
     int limit = 50,
   }) {
     return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
+      final metadata = await _prepareUnlocked(userId, characterId);
       final records = await _scanBackwards(
         userId,
         characterId,
+        include: (record) => record.id < beforeMessageId,
         stop: (collected, record) =>
-            record.seq < beforeSeq && collected.length >= limit,
-        include: (record) => record.seq < beforeSeq,
+            record.id < beforeMessageId && collected.length >= limit,
       );
-      return _applyReadState(records.take(limit), metadata)
+      return records
+          .take(limit)
+          .map((record) => _withEffectiveRead(record, metadata))
           .toList(growable: false);
     });
   }
@@ -470,14 +657,17 @@ class PersonaChatConversationStorage {
     int limit = 50,
   }) {
     return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
-      return _loadPendingUserMessagesUnlocked(
+      final metadata = await _prepareUnlocked(userId, characterId);
+      final newestFirst = await _scanBackwards(
         userId,
         characterId,
-        metadata.consumedThroughSeq ?? 0,
-        limit: limit,
+        include: (record) =>
+            record.id > metadata.agentProcessedThroughUserMessageId &&
+            !record.isFromCharacter,
+        stop: (_, record) =>
+            record.id <= metadata.agentProcessedThroughUserMessageId,
       );
+      return newestFirst.reversed.take(limit).toList(growable: false);
     });
   }
 
@@ -486,9 +676,8 @@ class PersonaChatConversationStorage {
     required String characterId,
   }) {
     return _synchronized(userId, characterId, () async {
-      return (await _readMetadataRepairingIfNeeded(userId, characterId))
-              .consumedThroughSeq ??
-          0;
+      return (await _prepareUnlocked(userId, characterId))
+          .agentProcessedThroughUserMessageId;
     });
   }
 
@@ -499,23 +688,38 @@ class PersonaChatConversationStorage {
     return _synchronized(
       userId,
       characterId,
-      () => _readMetadataRepairingIfNeeded(userId, characterId),
+      () => _prepareUnlocked(userId, characterId),
     );
+  }
+
+  Future<int> conversationGeneration({
+    required String userId,
+    required String characterId,
+  }) {
+    return _synchronized(userId, characterId, () async {
+      return (await _prepareUnlocked(userId, characterId)).generation;
+    });
   }
 
   Future<void> advanceCursor({
     required String userId,
     required String characterId,
-    required int consumedThroughSeq,
+    required int processedThroughUserMessageId,
   }) {
     return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
-      await _advanceCursorUnlocked(
+      final metadata = await _prepareUnlocked(userId, characterId);
+      _validateProcessedBoundary(metadata, processedThroughUserMessageId);
+      if (metadata.agentProcessedThroughUserMessageId >=
+          processedThroughUserMessageId) {
+        return;
+      }
+      await _writeMetadata(
         userId,
         characterId,
-        metadata,
-        consumedThroughSeq,
+        metadata.copyWith(
+          agentProcessedThroughUserMessageId: processedThroughUserMessageId,
+          updatedAt: DateTime.now(),
+        ),
       );
     });
   }
@@ -525,8 +729,7 @@ class PersonaChatConversationStorage {
     required String characterId,
   }) {
     return _synchronized(userId, characterId, () async {
-      return (await _readMetadataRepairingIfNeeded(userId, characterId))
-          .unreadCount;
+      return (await _prepareUnlocked(userId, characterId)).unreadCount;
     });
   }
 
@@ -543,27 +746,15 @@ class PersonaChatConversationStorage {
     required String characterId,
   }) {
     return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
+      final metadata = await _prepareUnlocked(userId, characterId);
       final changed = metadata.unreadCount;
       if (changed == 0) return 0;
-      final readThroughSeq = metadata.nextSeq - 1;
-      final append = await _jsonl.append(
-        _messagesFile(userId, characterId),
-        [
-          {
-            'record_type': _readBoundaryRecordType,
-            'read_through_seq': readThroughSeq,
-          },
-        ],
-      );
       await _writeMetadata(
         userId,
         characterId,
         metadata.copyWith(
           unreadCount: 0,
-          readThroughSeq: readThroughSeq,
-          messagesByteLength: append.endOffset,
+          readThroughMessageId: metadata.lastMessageId,
           updatedAt: DateTime.now(),
         ),
       );
@@ -574,23 +765,21 @@ class PersonaChatConversationStorage {
   Future<PersonaChatConversationRecord?> lastMessage({
     required String userId,
     required String characterId,
-  }) {
-    return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
-      final last = metadata.lastMessage;
-      return last == null ? null : _withEffectiveRead(last, metadata);
-    });
+  }) async {
+    final page = await loadMessagePage(
+      userId: userId,
+      characterId: characterId,
+      limit: 1,
+    );
+    return page.records.isEmpty ? null : page.records.first;
   }
 
-  Future<int> latestMessageSeq({
+  Future<int> latestMessageId({
     required String userId,
     required String characterId,
   }) {
     return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
-      return metadata.nextSeq - 1;
+      return (await _prepareUnlocked(userId, characterId)).lastMessageId;
     });
   }
 
@@ -600,61 +789,58 @@ class PersonaChatConversationStorage {
     required DateTime clearedAt,
   }) {
     return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
-      await _replaceFile(_messagesFile(userId, characterId), '');
-      final receipts = Directory(
-        _fileSystem.getCharacterConversationEpisodeReceiptsPath(
-          userId,
-          characterId,
-        ),
+      final metadata = await _prepareUnlocked(userId, characterId);
+      final next = PersonaChatConversationMetadata.initial().copyWith(
+        generation: metadata.generation + 1,
+        nextMessageId: metadata.nextMessageId,
+        clearedAt: clearedAt,
+        updatedAt: clearedAt,
       );
-      if (await receipts.exists()) await receipts.delete(recursive: true);
-      await _writeMetadata(
-        userId,
-        characterId,
-        PersonaChatConversationMetadata.initial().copyWith(
-          clearedAt: clearedAt,
-          updatedAt: clearedAt,
-        ),
+      await _commitUnlocked(
+        userId: userId,
+        characterId: characterId,
+        metadata: metadata,
+        records: const [],
+        nextMetadata: next,
+        baseOffset: 0,
+        truncateBeforeAppend: true,
       );
       return metadata.messageCount;
     });
   }
 
-  /// Imports a legacy snapshot only when the new conversation log is empty.
+  /// Imports SQLite history only when the workspace conversation is empty.
   Future<bool> importLegacySnapshot({
     required String userId,
     required String characterId,
     required List<PersonaChatConversationRecord> records,
-    int? consumedThroughSeq,
+    int? agentProcessedThroughUserMessageId,
   }) {
     return _synchronized(userId, characterId, () async {
-      final metadata =
-          await _readMetadataRepairingIfNeeded(userId, characterId);
+      final metadata = await _prepareUnlocked(userId, characterId);
       if (metadata.messageCount > 0 || records.isEmpty) return false;
       _verifyContiguousRecords(characterId, records);
-      final file = _messagesFile(userId, characterId);
-      final rows = <Map<String, dynamic>>[
-        ...records.map((record) => record.toJson()),
-        if (consumedThroughSeq != null)
-          {
-            'record_type': _replyCursorRecordType,
-            'consumed_through_seq': consumedThroughSeq,
-          },
-      ];
-      await _replaceFile(
-        file,
-        '${rows.map(jsonEncode).join('\n')}\n',
+      final readThrough = records
+          .where((record) => record.isFromCharacter && record.isRead)
+          .fold<int>(0,
+              (current, record) => record.id > current ? record.id : current);
+      final next = _metadataFromRecords(
+        records,
+        previous: metadata,
+        messagesByteLength:
+            _encodedRowsLength(records.map((record) => record.toJson())),
+        readThroughMessageId: readThrough,
+        agentProcessedThroughUserMessageId:
+            agentProcessedThroughUserMessageId ?? 0,
       );
-      await _writeMetadata(
-        userId,
-        characterId,
-        _metadataFromRecords(
-          records,
-          messagesByteLength: await file.length(),
-          consumedThroughSeq: consumedThroughSeq,
-        ),
+      await _commitUnlocked(
+        userId: userId,
+        characterId: characterId,
+        metadata: metadata,
+        records: records,
+        nextMetadata: next,
+        baseOffset: 0,
+        truncateBeforeAppend: true,
       );
       return true;
     });
@@ -676,256 +862,67 @@ class PersonaChatConversationStorage {
     return ids;
   }
 
-  Future<List<PersonaChatConversationRecord>> _appendEpisodeUnlocked({
-    required String userId,
-    required String characterId,
-    required PersonaChatConversationMetadata metadata,
-    required List<PersonaChatConversationRecord> Function(int nextSeq) records,
-    required String contactEpisodeId,
-    required int expectedRecordCount,
-  }) async {
-    final receiptFile = _episodeReceiptFile(
-      userId,
-      characterId,
-      contactEpisodeId,
-    );
-    final existing = await _readEpisodeReceipt(receiptFile, contactEpisodeId);
-    final persisted = await _loadEpisodeFromReceiptOrLog(
-      userId: userId,
-      characterId: characterId,
-      episodeId: contactEpisodeId,
-      receiptFile: receiptFile,
-      receipt: existing,
-    );
-    if (persisted != null) {
-      _verifyEpisodeCount(persisted, expectedRecordCount);
-      return persisted;
-    }
-    if (existing == null) {
-      await _writeEpisodeReceipt(receiptFile, contactEpisodeId);
-    }
-    final toWrite = records(metadata.nextSeq);
-    _verifyNewEpisode(
-      characterId,
-      contactEpisodeId,
-      metadata.nextSeq,
-      expectedRecordCount,
-      toWrite,
-    );
-    final lineOffset = metadata.messagesByteLength;
-    await _appendRecords(
-      userId: userId,
-      characterId: characterId,
-      metadata: metadata,
-      records: toWrite,
-      jsonRow: {
-        'record_type': _episodeRecordType,
-        'episode_id': contactEpisodeId,
-        'messages': toWrite.map((record) => record.toJson()).toList(),
-      },
-    );
-    await _writeEpisodeReceipt(
-      receiptFile,
-      contactEpisodeId,
-      lineOffset: lineOffset,
-    );
-    return toWrite;
-  }
-
-  Future<List<PersonaChatConversationRecord>?> _loadEpisodeFromReceiptOrLog({
-    required String userId,
-    required String characterId,
-    required String episodeId,
-    required File receiptFile,
-    required _EpisodeReceipt? receipt,
-  }) async {
-    Map<String, dynamic>? row;
-    var lineOffset = receipt?.lineOffset;
-    if (receipt?.isComplete == true && lineOffset != null) {
-      row = await _jsonl.readObjectAt(
-        _messagesFile(userId, characterId),
-        lineOffset,
+  Future<Set<String>> charactersWithPendingUserMessages(String userId) async {
+    final result = <String>{};
+    for (final characterId in await characterIds(userId)) {
+      final metadata = await loadMetadata(
+        userId: userId,
+        characterId: characterId,
       );
-      if (!_isEpisodeRow(row, episodeId)) row = null;
-    }
-    if (row == null && receipt != null) {
-      final located = await _jsonl.findLastObject(
-        _messagesFile(userId, characterId),
-        (candidate) => _isEpisodeRow(candidate, episodeId),
-      );
-      if (located != null) {
-        row = located.value;
-        lineOffset = located.startOffset;
-        await _writeEpisodeReceipt(
-          receiptFile,
-          episodeId,
-          lineOffset: lineOffset,
-        );
+      if (metadata.latestUserMessageId >
+          metadata.agentProcessedThroughUserMessageId) {
+        result.add(characterId);
       }
     }
-    if (row == null) return null;
-    final records = _recordsFromRow(row).toList(growable: false);
-    return records.isEmpty ? null : records;
+    return result;
   }
 
-  bool _isEpisodeRow(Map<String, dynamic>? row, String episodeId) =>
-      row?['record_type'] == _episodeRecordType &&
-      row?['episode_id'] == episodeId;
-
-  Future<PersonaChatConversationMetadata> _appendRecords({
+  Future<void> _commitUnlocked({
     required String userId,
     required String characterId,
     required PersonaChatConversationMetadata metadata,
     required List<PersonaChatConversationRecord> records,
-    required Map<String, dynamic> jsonRow,
-    int? consumedThroughSeq,
+    required PersonaChatConversationMetadata nextMetadata,
+    int? baseOffset,
+    bool truncateBeforeAppend = false,
   }) async {
-    final append = await _jsonl.append(
-      _messagesFile(userId, characterId),
-      [
-        {
-          ...jsonRow,
-          if (consumedThroughSeq != null)
-            'consumed_through_seq': consumedThroughSeq,
-        },
-      ],
+    await _journal.commit(
+      messagesFile: _messagesFile(userId, characterId),
+      metadataFile: _metadataFile(userId, characterId),
+      pendingFile: _pendingCommitFile(userId, characterId),
+      baseOffset: baseOffset ?? metadata.messagesByteLength,
+      messages: records.map((record) => record.toJson()).toList(),
+      targetMetadata: nextMetadata.toJson(),
+      truncateBeforeAppend: truncateBeforeAppend,
     );
-    final unreadAdded = records
-        .where((record) => record.isFromCharacter && !record.isRead)
-        .length;
-    final next = metadata.copyWith(
-      nextSeq: records.last.seq + 1,
-      messageCount: metadata.messageCount + records.length,
-      unreadCount: metadata.unreadCount + unreadAdded,
-      messagesByteLength: append.endOffset,
-      consumedThroughSeq: consumedThroughSeq,
-      lastMessage: records.last,
-      updatedAt: DateTime.now(),
-      clearClearedAt: true,
-    );
-    await _writeMetadata(userId, characterId, next);
-    return next;
   }
 
-  Future<List<PersonaChatConversationRecord>> _readAllRecords(
+  Future<PersonaChatConversationMetadata> _prepareUnlocked(
     String userId,
     String characterId,
   ) async {
-    return (await _readSnapshot(userId, characterId)).records;
+    await _ensureLayout(userId, characterId);
+    await _recoverPendingCommit(userId, characterId);
+    return _readMetadataRepairingIfNeeded(userId, characterId);
   }
 
-  Future<List<PersonaChatConversationRecord>> _readNewestRecords(
-    String userId,
-    String characterId,
-    int count,
-  ) async {
-    if (count <= 0) return const [];
-    return _scanBackwards(
-      userId,
-      characterId,
-      include: (_) => true,
-      stop: (collected, _) => collected.length >= count,
-    );
-  }
-
-  Future<_ConversationSnapshot> _readSnapshot(
+  Future<void> _recoverPendingCommit(
     String userId,
     String characterId,
   ) async {
-    final rows = await _jsonl.readAllRecoveringTail(
-      _messagesFile(userId, characterId),
+    await _journal.recover(
+      messagesFile: _messagesFile(userId, characterId),
+      metadataFile: _metadataFile(userId, characterId),
+      pendingFile: _pendingCommitFile(userId, characterId),
+      validateMetadata: (target) =>
+          PersonaChatConversationMetadata.fromJson(target) != null,
     );
-    final records = <PersonaChatConversationRecord>[];
-    var readThroughSeq = 0;
-    int? consumedThroughSeq;
-    for (final row in rows) {
-      records.addAll(_recordsFromRow(row));
-      final rowReadThrough = row['read_through_seq'];
-      if (rowReadThrough is num && rowReadThrough > readThroughSeq) {
-        readThroughSeq = rowReadThrough.toInt();
-      }
-      final rowConsumedThrough = row['consumed_through_seq'];
-      if (rowConsumedThrough is num &&
-          rowConsumedThrough > (consumedThroughSeq ?? 0)) {
-        consumedThroughSeq = rowConsumedThrough.toInt();
-      }
-    }
-    return _ConversationSnapshot(
-      records: records,
-      readThroughSeq: readThroughSeq,
-      consumedThroughSeq: consumedThroughSeq,
-    );
-  }
-
-  Future<List<PersonaChatConversationRecord>> _scanBackwards(
-    String userId,
-    String characterId, {
-    required bool Function(
-      List<PersonaChatConversationRecord> collected,
-      PersonaChatConversationRecord record,
-    ) stop,
-    required bool Function(PersonaChatConversationRecord record) include,
-  }) async {
-    const pageSize = 64;
-    int? cursor;
-    final collected = <PersonaChatConversationRecord>[];
-    while (true) {
-      final page = await _jsonl.readPageBefore(
-        _messagesFile(userId, characterId),
-        limit: pageSize,
-        beforeOffset: cursor,
-      );
-      if (page.rows.isEmpty) return collected;
-      final records =
-          page.rows.expand(_recordsFromRow).toList(growable: false).reversed;
-      for (final record in records) {
-        if (include(record)) collected.add(record);
-        if (stop(collected, record)) return collected;
-      }
-      cursor = page.olderOffset;
-      if (cursor == null) return collected;
-    }
-  }
-
-  Future<List<PersonaChatConversationRecord>> _loadPendingUserMessagesUnlocked(
-    String userId,
-    String characterId,
-    int cursorSeq, {
-    required int limit,
-  }) async {
-    final newestFirst = await _scanBackwards(
-      userId,
-      characterId,
-      include: (record) => record.seq > cursorSeq && !record.isFromCharacter,
-      stop: (_, record) => record.seq <= cursorSeq,
-    );
-    return newestFirst.reversed.take(limit).toList(growable: false);
-  }
-
-  Iterable<PersonaChatConversationRecord> _recordsFromRow(
-    Map<String, dynamic> row,
-  ) sync* {
-    if (row['record_type'] == _episodeRecordType) {
-      final messages = row['messages'];
-      if (messages is! List) return;
-      for (final raw in messages) {
-        if (raw is! Map) continue;
-        final record = PersonaChatConversationRecord.fromJson(
-          Map<String, dynamic>.from(raw),
-        );
-        if (record != null) yield record;
-      }
-      return;
-    }
-    final record = PersonaChatConversationRecord.fromJson(row);
-    if (record != null) yield record;
   }
 
   Future<PersonaChatConversationMetadata> _readMetadataRepairingIfNeeded(
     String userId,
     String characterId,
   ) async {
-    await _ensureLayout(userId, characterId);
     final file = _metadataFile(userId, characterId);
     PersonaChatConversationMetadata? metadata;
     try {
@@ -942,91 +939,223 @@ class PersonaChatConversationStorage {
     if (metadata != null && metadata.messagesByteLength == messagesLength) {
       return metadata;
     }
-    final snapshot = await _readSnapshot(userId, characterId);
+
+    final records = await _readAllRecords(userId, characterId);
     final repaired = _metadataFromRecords(
-      snapshot.records,
+      records,
+      previous: metadata ?? PersonaChatConversationMetadata.initial(),
       messagesByteLength: await _messagesFile(userId, characterId).length(),
-      readThroughSeq: snapshot.readThroughSeq,
-      consumedThroughSeq: snapshot.consumedThroughSeq,
-      clearedAt: metadata?.clearedAt,
+      readThroughMessageId: metadata?.readThroughMessageId ?? 0,
+      agentProcessedThroughUserMessageId:
+          metadata?.agentProcessedThroughUserMessageId ?? 0,
     );
     await _writeMetadata(userId, characterId, repaired);
     return repaired;
   }
 
-  PersonaChatConversationMetadata _metadataFromRecords(
+  PersonaChatConversationMetadata _metadataAfterAppend(
+    PersonaChatConversationMetadata metadata,
     List<PersonaChatConversationRecord> records, {
     required int messagesByteLength,
-    int readThroughSeq = 0,
-    int? consumedThroughSeq,
-    DateTime? clearedAt,
+    int? readThroughMessageId,
+    int? agentProcessedThroughUserMessageId,
+    String? lastTurnId,
   }) {
+    final effectiveReadThrough = readThroughMessageId == null
+        ? metadata.readThroughMessageId
+        : readThroughMessageId > metadata.readThroughMessageId
+            ? readThroughMessageId
+            : metadata.readThroughMessageId;
+    final unreadAdded = records
+        .where(
+          (record) =>
+              record.isFromCharacter && record.id > effectiveReadThrough,
+        )
+        .length;
+    final latestUser = records
+        .where((record) => !record.isFromCharacter)
+        .fold<int>(metadata.latestUserMessageId, (current, record) {
+      return record.id > current ? record.id : current;
+    });
+    final last = records.last;
+    return metadata.copyWith(
+      nextMessageId: last.id + 1,
+      messageCount: metadata.messageCount + records.length,
+      unreadCount: metadata.unreadCount + unreadAdded,
+      messagesByteLength: messagesByteLength,
+      readThroughMessageId: effectiveReadThrough,
+      agentProcessedThroughUserMessageId: agentProcessedThroughUserMessageId,
+      lastMessageId: last.id,
+      latestUserMessageId: latestUser,
+      lastTurnId: lastTurnId,
+      lastTurnFirstMessageId: lastTurnId == null ? null : records.first.id,
+      lastTurnLastMessageId: lastTurnId == null ? null : records.last.id,
+      updatedAt: DateTime.now(),
+      clearClearedAt: true,
+    );
+  }
+
+  PersonaChatConversationMetadata _metadataFromRecords(
+    List<PersonaChatConversationRecord> records, {
+    required PersonaChatConversationMetadata previous,
+    required int messagesByteLength,
+    required int readThroughMessageId,
+    required int agentProcessedThroughUserMessageId,
+  }) {
+    final lastId = records.isEmpty ? 0 : records.last.id;
+    final latestUser = records
+        .where((record) => !record.isFromCharacter)
+        .fold<int>(
+            0, (current, record) => record.id > current ? record.id : current);
     final unread = records
         .where(
           (record) =>
-              record.isFromCharacter &&
-              !record.isRead &&
-              record.seq > readThroughSeq,
+              record.isFromCharacter && record.id > readThroughMessageId,
         )
         .length;
+    final lastTurnId = records.isEmpty ? null : records.last.turnId;
+    int? firstTurnId;
+    if (lastTurnId != null) {
+      for (final record in records.reversed) {
+        if (record.turnId != lastTurnId) break;
+        firstTurnId = record.id;
+      }
+    }
     return PersonaChatConversationMetadata(
       schemaVersion: schemaVersion,
-      nextSeq: records.isEmpty ? 1 : records.last.seq + 1,
+      generation: previous.generation,
+      nextMessageId: previous.nextMessageId > lastId + 1
+          ? previous.nextMessageId
+          : lastId + 1,
       messageCount: records.length,
       unreadCount: unread,
       messagesByteLength: messagesByteLength,
-      readThroughSeq: readThroughSeq,
-      consumedThroughSeq: consumedThroughSeq,
-      lastMessage: records.isEmpty ? null : records.last,
+      readThroughMessageId: readThroughMessageId,
+      agentProcessedThroughUserMessageId: agentProcessedThroughUserMessageId,
+      lastMessageId: lastId,
+      latestUserMessageId: latestUser,
+      lastTurnId: lastTurnId,
+      lastTurnFirstMessageId: firstTurnId,
+      lastTurnLastMessageId: lastTurnId == null ? null : lastId,
       updatedAt: DateTime.now(),
-      clearedAt: records.isEmpty ? clearedAt : null,
+      clearedAt: records.isEmpty ? previous.clearedAt : null,
     );
   }
 
-  Future<PersonaChatConversationMetadata> _advanceCursorUnlocked(
+  Future<List<PersonaChatConversationRecord>?> _loadCommittedTurn(
+      String userId,
+      String characterId,
+      PersonaChatConversationMetadata metadata,
+      String turnId,
+      {required bool searchHistory}) async {
+    if (metadata.lastTurnId == turnId &&
+        metadata.lastTurnFirstMessageId != null &&
+        metadata.lastTurnLastMessageId != null) {
+      final newestFirst = await _scanBackwards(
+        userId,
+        characterId,
+        include: (record) =>
+            record.id >= metadata.lastTurnFirstMessageId! &&
+            record.id <= metadata.lastTurnLastMessageId! &&
+            record.turnId == turnId,
+        stop: (_, record) => record.id < metadata.lastTurnFirstMessageId!,
+      );
+      return newestFirst.reversed.toList(growable: false);
+    }
+    if (!searchHistory) return null;
+
+    final newestFirst = await _scanBackwards(
+      userId,
+      characterId,
+      include: (record) => record.turnId == turnId,
+      stop: (collected, record) =>
+          collected.isNotEmpty && record.turnId != turnId,
+    );
+    return newestFirst.isEmpty
+        ? null
+        : newestFirst.reversed.toList(growable: false);
+  }
+
+  Future<List<PersonaChatConversationRecord>> _readAllRecords(
     String userId,
     String characterId,
-    PersonaChatConversationMetadata metadata,
-    int nextSeq,
   ) async {
-    if (nextSeq <= 0 || nextSeq >= metadata.nextSeq) {
-      throw ArgumentError.value(nextSeq, 'consumedThroughSeq');
-    }
-    if ((metadata.consumedThroughSeq ?? 0) >= nextSeq) return metadata;
-    final append = await _jsonl.append(
+    final rows = await _jsonl.readAllRecoveringTail(
       _messagesFile(userId, characterId),
-      [
-        {
-          'record_type': _replyCursorRecordType,
-          'consumed_through_seq': nextSeq,
-        },
-      ],
     );
-    final next = metadata.copyWith(
-      consumedThroughSeq: nextSeq,
-      messagesByteLength: append.endOffset,
-      updatedAt: DateTime.now(),
-    );
-    await _writeMetadata(userId, characterId, next);
-    return next;
+    return rows
+        .map(
+          (row) => PersonaChatConversationRecord.fromJson(
+            row,
+            characterId: characterId,
+          ),
+        )
+        .whereType<PersonaChatConversationRecord>()
+        .toList(growable: false);
   }
 
-  Iterable<PersonaChatConversationRecord> _applyReadState(
-    Iterable<PersonaChatConversationRecord> records,
-    PersonaChatConversationMetadata metadata,
-  ) =>
-      records.map((record) => _withEffectiveRead(record, metadata));
+  Future<List<PersonaChatConversationRecord>> _scanBackwards(
+    String userId,
+    String characterId, {
+    required bool Function(PersonaChatConversationRecord record) include,
+    required bool Function(
+      List<PersonaChatConversationRecord> collected,
+      PersonaChatConversationRecord record,
+    ) stop,
+  }) async {
+    int? cursor;
+    final collected = <PersonaChatConversationRecord>[];
+    while (true) {
+      final page = await _jsonl.readPageBefore(
+        _messagesFile(userId, characterId),
+        limit: _scanPageSize,
+        beforeOffset: cursor,
+      );
+      if (page.rows.isEmpty) return collected;
+      for (final row in page.rows.reversed) {
+        final record = PersonaChatConversationRecord.fromJson(
+          row,
+          characterId: characterId,
+        );
+        if (record == null) continue;
+        if (include(record)) collected.add(record);
+        if (stop(collected, record)) return collected;
+      }
+      cursor = page.olderOffset;
+      if (cursor == null) return collected;
+    }
+  }
+
+  int? _readBoundaryFromRecords(
+    List<PersonaChatConversationRecord> records,
+  ) {
+    int? result;
+    for (final record in records) {
+      if (record.isFromCharacter && record.isRead) result = record.id;
+    }
+    return result;
+  }
 
   PersonaChatConversationRecord _withEffectiveRead(
     PersonaChatConversationRecord record,
     PersonaChatConversationMetadata metadata,
   ) {
-    if (!record.isFromCharacter ||
-        record.isRead ||
-        record.seq > metadata.readThroughSeq) {
-      return record;
+    if (!record.isFromCharacter || record.id <= metadata.readThroughMessageId) {
+      return record.copyWith(isRead: true);
     }
-    return record.copyWith(isRead: true);
+    return record.copyWith(isRead: false);
+  }
+
+  void _validateProcessedBoundary(
+    PersonaChatConversationMetadata metadata,
+    int value,
+  ) {
+    if (value <= 0 || value >= metadata.nextMessageId) {
+      throw ArgumentError.value(
+        value,
+        'agentProcessedThroughUserMessageId',
+      );
+    }
   }
 
   Future<void> _ensureLayout(String userId, String characterId) async {
@@ -1059,8 +1188,7 @@ class PersonaChatConversationStorage {
       await Directory(
         _fileSystem.getCharacterConversationPath(userId, characterId),
       ).create(recursive: true);
-      final lockFile = File(lockPath);
-      final handle = await lockFile.open(mode: FileMode.append);
+      final handle = await File(lockPath).open(mode: FileMode.append);
       await handle.lock(FileLock.exclusive);
       try {
         return await action();
@@ -1079,50 +1207,12 @@ class PersonaChatConversationStorage {
         _fileSystem.getCharacterConversationMetadataPath(userId, characterId),
       );
 
-  File _episodeReceiptFile(
-    String userId,
-    String characterId,
-    String episodeId,
-  ) {
-    final name = sha256.convert(utf8.encode(episodeId)).toString();
-    return File(
-      _fileSystem.getCharacterConversationEpisodeReceiptPath(
-        userId,
-        characterId,
-        name,
-      ),
-    );
-  }
-
-  Future<_EpisodeReceipt?> _readEpisodeReceipt(
-    File file,
-    String expectedEpisodeId,
-  ) async {
-    if (!await file.exists()) return null;
-    try {
-      final decoded = jsonDecode(await file.readAsString());
-      if (decoded is! Map || decoded['episode_id'] != expectedEpisodeId) {
-        throw const FormatException('Episode receipt identity mismatch');
-      }
-      return _EpisodeReceipt(
-        isComplete: decoded['status'] == 'complete',
-        lineOffset: decoded['line_offset'] is num
-            ? (decoded['line_offset'] as num).toInt()
-            : null,
+  File _pendingCommitFile(String userId, String characterId) => File(
+        _fileSystem.getCharacterConversationPendingCommitPath(
+          userId,
+          characterId,
+        ),
       );
-    } catch (_) {
-      return const _EpisodeReceipt(isComplete: false);
-    }
-  }
-
-  Future<void> _writeEpisodeReceipt(File file, String episodeId,
-      {int? lineOffset}) {
-    return _writeJsonFile(file, {
-      'episode_id': episodeId,
-      'status': lineOffset == null ? 'pending' : 'complete',
-      if (lineOffset != null) 'line_offset': lineOffset,
-    });
-  }
 
   Future<void> _writeMetadata(
     String userId,
@@ -1130,62 +1220,56 @@ class PersonaChatConversationStorage {
     PersonaChatConversationMetadata metadata,
   ) {
     return _writeJsonFile(
-        _metadataFile(userId, characterId), metadata.toJson());
+      _metadataFile(userId, characterId),
+      metadata.toJson(),
+    );
   }
 
   Future<void> _writeJsonFile(File file, Map<String, dynamic> value) {
-    const encoder = JsonEncoder.withIndent('  ');
-    return _replaceFile(file, '${encoder.convert(value)}\n');
+    return _journal.writeJsonFile(file, value);
   }
 
-  Future<void> _replaceFile(File file, String content) async {
-    await file.parent.create(recursive: true);
-    final temporary = File('${file.path}.tmp');
-    await temporary.writeAsString(content, encoding: utf8, flush: true);
-    try {
-      await temporary.rename(file.path);
-    } on FileSystemException {
-      if (await file.exists()) await file.delete();
-      await temporary.rename(file.path);
-    }
+  int _encodedRowsLength(Iterable<Map<String, dynamic>> rows) {
+    final materialized = rows.toList(growable: false);
+    if (materialized.isEmpty) return 0;
+    return utf8.encode('${materialized.map(jsonEncode).join('\n')}\n').length;
   }
 
-  void _validateEpisode(String episodeId, int expectedCount) {
-    if (episodeId.trim().isEmpty) {
-      throw ArgumentError.value(episodeId, 'contactEpisodeId');
+  void _validateTurn(String turnId, int expectedCount) {
+    if (turnId.trim().isEmpty) {
+      throw ArgumentError.value(turnId, 'turnId');
     }
     if (expectedCount <= 0) {
       throw ArgumentError.value(expectedCount, 'expectedRecordCount');
     }
   }
 
-  void _verifyEpisodeCount(
+  void _verifyTurnCount(
     List<PersonaChatConversationRecord> records,
     int expectedCount,
   ) {
     if (records.length != expectedCount) {
       throw StateError(
-        'Persisted episode contains ${records.length} messages; '
+        'Persisted turn contains ${records.length} messages; '
         'expected $expectedCount.',
       );
     }
   }
 
-  void _verifyNewEpisode(
+  void _verifyNewTurn(
     String characterId,
-    String episodeId,
-    int nextSeq,
+    String turnId,
+    int firstMessageId,
     int expectedCount,
     List<PersonaChatConversationRecord> records,
   ) {
-    _verifyEpisodeCount(records, expectedCount);
+    _verifyTurnCount(records, expectedCount);
     for (var index = 0; index < records.length; index++) {
       final record = records[index];
       if (record.characterId != characterId ||
-          record.contactEpisodeId != episodeId ||
-          record.seq != nextSeq + index) {
-        throw StateError(
-            'Episode $episodeId has an invalid message at $index.');
+          record.turnId != turnId ||
+          record.id != firstMessageId + index) {
+        throw StateError('Turn $turnId has an invalid message at $index.');
       }
     }
   }
@@ -1196,28 +1280,9 @@ class PersonaChatConversationStorage {
   ) {
     for (var index = 0; index < records.length; index++) {
       if (records[index].characterId != characterId ||
-          records[index].seq != index + 1) {
+          records[index].id != index + 1) {
         throw StateError('Legacy conversation snapshot is not contiguous.');
       }
     }
   }
-}
-
-class _EpisodeReceipt {
-  const _EpisodeReceipt({required this.isComplete, this.lineOffset});
-
-  final bool isComplete;
-  final int? lineOffset;
-}
-
-class _ConversationSnapshot {
-  const _ConversationSnapshot({
-    required this.records,
-    required this.readThroughSeq,
-    this.consumedThroughSeq,
-  });
-
-  final List<PersonaChatConversationRecord> records;
-  final int readThroughSeq;
-  final int? consumedThroughSeq;
 }

--- a/lib/data/services/persona_chat_legacy_migration_service.dart
+++ b/lib/data/services/persona_chat_legacy_migration_service.dart
@@ -1,0 +1,90 @@
+import 'package:drift/drift.dart';
+import 'package:memex/data/services/migration_state_service.dart';
+import 'package:memex/data/services/persona_chat_conversation_storage.dart';
+import 'package:memex/db/app_database.dart';
+
+/// One-way boundary from the legacy SQLite persona chat tables to the
+/// workspace conversation store. Runtime chat code never reads SQLite after
+/// this migration completes.
+class PersonaChatLegacyMigrationService {
+  PersonaChatLegacyMigrationService({
+    PersonaChatConversationStorage? storage,
+    MigrationStateService? migrationState,
+  })  : _storage = storage ?? PersonaChatConversationStorage.instance,
+        _migrationState = migrationState ?? MigrationStateService.instance;
+
+  final PersonaChatConversationStorage _storage;
+  final MigrationStateService _migrationState;
+
+  Future<void> ensureMigrated({
+    required String userId,
+    required AppDatabase database,
+  }) async {
+    await _migrationState.runOnce(
+      userId: userId,
+      key: PersonaChatConversationStorage.storageMigrationKey,
+      migrate: () => _migrate(userId, database),
+    );
+  }
+
+  Future<bool> _migrate(String userId, AppDatabase database) async {
+    final characterIds = await _legacyCharacterIds(database);
+    for (final characterId in characterIds) {
+      final rows = await (database.select(database.personaChatMessages)
+            ..where((row) => row.characterId.equals(characterId))
+            ..orderBy([
+              (row) => OrderingTerm.asc(row.timestamp),
+              (row) => OrderingTerm.asc(row.id),
+            ]))
+          .get();
+      if (rows.isEmpty) continue;
+
+      final records = <PersonaChatConversationRecord>[];
+      final seqByLegacyId = <int, int>{};
+      for (var index = 0; index < rows.length; index++) {
+        final row = rows[index];
+        final seq = index + 1;
+        seqByLegacyId[row.id] = seq;
+        records.add(
+          PersonaChatConversationRecord(
+            id: 'legacy-${row.id}',
+            seq: seq,
+            characterId: row.characterId,
+            isFromCharacter: row.isFromCharacter,
+            content: row.content,
+            factId: row.factId,
+            isRead: row.isRead,
+            timestamp: row.timestamp,
+            messageType: row.messageType,
+            origin: row.origin,
+            contactEpisodeId: row.contactEpisodeId,
+          ),
+        );
+      }
+
+      final cursor = await (database.select(database.personaChatReplyCursors)
+            ..where((row) => row.characterId.equals(characterId)))
+          .getSingleOrNull();
+      await _storage.importLegacySnapshot(
+        userId: userId,
+        characterId: characterId,
+        records: records,
+        consumedThroughSeq: cursor == null
+            ? null
+            : seqByLegacyId[cursor.consumedThroughMessageId],
+      );
+    }
+    return true;
+  }
+
+  Future<Set<String>> _legacyCharacterIds(AppDatabase database) async {
+    final query = database.selectOnly(database.personaChatMessages,
+        distinct: true)
+      ..addColumns([database.personaChatMessages.characterId]);
+    final rows = await query.get();
+    return rows
+        .map((row) => row.read(database.personaChatMessages.characterId))
+        .whereType<String>()
+        .toSet();
+  }
+}

--- a/lib/data/services/persona_chat_legacy_migration_service.dart
+++ b/lib/data/services/persona_chat_legacy_migration_service.dart
@@ -40,15 +40,14 @@ class PersonaChatLegacyMigrationService {
       if (rows.isEmpty) continue;
 
       final records = <PersonaChatConversationRecord>[];
-      final seqByLegacyId = <int, int>{};
+      final messageIdByLegacyId = <int, int>{};
       for (var index = 0; index < rows.length; index++) {
         final row = rows[index];
-        final seq = index + 1;
-        seqByLegacyId[row.id] = seq;
+        final messageId = index + 1;
+        messageIdByLegacyId[row.id] = messageId;
         records.add(
           PersonaChatConversationRecord(
-            id: 'legacy-${row.id}',
-            seq: seq,
+            id: messageId,
             characterId: row.characterId,
             isFromCharacter: row.isFromCharacter,
             content: row.content,
@@ -57,7 +56,7 @@ class PersonaChatLegacyMigrationService {
             timestamp: row.timestamp,
             messageType: row.messageType,
             origin: row.origin,
-            contactEpisodeId: row.contactEpisodeId,
+            turnId: row.contactEpisodeId,
           ),
         );
       }
@@ -69,9 +68,9 @@ class PersonaChatLegacyMigrationService {
         userId: userId,
         characterId: characterId,
         records: records,
-        consumedThroughSeq: cursor == null
+        agentProcessedThroughUserMessageId: cursor == null
             ? null
-            : seqByLegacyId[cursor.consumedThroughMessageId],
+            : messageIdByLegacyId[cursor.consumedThroughMessageId],
       );
     }
     return true;

--- a/lib/data/services/persona_chat_service.dart
+++ b/lib/data/services/persona_chat_service.dart
@@ -1,7 +1,9 @@
 import 'package:drift/drift.dart';
 import 'package:flutter/foundation.dart';
+import 'package:memex/data/services/persona_chat_conversation_storage.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/domain/models/character_message.dart';
+import 'package:uuid/uuid.dart';
 
 abstract final class PersonaChatMessageOrigin {
   static const conversation = 'conversation';
@@ -16,17 +18,48 @@ class PersonaChatService {
     return _instance!;
   }
 
-  PersonaChatService._() : _testDb = null;
+  PersonaChatService._()
+      : _testDb = null,
+        _boundUserId = null,
+        _storage = PersonaChatConversationStorage.instance,
+        _uuid = const Uuid();
 
   @visibleForTesting
-  PersonaChatService.forTesting(AppDatabase database) : _testDb = database;
+  PersonaChatService.forTesting(
+    AppDatabase database, {
+    String? userId,
+    PersonaChatConversationStorage? storage,
+  })  : _testDb = database,
+        _boundUserId = userId,
+        _storage = storage,
+        _uuid = const Uuid();
 
   final AppDatabase? _testDb;
+  final String? _boundUserId;
+  final PersonaChatConversationStorage? _storage;
+  final Uuid _uuid;
+  String? _sessionUserId;
 
   AppDatabase get _db => _testDb ?? AppDatabase.instance;
 
-  Future<List<PersonaChatMessage>> getMessages(String characterId,
-      {int limit = 50, int offset = 0}) async {
+  void bindUser(String userId) {
+    _sessionUserId = userId;
+  }
+
+  Future<void> reconcileFromWorkspace(String userId) async {
+    final storage = _storage;
+    if (storage == null) return;
+    await storage.ensureMigrated(userId: userId, db: _db);
+    await storage.reconcileAll(userId: userId, db: _db);
+  }
+
+  Future<List<PersonaChatMessage>> getMessages(
+    String characterId, {
+    int limit = 50,
+    int offset = 0,
+    String? userId,
+  }) async {
+    await _ensureProjected(characterId, userId: userId);
     return (_db.select(_db.personaChatMessages)
           ..where((t) => t.characterId.equals(characterId))
           ..orderBy([
@@ -43,7 +76,9 @@ class PersonaChatService {
     String characterId, {
     required int beforeMessageId,
     int limit = 50,
+    String? userId,
   }) async {
+    await _ensureProjected(characterId, userId: userId);
     return (_db.select(_db.personaChatMessages)
           ..where((t) =>
               t.characterId.equals(characterId) &
@@ -56,28 +91,43 @@ class PersonaChatService {
         .get();
   }
 
-  Future<int> addUserMessage(String characterId, String content,
-      {DateTime? timestamp}) async {
+  Future<int> addUserMessage(
+    String characterId,
+    String content, {
+    DateTime? timestamp,
+    String? userId,
+  }) async {
     final createdAt = timestamp ?? DateTime.now();
     final normalized = content.trim();
-    final id = await _db.into(_db.personaChatMessages).insert(
+    final messageType = isEmojiOnlyMessage(normalized)
+        ? PersonaChatMessageTypes.emoji
+        : PersonaChatMessageTypes.text;
+    final resolvedUserId = _resolveUserId(userId);
+    final record = await _persistToWorkspace(
+      userId: resolvedUserId,
+      characterId: characterId,
+      isFromCharacter: false,
+      content: normalized,
+      timestamp: createdAt,
+      messageType: messageType,
+      origin: PersonaChatMessageOrigin.conversation,
+      isRead: true,
+    );
+    return _db.into(_db.personaChatMessages).insert(
           PersonaChatMessagesCompanion.insert(
             characterId: characterId,
             isFromCharacter: false,
             content: normalized,
             isRead: const Value(true),
             timestamp: createdAt,
-            messageType: Value(
-              isEmojiOnlyMessage(normalized)
-                  ? PersonaChatMessageTypes.emoji
-                  : PersonaChatMessageTypes.text,
-            ),
+            messageType: Value(messageType),
+            stableId: Value(record?.id ?? _uuid.v4()),
           ),
         );
-    return id;
   }
 
-  Future<int> getReplyCursor(String characterId) async {
+  Future<int> getReplyCursor(String characterId, {String? userId}) async {
+    await _ensureProjected(characterId, userId: userId);
     final cursor = await (_db.select(_db.personaChatReplyCursors)
           ..where((row) => row.characterId.equals(characterId)))
         .getSingleOrNull();
@@ -87,8 +137,10 @@ class PersonaChatService {
   Future<List<PersonaChatMessage>> getPendingUserMessages(
     String characterId, {
     int limit = 50,
+    String? userId,
   }) async {
-    final cursor = await getReplyCursor(characterId);
+    await _ensureProjected(characterId, userId: userId);
+    final cursor = await getReplyCursor(characterId, userId: userId);
     return (_db.select(_db.personaChatMessages)
           ..where((t) =>
               t.characterId.equals(characterId) &
@@ -104,6 +156,7 @@ class PersonaChatService {
   Future<void> advanceReplyCursor({
     required String characterId,
     required int consumedThroughMessageId,
+    String? userId,
   }) {
     if (consumedThroughMessageId <= 0) {
       throw ArgumentError.value(
@@ -111,20 +164,29 @@ class PersonaChatService {
         'consumedThroughMessageId',
       );
     }
-    return _db.transaction(
-      () => _advanceReplyCursor(
+    return _db.transaction(() async {
+      await _advanceWorkspaceCursor(
         characterId: characterId,
         consumedThroughMessageId: consumedThroughMessageId,
-      ),
-    );
+        userId: userId,
+      );
+      await _advanceReplyCursor(
+        characterId: characterId,
+        consumedThroughMessageId: consumedThroughMessageId,
+      );
+    });
   }
 
-  Future<int> addCharacterMessage(String characterId, String content,
-      {String? factId,
-      bool isRead = false,
-      DateTime? timestamp,
-      String origin = PersonaChatMessageOrigin.conversation,
-      String? contactEpisodeId}) async {
+  Future<int> addCharacterMessage(
+    String characterId,
+    String content, {
+    String? factId,
+    bool isRead = false,
+    DateTime? timestamp,
+    String origin = PersonaChatMessageOrigin.conversation,
+    String? contactEpisodeId,
+    String? userId,
+  }) async {
     final message = CharacterOutgoingMessage.fromContent(content);
     final ids = await addCharacterMessages(
       characterId,
@@ -134,6 +196,7 @@ class PersonaChatService {
       timestamp: timestamp,
       origin: origin,
       contactEpisodeId: contactEpisodeId,
+      userId: userId,
     );
     return ids.single;
   }
@@ -149,6 +212,7 @@ class PersonaChatService {
     DateTime? timestamp,
     String origin = PersonaChatMessageOrigin.conversation,
     String? contactEpisodeId,
+    String? userId,
   }) async {
     final createdAt = timestamp ?? DateTime.now();
     if (messages.isEmpty) {
@@ -171,8 +235,20 @@ class PersonaChatService {
         }
       }
 
+      final workspaceRecords = await _persistEpisodeToWorkspace(
+        userId: _resolveUserId(userId),
+        characterId: characterId,
+        messages: messages,
+        factId: factId,
+        isRead: isRead,
+        timestamp: createdAt,
+        origin: origin,
+        contactEpisodeId: contactEpisodeId,
+      );
+
       final ids = <int>[];
-      for (final message in messages) {
+      for (var index = 0; index < messages.length; index++) {
+        final message = messages[index];
         ids.add(
           await _db.into(_db.personaChatMessages).insert(
                 PersonaChatMessagesCompanion.insert(
@@ -185,6 +261,11 @@ class PersonaChatService {
                   messageType: Value(message.storageType),
                   origin: Value(origin),
                   contactEpisodeId: Value(contactEpisodeId),
+                  stableId: Value(
+                    workspaceRecords != null
+                        ? workspaceRecords[index].id
+                        : _uuid.v4(),
+                  ),
                 ),
               ),
         );
@@ -205,12 +286,14 @@ class PersonaChatService {
     bool isRead = false,
     DateTime? timestamp,
     required String contactEpisodeId,
+    String? userId,
   }) async {
     final createdAt = timestamp ?? DateTime.now();
     if (messages.isEmpty) {
       throw ArgumentError('Character messages must be non-empty.');
     }
 
+    await _ensureProjected(characterId, userId: userId);
     return _db.transaction(() async {
       final existing = await (_db.select(_db.personaChatMessages)
             ..where((t) =>
@@ -234,7 +317,19 @@ class PersonaChatService {
           .getSingleOrNull();
       if (pendingUserMessage != null) return false;
 
-      for (final message in messages) {
+      final workspaceRecords = await _persistEpisodeToWorkspace(
+        userId: _resolveUserId(userId),
+        characterId: characterId,
+        messages: messages,
+        factId: factId,
+        isRead: isRead,
+        timestamp: createdAt,
+        origin: PersonaChatMessageOrigin.initiative,
+        contactEpisodeId: contactEpisodeId,
+      );
+
+      for (var index = 0; index < messages.length; index++) {
+        final message = messages[index];
         await _db.into(_db.personaChatMessages).insert(
               PersonaChatMessagesCompanion.insert(
                 characterId: characterId,
@@ -246,6 +341,11 @@ class PersonaChatService {
                 messageType: Value(message.storageType),
                 origin: const Value(PersonaChatMessageOrigin.initiative),
                 contactEpisodeId: Value(contactEpisodeId),
+                stableId: Value(
+                  workspaceRecords != null
+                      ? workspaceRecords[index].id
+                      : _uuid.v4(),
+                ),
               ),
             );
       }
@@ -263,6 +363,7 @@ class PersonaChatService {
     required String episodeId,
     required DateTime timestamp,
     bool isRead = false,
+    String? userId,
   }) async {
     if (consumedThroughMessageId <= 0) {
       throw ArgumentError.value(
@@ -274,6 +375,7 @@ class PersonaChatService {
       throw ArgumentError('Character messages must be non-empty.');
     }
 
+    await _ensureProjected(characterId, userId: userId);
     return _db.transaction(() async {
       final existing = await (_db.select(_db.personaChatMessages)
             ..where((t) =>
@@ -284,7 +386,17 @@ class PersonaChatService {
 
       final ids = existing.map((message) => message.id).toList();
       if (ids.isEmpty) {
-        for (final message in characterMessages) {
+        final workspaceRecords = await _persistEpisodeToWorkspace(
+          userId: _resolveUserId(userId),
+          characterId: characterId,
+          messages: characterMessages,
+          isRead: isRead,
+          timestamp: timestamp,
+          origin: PersonaChatMessageOrigin.conversation,
+          contactEpisodeId: episodeId,
+        );
+        for (var index = 0; index < characterMessages.length; index++) {
+          final message = characterMessages[index];
           ids.add(
             await _db.into(_db.personaChatMessages).insert(
                   PersonaChatMessagesCompanion.insert(
@@ -298,12 +410,22 @@ class PersonaChatService {
                       PersonaChatMessageOrigin.conversation,
                     ),
                     contactEpisodeId: Value(episodeId),
+                    stableId: Value(
+                      workspaceRecords != null
+                          ? workspaceRecords[index].id
+                          : _uuid.v4(),
+                    ),
                   ),
                 ),
           );
         }
       }
 
+      await _advanceWorkspaceCursor(
+        characterId: characterId,
+        consumedThroughMessageId: consumedThroughMessageId,
+        userId: userId,
+      );
       await _advanceReplyCursor(
         characterId: characterId,
         consumedThroughMessageId: consumedThroughMessageId,
@@ -347,10 +469,27 @@ class PersonaChatService {
 
   /// Adds a narrative/action message from the character (e.g. *leans closer*).
   /// Rendered differently in the UI — no bubble, italic, centered.
-  Future<int> addActionMessage(String characterId, String content,
-      {String? factId, bool isRead = false, DateTime? timestamp}) async {
+  Future<int> addActionMessage(
+    String characterId,
+    String content, {
+    String? factId,
+    bool isRead = false,
+    DateTime? timestamp,
+    String? userId,
+  }) async {
     final createdAt = timestamp ?? DateTime.now();
-    final id = await _db.into(_db.personaChatMessages).insert(
+    final record = await _persistToWorkspace(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      isFromCharacter: true,
+      content: content,
+      timestamp: createdAt,
+      messageType: PersonaChatMessageTypes.action,
+      origin: PersonaChatMessageOrigin.conversation,
+      factId: factId,
+      isRead: isRead,
+    );
+    return _db.into(_db.personaChatMessages).insert(
           PersonaChatMessagesCompanion.insert(
             characterId: characterId,
             isFromCharacter: true,
@@ -359,12 +498,13 @@ class PersonaChatService {
             isRead: Value(isRead),
             timestamp: createdAt,
             messageType: const Value(PersonaChatMessageTypes.action),
+            stableId: Value(record?.id ?? _uuid.v4()),
           ),
         );
-    return id;
   }
 
-  Future<int> getUnreadCount(String characterId) async {
+  Future<int> getUnreadCount(String characterId, {String? userId}) async {
+    await _ensureProjected(characterId, userId: userId);
     final query = _db.selectOnly(_db.personaChatMessages)
       ..addColumns([_db.personaChatMessages.id.count()])
       ..where(_db.personaChatMessages.characterId.equals(characterId) &
@@ -374,7 +514,7 @@ class PersonaChatService {
     return row.read(_db.personaChatMessages.id.count()) ?? 0;
   }
 
-  Future<int> getTotalUnreadCount() async {
+  Future<int> getTotalUnreadCount({String? userId}) async {
     final query = _db.selectOnly(_db.personaChatMessages)
       ..addColumns([_db.personaChatMessages.id.count()])
       ..where(_db.personaChatMessages.isFromCharacter.equals(true) &
@@ -383,7 +523,15 @@ class PersonaChatService {
     return row.read(_db.personaChatMessages.id.count()) ?? 0;
   }
 
-  Future<int> markAllRead(String characterId) async {
+  Future<int> markAllRead(String characterId, {String? userId}) async {
+    final storage = _storage;
+    final resolvedUserId = storage == null ? null : _resolveUserId(userId);
+    if (storage != null && resolvedUserId != null) {
+      await storage.markAllRead(
+        userId: resolvedUserId,
+        characterId: characterId,
+      );
+    }
     return (_db.update(_db.personaChatMessages)
           ..where((t) =>
               t.characterId.equals(characterId) &
@@ -392,7 +540,11 @@ class PersonaChatService {
         .write(const PersonaChatMessagesCompanion(isRead: Value(true)));
   }
 
-  Future<PersonaChatMessage?> getLastMessage(String characterId) async {
+  Future<PersonaChatMessage?> getLastMessage(
+    String characterId, {
+    String? userId,
+  }) async {
+    await _ensureProjected(characterId, userId: userId);
     final results = await (_db.select(_db.personaChatMessages)
           ..where((t) => t.characterId.equals(characterId))
           ..orderBy([
@@ -404,7 +556,8 @@ class PersonaChatService {
     return results.isEmpty ? null : results.first;
   }
 
-  Future<int> getLatestMessageId(String characterId) async {
+  Future<int> getLatestMessageId(String characterId, {String? userId}) async {
+    await _ensureProjected(characterId, userId: userId);
     final maxId = _db.personaChatMessages.id.max();
     final result = await (_db.selectOnly(_db.personaChatMessages)
           ..addColumns([maxId])
@@ -413,9 +566,167 @@ class PersonaChatService {
     return result.read(maxId) ?? 0;
   }
 
-  Future<int> clearMessages(String characterId) async {
+  Future<int> clearMessages(String characterId, {String? userId}) async {
+    final storage = _storage;
+    final resolvedUserId = storage == null ? null : _resolveUserId(userId);
+    if (storage != null && resolvedUserId != null) {
+      await storage.clearConversation(
+        userId: resolvedUserId,
+        characterId: characterId,
+        clearedAt: DateTime.now(),
+      );
+    }
+    await (_db.delete(_db.personaChatReplyCursors)
+          ..where((t) => t.characterId.equals(characterId)))
+        .go();
     return (_db.delete(_db.personaChatMessages)
           ..where((t) => t.characterId.equals(characterId)))
         .go();
+  }
+
+  String? _resolveUserId(String? userId) {
+    if (userId != null && userId.isNotEmpty) return userId;
+    return _boundUserId ?? _sessionUserId;
+  }
+
+  Future<void> _ensureProjected(String characterId, {String? userId}) async {
+    final storage = _storage;
+    final resolvedUserId = _resolveUserId(userId);
+    if (storage == null || resolvedUserId == null) return;
+    final sqliteCount = await _sqliteCount(characterId);
+    final records = await storage.loadMessages(
+      userId: resolvedUserId,
+      characterId: characterId,
+    );
+    if (records.isEmpty) {
+      if (sqliteCount == 0) return;
+      final state = await storage.loadState(
+        userId: resolvedUserId,
+        characterId: characterId,
+      );
+      if (state.clearedAt == null) return;
+    } else if (sqliteCount == records.length) {
+      return;
+    }
+    await storage.rebuildSqliteProjection(
+      userId: resolvedUserId,
+      characterId: characterId,
+      db: _db,
+    );
+  }
+
+  Future<int> _sqliteCount(String characterId) async {
+    final count = _db.personaChatMessages.id.count();
+    final row = await (_db.selectOnly(_db.personaChatMessages)
+          ..addColumns([count])
+          ..where(_db.personaChatMessages.characterId.equals(characterId)))
+        .getSingle();
+    return row.read(count) ?? 0;
+  }
+
+  Future<PersonaChatConversationRecord?> _persistToWorkspace({
+    required String? userId,
+    required String characterId,
+    required bool isFromCharacter,
+    required String content,
+    required DateTime timestamp,
+    required String messageType,
+    required String origin,
+    String? factId,
+    bool isRead = false,
+    String? contactEpisodeId,
+  }) async {
+    final storage = _storage;
+    if (storage == null || userId == null) return null;
+    return storage.appendMessage(
+      userId: userId,
+      characterId: characterId,
+      isFromCharacter: isFromCharacter,
+      content: content,
+      timestamp: timestamp,
+      messageType: messageType,
+      origin: origin,
+      factId: factId,
+      isRead: isRead,
+      contactEpisodeId: contactEpisodeId,
+    );
+  }
+
+  Future<List<PersonaChatConversationRecord>?> _persistEpisodeToWorkspace({
+    required String? userId,
+    required String characterId,
+    required List<CharacterOutgoingMessage> messages,
+    required DateTime timestamp,
+    required String origin,
+    String? factId,
+    bool isRead = false,
+    String? contactEpisodeId,
+  }) async {
+    final storage = _storage;
+    if (storage == null || userId == null) return null;
+    if (contactEpisodeId == null) {
+      final records = <PersonaChatConversationRecord>[];
+      for (final message in messages) {
+        records.add(
+          await storage.appendMessage(
+            userId: userId,
+            characterId: characterId,
+            isFromCharacter: true,
+            content: message.content,
+            timestamp: timestamp,
+            messageType: message.storageType,
+            origin: origin,
+            factId: factId,
+            isRead: isRead,
+          ),
+        );
+      }
+      return records;
+    }
+    return storage.appendEpisode(
+      userId: userId,
+      characterId: characterId,
+      contactEpisodeId: contactEpisodeId,
+      records: (nextSeq) {
+        return [
+          for (var index = 0; index < messages.length; index++)
+            PersonaChatConversationRecord(
+              id: _uuid.v4(),
+              seq: nextSeq + index,
+              characterId: characterId,
+              isFromCharacter: true,
+              content: messages[index].content,
+              factId: factId,
+              isRead: isRead,
+              timestamp: timestamp,
+              messageType: messages[index].storageType,
+              origin: origin,
+              contactEpisodeId: contactEpisodeId,
+            ),
+        ];
+      },
+    );
+  }
+
+  Future<void> _advanceWorkspaceCursor({
+    required String characterId,
+    required int consumedThroughMessageId,
+    String? userId,
+  }) async {
+    final storage = _storage;
+    final resolvedUserId = _resolveUserId(userId);
+    if (storage == null || resolvedUserId == null) return;
+    final row = await (_db.select(_db.personaChatMessages)
+          ..where((t) =>
+              t.characterId.equals(characterId) &
+              t.id.equals(consumedThroughMessageId)))
+        .getSingleOrNull();
+    final stableId = row?.stableId;
+    if (stableId == null || stableId.isEmpty) return;
+    await storage.advanceCursor(
+      userId: resolvedUserId,
+      characterId: characterId,
+      consumedThroughMessageId: stableId,
+    );
   }
 }

--- a/lib/data/services/persona_chat_service.dart
+++ b/lib/data/services/persona_chat_service.dart
@@ -221,17 +221,18 @@ class PersonaChatService {
 
     final result = await _db.transaction(() async {
       if (contactEpisodeId != null) {
-        final existing = await (_db.select(_db.personaChatMessages)
-              ..where((t) =>
-                  t.characterId.equals(characterId) &
-                  t.contactEpisodeId.equals(contactEpisodeId))
-              ..orderBy([(t) => OrderingTerm.asc(t.id)]))
-            .get();
+        final existing = await _getEpisodeMessages(
+          characterId,
+          contactEpisodeId,
+        );
         if (existing.isNotEmpty) {
-          return (
-            ids: existing.map((message) => message.id).toList(),
-            inserted: false
-          );
+          if (existing.length == messages.length) {
+            return (
+              ids: existing.map((message) => message.id).toList(),
+              inserted: false
+            );
+          }
+          await _deleteEpisodeMessages(characterId, contactEpisodeId);
         }
       }
 
@@ -295,13 +296,14 @@ class PersonaChatService {
 
     await _ensureProjected(characterId, userId: userId);
     return _db.transaction(() async {
-      final existing = await (_db.select(_db.personaChatMessages)
-            ..where((t) =>
-                t.characterId.equals(characterId) &
-                t.contactEpisodeId.equals(contactEpisodeId))
-            ..limit(1))
-          .getSingleOrNull();
-      if (existing != null) return true;
+      final existing = await _getEpisodeMessages(
+        characterId,
+        contactEpisodeId,
+      );
+      if (existing.isNotEmpty) {
+        if (existing.length == messages.length) return true;
+        await _deleteEpisodeMessages(characterId, contactEpisodeId);
+      }
 
       final cursor = await (_db.select(_db.personaChatReplyCursors)
             ..where((row) => row.characterId.equals(characterId)))
@@ -377,14 +379,13 @@ class PersonaChatService {
 
     await _ensureProjected(characterId, userId: userId);
     return _db.transaction(() async {
-      final existing = await (_db.select(_db.personaChatMessages)
-            ..where((t) =>
-                t.characterId.equals(characterId) &
-                t.contactEpisodeId.equals(episodeId))
-            ..orderBy([(t) => OrderingTerm.asc(t.id)]))
-          .get();
+      final existing = await _getEpisodeMessages(characterId, episodeId);
 
       final ids = existing.map((message) => message.id).toList();
+      if (ids.isNotEmpty && ids.length != characterMessages.length) {
+        await _deleteEpisodeMessages(characterId, episodeId);
+        ids.clear();
+      }
       if (ids.isEmpty) {
         final workspaceRecords = await _persistEpisodeToWorkspace(
           userId: _resolveUserId(userId),
@@ -624,6 +625,29 @@ class PersonaChatService {
     return row.read(count) ?? 0;
   }
 
+  Future<List<PersonaChatMessage>> _getEpisodeMessages(
+    String characterId,
+    String episodeId,
+  ) {
+    return (_db.select(_db.personaChatMessages)
+          ..where((row) =>
+              row.characterId.equals(characterId) &
+              row.contactEpisodeId.equals(episodeId))
+          ..orderBy([(row) => OrderingTerm.asc(row.id)]))
+        .get();
+  }
+
+  Future<int> _deleteEpisodeMessages(
+    String characterId,
+    String episodeId,
+  ) {
+    return (_db.delete(_db.personaChatMessages)
+          ..where((row) =>
+              row.characterId.equals(characterId) &
+              row.contactEpisodeId.equals(episodeId)))
+        .go();
+  }
+
   Future<PersonaChatConversationRecord?> _persistToWorkspace({
     required String? userId,
     required String characterId,
@@ -687,6 +711,7 @@ class PersonaChatService {
       userId: userId,
       characterId: characterId,
       contactEpisodeId: contactEpisodeId,
+      expectedRecordCount: messages.length,
       records: (nextSeq) {
         return [
           for (var index = 0; index < messages.length; index++)

--- a/lib/data/services/persona_chat_service.dart
+++ b/lib/data/services/persona_chat_service.dart
@@ -3,11 +3,22 @@ import 'package:memex/data/services/persona_chat_conversation_storage.dart';
 import 'package:memex/data/services/persona_chat_legacy_migration_service.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/domain/models/character_message.dart';
-import 'package:uuid/uuid.dart';
 
 abstract final class PersonaChatMessageOrigin {
   static const conversation = 'conversation';
   static const initiative = 'initiative';
+}
+
+class PersonaChatMessagePage {
+  const PersonaChatMessagePage({
+    required this.messages,
+    required this.olderCursor,
+    required this.newestCursor,
+  });
+
+  final List<PersonaChatMessage> messages;
+  final int? olderCursor;
+  final int newestCursor;
 }
 
 /// Persona chat application service.
@@ -17,24 +28,20 @@ abstract final class PersonaChatMessageOrigin {
 class PersonaChatService {
   PersonaChatService._()
       : _storage = PersonaChatConversationStorage.instance,
-        _migration = PersonaChatLegacyMigrationService(),
-        _uuid = const Uuid();
+        _migration = PersonaChatLegacyMigrationService();
 
   @visibleForTesting
   PersonaChatService.forTesting({
     required PersonaChatConversationStorage storage,
     required String userId,
-    Uuid uuid = const Uuid(),
   })  : _storage = storage,
         _migration = null,
-        _uuid = uuid,
         _sessionUserId = userId;
 
   static final PersonaChatService instance = PersonaChatService._();
 
   final PersonaChatConversationStorage _storage;
   final PersonaChatLegacyMigrationService? _migration;
-  final Uuid _uuid;
   String? _sessionUserId;
 
   Future<void> initialize(String userId, AppDatabase database) async {
@@ -57,6 +64,42 @@ class PersonaChatService {
     return records.map(_toMessage).toList(growable: false);
   }
 
+  Future<PersonaChatMessagePage> getMessagePage(
+    String characterId, {
+    int limit = 50,
+    int? beforeCursor,
+    String? userId,
+  }) async {
+    final page = await _storage.loadMessagePage(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      limit: limit,
+      beforeCursor: beforeCursor,
+    );
+    return PersonaChatMessagePage(
+      messages: page.records.map(_toMessage).toList(growable: false),
+      olderCursor: page.olderCursor,
+      newestCursor: page.newestCursor,
+    );
+  }
+
+  Future<PersonaChatMessagePage> getMessagesAfter(
+    String characterId, {
+    required int afterCursor,
+    String? userId,
+  }) async {
+    final page = await _storage.loadMessagesAfter(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      afterCursor: afterCursor,
+    );
+    return PersonaChatMessagePage(
+      messages: page.records.map(_toMessage).toList(growable: false),
+      olderCursor: page.olderCursor,
+      newestCursor: page.newestCursor,
+    );
+  }
+
   Future<List<PersonaChatMessage>> getMessagesBefore(
     String characterId, {
     required int beforeMessageId,
@@ -66,7 +109,7 @@ class PersonaChatService {
     final records = await _storage.loadMessagesBefore(
       userId: _resolveUserId(userId),
       characterId: characterId,
-      beforeSeq: beforeMessageId,
+      beforeMessageId: beforeMessageId,
       limit: limit,
     );
     return records.map(_toMessage).toList(growable: false);
@@ -91,11 +134,21 @@ class PersonaChatService {
       origin: PersonaChatMessageOrigin.conversation,
       isRead: true,
     );
-    return record.seq;
+    return record.id;
   }
 
   Future<int> getReplyCursor(String characterId, {String? userId}) {
     return _storage.getReplyCursor(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+    );
+  }
+
+  Future<int> getConversationGeneration(
+    String characterId, {
+    String? userId,
+  }) {
+    return _storage.conversationGeneration(
       userId: _resolveUserId(userId),
       characterId: characterId,
     );
@@ -122,7 +175,7 @@ class PersonaChatService {
     return _storage.advanceCursor(
       userId: _resolveUserId(userId),
       characterId: characterId,
-      consumedThroughSeq: consumedThroughMessageId,
+      processedThroughUserMessageId: consumedThroughMessageId,
     );
   }
 
@@ -163,23 +216,23 @@ class PersonaChatService {
     final resolvedUserId = _resolveUserId(userId);
     final createdAt = timestamp ?? DateTime.now();
     if (contactEpisodeId != null) {
-      final records = await _storage.appendEpisode(
+      final records = await _storage.appendTurn(
         userId: resolvedUserId,
         characterId: characterId,
-        contactEpisodeId: contactEpisodeId,
+        turnId: contactEpisodeId,
         expectedRecordCount: messages.length,
-        records: (nextSeq) => _buildRecords(
+        records: (firstMessageId) => _buildRecords(
           characterId: characterId,
           messages: messages,
-          nextSeq: nextSeq,
+          firstMessageId: firstMessageId,
           timestamp: createdAt,
           origin: origin,
           factId: factId,
           isRead: isRead,
-          episodeId: contactEpisodeId,
+          turnId: contactEpisodeId,
         ),
       );
-      return records.map((record) => record.seq).toList(growable: false);
+      return records.map((record) => record.id).toList(growable: false);
     }
 
     final ids = <int>[];
@@ -195,7 +248,7 @@ class PersonaChatService {
         messageType: message.storageType,
         origin: origin,
       );
-      ids.add(record.seq);
+      ids.add(record.id);
     }
     return ids;
   }
@@ -207,24 +260,26 @@ class PersonaChatService {
     bool isRead = false,
     DateTime? timestamp,
     required String contactEpisodeId,
+    int? expectedGeneration,
     String? userId,
   }) {
     _requireMessages(messages);
     final createdAt = timestamp ?? DateTime.now();
-    return _storage.tryAppendInitiativeEpisode(
+    return _storage.tryAppendInitiativeTurn(
       userId: _resolveUserId(userId),
       characterId: characterId,
-      contactEpisodeId: contactEpisodeId,
+      turnId: contactEpisodeId,
       expectedRecordCount: messages.length,
-      records: (nextSeq) => _buildRecords(
+      expectedGeneration: expectedGeneration,
+      records: (firstMessageId) => _buildRecords(
         characterId: characterId,
         messages: messages,
-        nextSeq: nextSeq,
+        firstMessageId: firstMessageId,
         timestamp: createdAt,
         origin: PersonaChatMessageOrigin.initiative,
         factId: factId,
         isRead: isRead,
-        episodeId: contactEpisodeId,
+        turnId: contactEpisodeId,
       ),
     );
   }
@@ -236,6 +291,7 @@ class PersonaChatService {
     required String episodeId,
     required DateTime timestamp,
     bool isRead = false,
+    int? expectedGeneration,
     String? userId,
   }) async {
     if (consumedThroughMessageId <= 0) {
@@ -245,23 +301,24 @@ class PersonaChatService {
       );
     }
     _requireMessages(characterMessages);
-    final records = await _storage.appendEpisode(
+    final records = await _storage.appendTurn(
       userId: _resolveUserId(userId),
       characterId: characterId,
-      contactEpisodeId: episodeId,
+      turnId: episodeId,
       expectedRecordCount: characterMessages.length,
-      consumedThroughSeq: consumedThroughMessageId,
-      records: (nextSeq) => _buildRecords(
+      agentProcessedThroughUserMessageId: consumedThroughMessageId,
+      expectedGeneration: expectedGeneration,
+      records: (firstMessageId) => _buildRecords(
         characterId: characterId,
         messages: characterMessages,
-        nextSeq: nextSeq,
+        firstMessageId: firstMessageId,
         timestamp: timestamp,
         origin: PersonaChatMessageOrigin.conversation,
         isRead: isRead,
-        episodeId: episodeId,
+        turnId: episodeId,
       ),
     );
-    return records.map((record) => record.seq).toList(growable: false);
+    return records.map((record) => record.id).toList(growable: false);
   }
 
   Future<int> addActionMessage(
@@ -283,7 +340,7 @@ class PersonaChatService {
       messageType: PersonaChatMessageTypes.action,
       origin: PersonaChatMessageOrigin.conversation,
     );
-    return record.seq;
+    return record.id;
   }
 
   Future<int> getUnreadCount(String characterId, {String? userId}) {
@@ -295,6 +352,11 @@ class PersonaChatService {
 
   Future<int> getTotalUnreadCount({String? userId}) {
     return _storage.totalUnreadCount(_resolveUserId(userId));
+  }
+
+  Future<Set<String>> getCharactersWithPendingUserMessages({String? userId}) {
+    final resolvedUserId = _resolveUserId(userId);
+    return _storage.charactersWithPendingUserMessages(resolvedUserId);
   }
 
   Future<int> markAllRead(String characterId, {String? userId}) {
@@ -316,7 +378,7 @@ class PersonaChatService {
   }
 
   Future<int> getLatestMessageId(String characterId, {String? userId}) {
-    return _storage.latestMessageSeq(
+    return _storage.latestMessageId(
       userId: _resolveUserId(userId),
       characterId: characterId,
     );
@@ -342,18 +404,17 @@ class PersonaChatService {
   List<PersonaChatConversationRecord> _buildRecords({
     required String characterId,
     required List<CharacterOutgoingMessage> messages,
-    required int nextSeq,
+    required int firstMessageId,
     required DateTime timestamp,
     required String origin,
     required bool isRead,
-    required String episodeId,
+    required String turnId,
     String? factId,
   }) {
     return [
       for (var index = 0; index < messages.length; index++)
         PersonaChatConversationRecord(
-          id: _uuid.v4(),
-          seq: nextSeq + index,
+          id: firstMessageId + index,
           characterId: characterId,
           isFromCharacter: true,
           content: messages[index].content,
@@ -362,14 +423,14 @@ class PersonaChatService {
           timestamp: timestamp,
           messageType: messages[index].storageType,
           origin: origin,
-          contactEpisodeId: episodeId,
+          turnId: turnId,
         ),
     ];
   }
 
   PersonaChatMessage _toMessage(PersonaChatConversationRecord record) {
     return PersonaChatMessage(
-      id: record.seq,
+      id: record.id,
       characterId: record.characterId,
       isFromCharacter: record.isFromCharacter,
       content: record.content,
@@ -378,7 +439,7 @@ class PersonaChatService {
       timestamp: record.timestamp,
       messageType: record.messageType,
       origin: record.origin,
-      contactEpisodeId: record.contactEpisodeId,
+      contactEpisodeId: record.turnId,
     );
   }
 

--- a/lib/data/services/persona_chat_service.dart
+++ b/lib/data/services/persona_chat_service.dart
@@ -1,6 +1,6 @@
-import 'package:drift/drift.dart';
 import 'package:flutter/foundation.dart';
 import 'package:memex/data/services/persona_chat_conversation_storage.dart';
+import 'package:memex/data/services/persona_chat_legacy_migration_service.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/domain/models/character_message.dart';
 import 'package:uuid/uuid.dart';
@@ -10,47 +10,36 @@ abstract final class PersonaChatMessageOrigin {
   static const initiative = 'initiative';
 }
 
-/// Service for managing persona chat messages.
+/// Persona chat application service.
+///
+/// Runtime operations delegate to the character workspace store. SQLite is
+/// consulted only by [initialize] for one-way legacy migration.
 class PersonaChatService {
-  static PersonaChatService? _instance;
-  static PersonaChatService get instance {
-    _instance ??= PersonaChatService._();
-    return _instance!;
-  }
-
   PersonaChatService._()
-      : _testDb = null,
-        _boundUserId = null,
-        _storage = PersonaChatConversationStorage.instance,
+      : _storage = PersonaChatConversationStorage.instance,
+        _migration = PersonaChatLegacyMigrationService(),
         _uuid = const Uuid();
 
   @visibleForTesting
-  PersonaChatService.forTesting(
-    AppDatabase database, {
-    String? userId,
-    PersonaChatConversationStorage? storage,
-  })  : _testDb = database,
-        _boundUserId = userId,
-        _storage = storage,
-        _uuid = const Uuid();
+  PersonaChatService.forTesting({
+    required PersonaChatConversationStorage storage,
+    required String userId,
+    Uuid uuid = const Uuid(),
+  })  : _storage = storage,
+        _migration = null,
+        _uuid = uuid,
+        _sessionUserId = userId;
 
-  final AppDatabase? _testDb;
-  final String? _boundUserId;
-  final PersonaChatConversationStorage? _storage;
+  static final PersonaChatService instance = PersonaChatService._();
+
+  final PersonaChatConversationStorage _storage;
+  final PersonaChatLegacyMigrationService? _migration;
   final Uuid _uuid;
   String? _sessionUserId;
 
-  AppDatabase get _db => _testDb ?? AppDatabase.instance;
-
-  void bindUser(String userId) {
+  Future<void> initialize(String userId, AppDatabase database) async {
     _sessionUserId = userId;
-  }
-
-  Future<void> reconcileFromWorkspace(String userId) async {
-    final storage = _storage;
-    if (storage == null) return;
-    await storage.ensureMigrated(userId: userId, db: _db);
-    await storage.reconcileAll(userId: userId, db: _db);
+    await _migration?.ensureMigrated(userId: userId, database: database);
   }
 
   Future<List<PersonaChatMessage>> getMessages(
@@ -59,36 +48,28 @@ class PersonaChatService {
     int offset = 0,
     String? userId,
   }) async {
-    await _ensureProjected(characterId, userId: userId);
-    return (_db.select(_db.personaChatMessages)
-          ..where((t) => t.characterId.equals(characterId))
-          ..orderBy([
-            (t) => OrderingTerm.desc(t.timestamp),
-            (t) => OrderingTerm.desc(t.id),
-          ])
-          ..limit(limit, offset: offset))
-        .get();
+    final records = await _storage.loadMessages(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      limit: limit,
+      offset: offset,
+    );
+    return records.map(_toMessage).toList(growable: false);
   }
 
-  /// Returns the canonical chat history preceding one already-persisted user
-  /// message. Results remain newest-first, matching [getMessages].
   Future<List<PersonaChatMessage>> getMessagesBefore(
     String characterId, {
     required int beforeMessageId,
     int limit = 50,
     String? userId,
   }) async {
-    await _ensureProjected(characterId, userId: userId);
-    return (_db.select(_db.personaChatMessages)
-          ..where((t) =>
-              t.characterId.equals(characterId) &
-              t.id.isSmallerThanValue(beforeMessageId))
-          ..orderBy([
-            (t) => OrderingTerm.desc(t.timestamp),
-            (t) => OrderingTerm.desc(t.id),
-          ])
-          ..limit(limit))
-        .get();
+    final records = await _storage.loadMessagesBefore(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      beforeSeq: beforeMessageId,
+      limit: limit,
+    );
+    return records.map(_toMessage).toList(growable: false);
   }
 
   Future<int> addUserMessage(
@@ -97,41 +78,27 @@ class PersonaChatService {
     DateTime? timestamp,
     String? userId,
   }) async {
-    final createdAt = timestamp ?? DateTime.now();
     final normalized = content.trim();
-    final messageType = isEmojiOnlyMessage(normalized)
-        ? PersonaChatMessageTypes.emoji
-        : PersonaChatMessageTypes.text;
-    final resolvedUserId = _resolveUserId(userId);
-    final record = await _persistToWorkspace(
-      userId: resolvedUserId,
+    final record = await _storage.appendMessage(
+      userId: _resolveUserId(userId),
       characterId: characterId,
       isFromCharacter: false,
       content: normalized,
-      timestamp: createdAt,
-      messageType: messageType,
+      timestamp: timestamp ?? DateTime.now(),
+      messageType: isEmojiOnlyMessage(normalized)
+          ? PersonaChatMessageTypes.emoji
+          : PersonaChatMessageTypes.text,
       origin: PersonaChatMessageOrigin.conversation,
       isRead: true,
     );
-    return _db.into(_db.personaChatMessages).insert(
-          PersonaChatMessagesCompanion.insert(
-            characterId: characterId,
-            isFromCharacter: false,
-            content: normalized,
-            isRead: const Value(true),
-            timestamp: createdAt,
-            messageType: Value(messageType),
-            stableId: Value(record?.id ?? _uuid.v4()),
-          ),
-        );
+    return record.seq;
   }
 
-  Future<int> getReplyCursor(String characterId, {String? userId}) async {
-    await _ensureProjected(characterId, userId: userId);
-    final cursor = await (_db.select(_db.personaChatReplyCursors)
-          ..where((row) => row.characterId.equals(characterId)))
-        .getSingleOrNull();
-    return cursor?.consumedThroughMessageId ?? 0;
+  Future<int> getReplyCursor(String characterId, {String? userId}) {
+    return _storage.getReplyCursor(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+    );
   }
 
   Future<List<PersonaChatMessage>> getPendingUserMessages(
@@ -139,18 +106,12 @@ class PersonaChatService {
     int limit = 50,
     String? userId,
   }) async {
-    await _ensureProjected(characterId, userId: userId);
-    final cursor = await getReplyCursor(characterId, userId: userId);
-    return (_db.select(_db.personaChatMessages)
-          ..where((t) =>
-              t.characterId.equals(characterId) &
-              t.isFromCharacter.equals(false) &
-              t.id.isBiggerThanValue(cursor))
-          ..orderBy([
-            (t) => OrderingTerm.asc(t.id),
-          ])
-          ..limit(limit))
-        .get();
+    final records = await _storage.loadPendingUserMessages(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      limit: limit,
+    );
+    return records.map(_toMessage).toList(growable: false);
   }
 
   Future<void> advanceReplyCursor({
@@ -158,23 +119,11 @@ class PersonaChatService {
     required int consumedThroughMessageId,
     String? userId,
   }) {
-    if (consumedThroughMessageId <= 0) {
-      throw ArgumentError.value(
-        consumedThroughMessageId,
-        'consumedThroughMessageId',
-      );
-    }
-    return _db.transaction(() async {
-      await _advanceWorkspaceCursor(
-        characterId: characterId,
-        consumedThroughMessageId: consumedThroughMessageId,
-        userId: userId,
-      );
-      await _advanceReplyCursor(
-        characterId: characterId,
-        consumedThroughMessageId: consumedThroughMessageId,
-      );
-    });
+    return _storage.advanceCursor(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      consumedThroughSeq: consumedThroughMessageId,
+    );
   }
 
   Future<int> addCharacterMessage(
@@ -187,10 +136,9 @@ class PersonaChatService {
     String? contactEpisodeId,
     String? userId,
   }) async {
-    final message = CharacterOutgoingMessage.fromContent(content);
     final ids = await addCharacterMessages(
       characterId,
-      [message],
+      [CharacterOutgoingMessage.fromContent(content)],
       factId: factId,
       isRead: isRead,
       timestamp: timestamp,
@@ -201,9 +149,6 @@ class PersonaChatService {
     return ids.single;
   }
 
-  /// Atomically persists the bubbles from one character contact decision.
-  /// A repeated [contactEpisodeId] returns the existing rows without writing
-  /// duplicate chat or timeline events.
   Future<List<int>> addCharacterMessages(
     String characterId,
     List<CharacterOutgoingMessage> messages, {
@@ -214,72 +159,47 @@ class PersonaChatService {
     String? contactEpisodeId,
     String? userId,
   }) async {
+    _requireMessages(messages);
+    final resolvedUserId = _resolveUserId(userId);
     final createdAt = timestamp ?? DateTime.now();
-    if (messages.isEmpty) {
-      throw ArgumentError('Character messages must be non-empty.');
+    if (contactEpisodeId != null) {
+      final records = await _storage.appendEpisode(
+        userId: resolvedUserId,
+        characterId: characterId,
+        contactEpisodeId: contactEpisodeId,
+        expectedRecordCount: messages.length,
+        records: (nextSeq) => _buildRecords(
+          characterId: characterId,
+          messages: messages,
+          nextSeq: nextSeq,
+          timestamp: createdAt,
+          origin: origin,
+          factId: factId,
+          isRead: isRead,
+          episodeId: contactEpisodeId,
+        ),
+      );
+      return records.map((record) => record.seq).toList(growable: false);
     }
 
-    final result = await _db.transaction(() async {
-      if (contactEpisodeId != null) {
-        final existing = await _getEpisodeMessages(
-          characterId,
-          contactEpisodeId,
-        );
-        if (existing.isNotEmpty) {
-          if (existing.length == messages.length) {
-            return (
-              ids: existing.map((message) => message.id).toList(),
-              inserted: false
-            );
-          }
-          await _deleteEpisodeMessages(characterId, contactEpisodeId);
-        }
-      }
-
-      final workspaceRecords = await _persistEpisodeToWorkspace(
-        userId: _resolveUserId(userId),
+    final ids = <int>[];
+    for (final message in messages) {
+      final record = await _storage.appendMessage(
+        userId: resolvedUserId,
         characterId: characterId,
-        messages: messages,
+        isFromCharacter: true,
+        content: message.content,
         factId: factId,
         isRead: isRead,
         timestamp: createdAt,
+        messageType: message.storageType,
         origin: origin,
-        contactEpisodeId: contactEpisodeId,
       );
-
-      final ids = <int>[];
-      for (var index = 0; index < messages.length; index++) {
-        final message = messages[index];
-        ids.add(
-          await _db.into(_db.personaChatMessages).insert(
-                PersonaChatMessagesCompanion.insert(
-                  characterId: characterId,
-                  isFromCharacter: true,
-                  content: message.content,
-                  factId: Value(factId),
-                  isRead: Value(isRead),
-                  timestamp: createdAt,
-                  messageType: Value(message.storageType),
-                  origin: Value(origin),
-                  contactEpisodeId: Value(contactEpisodeId),
-                  stableId: Value(
-                    workspaceRecords != null
-                        ? workspaceRecords[index].id
-                        : _uuid.v4(),
-                  ),
-                ),
-              ),
-        );
-      }
-      return (ids: ids, inserted: true);
-    });
-
-    return result.ids;
+      ids.add(record.seq);
+    }
+    return ids;
   }
 
-  /// Commits an Initiative episode only when no direct user message is waiting
-  /// for Conversation. The check and inserts share one database transaction so
-  /// a proactive reply cannot knowingly overtake an unanswered user turn.
   Future<bool> tryAddInitiativeMessages(
     String characterId,
     List<CharacterOutgoingMessage> messages, {
@@ -288,76 +208,27 @@ class PersonaChatService {
     DateTime? timestamp,
     required String contactEpisodeId,
     String? userId,
-  }) async {
+  }) {
+    _requireMessages(messages);
     final createdAt = timestamp ?? DateTime.now();
-    if (messages.isEmpty) {
-      throw ArgumentError('Character messages must be non-empty.');
-    }
-
-    await _ensureProjected(characterId, userId: userId);
-    return _db.transaction(() async {
-      final existing = await _getEpisodeMessages(
-        characterId,
-        contactEpisodeId,
-      );
-      if (existing.isNotEmpty) {
-        if (existing.length == messages.length) return true;
-        await _deleteEpisodeMessages(characterId, contactEpisodeId);
-      }
-
-      final cursor = await (_db.select(_db.personaChatReplyCursors)
-            ..where((row) => row.characterId.equals(characterId)))
-          .getSingleOrNull();
-      final pendingUserMessage = await (_db.select(_db.personaChatMessages)
-            ..where((t) =>
-                t.characterId.equals(characterId) &
-                t.isFromCharacter.equals(false) &
-                t.id.isBiggerThanValue(
-                  cursor?.consumedThroughMessageId ?? 0,
-                ))
-            ..limit(1))
-          .getSingleOrNull();
-      if (pendingUserMessage != null) return false;
-
-      final workspaceRecords = await _persistEpisodeToWorkspace(
-        userId: _resolveUserId(userId),
+    return _storage.tryAppendInitiativeEpisode(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      contactEpisodeId: contactEpisodeId,
+      expectedRecordCount: messages.length,
+      records: (nextSeq) => _buildRecords(
         characterId: characterId,
         messages: messages,
-        factId: factId,
-        isRead: isRead,
+        nextSeq: nextSeq,
         timestamp: createdAt,
         origin: PersonaChatMessageOrigin.initiative,
-        contactEpisodeId: contactEpisodeId,
-      );
-
-      for (var index = 0; index < messages.length; index++) {
-        final message = messages[index];
-        await _db.into(_db.personaChatMessages).insert(
-              PersonaChatMessagesCompanion.insert(
-                characterId: characterId,
-                isFromCharacter: true,
-                content: message.content,
-                factId: Value(factId),
-                isRead: Value(isRead),
-                timestamp: createdAt,
-                messageType: Value(message.storageType),
-                origin: const Value(PersonaChatMessageOrigin.initiative),
-                contactEpisodeId: Value(contactEpisodeId),
-                stableId: Value(
-                  workspaceRecords != null
-                      ? workspaceRecords[index].id
-                      : _uuid.v4(),
-                ),
-              ),
-            );
-      }
-      return true;
-    });
+        factId: factId,
+        isRead: isRead,
+        episodeId: contactEpisodeId,
+      ),
+    );
   }
 
-  /// Atomically records one character speaking episode and advances the
-  /// private-chat inbox cursor through the messages it considered. Retrying
-  /// the same episode is idempotent.
   Future<List<int>> completeConversationEpisode({
     required String characterId,
     required int consumedThroughMessageId,
@@ -373,103 +244,26 @@ class PersonaChatService {
         'consumedThroughMessageId',
       );
     }
-    if (characterMessages.isEmpty) {
-      throw ArgumentError('Character messages must be non-empty.');
-    }
-
-    await _ensureProjected(characterId, userId: userId);
-    return _db.transaction(() async {
-      final existing = await _getEpisodeMessages(characterId, episodeId);
-
-      final ids = existing.map((message) => message.id).toList();
-      if (ids.isNotEmpty && ids.length != characterMessages.length) {
-        await _deleteEpisodeMessages(characterId, episodeId);
-        ids.clear();
-      }
-      if (ids.isEmpty) {
-        final workspaceRecords = await _persistEpisodeToWorkspace(
-          userId: _resolveUserId(userId),
-          characterId: characterId,
-          messages: characterMessages,
-          isRead: isRead,
-          timestamp: timestamp,
-          origin: PersonaChatMessageOrigin.conversation,
-          contactEpisodeId: episodeId,
-        );
-        for (var index = 0; index < characterMessages.length; index++) {
-          final message = characterMessages[index];
-          ids.add(
-            await _db.into(_db.personaChatMessages).insert(
-                  PersonaChatMessagesCompanion.insert(
-                    characterId: characterId,
-                    isFromCharacter: true,
-                    content: message.content,
-                    isRead: Value(isRead),
-                    timestamp: timestamp,
-                    messageType: Value(message.storageType),
-                    origin: const Value(
-                      PersonaChatMessageOrigin.conversation,
-                    ),
-                    contactEpisodeId: Value(episodeId),
-                    stableId: Value(
-                      workspaceRecords != null
-                          ? workspaceRecords[index].id
-                          : _uuid.v4(),
-                    ),
-                  ),
-                ),
-          );
-        }
-      }
-
-      await _advanceWorkspaceCursor(
+    _requireMessages(characterMessages);
+    final records = await _storage.appendEpisode(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      contactEpisodeId: episodeId,
+      expectedRecordCount: characterMessages.length,
+      consumedThroughSeq: consumedThroughMessageId,
+      records: (nextSeq) => _buildRecords(
         characterId: characterId,
-        consumedThroughMessageId: consumedThroughMessageId,
-        userId: userId,
-      );
-      await _advanceReplyCursor(
-        characterId: characterId,
-        consumedThroughMessageId: consumedThroughMessageId,
-      );
-      return ids;
-    });
-  }
-
-  Future<void> _advanceReplyCursor({
-    required String characterId,
-    required int consumedThroughMessageId,
-  }) async {
-    final current = await (_db.select(_db.personaChatReplyCursors)
-          ..where((row) => row.characterId.equals(characterId)))
-        .getSingleOrNull();
-    if (current != null &&
-        current.consumedThroughMessageId >= consumedThroughMessageId) {
-      return;
-    }
-
-    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    if (current == null) {
-      await _db.into(_db.personaChatReplyCursors).insert(
-            PersonaChatReplyCursorsCompanion.insert(
-              characterId: characterId,
-              consumedThroughMessageId: Value(consumedThroughMessageId),
-              updatedAt: now,
-            ),
-          );
-      return;
-    }
-    await (_db.update(_db.personaChatReplyCursors)
-          ..where((row) => row.characterId.equals(characterId)))
-        .write(
-      PersonaChatReplyCursorsCompanion(
-        consumedThroughMessageId: Value(consumedThroughMessageId),
-        updatedAt: Value(now),
+        messages: characterMessages,
+        nextSeq: nextSeq,
+        timestamp: timestamp,
+        origin: PersonaChatMessageOrigin.conversation,
+        isRead: isRead,
+        episodeId: episodeId,
       ),
     );
+    return records.map((record) => record.seq).toList(growable: false);
   }
 
-  /// Adds a narrative/action message from the character (e.g. *leans closer*).
-  /// Rendered differently in the UI — no bubble, italic, centered.
   Future<int> addActionMessage(
     String characterId,
     String content, {
@@ -478,280 +272,119 @@ class PersonaChatService {
     DateTime? timestamp,
     String? userId,
   }) async {
-    final createdAt = timestamp ?? DateTime.now();
-    final record = await _persistToWorkspace(
+    final record = await _storage.appendMessage(
       userId: _resolveUserId(userId),
       characterId: characterId,
       isFromCharacter: true,
       content: content,
-      timestamp: createdAt,
-      messageType: PersonaChatMessageTypes.action,
-      origin: PersonaChatMessageOrigin.conversation,
       factId: factId,
       isRead: isRead,
+      timestamp: timestamp ?? DateTime.now(),
+      messageType: PersonaChatMessageTypes.action,
+      origin: PersonaChatMessageOrigin.conversation,
     );
-    return _db.into(_db.personaChatMessages).insert(
-          PersonaChatMessagesCompanion.insert(
-            characterId: characterId,
-            isFromCharacter: true,
-            content: content,
-            factId: Value(factId),
-            isRead: Value(isRead),
-            timestamp: createdAt,
-            messageType: const Value(PersonaChatMessageTypes.action),
-            stableId: Value(record?.id ?? _uuid.v4()),
-          ),
-        );
+    return record.seq;
   }
 
-  Future<int> getUnreadCount(String characterId, {String? userId}) async {
-    await _ensureProjected(characterId, userId: userId);
-    final query = _db.selectOnly(_db.personaChatMessages)
-      ..addColumns([_db.personaChatMessages.id.count()])
-      ..where(_db.personaChatMessages.characterId.equals(characterId) &
-          _db.personaChatMessages.isFromCharacter.equals(true) &
-          _db.personaChatMessages.isRead.equals(false));
-    final row = await query.getSingle();
-    return row.read(_db.personaChatMessages.id.count()) ?? 0;
+  Future<int> getUnreadCount(String characterId, {String? userId}) {
+    return _storage.unreadCount(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+    );
   }
 
-  Future<int> getTotalUnreadCount({String? userId}) async {
-    final query = _db.selectOnly(_db.personaChatMessages)
-      ..addColumns([_db.personaChatMessages.id.count()])
-      ..where(_db.personaChatMessages.isFromCharacter.equals(true) &
-          _db.personaChatMessages.isRead.equals(false));
-    final row = await query.getSingle();
-    return row.read(_db.personaChatMessages.id.count()) ?? 0;
+  Future<int> getTotalUnreadCount({String? userId}) {
+    return _storage.totalUnreadCount(_resolveUserId(userId));
   }
 
-  Future<int> markAllRead(String characterId, {String? userId}) async {
-    final storage = _storage;
-    final resolvedUserId = storage == null ? null : _resolveUserId(userId);
-    if (storage != null && resolvedUserId != null) {
-      await storage.markAllRead(
-        userId: resolvedUserId,
-        characterId: characterId,
-      );
-    }
-    return (_db.update(_db.personaChatMessages)
-          ..where((t) =>
-              t.characterId.equals(characterId) &
-              t.isFromCharacter.equals(true) &
-              t.isRead.equals(false)))
-        .write(const PersonaChatMessagesCompanion(isRead: Value(true)));
+  Future<int> markAllRead(String characterId, {String? userId}) {
+    return _storage.markAllRead(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+    );
   }
 
   Future<PersonaChatMessage?> getLastMessage(
     String characterId, {
     String? userId,
   }) async {
-    await _ensureProjected(characterId, userId: userId);
-    final results = await (_db.select(_db.personaChatMessages)
-          ..where((t) => t.characterId.equals(characterId))
-          ..orderBy([
-            (t) => OrderingTerm.desc(t.timestamp),
-            (t) => OrderingTerm.desc(t.id),
-          ])
-          ..limit(1))
-        .get();
-    return results.isEmpty ? null : results.first;
+    final record = await _storage.lastMessage(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+    );
+    return record == null ? null : _toMessage(record);
   }
 
-  Future<int> getLatestMessageId(String characterId, {String? userId}) async {
-    await _ensureProjected(characterId, userId: userId);
-    final maxId = _db.personaChatMessages.id.max();
-    final result = await (_db.selectOnly(_db.personaChatMessages)
-          ..addColumns([maxId])
-          ..where(_db.personaChatMessages.characterId.equals(characterId)))
-        .getSingle();
-    return result.read(maxId) ?? 0;
+  Future<int> getLatestMessageId(String characterId, {String? userId}) {
+    return _storage.latestMessageSeq(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+    );
   }
 
-  Future<int> clearMessages(String characterId, {String? userId}) async {
-    final storage = _storage;
-    final resolvedUserId = storage == null ? null : _resolveUserId(userId);
-    if (storage != null && resolvedUserId != null) {
-      await storage.clearConversation(
-        userId: resolvedUserId,
-        characterId: characterId,
-        clearedAt: DateTime.now(),
-      );
+  Future<int> clearMessages(String characterId, {String? userId}) {
+    return _storage.clearConversation(
+      userId: _resolveUserId(userId),
+      characterId: characterId,
+      clearedAt: DateTime.now(),
+    );
+  }
+
+  String _resolveUserId(String? userId) {
+    final resolved =
+        userId?.trim().isNotEmpty == true ? userId!.trim() : _sessionUserId;
+    if (resolved == null || resolved.isEmpty) {
+      throw StateError('PersonaChatService has not been initialized.');
     }
-    await (_db.delete(_db.personaChatReplyCursors)
-          ..where((t) => t.characterId.equals(characterId)))
-        .go();
-    return (_db.delete(_db.personaChatMessages)
-          ..where((t) => t.characterId.equals(characterId)))
-        .go();
+    return resolved;
   }
 
-  String? _resolveUserId(String? userId) {
-    if (userId != null && userId.isNotEmpty) return userId;
-    return _boundUserId ?? _sessionUserId;
-  }
-
-  Future<void> _ensureProjected(String characterId, {String? userId}) async {
-    final storage = _storage;
-    final resolvedUserId = _resolveUserId(userId);
-    if (storage == null || resolvedUserId == null) return;
-    final sqliteCount = await _sqliteCount(characterId);
-    final records = await storage.loadMessages(
-      userId: resolvedUserId,
-      characterId: characterId,
-    );
-    if (records.isEmpty) {
-      if (sqliteCount == 0) return;
-      final state = await storage.loadState(
-        userId: resolvedUserId,
-        characterId: characterId,
-      );
-      if (state.clearedAt == null) return;
-    } else if (sqliteCount == records.length) {
-      return;
-    }
-    await storage.rebuildSqliteProjection(
-      userId: resolvedUserId,
-      characterId: characterId,
-      db: _db,
-    );
-  }
-
-  Future<int> _sqliteCount(String characterId) async {
-    final count = _db.personaChatMessages.id.count();
-    final row = await (_db.selectOnly(_db.personaChatMessages)
-          ..addColumns([count])
-          ..where(_db.personaChatMessages.characterId.equals(characterId)))
-        .getSingle();
-    return row.read(count) ?? 0;
-  }
-
-  Future<List<PersonaChatMessage>> _getEpisodeMessages(
-    String characterId,
-    String episodeId,
-  ) {
-    return (_db.select(_db.personaChatMessages)
-          ..where((row) =>
-              row.characterId.equals(characterId) &
-              row.contactEpisodeId.equals(episodeId))
-          ..orderBy([(row) => OrderingTerm.asc(row.id)]))
-        .get();
-  }
-
-  Future<int> _deleteEpisodeMessages(
-    String characterId,
-    String episodeId,
-  ) {
-    return (_db.delete(_db.personaChatMessages)
-          ..where((row) =>
-              row.characterId.equals(characterId) &
-              row.contactEpisodeId.equals(episodeId)))
-        .go();
-  }
-
-  Future<PersonaChatConversationRecord?> _persistToWorkspace({
-    required String? userId,
-    required String characterId,
-    required bool isFromCharacter,
-    required String content,
-    required DateTime timestamp,
-    required String messageType,
-    required String origin,
-    String? factId,
-    bool isRead = false,
-    String? contactEpisodeId,
-  }) async {
-    final storage = _storage;
-    if (storage == null || userId == null) return null;
-    return storage.appendMessage(
-      userId: userId,
-      characterId: characterId,
-      isFromCharacter: isFromCharacter,
-      content: content,
-      timestamp: timestamp,
-      messageType: messageType,
-      origin: origin,
-      factId: factId,
-      isRead: isRead,
-      contactEpisodeId: contactEpisodeId,
-    );
-  }
-
-  Future<List<PersonaChatConversationRecord>?> _persistEpisodeToWorkspace({
-    required String? userId,
+  List<PersonaChatConversationRecord> _buildRecords({
     required String characterId,
     required List<CharacterOutgoingMessage> messages,
+    required int nextSeq,
     required DateTime timestamp,
     required String origin,
+    required bool isRead,
+    required String episodeId,
     String? factId,
-    bool isRead = false,
-    String? contactEpisodeId,
-  }) async {
-    final storage = _storage;
-    if (storage == null || userId == null) return null;
-    if (contactEpisodeId == null) {
-      final records = <PersonaChatConversationRecord>[];
-      for (final message in messages) {
-        records.add(
-          await storage.appendMessage(
-            userId: userId,
-            characterId: characterId,
-            isFromCharacter: true,
-            content: message.content,
-            timestamp: timestamp,
-            messageType: message.storageType,
-            origin: origin,
-            factId: factId,
-            isRead: isRead,
-          ),
-        );
-      }
-      return records;
-    }
-    return storage.appendEpisode(
-      userId: userId,
-      characterId: characterId,
-      contactEpisodeId: contactEpisodeId,
-      expectedRecordCount: messages.length,
-      records: (nextSeq) {
-        return [
-          for (var index = 0; index < messages.length; index++)
-            PersonaChatConversationRecord(
-              id: _uuid.v4(),
-              seq: nextSeq + index,
-              characterId: characterId,
-              isFromCharacter: true,
-              content: messages[index].content,
-              factId: factId,
-              isRead: isRead,
-              timestamp: timestamp,
-              messageType: messages[index].storageType,
-              origin: origin,
-              contactEpisodeId: contactEpisodeId,
-            ),
-        ];
-      },
+  }) {
+    return [
+      for (var index = 0; index < messages.length; index++)
+        PersonaChatConversationRecord(
+          id: _uuid.v4(),
+          seq: nextSeq + index,
+          characterId: characterId,
+          isFromCharacter: true,
+          content: messages[index].content,
+          factId: factId,
+          isRead: isRead,
+          timestamp: timestamp,
+          messageType: messages[index].storageType,
+          origin: origin,
+          contactEpisodeId: episodeId,
+        ),
+    ];
+  }
+
+  PersonaChatMessage _toMessage(PersonaChatConversationRecord record) {
+    return PersonaChatMessage(
+      id: record.seq,
+      characterId: record.characterId,
+      isFromCharacter: record.isFromCharacter,
+      content: record.content,
+      factId: record.factId,
+      isRead: record.isRead,
+      timestamp: record.timestamp,
+      messageType: record.messageType,
+      origin: record.origin,
+      contactEpisodeId: record.contactEpisodeId,
     );
   }
 
-  Future<void> _advanceWorkspaceCursor({
-    required String characterId,
-    required int consumedThroughMessageId,
-    String? userId,
-  }) async {
-    final storage = _storage;
-    final resolvedUserId = _resolveUserId(userId);
-    if (storage == null || resolvedUserId == null) return;
-    final row = await (_db.select(_db.personaChatMessages)
-          ..where((t) =>
-              t.characterId.equals(characterId) &
-              t.id.equals(consumedThroughMessageId)))
-        .getSingleOrNull();
-    final stableId = row?.stableId;
-    if (stableId == null || stableId.isEmpty) return;
-    await storage.advanceCursor(
-      userId: resolvedUserId,
-      characterId: characterId,
-      consumedThroughMessageId: stableId,
-    );
+  void _requireMessages(List<CharacterOutgoingMessage> messages) {
+    if (messages.isEmpty) {
+      throw ArgumentError('Character messages must be non-empty.');
+    }
   }
 }

--- a/lib/data/services/task_handlers/character_conversation_handler.dart
+++ b/lib/data/services/task_handlers/character_conversation_handler.dart
@@ -85,13 +85,17 @@ class CharacterConversationTaskHandler {
     required Map<String, dynamic> payload,
     required TaskContext taskContext,
   }) async {
-    final incoming = await _chatService.getPendingUserMessages(character.id);
+    final incoming = await _chatService.getPendingUserMessages(
+      character.id,
+      userId: userId,
+    );
     if (incoming.isEmpty) return;
 
     final history = await _chatService.getMessagesBefore(
       character.id,
       beforeMessageId: incoming.first.id,
       limit: 24,
+      userId: userId,
     );
     final context = CharacterConversationContext(
       sourceEventId: 'private_chat:${incoming.first.id}',
@@ -119,6 +123,7 @@ class CharacterConversationTaskHandler {
             characterMessages: decision.messages,
             episodeId: episodeId,
             timestamp: _clock(),
+            userId: userId,
           );
           _logger.info(
             'Character ${character.id} replied with '
@@ -126,6 +131,7 @@ class CharacterConversationTaskHandler {
           );
           replyPending = (await _chatService.getPendingUserMessages(
             character.id,
+            userId: userId,
           ))
               .isNotEmpty;
         case CharacterConversationAction.thinkLater:
@@ -134,8 +140,10 @@ class CharacterConversationTaskHandler {
           if (wakeAt == null || !wakeAt.isAfter(_clock()) || reason.isEmpty) {
             throw StateError('Invalid ThinkLater conversation decision.');
           }
-          final latestPending =
-              await _chatService.getPendingUserMessages(character.id);
+          final latestPending = await _chatService.getPendingUserMessages(
+            character.id,
+            userId: userId,
+          );
           final hasNewerInput = latestPending.any(
             (message) => !incomingIds.contains(message.id),
           );
@@ -161,12 +169,14 @@ class CharacterConversationTaskHandler {
           await _chatService.advanceReplyCursor(
             characterId: character.id,
             consumedThroughMessageId: incoming.last.id,
+            userId: userId,
           );
           _logger.info(
             'Character ${character.id} stayed quiet: ${decision.reason}',
           );
           replyPending = (await _chatService.getPendingUserMessages(
             character.id,
+            userId: userId,
           ))
               .isNotEmpty;
       }

--- a/lib/data/services/task_handlers/character_conversation_handler.dart
+++ b/lib/data/services/task_handlers/character_conversation_handler.dart
@@ -74,7 +74,6 @@ class CharacterConversationTaskHandler {
         userId: userId,
         character: character,
         payload: payload,
-        taskContext: taskContext,
       ),
     );
   }
@@ -83,13 +82,21 @@ class CharacterConversationTaskHandler {
     required String userId,
     required CharacterModel character,
     required Map<String, dynamic> payload,
-    required TaskContext taskContext,
   }) async {
+    final conversationGeneration = await _chatService
+        .getConversationGeneration(character.id, userId: userId);
     final incoming = await _chatService.getPendingUserMessages(
       character.id,
       userId: userId,
     );
     if (incoming.isEmpty) return;
+    if (await _chatService.getConversationGeneration(
+          character.id,
+          userId: userId,
+        ) !=
+        conversationGeneration) {
+      return;
+    }
 
     final history = await _chatService.getMessagesBefore(
       character.id,
@@ -112,7 +119,8 @@ class CharacterConversationTaskHandler {
         context: context,
         workspaceService: _workspaceService,
       );
-      final episodeId = 'character_conversation:${taskContext.taskId}';
+      final turnId =
+          'character_conversation:${incoming.first.id}-${incoming.last.id}';
       final incomingIds = incoming.map((message) => message.id).toList();
       var replyPending = false;
       switch (decision.action) {
@@ -121,8 +129,9 @@ class CharacterConversationTaskHandler {
             characterId: character.id,
             consumedThroughMessageId: incoming.last.id,
             characterMessages: decision.messages,
-            episodeId: episodeId,
+            episodeId: turnId,
             timestamp: _clock(),
+            expectedGeneration: conversationGeneration,
             userId: userId,
           );
           _logger.info(

--- a/lib/data/services/task_handlers/character_initiative_handler.dart
+++ b/lib/data/services/task_handlers/character_initiative_handler.dart
@@ -36,6 +36,7 @@ typedef CharacterInitiativeMessageSender = Future<bool> Function({
   required List<CharacterOutgoingMessage> messages,
   required DateTime timestamp,
   required String contactEpisodeId,
+  required int expectedGeneration,
   String? factId,
 });
 
@@ -235,6 +236,7 @@ class CharacterInitiativeTaskHandler {
       resumedThought: resumedThought,
       wakeReason: resumedThought?.reason ?? payload['wake_reason'] as String?,
       latestPrivateMessageId: baseContext.latestPrivateMessageId,
+      conversationGeneration: baseContext.conversationGeneration,
     );
 
     try {
@@ -290,7 +292,8 @@ class CharacterInitiativeTaskHandler {
               messages: messages,
               factId: factId,
               timestamp: _clock(),
-              contactEpisodeId: 'character_initiative:${taskContext.taskId}',
+              contactEpisodeId: 'character_initiative:$sourceEventId',
+              expectedGeneration: context.conversationGeneration,
             );
             if (committed) {
               _logger.info(
@@ -357,11 +360,35 @@ class CharacterInitiativeTaskHandler {
     required DateTime now,
     String? factId,
   }) async {
-    final messages = await PersonaChatService.instance.getMessages(
+    final chatService = PersonaChatService.instance;
+    var conversationGeneration = await chatService.getConversationGeneration(
+      character.id,
+      userId: userId,
+    );
+    var messages = await chatService.getMessages(
       character.id,
       limit: 24,
       userId: userId,
     );
+    var generationAfterRead = await chatService.getConversationGeneration(
+      character.id,
+      userId: userId,
+    );
+    if (generationAfterRead != conversationGeneration) {
+      conversationGeneration = generationAfterRead;
+      messages = await chatService.getMessages(
+        character.id,
+        limit: 24,
+        userId: userId,
+      );
+      generationAfterRead = await chatService.getConversationGeneration(
+        character.id,
+        userId: userId,
+      );
+      if (generationAfterRead != conversationGeneration) {
+        throw StateError('Persona conversation changed while loading context.');
+      }
+    }
     final recentPrivateChat = messages.reversed
         .map(
           (message) => CharacterConversationTurn(
@@ -399,6 +426,7 @@ class CharacterInitiativeTaskHandler {
         0,
         (latest, message) => message.id > latest ? message.id : latest,
       ),
+      conversationGeneration: conversationGeneration,
     );
   }
 
@@ -455,6 +483,7 @@ class CharacterInitiativeTaskHandler {
       required List<CharacterOutgoingMessage> messages,
       required DateTime timestamp,
       required String contactEpisodeId,
+      required int expectedGeneration,
       String? factId,
     }) async {
       final committed = await chatService.tryAddInitiativeMessages(
@@ -464,6 +493,7 @@ class CharacterInitiativeTaskHandler {
         isRead: false,
         timestamp: timestamp,
         contactEpisodeId: contactEpisodeId,
+        expectedGeneration: expectedGeneration,
       );
       if (!committed) return false;
       eventBus.emitEvent(

--- a/lib/data/services/task_handlers/character_initiative_handler.dart
+++ b/lib/data/services/task_handlers/character_initiative_handler.dart
@@ -360,6 +360,7 @@ class CharacterInitiativeTaskHandler {
     final messages = await PersonaChatService.instance.getMessages(
       character.id,
       limit: 24,
+      userId: userId,
     );
     final recentPrivateChat = messages.reversed
         .map(

--- a/lib/db/app_database.dart
+++ b/lib/db/app_database.dart
@@ -101,7 +101,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 20;
+  int get schemaVersion => 19;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -130,7 +130,6 @@ class AppDatabase extends _$AppDatabase {
             'CREATE INDEX IF NOT EXISTS idx_system_actions_status ON system_actions(status)',
           );
           await _createPersonaChatEpisodeIndex();
-          await _createPersonaChatStableIdIndex();
           await _createClarificationRequestIndices();
           await _createUserNotificationIndices();
           // Create FTS5 virtual tables for full-text search
@@ -243,9 +242,6 @@ class AppDatabase extends _$AppDatabase {
           if (from < 19) {
             await _addPersonaChatReplyCursors(m, from: from);
           }
-          if (from < 20) {
-            await _addPersonaChatStableId(m);
-          }
         },
       );
 
@@ -274,33 +270,6 @@ class AppDatabase extends _$AppDatabase {
       'CREATE INDEX IF NOT EXISTS idx_persona_chat_episode '
       'ON persona_chat_messages(character_id, contact_episode_id)',
     );
-  }
-
-  Future<void> _createPersonaChatStableIdIndex() async {
-    await customStatement(
-      'CREATE UNIQUE INDEX IF NOT EXISTS idx_persona_chat_stable_id '
-      'ON persona_chat_messages(character_id, stable_id) '
-      'WHERE stable_id IS NOT NULL',
-    );
-  }
-
-  Future<void> _addPersonaChatStableId(Migrator m) async {
-    try {
-      await m.addColumn(personaChatMessages, personaChatMessages.stableId);
-    } catch (e) {
-      final errorStr = e.toString().toLowerCase();
-      if (errorStr.contains('duplicate column') ||
-          errorStr.contains('stable_id')) {
-        _logger.info('stable_id column may already exist, skipping: $e');
-      } else {
-        rethrow;
-      }
-    }
-    await customStatement(
-      "UPDATE persona_chat_messages SET stable_id = 'legacy-' || id "
-      'WHERE stable_id IS NULL OR stable_id = \'\'',
-    );
-    await _createPersonaChatStableIdIndex();
   }
 
   Future<void> _addPersonaChatReplyCursors(

--- a/lib/db/app_database.dart
+++ b/lib/db/app_database.dart
@@ -101,7 +101,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 19;
+  int get schemaVersion => 20;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -130,6 +130,7 @@ class AppDatabase extends _$AppDatabase {
             'CREATE INDEX IF NOT EXISTS idx_system_actions_status ON system_actions(status)',
           );
           await _createPersonaChatEpisodeIndex();
+          await _createPersonaChatStableIdIndex();
           await _createClarificationRequestIndices();
           await _createUserNotificationIndices();
           // Create FTS5 virtual tables for full-text search
@@ -242,6 +243,9 @@ class AppDatabase extends _$AppDatabase {
           if (from < 19) {
             await _addPersonaChatReplyCursors(m, from: from);
           }
+          if (from < 20) {
+            await _addPersonaChatStableId(m);
+          }
         },
       );
 
@@ -270,6 +274,33 @@ class AppDatabase extends _$AppDatabase {
       'CREATE INDEX IF NOT EXISTS idx_persona_chat_episode '
       'ON persona_chat_messages(character_id, contact_episode_id)',
     );
+  }
+
+  Future<void> _createPersonaChatStableIdIndex() async {
+    await customStatement(
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_persona_chat_stable_id '
+      'ON persona_chat_messages(character_id, stable_id) '
+      'WHERE stable_id IS NOT NULL',
+    );
+  }
+
+  Future<void> _addPersonaChatStableId(Migrator m) async {
+    try {
+      await m.addColumn(personaChatMessages, personaChatMessages.stableId);
+    } catch (e) {
+      final errorStr = e.toString().toLowerCase();
+      if (errorStr.contains('duplicate column') ||
+          errorStr.contains('stable_id')) {
+        _logger.info('stable_id column may already exist, skipping: $e');
+      } else {
+        rethrow;
+      }
+    }
+    await customStatement(
+      "UPDATE persona_chat_messages SET stable_id = 'legacy-' || id "
+      'WHERE stable_id IS NULL OR stable_id = \'\'',
+    );
+    await _createPersonaChatStableIdIndex();
   }
 
   Future<void> _addPersonaChatReplyCursors(

--- a/lib/db/app_database.g.dart
+++ b/lib/db/app_database.g.dart
@@ -3333,6 +3333,12 @@ class $PersonaChatMessagesTable extends PersonaChatMessages
   late final GeneratedColumn<String> contactEpisodeId = GeneratedColumn<String>(
       'contact_episode_id', aliasedName, true,
       type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _stableIdMeta =
+      const VerificationMeta('stableId');
+  @override
+  late final GeneratedColumn<String> stableId = GeneratedColumn<String>(
+      'stable_id', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -3344,7 +3350,8 @@ class $PersonaChatMessagesTable extends PersonaChatMessages
         timestamp,
         messageType,
         origin,
-        contactEpisodeId
+        contactEpisodeId,
+        stableId
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -3411,6 +3418,10 @@ class $PersonaChatMessagesTable extends PersonaChatMessages
           contactEpisodeId.isAcceptableOrUnknown(
               data['contact_episode_id']!, _contactEpisodeIdMeta));
     }
+    if (data.containsKey('stable_id')) {
+      context.handle(_stableIdMeta,
+          stableId.isAcceptableOrUnknown(data['stable_id']!, _stableIdMeta));
+    }
     return context;
   }
 
@@ -3440,6 +3451,8 @@ class $PersonaChatMessagesTable extends PersonaChatMessages
           .read(DriftSqlType.string, data['${effectivePrefix}origin'])!,
       contactEpisodeId: attachedDatabase.typeMapping.read(
           DriftSqlType.string, data['${effectivePrefix}contact_episode_id']),
+      stableId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}stable_id']),
     );
   }
 
@@ -3469,6 +3482,10 @@ class PersonaChatMessage extends DataClass
   /// Groups bubbles produced by one character speaking episode. A stable value
   /// also makes persistent task retries idempotent.
   final String? contactEpisodeId;
+
+  /// Durable identity from the character workspace conversation store.
+  /// SQLite autoincrement [id] is only a rebuildable projection key.
+  final String? stableId;
   const PersonaChatMessage(
       {required this.id,
       required this.characterId,
@@ -3479,7 +3496,8 @@ class PersonaChatMessage extends DataClass
       required this.timestamp,
       required this.messageType,
       required this.origin,
-      this.contactEpisodeId});
+      this.contactEpisodeId,
+      this.stableId});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -3496,6 +3514,9 @@ class PersonaChatMessage extends DataClass
     map['origin'] = Variable<String>(origin);
     if (!nullToAbsent || contactEpisodeId != null) {
       map['contact_episode_id'] = Variable<String>(contactEpisodeId);
+    }
+    if (!nullToAbsent || stableId != null) {
+      map['stable_id'] = Variable<String>(stableId);
     }
     return map;
   }
@@ -3515,6 +3536,9 @@ class PersonaChatMessage extends DataClass
       contactEpisodeId: contactEpisodeId == null && nullToAbsent
           ? const Value.absent()
           : Value(contactEpisodeId),
+      stableId: stableId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(stableId),
     );
   }
 
@@ -3532,6 +3556,7 @@ class PersonaChatMessage extends DataClass
       messageType: serializer.fromJson<String>(json['messageType']),
       origin: serializer.fromJson<String>(json['origin']),
       contactEpisodeId: serializer.fromJson<String?>(json['contactEpisodeId']),
+      stableId: serializer.fromJson<String?>(json['stableId']),
     );
   }
   @override
@@ -3548,6 +3573,7 @@ class PersonaChatMessage extends DataClass
       'messageType': serializer.toJson<String>(messageType),
       'origin': serializer.toJson<String>(origin),
       'contactEpisodeId': serializer.toJson<String?>(contactEpisodeId),
+      'stableId': serializer.toJson<String?>(stableId),
     };
   }
 
@@ -3561,7 +3587,8 @@ class PersonaChatMessage extends DataClass
           DateTime? timestamp,
           String? messageType,
           String? origin,
-          Value<String?> contactEpisodeId = const Value.absent()}) =>
+          Value<String?> contactEpisodeId = const Value.absent(),
+          Value<String?> stableId = const Value.absent()}) =>
       PersonaChatMessage(
         id: id ?? this.id,
         characterId: characterId ?? this.characterId,
@@ -3575,6 +3602,7 @@ class PersonaChatMessage extends DataClass
         contactEpisodeId: contactEpisodeId.present
             ? contactEpisodeId.value
             : this.contactEpisodeId,
+        stableId: stableId.present ? stableId.value : this.stableId,
       );
   PersonaChatMessage copyWithCompanion(PersonaChatMessagesCompanion data) {
     return PersonaChatMessage(
@@ -3594,6 +3622,7 @@ class PersonaChatMessage extends DataClass
       contactEpisodeId: data.contactEpisodeId.present
           ? data.contactEpisodeId.value
           : this.contactEpisodeId,
+      stableId: data.stableId.present ? data.stableId.value : this.stableId,
     );
   }
 
@@ -3609,14 +3638,25 @@ class PersonaChatMessage extends DataClass
           ..write('timestamp: $timestamp, ')
           ..write('messageType: $messageType, ')
           ..write('origin: $origin, ')
-          ..write('contactEpisodeId: $contactEpisodeId')
+          ..write('contactEpisodeId: $contactEpisodeId, ')
+          ..write('stableId: $stableId')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, characterId, isFromCharacter, content,
-      factId, isRead, timestamp, messageType, origin, contactEpisodeId);
+  int get hashCode => Object.hash(
+      id,
+      characterId,
+      isFromCharacter,
+      content,
+      factId,
+      isRead,
+      timestamp,
+      messageType,
+      origin,
+      contactEpisodeId,
+      stableId);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3630,7 +3670,8 @@ class PersonaChatMessage extends DataClass
           other.timestamp == this.timestamp &&
           other.messageType == this.messageType &&
           other.origin == this.origin &&
-          other.contactEpisodeId == this.contactEpisodeId);
+          other.contactEpisodeId == this.contactEpisodeId &&
+          other.stableId == this.stableId);
 }
 
 class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
@@ -3644,6 +3685,7 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
   final Value<String> messageType;
   final Value<String> origin;
   final Value<String?> contactEpisodeId;
+  final Value<String?> stableId;
   const PersonaChatMessagesCompanion({
     this.id = const Value.absent(),
     this.characterId = const Value.absent(),
@@ -3655,6 +3697,7 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
     this.messageType = const Value.absent(),
     this.origin = const Value.absent(),
     this.contactEpisodeId = const Value.absent(),
+    this.stableId = const Value.absent(),
   });
   PersonaChatMessagesCompanion.insert({
     this.id = const Value.absent(),
@@ -3667,6 +3710,7 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
     this.messageType = const Value.absent(),
     this.origin = const Value.absent(),
     this.contactEpisodeId = const Value.absent(),
+    this.stableId = const Value.absent(),
   })  : characterId = Value(characterId),
         isFromCharacter = Value(isFromCharacter),
         content = Value(content),
@@ -3682,6 +3726,7 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
     Expression<String>? messageType,
     Expression<String>? origin,
     Expression<String>? contactEpisodeId,
+    Expression<String>? stableId,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -3694,6 +3739,7 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
       if (messageType != null) 'message_type': messageType,
       if (origin != null) 'origin': origin,
       if (contactEpisodeId != null) 'contact_episode_id': contactEpisodeId,
+      if (stableId != null) 'stable_id': stableId,
     });
   }
 
@@ -3707,7 +3753,8 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
       Value<DateTime>? timestamp,
       Value<String>? messageType,
       Value<String>? origin,
-      Value<String?>? contactEpisodeId}) {
+      Value<String?>? contactEpisodeId,
+      Value<String?>? stableId}) {
     return PersonaChatMessagesCompanion(
       id: id ?? this.id,
       characterId: characterId ?? this.characterId,
@@ -3719,6 +3766,7 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
       messageType: messageType ?? this.messageType,
       origin: origin ?? this.origin,
       contactEpisodeId: contactEpisodeId ?? this.contactEpisodeId,
+      stableId: stableId ?? this.stableId,
     );
   }
 
@@ -3755,6 +3803,9 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
     if (contactEpisodeId.present) {
       map['contact_episode_id'] = Variable<String>(contactEpisodeId.value);
     }
+    if (stableId.present) {
+      map['stable_id'] = Variable<String>(stableId.value);
+    }
     return map;
   }
 
@@ -3770,7 +3821,8 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
           ..write('timestamp: $timestamp, ')
           ..write('messageType: $messageType, ')
           ..write('origin: $origin, ')
-          ..write('contactEpisodeId: $contactEpisodeId')
+          ..write('contactEpisodeId: $contactEpisodeId, ')
+          ..write('stableId: $stableId')
           ..write(')'))
         .toString();
   }
@@ -6028,6 +6080,7 @@ typedef $$PersonaChatMessagesTableCreateCompanionBuilder
   Value<String> messageType,
   Value<String> origin,
   Value<String?> contactEpisodeId,
+  Value<String?> stableId,
 });
 typedef $$PersonaChatMessagesTableUpdateCompanionBuilder
     = PersonaChatMessagesCompanion Function({
@@ -6041,6 +6094,7 @@ typedef $$PersonaChatMessagesTableUpdateCompanionBuilder
   Value<String> messageType,
   Value<String> origin,
   Value<String?> contactEpisodeId,
+  Value<String?> stableId,
 });
 
 class $$PersonaChatMessagesTableFilterComposer
@@ -6083,6 +6137,9 @@ class $$PersonaChatMessagesTableFilterComposer
   ColumnFilters<String> get contactEpisodeId => $composableBuilder(
       column: $table.contactEpisodeId,
       builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get stableId => $composableBuilder(
+      column: $table.stableId, builder: (column) => ColumnFilters(column));
 }
 
 class $$PersonaChatMessagesTableOrderingComposer
@@ -6125,6 +6182,9 @@ class $$PersonaChatMessagesTableOrderingComposer
   ColumnOrderings<String> get contactEpisodeId => $composableBuilder(
       column: $table.contactEpisodeId,
       builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get stableId => $composableBuilder(
+      column: $table.stableId, builder: (column) => ColumnOrderings(column));
 }
 
 class $$PersonaChatMessagesTableAnnotationComposer
@@ -6165,6 +6225,9 @@ class $$PersonaChatMessagesTableAnnotationComposer
 
   GeneratedColumn<String> get contactEpisodeId => $composableBuilder(
       column: $table.contactEpisodeId, builder: (column) => column);
+
+  GeneratedColumn<String> get stableId =>
+      $composableBuilder(column: $table.stableId, builder: (column) => column);
 }
 
 class $$PersonaChatMessagesTableTableManager extends RootTableManager<
@@ -6207,6 +6270,7 @@ class $$PersonaChatMessagesTableTableManager extends RootTableManager<
             Value<String> messageType = const Value.absent(),
             Value<String> origin = const Value.absent(),
             Value<String?> contactEpisodeId = const Value.absent(),
+            Value<String?> stableId = const Value.absent(),
           }) =>
               PersonaChatMessagesCompanion(
             id: id,
@@ -6219,6 +6283,7 @@ class $$PersonaChatMessagesTableTableManager extends RootTableManager<
             messageType: messageType,
             origin: origin,
             contactEpisodeId: contactEpisodeId,
+            stableId: stableId,
           ),
           createCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -6231,6 +6296,7 @@ class $$PersonaChatMessagesTableTableManager extends RootTableManager<
             Value<String> messageType = const Value.absent(),
             Value<String> origin = const Value.absent(),
             Value<String?> contactEpisodeId = const Value.absent(),
+            Value<String?> stableId = const Value.absent(),
           }) =>
               PersonaChatMessagesCompanion.insert(
             id: id,
@@ -6243,6 +6309,7 @@ class $$PersonaChatMessagesTableTableManager extends RootTableManager<
             messageType: messageType,
             origin: origin,
             contactEpisodeId: contactEpisodeId,
+            stableId: stableId,
           ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))

--- a/lib/db/app_database.g.dart
+++ b/lib/db/app_database.g.dart
@@ -3333,12 +3333,6 @@ class $PersonaChatMessagesTable extends PersonaChatMessages
   late final GeneratedColumn<String> contactEpisodeId = GeneratedColumn<String>(
       'contact_episode_id', aliasedName, true,
       type: DriftSqlType.string, requiredDuringInsert: false);
-  static const VerificationMeta _stableIdMeta =
-      const VerificationMeta('stableId');
-  @override
-  late final GeneratedColumn<String> stableId = GeneratedColumn<String>(
-      'stable_id', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -3350,8 +3344,7 @@ class $PersonaChatMessagesTable extends PersonaChatMessages
         timestamp,
         messageType,
         origin,
-        contactEpisodeId,
-        stableId
+        contactEpisodeId
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -3418,10 +3411,6 @@ class $PersonaChatMessagesTable extends PersonaChatMessages
           contactEpisodeId.isAcceptableOrUnknown(
               data['contact_episode_id']!, _contactEpisodeIdMeta));
     }
-    if (data.containsKey('stable_id')) {
-      context.handle(_stableIdMeta,
-          stableId.isAcceptableOrUnknown(data['stable_id']!, _stableIdMeta));
-    }
     return context;
   }
 
@@ -3451,8 +3440,6 @@ class $PersonaChatMessagesTable extends PersonaChatMessages
           .read(DriftSqlType.string, data['${effectivePrefix}origin'])!,
       contactEpisodeId: attachedDatabase.typeMapping.read(
           DriftSqlType.string, data['${effectivePrefix}contact_episode_id']),
-      stableId: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}stable_id']),
     );
   }
 
@@ -3482,10 +3469,6 @@ class PersonaChatMessage extends DataClass
   /// Groups bubbles produced by one character speaking episode. A stable value
   /// also makes persistent task retries idempotent.
   final String? contactEpisodeId;
-
-  /// Durable identity from the character workspace conversation store.
-  /// SQLite autoincrement [id] is only a rebuildable projection key.
-  final String? stableId;
   const PersonaChatMessage(
       {required this.id,
       required this.characterId,
@@ -3496,8 +3479,7 @@ class PersonaChatMessage extends DataClass
       required this.timestamp,
       required this.messageType,
       required this.origin,
-      this.contactEpisodeId,
-      this.stableId});
+      this.contactEpisodeId});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -3514,9 +3496,6 @@ class PersonaChatMessage extends DataClass
     map['origin'] = Variable<String>(origin);
     if (!nullToAbsent || contactEpisodeId != null) {
       map['contact_episode_id'] = Variable<String>(contactEpisodeId);
-    }
-    if (!nullToAbsent || stableId != null) {
-      map['stable_id'] = Variable<String>(stableId);
     }
     return map;
   }
@@ -3536,9 +3515,6 @@ class PersonaChatMessage extends DataClass
       contactEpisodeId: contactEpisodeId == null && nullToAbsent
           ? const Value.absent()
           : Value(contactEpisodeId),
-      stableId: stableId == null && nullToAbsent
-          ? const Value.absent()
-          : Value(stableId),
     );
   }
 
@@ -3556,7 +3532,6 @@ class PersonaChatMessage extends DataClass
       messageType: serializer.fromJson<String>(json['messageType']),
       origin: serializer.fromJson<String>(json['origin']),
       contactEpisodeId: serializer.fromJson<String?>(json['contactEpisodeId']),
-      stableId: serializer.fromJson<String?>(json['stableId']),
     );
   }
   @override
@@ -3573,7 +3548,6 @@ class PersonaChatMessage extends DataClass
       'messageType': serializer.toJson<String>(messageType),
       'origin': serializer.toJson<String>(origin),
       'contactEpisodeId': serializer.toJson<String?>(contactEpisodeId),
-      'stableId': serializer.toJson<String?>(stableId),
     };
   }
 
@@ -3587,8 +3561,7 @@ class PersonaChatMessage extends DataClass
           DateTime? timestamp,
           String? messageType,
           String? origin,
-          Value<String?> contactEpisodeId = const Value.absent(),
-          Value<String?> stableId = const Value.absent()}) =>
+          Value<String?> contactEpisodeId = const Value.absent()}) =>
       PersonaChatMessage(
         id: id ?? this.id,
         characterId: characterId ?? this.characterId,
@@ -3602,7 +3575,6 @@ class PersonaChatMessage extends DataClass
         contactEpisodeId: contactEpisodeId.present
             ? contactEpisodeId.value
             : this.contactEpisodeId,
-        stableId: stableId.present ? stableId.value : this.stableId,
       );
   PersonaChatMessage copyWithCompanion(PersonaChatMessagesCompanion data) {
     return PersonaChatMessage(
@@ -3622,7 +3594,6 @@ class PersonaChatMessage extends DataClass
       contactEpisodeId: data.contactEpisodeId.present
           ? data.contactEpisodeId.value
           : this.contactEpisodeId,
-      stableId: data.stableId.present ? data.stableId.value : this.stableId,
     );
   }
 
@@ -3638,25 +3609,14 @@ class PersonaChatMessage extends DataClass
           ..write('timestamp: $timestamp, ')
           ..write('messageType: $messageType, ')
           ..write('origin: $origin, ')
-          ..write('contactEpisodeId: $contactEpisodeId, ')
-          ..write('stableId: $stableId')
+          ..write('contactEpisodeId: $contactEpisodeId')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(
-      id,
-      characterId,
-      isFromCharacter,
-      content,
-      factId,
-      isRead,
-      timestamp,
-      messageType,
-      origin,
-      contactEpisodeId,
-      stableId);
+  int get hashCode => Object.hash(id, characterId, isFromCharacter, content,
+      factId, isRead, timestamp, messageType, origin, contactEpisodeId);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3670,8 +3630,7 @@ class PersonaChatMessage extends DataClass
           other.timestamp == this.timestamp &&
           other.messageType == this.messageType &&
           other.origin == this.origin &&
-          other.contactEpisodeId == this.contactEpisodeId &&
-          other.stableId == this.stableId);
+          other.contactEpisodeId == this.contactEpisodeId);
 }
 
 class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
@@ -3685,7 +3644,6 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
   final Value<String> messageType;
   final Value<String> origin;
   final Value<String?> contactEpisodeId;
-  final Value<String?> stableId;
   const PersonaChatMessagesCompanion({
     this.id = const Value.absent(),
     this.characterId = const Value.absent(),
@@ -3697,7 +3655,6 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
     this.messageType = const Value.absent(),
     this.origin = const Value.absent(),
     this.contactEpisodeId = const Value.absent(),
-    this.stableId = const Value.absent(),
   });
   PersonaChatMessagesCompanion.insert({
     this.id = const Value.absent(),
@@ -3710,7 +3667,6 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
     this.messageType = const Value.absent(),
     this.origin = const Value.absent(),
     this.contactEpisodeId = const Value.absent(),
-    this.stableId = const Value.absent(),
   })  : characterId = Value(characterId),
         isFromCharacter = Value(isFromCharacter),
         content = Value(content),
@@ -3726,7 +3682,6 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
     Expression<String>? messageType,
     Expression<String>? origin,
     Expression<String>? contactEpisodeId,
-    Expression<String>? stableId,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -3739,7 +3694,6 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
       if (messageType != null) 'message_type': messageType,
       if (origin != null) 'origin': origin,
       if (contactEpisodeId != null) 'contact_episode_id': contactEpisodeId,
-      if (stableId != null) 'stable_id': stableId,
     });
   }
 
@@ -3753,8 +3707,7 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
       Value<DateTime>? timestamp,
       Value<String>? messageType,
       Value<String>? origin,
-      Value<String?>? contactEpisodeId,
-      Value<String?>? stableId}) {
+      Value<String?>? contactEpisodeId}) {
     return PersonaChatMessagesCompanion(
       id: id ?? this.id,
       characterId: characterId ?? this.characterId,
@@ -3766,7 +3719,6 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
       messageType: messageType ?? this.messageType,
       origin: origin ?? this.origin,
       contactEpisodeId: contactEpisodeId ?? this.contactEpisodeId,
-      stableId: stableId ?? this.stableId,
     );
   }
 
@@ -3803,9 +3755,6 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
     if (contactEpisodeId.present) {
       map['contact_episode_id'] = Variable<String>(contactEpisodeId.value);
     }
-    if (stableId.present) {
-      map['stable_id'] = Variable<String>(stableId.value);
-    }
     return map;
   }
 
@@ -3821,8 +3770,7 @@ class PersonaChatMessagesCompanion extends UpdateCompanion<PersonaChatMessage> {
           ..write('timestamp: $timestamp, ')
           ..write('messageType: $messageType, ')
           ..write('origin: $origin, ')
-          ..write('contactEpisodeId: $contactEpisodeId, ')
-          ..write('stableId: $stableId')
+          ..write('contactEpisodeId: $contactEpisodeId')
           ..write(')'))
         .toString();
   }
@@ -6080,7 +6028,6 @@ typedef $$PersonaChatMessagesTableCreateCompanionBuilder
   Value<String> messageType,
   Value<String> origin,
   Value<String?> contactEpisodeId,
-  Value<String?> stableId,
 });
 typedef $$PersonaChatMessagesTableUpdateCompanionBuilder
     = PersonaChatMessagesCompanion Function({
@@ -6094,7 +6041,6 @@ typedef $$PersonaChatMessagesTableUpdateCompanionBuilder
   Value<String> messageType,
   Value<String> origin,
   Value<String?> contactEpisodeId,
-  Value<String?> stableId,
 });
 
 class $$PersonaChatMessagesTableFilterComposer
@@ -6137,9 +6083,6 @@ class $$PersonaChatMessagesTableFilterComposer
   ColumnFilters<String> get contactEpisodeId => $composableBuilder(
       column: $table.contactEpisodeId,
       builder: (column) => ColumnFilters(column));
-
-  ColumnFilters<String> get stableId => $composableBuilder(
-      column: $table.stableId, builder: (column) => ColumnFilters(column));
 }
 
 class $$PersonaChatMessagesTableOrderingComposer
@@ -6182,9 +6125,6 @@ class $$PersonaChatMessagesTableOrderingComposer
   ColumnOrderings<String> get contactEpisodeId => $composableBuilder(
       column: $table.contactEpisodeId,
       builder: (column) => ColumnOrderings(column));
-
-  ColumnOrderings<String> get stableId => $composableBuilder(
-      column: $table.stableId, builder: (column) => ColumnOrderings(column));
 }
 
 class $$PersonaChatMessagesTableAnnotationComposer
@@ -6225,9 +6165,6 @@ class $$PersonaChatMessagesTableAnnotationComposer
 
   GeneratedColumn<String> get contactEpisodeId => $composableBuilder(
       column: $table.contactEpisodeId, builder: (column) => column);
-
-  GeneratedColumn<String> get stableId =>
-      $composableBuilder(column: $table.stableId, builder: (column) => column);
 }
 
 class $$PersonaChatMessagesTableTableManager extends RootTableManager<
@@ -6270,7 +6207,6 @@ class $$PersonaChatMessagesTableTableManager extends RootTableManager<
             Value<String> messageType = const Value.absent(),
             Value<String> origin = const Value.absent(),
             Value<String?> contactEpisodeId = const Value.absent(),
-            Value<String?> stableId = const Value.absent(),
           }) =>
               PersonaChatMessagesCompanion(
             id: id,
@@ -6283,7 +6219,6 @@ class $$PersonaChatMessagesTableTableManager extends RootTableManager<
             messageType: messageType,
             origin: origin,
             contactEpisodeId: contactEpisodeId,
-            stableId: stableId,
           ),
           createCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -6296,7 +6231,6 @@ class $$PersonaChatMessagesTableTableManager extends RootTableManager<
             Value<String> messageType = const Value.absent(),
             Value<String> origin = const Value.absent(),
             Value<String?> contactEpisodeId = const Value.absent(),
-            Value<String?> stableId = const Value.absent(),
           }) =>
               PersonaChatMessagesCompanion.insert(
             id: id,
@@ -6309,7 +6243,6 @@ class $$PersonaChatMessagesTableTableManager extends RootTableManager<
             messageType: messageType,
             origin: origin,
             contactEpisodeId: contactEpisodeId,
-            stableId: stableId,
           ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))

--- a/lib/db/tables.dart
+++ b/lib/db/tables.dart
@@ -170,6 +170,10 @@ class PersonaChatMessages extends Table {
   /// Groups bubbles produced by one character speaking episode. A stable value
   /// also makes persistent task retries idempotent.
   TextColumn get contactEpisodeId => text().nullable()();
+
+  /// Durable identity from the character workspace conversation store.
+  /// SQLite autoincrement [id] is only a rebuildable projection key.
+  TextColumn get stableId => text().nullable()();
 }
 
 /// Monotonic consumption boundary for each character's private-chat inbox.

--- a/lib/db/tables.dart
+++ b/lib/db/tables.dart
@@ -170,10 +170,6 @@ class PersonaChatMessages extends Table {
   /// Groups bubbles produced by one character speaking episode. A stable value
   /// also makes persistent task retries idempotent.
   TextColumn get contactEpisodeId => text().nullable()();
-
-  /// Durable identity from the character workspace conversation store.
-  /// SQLite autoincrement [id] is only a rebuildable projection key.
-  TextColumn get stableId => text().nullable()();
 }
 
 /// Monotonic consumption boundary for each character's private-chat inbox.

--- a/lib/domain/models/character_initiative.dart
+++ b/lib/domain/models/character_initiative.dart
@@ -139,6 +139,7 @@ class CharacterInitiativeContext {
     this.resumedThought,
     this.wakeReason,
     this.latestPrivateMessageId = 0,
+    this.conversationGeneration = 1,
   });
 
   final String sourceEventId;
@@ -154,4 +155,8 @@ class CharacterInitiativeContext {
   /// revalidates it before delivering a proactive message so a newly arrived
   /// direct message cannot be overtaken by a stale initiative decision.
   final int latestPrivateMessageId;
+
+  /// Changes when the private conversation is cleared. Agent output generated
+  /// against an older generation must not reappear after that reset.
+  final int conversationGeneration;
 }

--- a/lib/domain/models/persona_chat.dart
+++ b/lib/domain/models/persona_chat.dart
@@ -21,7 +21,7 @@ class PersonaChatMessageModel {
     required this.messageType,
     required this.origin,
     this.factId,
-    this.episodeId,
+    this.turnId,
   });
 
   final int id;
@@ -33,7 +33,7 @@ class PersonaChatMessageModel {
   final DateTime timestamp;
   final String messageType;
   final String origin;
-  final String? episodeId;
+  final String? turnId;
 }
 
 class PersonaChatThreadModel {
@@ -41,6 +41,8 @@ class PersonaChatThreadModel {
     required this.character,
     required this.userId,
     required this.messages,
+    required this.olderCursor,
+    required this.newestCursor,
     this.userAvatar,
   });
 
@@ -48,4 +50,18 @@ class PersonaChatThreadModel {
   final String userId;
   final String? userAvatar;
   final List<PersonaChatMessageModel> messages;
+  final int? olderCursor;
+  final int newestCursor;
+}
+
+class PersonaChatMessagePageModel {
+  const PersonaChatMessagePageModel({
+    required this.messages,
+    required this.olderCursor,
+    required this.newestCursor,
+  });
+
+  final List<PersonaChatMessageModel> messages;
+  final int? olderCursor;
+  final int newestCursor;
 }

--- a/lib/ui/character/view_models/persona_chat_viewmodel.dart
+++ b/lib/ui/character/view_models/persona_chat_viewmodel.dart
@@ -32,7 +32,11 @@ class PersonaChatViewModel extends ChangeNotifier {
 
   String _currentCharacterId;
   Timer? _typingIndicatorTimer;
+  Future<void>? _refreshLatestFuture;
+  bool _refreshLatestAgain = false;
   bool _replyPending = false;
+  int? _olderCursor;
+  int _newestCursor = 0;
   CharacterModel? character;
   String? userId;
   String? userAvatar;
@@ -82,22 +86,49 @@ class PersonaChatViewModel extends ChangeNotifier {
     );
     if (sent && characterId == _currentCharacterId) {
       _setReplyPending(true);
-      await refreshLatest(extraCapacity: 1);
+      await refreshLatest();
     } else {
       _notify();
     }
     return sent;
   }
 
-  Future<void> refreshLatest({int extraCapacity = 5}) async {
+  Future<void> refreshLatest() {
+    final running = _refreshLatestFuture;
+    if (running != null) {
+      _refreshLatestAgain = true;
+      return running;
+    }
+    final future = _runRefreshLatestLoop();
+    _refreshLatestFuture = future;
+    return future.whenComplete(() {
+      if (identical(_refreshLatestFuture, future)) {
+        _refreshLatestFuture = null;
+      }
+    });
+  }
+
+  Future<void> _runRefreshLatestLoop() async {
+    do {
+      _refreshLatestAgain = false;
+      await _refreshLatestOnce();
+    } while (_refreshLatestAgain && !_disposed);
+  }
+
+  Future<void> _refreshLatestOnce() async {
     final characterId = _currentCharacterId;
-    final result = await _router.fetchPersonaChatMessages(
+    final cursor = _newestCursor;
+    final result = await _router.fetchNewPersonaChatMessages(
       characterId,
-      limit: messages.length + extraCapacity,
+      afterCursor: cursor,
     );
     result.when(
-      onOk: (updated) {
-        if (characterId == _currentCharacterId) messages = updated;
+      onOk: (page) {
+        if (characterId != _currentCharacterId || cursor != _newestCursor) {
+          return;
+        }
+        messages = _mergeMessages(messages, page.messages);
+        _newestCursor = page.newestCursor;
       },
       onError: (error, _) => errorMessage = error.toString(),
     );
@@ -109,16 +140,24 @@ class PersonaChatViewModel extends ChangeNotifier {
     isLoadingMore = true;
     _notify();
     final characterId = _currentCharacterId;
-    final result = await _router.fetchPersonaChatMessages(
+    final beforeCursor = _olderCursor;
+    if (beforeCursor == null) {
+      hasMoreHistory = false;
+      isLoadingMore = false;
+      _notify();
+      return;
+    }
+    final result = await _router.fetchPersonaChatMessagePage(
       characterId,
       limit: pageSize,
-      offset: messages.length,
+      beforeCursor: beforeCursor,
     );
     result.when(
-      onOk: (older) {
+      onOk: (page) {
         if (characterId != _currentCharacterId) return;
-        messages = [...messages, ...older];
-        hasMoreHistory = older.length >= pageSize;
+        messages = _mergeMessages(messages, page.messages);
+        _olderCursor = page.olderCursor;
+        hasMoreHistory = page.olderCursor != null;
       },
       onError: (error, _) => errorMessage = error.toString(),
     );
@@ -143,6 +182,8 @@ class PersonaChatViewModel extends ChangeNotifier {
     _typingIndicatorTimer?.cancel();
     _typingIndicatorTimer = null;
     _replyPending = false;
+    _olderCursor = null;
+    _newestCursor = 0;
     isReplying = false;
     errorMessage = null;
     _notify();
@@ -174,7 +215,21 @@ class PersonaChatViewModel extends ChangeNotifier {
     userId = thread.userId;
     userAvatar = thread.userAvatar;
     messages = thread.messages;
-    hasMoreHistory = thread.messages.length >= pageSize;
+    _olderCursor = thread.olderCursor;
+    _newestCursor = thread.newestCursor;
+    hasMoreHistory = thread.olderCursor != null;
+  }
+
+  List<PersonaChatMessageModel> _mergeMessages(
+    List<PersonaChatMessageModel> current,
+    List<PersonaChatMessageModel> incoming,
+  ) {
+    final byId = <int, PersonaChatMessageModel>{
+      for (final message in current) message.id: message,
+      for (final message in incoming) message.id: message,
+    };
+    return byId.values.toList(growable: false)
+      ..sort((a, b) => b.id.compareTo(a.id));
   }
 
   void _onPersonaChatMessageAdded(EventBusMessage message) {

--- a/test/data/services/character_conversation_handler_test.dart
+++ b/test/data/services/character_conversation_handler_test.dart
@@ -138,7 +138,7 @@ void main() {
     ]);
     expect(
       characterRows.map((message) => message.contactEpisodeId).toSet(),
-      {'character_conversation:reply-1'},
+      {'character_conversation:3-5'},
     );
     expect(await chatService.getReplyCursor('yaoyao'), 5);
     expect(await chatService.getUnreadCount('yaoyao'), 2);

--- a/test/data/services/character_conversation_handler_test.dart
+++ b/test/data/services/character_conversation_handler_test.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/character_execution_coordinator.dart';
@@ -9,6 +8,7 @@ import 'package:memex/data/services/character_workspace_service.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/data/services/persona_chat_conversation_storage.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/data/services/task_handlers/character_conversation_handler.dart';
 import 'package:memex/db/app_database.dart';
@@ -22,9 +22,14 @@ void main() {
   test('one conversation decision writes several character bubbles', () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     final executor = LocalTaskExecutor.forTesting(db: db);
-    final chatService = PersonaChatService.forTesting(db);
     final tempRoot =
         await Directory.systemTemp.createTemp('conversation_handler_');
+    final chatService = PersonaChatService.forTesting(
+      storage: PersonaChatConversationStorage(
+        fileSystem: FileSystemService.detached(dataRoot: tempRoot.path),
+      ),
+      userId: 'user-1',
+    );
     final eventBus = EventBusService.instance;
     await eventBus.connect();
     final eventReceived = Completer<PersonaChatMessageAddedMessage>();
@@ -117,12 +122,12 @@ void main() {
       TaskContext(taskId: 'reply-1', taskType: 'character_conversation_task'),
     );
 
-    final characterRows = await (db.select(db.personaChatMessages)
-          ..where((message) =>
-              message.isFromCharacter.equals(true) &
-              message.origin.equals(PersonaChatMessageOrigin.conversation))
-          ..orderBy([(message) => OrderingTerm.asc(message.id)]))
-        .get();
+    final characterRows = (await chatService.getMessages('yaoyao'))
+        .where((message) =>
+            message.isFromCharacter &&
+            message.origin == PersonaChatMessageOrigin.conversation)
+        .toList()
+        .reversed;
     expect(characterRows.map((message) => message.content), [
       '醒啦。',
       '🙂🙂',

--- a/test/data/services/character_conversation_service_test.dart
+++ b/test/data/services/character_conversation_service_test.dart
@@ -65,7 +65,7 @@ void main() {
     );
   });
 
-  test('initiative recovery creates a missing reply task immediately',
+  test('startup reconciliation rebuilds only missing workspace replies',
       () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     final executor = LocalTaskExecutor.forTesting(db: db);
@@ -84,10 +84,13 @@ void main() {
     });
 
     await chatService.addUserMessage('yaoyao', '这条消息的任务丢了');
-    await service.ensurePendingReplyScheduled(
-      userId: 'user-1',
-      characterId: 'yaoyao',
+    final handled = await chatService.addUserMessage('auntie', '已经处理的消息');
+    await chatService.advanceReplyCursor(
+      characterId: 'auntie',
+      consumedThroughMessageId: handled,
     );
+    await service.reconcilePendingReplies(userId: 'user-1');
+    await service.reconcilePendingReplies(userId: 'user-1');
 
     final task = (await db.select(db.tasks).get()).single;
     expect(task.bizId, 'character_conversation:yaoyao');

--- a/test/data/services/character_conversation_service_test.dart
+++ b/test/data/services/character_conversation_service_test.dart
@@ -4,14 +4,15 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/character_conversation_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
-import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/db/app_database.dart';
+import '../../helpers/persona_chat_test_harness.dart';
 
 void main() {
   test('consecutive user bubbles share one rescheduled reply task', () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     final executor = LocalTaskExecutor.forTesting(db: db);
-    final chatService = PersonaChatService.forTesting(db);
+    final chatHarness = await PersonaChatTestHarness.create(userId: 'user-1');
+    final chatService = chatHarness.service;
     final now = DateTime.parse('2026-07-15T09:00:00+08:00');
     final service = CharacterConversationService.forTesting(
       chatService: chatService,
@@ -21,6 +22,7 @@ void main() {
     addTearDown(() async {
       await executor.stop();
       await db.close();
+      await chatHarness.dispose();
     });
 
     await service.sendUserMessage(
@@ -67,7 +69,8 @@ void main() {
       () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     final executor = LocalTaskExecutor.forTesting(db: db);
-    final chatService = PersonaChatService.forTesting(db);
+    final chatHarness = await PersonaChatTestHarness.create(userId: 'user-1');
+    final chatService = chatHarness.service;
     final now = DateTime.parse('2026-07-15T09:00:00+08:00');
     final service = CharacterConversationService.forTesting(
       chatService: chatService,
@@ -77,6 +80,7 @@ void main() {
     addTearDown(() async {
       await executor.stop();
       await db.close();
+      await chatHarness.dispose();
     });
 
     await chatService.addUserMessage('yaoyao', '这条消息的任务丢了');

--- a/test/data/services/character_initiative_flow_test.dart
+++ b/test/data/services/character_initiative_flow_test.dart
@@ -117,7 +117,7 @@ void main() {
       ),
     );
 
-    // Persistent task retries use the same episode id and must be idempotent.
+    // Persistent task retries use the same source turn and must be idempotent.
     await handler.call(
       'user-1',
       {
@@ -144,7 +144,7 @@ void main() {
       messages.every(
         (message) =>
             message.origin == PersonaChatMessageOrigin.initiative &&
-            message.contactEpisodeId == 'character_initiative:task-flow-1',
+            message.contactEpisodeId == 'character_initiative:event-flow-1',
       ),
       isTrue,
     );

--- a/test/data/services/character_initiative_flow_test.dart
+++ b/test/data/services/character_initiative_flow_test.dart
@@ -7,6 +7,7 @@ import 'package:memex/data/services/character_workspace_service.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/data/services/persona_chat_conversation_storage.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/data/services/task_handlers/character_initiative_handler.dart';
 import 'package:memex/db/app_database.dart';
@@ -21,7 +22,12 @@ void main() {
     final tempRoot =
         await Directory.systemTemp.createTemp('initiative_flow_workspace_');
     final db = AppDatabase.forTesting(NativeDatabase.memory());
-    final chatService = PersonaChatService.forTesting(db);
+    final chatService = PersonaChatService.forTesting(
+      storage: PersonaChatConversationStorage(
+        fileSystem: FileSystemService.detached(dataRoot: tempRoot.path),
+      ),
+      userId: 'user-1',
+    );
     final eventBus = EventBusService.instance;
     await eventBus.connect();
     final eventReceived = Completer<PersonaChatMessageAddedMessage>();

--- a/test/data/services/character_initiative_handler_test.dart
+++ b/test/data/services/character_initiative_handler_test.dart
@@ -34,8 +34,7 @@ void main() {
     }
   });
 
-  test('persists one unread contact episode selected by the character',
-      () async {
+  test('persists one unread message turn selected by the character', () async {
     List<CharacterOutgoingMessage>? sentMessages;
     String? sentFactId;
     String? sentEpisodeId;
@@ -81,6 +80,7 @@ void main() {
         required messages,
         required timestamp,
         required contactEpisodeId,
+        required expectedGeneration,
         factId,
       }) async {
         expect(characterId, 'yaoyao');
@@ -114,7 +114,7 @@ void main() {
       ['你刚才那句，', '我过了一会儿还是觉得有点可爱。'],
     );
     expect(sentFactId, '2026/07/13.md#ts_1');
-    expect(sentEpisodeId, 'character_initiative:task-1');
+    expect(sentEpisodeId, 'character_initiative:event-1');
     expect(scheduledWakeAt, now.add(const Duration(hours: 6)));
     expect(scheduledWakeReason, '晚上再想想她今天过得怎么样。');
   });
@@ -163,6 +163,7 @@ void main() {
         required messages,
         required timestamp,
         required contactEpisodeId,
+        required expectedGeneration,
         factId,
       }) async {
         sent = true;
@@ -254,6 +255,7 @@ void main() {
         required messages,
         required timestamp,
         required contactEpisodeId,
+        required expectedGeneration,
         factId,
       }) async {
         sent = true;
@@ -326,6 +328,7 @@ void main() {
         required messages,
         required timestamp,
         required contactEpisodeId,
+        required expectedGeneration,
         factId,
       }) async =>
           true,
@@ -404,6 +407,7 @@ void main() {
         required messages,
         required timestamp,
         required contactEpisodeId,
+        required expectedGeneration,
         factId,
       }) async =>
           true,
@@ -486,6 +490,7 @@ void main() {
         required messages,
         required timestamp,
         required contactEpisodeId,
+        required expectedGeneration,
         factId,
       }) async {
         sent = true;
@@ -580,6 +585,7 @@ void main() {
         required messages,
         required timestamp,
         required contactEpisodeId,
+        required expectedGeneration,
         factId,
       }) async {
         sent = true;

--- a/test/data/services/character_workspace_service_test.dart
+++ b/test/data/services/character_workspace_service_test.dart
@@ -42,6 +42,7 @@ void main() {
       expect(await Directory(p.join(root, 'PKM')).exists(), isTrue);
       expect(await Directory(p.join(root, 'Journal')).exists(), isTrue);
       expect(await Directory(p.join(root, 'World')).exists(), isTrue);
+      expect(await Directory(p.join(root, 'Conversation')).exists(), isTrue);
 
       final identity = await File(
         fileSystem.getCharacterIdentityPath('wujia', 'yaoyao'),
@@ -206,7 +207,7 @@ void main() {
               'keys': ['家里'],
               'content': '家里有一个正在长大的小朋友。',
               'enabled': true,
-        })}\n',
+            })}\n',
       );
       await legacyRelationship.parent.create(recursive: true);
       await legacyRelationship.writeAsString(

--- a/test/data/services/chat_session_storage_test.dart
+++ b/test/data/services/chat_session_storage_test.dart
@@ -221,6 +221,40 @@ void main() {
       expect(jsonDecode(lines.single)['role'], 'user');
     });
 
+    test('recovers valid messages from an incomplete UTF-8 tail', () async {
+      const sessionId = 'memex_agent_truncated_tail';
+      final storage = ChatSessionStorage.instance;
+      await storage.createSession(
+        userId: userId,
+        sessionId: sessionId,
+        metadata: {
+          'session_id': sessionId,
+          'agent_name': 'memex_agent',
+          'title': 'Tail recovery',
+        },
+      );
+      await storage.appendMessage(
+        userId: userId,
+        sessionId: sessionId,
+        message: {
+          'role': 'user',
+          'content': [
+            {'type': 'text', 'text': '保留这句'},
+          ],
+          'timestamp': '2026-06-22T12:01:00.000',
+        },
+      );
+      final file = File(storage.messagesPath(userId, sessionId));
+      await file.writeAsBytes(
+        [...await file.readAsBytes(), 0xF0, 0x9F],
+        flush: true,
+      );
+
+      final messages = await storage.loadMessages(userId, sessionId);
+      expect(_messageText(messages.single), '保留这句');
+      expect(await storage.loadMessages(userId, sessionId), hasLength(1));
+    });
+
     test('loads paged messages from newest backwards', () async {
       const sessionId = 'memex_agent_paged_storage';
       final storage = ChatSessionStorage.instance;

--- a/test/data/services/chat_session_storage_test.dart
+++ b/test/data/services/chat_session_storage_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -5,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/model/chat_artifact.dart';
 import 'package:memex/data/services/chat_session_storage.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/jsonl_file_store.dart';
 import 'package:memex/data/services/local_asset_server.dart';
 import 'package:memex/data/services/migration_state_service.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -255,6 +257,53 @@ void main() {
       expect(await storage.loadMessages(userId, sessionId), hasLength(1));
     });
 
+    test('does not repair a tail while the same session is still appending',
+        () async {
+      const sessionId = 'memex_agent_concurrent_tail';
+      final jsonl = _BlockingJsonlFileStore();
+      final storage = ChatSessionStorage.forTesting(
+        fileService: FileSystemService.instance,
+        jsonl: jsonl,
+      );
+      await storage.createSession(
+        userId: userId,
+        sessionId: sessionId,
+        metadata: {
+          'session_id': sessionId,
+          'agent_name': 'memex_agent',
+          'title': 'Concurrent tail',
+        },
+      );
+
+      jsonl.blockNextAppend();
+      final append = storage.appendMessage(
+        userId: userId,
+        sessionId: sessionId,
+        message: {
+          'role': 'ai',
+          'content': [
+            {'type': 'text', 'text': '完整回复'},
+          ],
+          'timestamp': '2026-06-22T12:01:00.000',
+        },
+      );
+      await jsonl.partialWritten;
+
+      var readCompleted = false;
+      final read = storage.loadMessages(userId, sessionId).then((messages) {
+        readCompleted = true;
+        return messages;
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(readCompleted, isFalse);
+
+      jsonl.finishAppend();
+      await append;
+      final messages = await read;
+      expect(messages, hasLength(1));
+      expect(_messageText(messages.single), '完整回复');
+    });
+
     test('loads paged messages from newest backwards', () async {
       const sessionId = 'memex_agent_paged_storage';
       final storage = ChatSessionStorage.instance;
@@ -392,6 +441,58 @@ void main() {
       expect(older.hasMoreMessages, isFalse);
     });
   });
+}
+
+class _BlockingJsonlFileStore extends JsonlFileStore {
+  _BlockingJsonlFileStore() : super(loggerName: 'BlockingChatSessionJsonl');
+
+  Completer<void>? _partialWritten;
+  Completer<void>? _finish;
+  bool _blockNext = false;
+
+  Future<void> get partialWritten => _partialWritten!.future;
+
+  void blockNextAppend() {
+    _partialWritten = Completer<void>();
+    _finish = Completer<void>();
+    _blockNext = true;
+  }
+
+  void finishAppend() => _finish!.complete();
+
+  @override
+  Future<JsonlAppendResult> append(
+    File file,
+    List<Map<String, dynamic>> objects,
+  ) async {
+    final partialWritten = _partialWritten;
+    final finish = _finish;
+    if (!_blockNext || partialWritten == null || finish == null) {
+      return super.append(file, objects);
+    }
+    _blockNext = false;
+
+    await file.parent.create(recursive: true);
+    final startOffset = await file.exists() ? await file.length() : 0;
+    final bytes = utf8.encode('${objects.map(jsonEncode).join('\n')}\n');
+    final split = bytes.length - 3;
+    await file.writeAsBytes(
+      bytes.sublist(0, split),
+      mode: FileMode.append,
+      flush: true,
+    );
+    partialWritten.complete();
+    await finish.future;
+    await file.writeAsBytes(
+      bytes.sublist(split),
+      mode: FileMode.append,
+      flush: true,
+    );
+    return JsonlAppendResult(
+      startOffset: startOffset,
+      endOffset: startOffset + bytes.length,
+    );
+  }
 }
 
 String _messageText(Map<String, dynamic> message) {

--- a/test/data/services/persona_chat_conversation_storage_test.dart
+++ b/test/data/services/persona_chat_conversation_storage_test.dart
@@ -28,127 +28,271 @@ void main() {
       if (await tempRoot.exists()) await tempRoot.delete(recursive: true);
     });
 
-    test('appends one atomic JSONL envelope per episode and paginates bubbles',
-        () async {
+    test('stores only messages and commits a multi-bubble turn once', () async {
       await _appendUser(storage, content: '你醒了吗');
-      final episode = await storage.appendEpisode(
+      final cursorAfterUser = (await storage.loadMetadata(
         userId: _userId,
         characterId: _characterId,
-        contactEpisodeId: 'character_conversation:task-1',
-        expectedRecordCount: 2,
-        consumedThroughSeq: 1,
-        records: (nextSeq) => [
-          _record(nextSeq, '醒了。', id: 'bubble-1'),
-          _record(nextSeq + 1, '怎么了？', id: 'bubble-2'),
-        ],
-      );
-      final retry = await storage.appendEpisode(
-        userId: _userId,
-        characterId: _characterId,
-        contactEpisodeId: 'character_conversation:task-1',
-        expectedRecordCount: 2,
-        consumedThroughSeq: 1,
-        records: (_) => throw StateError('retry must not append'),
-      );
+      ))
+          .messagesByteLength;
 
-      expect(episode.map((record) => record.seq), [2, 3]);
-      expect(retry.map((record) => record.id), ['bubble-1', 'bubble-2']);
-      final lines = await _messagesFile(fileSystem).readAsLines();
-      expect(lines, hasLength(2));
-      expect(jsonDecode(lines.last)['record_type'], 'episode');
-      final receiptDirectory = Directory(
-        fileSystem.getCharacterConversationEpisodeReceiptsPath(
-          _userId,
-          _characterId,
-        ),
-      );
-      final receiptFile = await receiptDirectory
-          .list()
-          .where((entity) => entity is File)
-          .cast<File>()
-          .single;
-      final receipt = jsonDecode(await receiptFile.readAsString());
-      expect(receipt['status'], 'complete');
-      expect(receipt['line_offset'], isNonNegative);
-      expect(receipt, isNot(contains('records')));
-
-      final newest = await storage.loadMessages(
-        userId: _userId,
-        characterId: _characterId,
-        limit: 2,
-      );
-      expect(newest.map((record) => record.content), ['怎么了？', '醒了。']);
-      final older = await storage.loadMessages(
-        userId: _userId,
-        characterId: _characterId,
-        limit: 2,
-        offset: 2,
-      );
-      expect(older.single.content, '你醒了吗');
-
-      await File(
-        fileSystem.getCharacterConversationMetadataPath(
-          _userId,
-          _characterId,
-        ),
-      ).writeAsString('{}\n', flush: true);
-      expect(
-        (await storage.loadMetadata(
+      Future<List<PersonaChatConversationRecord>> commit() {
+        return storage.appendTurn(
           userId: _userId,
           characterId: _characterId,
-        ))
-            .consumedThroughSeq,
-        1,
-      );
-    });
+          turnId: 'character_conversation:1-1',
+          expectedRecordCount: 2,
+          agentProcessedThroughUserMessageId: 1,
+          records: (firstMessageId) => [
+            _record(firstMessageId, '醒了。'),
+            _record(firstMessageId + 1, '怎么了？'),
+          ],
+        );
+      }
 
-    test('recovers a pending episode receipt from the authoritative log',
-        () async {
-      await storage.appendEpisode(
+      expect((await commit()).map((record) => record.id), [2, 3]);
+      expect((await commit()).map((record) => record.id), [2, 3]);
+
+      final lines = await _messagesFile(fileSystem).readAsLines();
+      expect(lines, hasLength(3));
+      for (final line in lines) {
+        final message = jsonDecode(line) as Map<String, dynamic>;
+        expect(message['id'], isA<int>());
+        expect(message['role'], isIn(['user', 'assistant']));
+        expect(message['content'], isA<List>());
+        expect(message, isNot(contains('seq')));
+        expect(message, isNot(contains('record_type')));
+        expect(message, isNot(contains('operation_id')));
+      }
+
+      final metadata = await storage.loadMetadata(
         userId: _userId,
         characterId: _characterId,
-        contactEpisodeId: 'character_conversation:task-1',
-        expectedRecordCount: 2,
-        records: (nextSeq) => [
-          _record(nextSeq, '第一句', id: 'bubble-1'),
-          _record(nextSeq + 1, '第二句', id: 'bubble-2'),
-        ],
       );
-      final receiptDirectory = Directory(
-        fileSystem.getCharacterConversationEpisodeReceiptsPath(
+      expect(metadata.nextMessageId, 4);
+      expect(metadata.agentProcessedThroughUserMessageId, 1);
+      expect(metadata.lastTurnId, 'character_conversation:1-1');
+      expect(
+        File(fileSystem.getCharacterConversationPendingCommitPath(
           _userId,
           _characterId,
-        ),
-      );
-      final receiptFile = await receiptDirectory
-          .list()
-          .where((entity) => entity is File)
-          .cast<File>()
-          .single;
-      await receiptFile.writeAsString(
-        '${jsonEncode({
-              'episode_id': 'character_conversation:task-1',
-              'status': 'pending',
-            })}\n',
-        flush: true,
+        )).existsSync(),
+        isFalse,
       );
 
-      final recovered = await storage.appendEpisode(
+      final newest = await storage.loadMessagePage(
         userId: _userId,
         characterId: _characterId,
-        contactEpisodeId: 'character_conversation:task-1',
-        expectedRecordCount: 2,
-        records: (_) => throw StateError('recovery must not append'),
+        limit: 2,
       );
+      expect(newest.records.map((record) => record.content), ['怎么了？', '醒了。']);
+      expect(newest.olderCursor, isNotNull);
+      final older = await storage.loadMessagePage(
+        userId: _userId,
+        characterId: _characterId,
+        limit: 2,
+        beforeCursor: newest.olderCursor,
+      );
+      expect(older.records.single.content, '你醒了吗');
 
-      expect(recovered.map((record) => record.id), ['bubble-1', 'bubble-2']);
-      expect(await _messagesFile(fileSystem).readAsLines(), hasLength(1));
-      final repairedReceipt = jsonDecode(await receiptFile.readAsString());
-      expect(repairedReceipt['status'], 'complete');
-      expect(repairedReceipt, isNot(contains('records')));
+      final appended = await storage.loadMessagesAfter(
+        userId: _userId,
+        characterId: _characterId,
+        afterCursor: cursorAfterUser,
+      );
+      expect(appended.records.map((record) => record.content), ['怎么了？', '醒了。']);
     });
 
-    test('serializes writers from separate storage instances', () async {
+    test('finds an older committed turn without a receipt or duplicate',
+        () async {
+      await _appendUser(storage, content: '第一句');
+      await storage.appendTurn(
+        userId: _userId,
+        characterId: _characterId,
+        turnId: 'character_conversation:1-1',
+        expectedRecordCount: 1,
+        agentProcessedThroughUserMessageId: 1,
+        records: (firstMessageId) => [_record(firstMessageId, '旧回复')],
+      );
+      await storage.tryAppendInitiativeTurn(
+        userId: _userId,
+        characterId: _characterId,
+        turnId: 'character_initiative:newer-source',
+        expectedRecordCount: 1,
+        records: (firstMessageId) => [
+          _record(
+            firstMessageId,
+            '后来的主动消息',
+            turnId: 'character_initiative:newer-source',
+          ),
+        ],
+      );
+
+      final retry = await storage.appendTurn(
+        userId: _userId,
+        characterId: _characterId,
+        turnId: 'character_conversation:1-1',
+        expectedRecordCount: 1,
+        agentProcessedThroughUserMessageId: 1,
+        records: (_) => throw StateError('retry must not regenerate'),
+      );
+
+      expect(retry.single.content, '旧回复');
+      expect(await _messagesFile(fileSystem).readAsLines(), hasLength(3));
+      await _appendUser(storage, content: '更新最后一个 turn 缓存');
+      await storage.appendTurn(
+        userId: _userId,
+        characterId: _characterId,
+        turnId: 'character_conversation:4-4',
+        expectedRecordCount: 1,
+        agentProcessedThroughUserMessageId: 4,
+        records: (firstMessageId) => [
+          _record(
+            firstMessageId,
+            '新回复',
+            turnId: 'character_conversation:4-4',
+          ),
+        ],
+      );
+      expect(
+        await storage.tryAppendInitiativeTurn(
+          userId: _userId,
+          characterId: _characterId,
+          turnId: 'character_initiative:newer-source',
+          expectedRecordCount: 1,
+          records: (_) => throw StateError('retry must not regenerate'),
+        ),
+        isTrue,
+      );
+      expect(await _messagesFile(fileSystem).readAsLines(), hasLength(5));
+      expect(
+        Directory(fileSystem.getCharacterConversationPath(
+          _userId,
+          _characterId,
+        )).listSync().whereType<File>().map((file) => file.path),
+        everyElement(isNot(contains('_episodes'))),
+      );
+    });
+
+    for (final phase in PersonaChatCommitPhase.values) {
+      test('recovers an interrupted turn after ${phase.name}', () async {
+        await _appendUser(storage, content: '第一句');
+        var failed = false;
+        final interrupted = PersonaChatConversationStorage(
+          fileSystem: fileSystem,
+          commitObserver: (current) async {
+            if (!failed && current == phase) {
+              failed = true;
+              throw StateError('simulated crash after ${phase.name}');
+            }
+          },
+        );
+
+        expect(
+          () => interrupted.appendTurn(
+            userId: _userId,
+            characterId: _characterId,
+            turnId: 'character_conversation:1-1',
+            expectedRecordCount: 2,
+            agentProcessedThroughUserMessageId: 1,
+            records: (firstMessageId) => [
+              _record(firstMessageId, '第二句'),
+              _record(firstMessageId + 1, '第三句'),
+            ],
+          ),
+          throwsStateError,
+        );
+
+        final recovered = PersonaChatConversationStorage(
+          fileSystem: fileSystem,
+        );
+        final messages = await recovered.loadMessages(
+          userId: _userId,
+          characterId: _characterId,
+        );
+        expect(
+          messages.reversed.map((record) => record.content),
+          ['第一句', '第二句', '第三句'],
+        );
+        expect(
+          await recovered.getReplyCursor(
+            userId: _userId,
+            characterId: _characterId,
+          ),
+          1,
+        );
+        expect(
+          File(fileSystem.getCharacterConversationPendingCommitPath(
+            _userId,
+            _characterId,
+          )).existsSync(),
+          isFalse,
+        );
+
+        final retry = await recovered.appendTurn(
+          userId: _userId,
+          characterId: _characterId,
+          turnId: 'character_conversation:1-1',
+          expectedRecordCount: 2,
+          agentProcessedThroughUserMessageId: 1,
+          records: (_) => throw StateError('retry must not regenerate'),
+        );
+        expect(retry.map((record) => record.id), [2, 3]);
+      });
+    }
+
+    test('replays a partially appended batch from its write-ahead file',
+        () async {
+      await _appendUser(storage, content: '第一句');
+      var interrupted = false;
+      final crashing = PersonaChatConversationStorage(
+        fileSystem: fileSystem,
+        commitObserver: (phase) async {
+          if (interrupted || phase != PersonaChatCommitPhase.pendingWritten) {
+            return;
+          }
+          interrupted = true;
+          final pending = File(
+            fileSystem.getCharacterConversationPendingCommitPath(
+              _userId,
+              _characterId,
+            ),
+          );
+          final payload = jsonDecode(await pending.readAsString()) as Map;
+          final firstRow = (payload['messages'] as List).first;
+          await _messagesFile(fileSystem).writeAsString(
+            '${jsonEncode(firstRow)}\n',
+            mode: FileMode.append,
+            flush: true,
+          );
+          throw StateError('simulated partial append');
+        },
+      );
+
+      await expectLater(
+        crashing.appendTurn(
+          userId: _userId,
+          characterId: _characterId,
+          turnId: 'character_conversation:1-1',
+          expectedRecordCount: 2,
+          agentProcessedThroughUserMessageId: 1,
+          records: (firstMessageId) => [
+            _record(firstMessageId, '第二句'),
+            _record(firstMessageId + 1, '第三句'),
+          ],
+        ),
+        throwsStateError,
+      );
+
+      final messages = await storage.loadMessages(
+        userId: _userId,
+        characterId: _characterId,
+      );
+      expect(messages.map((record) => record.id).toSet(), {1, 2, 3});
+      expect(await _messagesFile(fileSystem).readAsLines(), hasLength(3));
+    });
+
+    test('serializes writers and allocates one ordered message id', () async {
       final other = PersonaChatConversationStorage(fileSystem: fileSystem);
       await Future.wait([
         for (var index = 0; index < 12; index++)
@@ -171,23 +315,29 @@ void main() {
         limit: 20,
       );
       expect(messages, hasLength(12));
-      expect(messages.map((record) => record.seq).toSet(), hasLength(12));
+      expect(messages.map((record) => record.id).toSet(), {
+        for (var id = 1; id <= 12; id++) id,
+      });
       expect(
-          (await storage.loadMetadata(
-            userId: _userId,
-            characterId: _characterId,
-          ))
-              .nextSeq,
-          13);
+        (await storage.loadMetadata(
+          userId: _userId,
+          characterId: _characterId,
+        ))
+            .nextMessageId,
+        13,
+      );
     });
 
-    test('repairs metadata after a crash between JSONL append and metadata',
-        () async {
+    test('repairs derived metadata after an unindexed single append', () async {
       await _appendUser(storage, content: '第一句');
+      await storage.advanceCursor(
+        userId: _userId,
+        characterId: _characterId,
+        processedThroughUserMessageId: 1,
+      );
       final file = _messagesFile(fileSystem);
       final second = PersonaChatConversationRecord(
-        id: 'crash-gap',
-        seq: 2,
+        id: 2,
         characterId: _characterId,
         isFromCharacter: true,
         content: '写入后崩溃',
@@ -202,18 +352,14 @@ void main() {
         flush: true,
       );
 
-      final messages = await storage.loadMessages(
-        userId: _userId,
-        characterId: _characterId,
-      );
       final metadata = await storage.loadMetadata(
         userId: _userId,
         characterId: _characterId,
       );
-      expect(messages.map((record) => record.content), ['写入后崩溃', '第一句']);
-      expect(metadata.nextSeq, 3);
+      expect(metadata.nextMessageId, 3);
       expect(metadata.messageCount, 2);
       expect(metadata.unreadCount, 1);
+      expect(metadata.agentProcessedThroughUserMessageId, 1);
       expect(metadata.messagesByteLength, await file.length());
     });
 
@@ -238,7 +384,7 @@ void main() {
       expect(second.single.content, '保留中文');
     });
 
-    test('read and reply boundaries rebuild from the authoritative log',
+    test('keeps read and agent-processing boundaries outside messages',
         () async {
       await _appendUser(storage, content: '用户消息');
       await storage.appendMessage(
@@ -256,7 +402,7 @@ void main() {
       await storage.advanceCursor(
         userId: _userId,
         characterId: _characterId,
-        consumedThroughSeq: 1,
+        processedThroughUserMessageId: 1,
       );
       expect(
         await storage.markAllRead(
@@ -265,23 +411,15 @@ void main() {
         ),
         1,
       );
-      final after = await file.readAsBytes();
-      expect(after.sublist(0, before.length), before);
+      expect(await file.readAsBytes(), before);
 
-      final metadataFile = File(
-        fileSystem.getCharacterConversationMetadataPath(
-          _userId,
-          _characterId,
-        ),
-      );
-      await metadataFile.writeAsString('{}\n', flush: true);
-      final repaired = await storage.loadMetadata(
+      final metadata = await storage.loadMetadata(
         userId: _userId,
         characterId: _characterId,
       );
-      expect(repaired.consumedThroughSeq, 1);
-      expect(repaired.readThroughSeq, 2);
-      expect(repaired.unreadCount, 0);
+      expect(metadata.agentProcessedThroughUserMessageId, 1);
+      expect(metadata.readThroughMessageId, 2);
+      expect(metadata.unreadCount, 0);
       expect(
         (await storage.loadMessages(
           userId: _userId,
@@ -290,6 +428,169 @@ void main() {
             .first
             .isRead,
         isTrue,
+      );
+    });
+
+    test('clear changes generation and never reuses a message id', () async {
+      await _appendUser(storage, content: '旧消息');
+      final before = await storage.loadMetadata(
+        userId: _userId,
+        characterId: _characterId,
+      );
+      expect(
+        await storage.clearConversation(
+          userId: _userId,
+          characterId: _characterId,
+          clearedAt: DateTime.parse('2026-07-15T10:00:00+08:00'),
+        ),
+        1,
+      );
+      await expectLater(
+        storage.appendTurn(
+          userId: _userId,
+          characterId: _characterId,
+          turnId: 'character_conversation:1-1',
+          expectedRecordCount: 1,
+          agentProcessedThroughUserMessageId: 1,
+          expectedGeneration: before.generation,
+          records: (firstMessageId) => [
+            _record(firstMessageId, '不应出现的旧回复'),
+          ],
+        ),
+        throwsStateError,
+      );
+      expect(
+        await storage.tryAppendInitiativeTurn(
+          userId: _userId,
+          characterId: _characterId,
+          turnId: 'character_initiative:old-source',
+          expectedRecordCount: 1,
+          expectedGeneration: before.generation,
+          records: (firstMessageId) => [
+            _record(
+              firstMessageId,
+              '不应出现的旧主动消息',
+              turnId: 'character_initiative:old-source',
+            ),
+          ],
+        ),
+        isFalse,
+      );
+      final next = await storage.appendMessage(
+        userId: _userId,
+        characterId: _characterId,
+        isFromCharacter: false,
+        content: '新消息',
+        timestamp: DateTime.parse('2026-07-15T10:00:01+08:00'),
+        messageType: PersonaChatMessageTypes.text,
+        origin: PersonaChatMessageOrigin.conversation,
+      );
+      final after = await storage.loadMetadata(
+        userId: _userId,
+        characterId: _characterId,
+      );
+      expect(next.id, 2);
+      expect(after.generation, before.generation + 1);
+    });
+
+    for (final phase in PersonaChatCommitPhase.values) {
+      test('recovers an interrupted clear after ${phase.name}', () async {
+        await _appendUser(storage, content: '即将清空');
+        final before = await storage.loadMetadata(
+          userId: _userId,
+          characterId: _characterId,
+        );
+        var failed = false;
+        final interrupted = PersonaChatConversationStorage(
+          fileSystem: fileSystem,
+          commitObserver: (current) async {
+            if (!failed && current == phase) {
+              failed = true;
+              throw StateError('simulated clear crash after ${phase.name}');
+            }
+          },
+        );
+
+        await expectLater(
+          interrupted.clearConversation(
+            userId: _userId,
+            characterId: _characterId,
+            clearedAt: DateTime.parse('2026-07-15T10:00:00+08:00'),
+          ),
+          throwsStateError,
+        );
+
+        final recovered = PersonaChatConversationStorage(
+          fileSystem: fileSystem,
+        );
+        expect(
+          await recovered.loadMessages(
+            userId: _userId,
+            characterId: _characterId,
+          ),
+          isEmpty,
+        );
+        final metadata = await recovered.loadMetadata(
+          userId: _userId,
+          characterId: _characterId,
+        );
+        expect(metadata.generation, before.generation + 1);
+        expect(metadata.nextMessageId, before.nextMessageId);
+      });
+    }
+
+    test('recovers an interrupted legacy snapshot import', () async {
+      var failed = false;
+      final interrupted = PersonaChatConversationStorage(
+        fileSystem: fileSystem,
+        commitObserver: (phase) async {
+          if (!failed && phase == PersonaChatCommitPhase.messagesAppended) {
+            failed = true;
+            throw StateError('simulated import crash');
+          }
+        },
+      );
+      final records = [
+        PersonaChatConversationRecord(
+          id: 1,
+          characterId: _characterId,
+          isFromCharacter: false,
+          content: '旧用户消息',
+          isRead: true,
+          timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+          messageType: PersonaChatMessageTypes.text,
+          origin: PersonaChatMessageOrigin.conversation,
+        ),
+        _record(2, '旧角色回复'),
+      ];
+
+      await expectLater(
+        interrupted.importLegacySnapshot(
+          userId: _userId,
+          characterId: _characterId,
+          records: records,
+          agentProcessedThroughUserMessageId: 1,
+        ),
+        throwsStateError,
+      );
+
+      final recovered = PersonaChatConversationStorage(
+        fileSystem: fileSystem,
+      );
+      expect(
+        (await recovered.loadMessages(
+          userId: _userId,
+          characterId: _characterId,
+        ))
+            .map((record) => record.content),
+        ['旧角色回复', '旧用户消息'],
+      );
+      expect(
+        await recovered.getReplyCursor(
+          userId: _userId,
+          characterId: _characterId,
+        ),
+        1,
       );
     });
 
@@ -303,13 +604,12 @@ void main() {
 }
 
 PersonaChatConversationRecord _record(
-  int seq,
+  int id,
   String content, {
-  required String id,
+  String turnId = 'character_conversation:1-1',
 }) {
   return PersonaChatConversationRecord(
     id: id,
-    seq: seq,
     characterId: _characterId,
     isFromCharacter: true,
     content: content,
@@ -317,7 +617,7 @@ PersonaChatConversationRecord _record(
     timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
     messageType: PersonaChatMessageTypes.text,
     origin: PersonaChatMessageOrigin.conversation,
-    contactEpisodeId: 'character_conversation:task-1',
+    turnId: turnId,
   );
 }
 

--- a/test/data/services/persona_chat_conversation_storage_test.dart
+++ b/test/data/services/persona_chat_conversation_storage_test.dart
@@ -46,6 +46,7 @@ void main() {
         userId: 'wujia',
         characterId: 'yaoyao',
         contactEpisodeId: 'character_conversation:task-1',
+        expectedRecordCount: 2,
         records: (nextSeq) => [
           PersonaChatConversationRecord(
             id: 'bubble-1',
@@ -77,6 +78,7 @@ void main() {
         userId: 'wujia',
         characterId: 'yaoyao',
         contactEpisodeId: 'character_conversation:task-1',
+        expectedRecordCount: 2,
         records: (_) => throw StateError('retry must not write again'),
       );
 
@@ -121,6 +123,54 @@ void main() {
       );
       expect(records.map((record) => record.id), ['keep-me']);
       expect(await file.readAsString(), isNot(contains('partial')));
+
+      final reloaded = await storage.loadMessages(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+      );
+      expect(reloaded.map((record) => record.id), ['keep-me']);
+      expect(reloaded.single.content, '第一句');
+    });
+
+    test('rejects character ids that escape the character workspace', () {
+      expect(
+        () => fileSystem.getCharacterConversationPath('wujia', '../outside'),
+        throwsArgumentError,
+      );
+    });
+
+    test('truncates a tail ending inside a UTF-8 code point', () async {
+      await storage.appendMessage(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+        isFromCharacter: false,
+        content: '保留中文',
+        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+        messageType: PersonaChatMessageTypes.text,
+        origin: PersonaChatMessageOrigin.conversation,
+        isRead: true,
+        stableId: 'utf8-keep',
+      );
+      final file = File(
+        fileSystem.getCharacterConversationMessagesPath('wujia', 'yaoyao'),
+      );
+      await file.writeAsBytes(
+        [...await file.readAsBytes(), 0xF0, 0x9F],
+        flush: true,
+      );
+
+      final records = await storage.loadMessages(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+      );
+      expect(records.map((record) => record.id), ['utf8-keep']);
+      expect(
+        await storage.loadMessages(
+          userId: 'wujia',
+          characterId: 'yaoyao',
+        ),
+        hasLength(1),
+      );
     });
 
     test('clearing a conversation survives a later projection rebuild',

--- a/test/data/services/persona_chat_conversation_storage_test.dart
+++ b/test/data/services/persona_chat_conversation_storage_test.dart
@@ -1,0 +1,161 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/persona_chat_conversation_storage.dart';
+import 'package:memex/data/services/persona_chat_service.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/character_message.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PersonaChatConversationStorage', () {
+    late Directory tempRoot;
+    late FileSystemService fileSystem;
+    late PersonaChatConversationStorage storage;
+
+    setUp(() async {
+      tempRoot = await Directory.systemTemp.createTemp(
+        'memex_persona_chat_storage_',
+      );
+      fileSystem = FileSystemService.detached(dataRoot: tempRoot.path);
+      storage = PersonaChatConversationStorage(fileSystem: fileSystem);
+    });
+
+    tearDown(() async {
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('appends user and character messages under Conversation/', () async {
+      await storage.appendMessage(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+        isFromCharacter: false,
+        content: '你醒了吗',
+        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+        messageType: PersonaChatMessageTypes.text,
+        origin: PersonaChatMessageOrigin.conversation,
+        isRead: true,
+      );
+      final episode = await storage.appendEpisode(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+        contactEpisodeId: 'character_conversation:task-1',
+        records: (nextSeq) => [
+          PersonaChatConversationRecord(
+            id: 'bubble-1',
+            seq: nextSeq,
+            characterId: 'yaoyao',
+            isFromCharacter: true,
+            content: '醒了。',
+            isRead: false,
+            timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
+            messageType: PersonaChatMessageTypes.text,
+            origin: PersonaChatMessageOrigin.conversation,
+            contactEpisodeId: 'character_conversation:task-1',
+          ),
+          PersonaChatConversationRecord(
+            id: 'bubble-2',
+            seq: nextSeq + 1,
+            characterId: 'yaoyao',
+            isFromCharacter: true,
+            content: '怎么了？',
+            isRead: false,
+            timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
+            messageType: PersonaChatMessageTypes.text,
+            origin: PersonaChatMessageOrigin.conversation,
+            contactEpisodeId: 'character_conversation:task-1',
+          ),
+        ],
+      );
+      final retry = await storage.appendEpisode(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+        contactEpisodeId: 'character_conversation:task-1',
+        records: (_) => throw StateError('retry must not write again'),
+      );
+
+      expect(retry.map((record) => record.id), ['bubble-1', 'bubble-2']);
+      expect(episode, hasLength(2));
+
+      final messagesFile = File(
+        fileSystem.getCharacterConversationMessagesPath('wujia', 'yaoyao'),
+      );
+      final lines = (await messagesFile.readAsLines())
+          .where((line) => line.trim().isNotEmpty)
+          .toList();
+      expect(lines, hasLength(3));
+      expect(jsonDecode(lines.first)['speaker'], 'user');
+      expect(jsonDecode(lines[1])['contact_episode_id'],
+          'character_conversation:task-1');
+    });
+
+    test('keeps valid JSONL history when the last line is truncated', () async {
+      await storage.appendMessage(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+        isFromCharacter: false,
+        content: '第一句',
+        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+        messageType: PersonaChatMessageTypes.text,
+        origin: PersonaChatMessageOrigin.conversation,
+        isRead: true,
+        stableId: 'keep-me',
+      );
+      final file = File(
+        fileSystem.getCharacterConversationMessagesPath('wujia', 'yaoyao'),
+      );
+      await file.writeAsString(
+        '${await file.readAsString()}{"id":"partial"',
+        flush: true,
+      );
+
+      final records = await storage.loadMessages(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+      );
+      expect(records.map((record) => record.id), ['keep-me']);
+      expect(await file.readAsString(), isNot(contains('partial')));
+    });
+
+    test('clearing a conversation survives a later projection rebuild',
+        () async {
+      await storage.appendMessage(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+        isFromCharacter: false,
+        content: '稍后删掉',
+        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+        messageType: PersonaChatMessageTypes.text,
+        origin: PersonaChatMessageOrigin.conversation,
+        isRead: true,
+      );
+      await storage.clearConversation(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+        clearedAt: DateTime.parse('2026-07-15T10:00:00+08:00'),
+      );
+
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      await storage.rebuildSqliteProjection(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+        db: db,
+      );
+      final rows = await db.select(db.personaChatMessages).get();
+      expect(rows, isEmpty);
+      final state = await storage.loadState(
+        userId: 'wujia',
+        characterId: 'yaoyao',
+      );
+      expect(state.clearedAt, isNotNull);
+      expect(state.consumedThroughMessageId, isNull);
+    });
+  });
+}

--- a/test/data/services/persona_chat_conversation_storage_test.dart
+++ b/test/data/services/persona_chat_conversation_storage_test.dart
@@ -1,13 +1,14 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/persona_chat_conversation_storage.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
-import 'package:memex/db/app_database.dart';
 import 'package:memex/domain/models/character_message.dart';
+
+const _userId = 'wujia';
+const _characterId = 'yaoyao';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -18,194 +19,324 @@ void main() {
     late PersonaChatConversationStorage storage;
 
     setUp(() async {
-      tempRoot = await Directory.systemTemp.createTemp(
-        'memex_persona_chat_storage_',
-      );
+      tempRoot = await Directory.systemTemp.createTemp('persona_chat_store_');
       fileSystem = FileSystemService.detached(dataRoot: tempRoot.path);
       storage = PersonaChatConversationStorage(fileSystem: fileSystem);
     });
 
     tearDown(() async {
-      if (await tempRoot.exists()) {
-        await tempRoot.delete(recursive: true);
-      }
+      if (await tempRoot.exists()) await tempRoot.delete(recursive: true);
     });
 
-    test('appends user and character messages under Conversation/', () async {
-      await storage.appendMessage(
-        userId: 'wujia',
-        characterId: 'yaoyao',
-        isFromCharacter: false,
-        content: '你醒了吗',
-        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
-        messageType: PersonaChatMessageTypes.text,
-        origin: PersonaChatMessageOrigin.conversation,
-        isRead: true,
-      );
+    test('appends one atomic JSONL envelope per episode and paginates bubbles',
+        () async {
+      await _appendUser(storage, content: '你醒了吗');
       final episode = await storage.appendEpisode(
-        userId: 'wujia',
-        characterId: 'yaoyao',
+        userId: _userId,
+        characterId: _characterId,
         contactEpisodeId: 'character_conversation:task-1',
         expectedRecordCount: 2,
+        consumedThroughSeq: 1,
         records: (nextSeq) => [
-          PersonaChatConversationRecord(
-            id: 'bubble-1',
-            seq: nextSeq,
-            characterId: 'yaoyao',
-            isFromCharacter: true,
-            content: '醒了。',
-            isRead: false,
-            timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
-            messageType: PersonaChatMessageTypes.text,
-            origin: PersonaChatMessageOrigin.conversation,
-            contactEpisodeId: 'character_conversation:task-1',
-          ),
-          PersonaChatConversationRecord(
-            id: 'bubble-2',
-            seq: nextSeq + 1,
-            characterId: 'yaoyao',
-            isFromCharacter: true,
-            content: '怎么了？',
-            isRead: false,
-            timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
-            messageType: PersonaChatMessageTypes.text,
-            origin: PersonaChatMessageOrigin.conversation,
-            contactEpisodeId: 'character_conversation:task-1',
-          ),
+          _record(nextSeq, '醒了。', id: 'bubble-1'),
+          _record(nextSeq + 1, '怎么了？', id: 'bubble-2'),
         ],
       );
       final retry = await storage.appendEpisode(
-        userId: 'wujia',
-        characterId: 'yaoyao',
+        userId: _userId,
+        characterId: _characterId,
         contactEpisodeId: 'character_conversation:task-1',
         expectedRecordCount: 2,
-        records: (_) => throw StateError('retry must not write again'),
+        consumedThroughSeq: 1,
+        records: (_) => throw StateError('retry must not append'),
       );
 
+      expect(episode.map((record) => record.seq), [2, 3]);
       expect(retry.map((record) => record.id), ['bubble-1', 'bubble-2']);
-      expect(episode, hasLength(2));
-
-      final messagesFile = File(
-        fileSystem.getCharacterConversationMessagesPath('wujia', 'yaoyao'),
+      final lines = await _messagesFile(fileSystem).readAsLines();
+      expect(lines, hasLength(2));
+      expect(jsonDecode(lines.last)['record_type'], 'episode');
+      final receiptDirectory = Directory(
+        fileSystem.getCharacterConversationEpisodeReceiptsPath(
+          _userId,
+          _characterId,
+        ),
       );
-      final lines = (await messagesFile.readAsLines())
-          .where((line) => line.trim().isNotEmpty)
-          .toList();
-      expect(lines, hasLength(3));
-      expect(jsonDecode(lines.first)['speaker'], 'user');
-      expect(jsonDecode(lines[1])['contact_episode_id'],
-          'character_conversation:task-1');
+      final receiptFile = await receiptDirectory
+          .list()
+          .where((entity) => entity is File)
+          .cast<File>()
+          .single;
+      final receipt = jsonDecode(await receiptFile.readAsString());
+      expect(receipt['status'], 'complete');
+      expect(receipt['line_offset'], isNonNegative);
+      expect(receipt, isNot(contains('records')));
+
+      final newest = await storage.loadMessages(
+        userId: _userId,
+        characterId: _characterId,
+        limit: 2,
+      );
+      expect(newest.map((record) => record.content), ['怎么了？', '醒了。']);
+      final older = await storage.loadMessages(
+        userId: _userId,
+        characterId: _characterId,
+        limit: 2,
+        offset: 2,
+      );
+      expect(older.single.content, '你醒了吗');
+
+      await File(
+        fileSystem.getCharacterConversationMetadataPath(
+          _userId,
+          _characterId,
+        ),
+      ).writeAsString('{}\n', flush: true);
+      expect(
+        (await storage.loadMetadata(
+          userId: _userId,
+          characterId: _characterId,
+        ))
+            .consumedThroughSeq,
+        1,
+      );
     });
 
-    test('keeps valid JSONL history when the last line is truncated', () async {
-      await storage.appendMessage(
-        userId: 'wujia',
-        characterId: 'yaoyao',
-        isFromCharacter: false,
-        content: '第一句',
-        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
-        messageType: PersonaChatMessageTypes.text,
-        origin: PersonaChatMessageOrigin.conversation,
-        isRead: true,
-        stableId: 'keep-me',
+    test('recovers a pending episode receipt from the authoritative log',
+        () async {
+      await storage.appendEpisode(
+        userId: _userId,
+        characterId: _characterId,
+        contactEpisodeId: 'character_conversation:task-1',
+        expectedRecordCount: 2,
+        records: (nextSeq) => [
+          _record(nextSeq, '第一句', id: 'bubble-1'),
+          _record(nextSeq + 1, '第二句', id: 'bubble-2'),
+        ],
       );
-      final file = File(
-        fileSystem.getCharacterConversationMessagesPath('wujia', 'yaoyao'),
+      final receiptDirectory = Directory(
+        fileSystem.getCharacterConversationEpisodeReceiptsPath(
+          _userId,
+          _characterId,
+        ),
       );
-      await file.writeAsString(
-        '${await file.readAsString()}{"id":"partial"',
+      final receiptFile = await receiptDirectory
+          .list()
+          .where((entity) => entity is File)
+          .cast<File>()
+          .single;
+      await receiptFile.writeAsString(
+        '${jsonEncode({
+              'episode_id': 'character_conversation:task-1',
+              'status': 'pending',
+            })}\n',
         flush: true,
       );
 
-      final records = await storage.loadMessages(
-        userId: 'wujia',
-        characterId: 'yaoyao',
+      final recovered = await storage.appendEpisode(
+        userId: _userId,
+        characterId: _characterId,
+        contactEpisodeId: 'character_conversation:task-1',
+        expectedRecordCount: 2,
+        records: (_) => throw StateError('recovery must not append'),
       );
-      expect(records.map((record) => record.id), ['keep-me']);
-      expect(await file.readAsString(), isNot(contains('partial')));
 
-      final reloaded = await storage.loadMessages(
-        userId: 'wujia',
-        characterId: 'yaoyao',
-      );
-      expect(reloaded.map((record) => record.id), ['keep-me']);
-      expect(reloaded.single.content, '第一句');
+      expect(recovered.map((record) => record.id), ['bubble-1', 'bubble-2']);
+      expect(await _messagesFile(fileSystem).readAsLines(), hasLength(1));
+      final repairedReceipt = jsonDecode(await receiptFile.readAsString());
+      expect(repairedReceipt['status'], 'complete');
+      expect(repairedReceipt, isNot(contains('records')));
     });
 
-    test('rejects character ids that escape the character workspace', () {
+    test('serializes writers from separate storage instances', () async {
+      final other = PersonaChatConversationStorage(fileSystem: fileSystem);
+      await Future.wait([
+        for (var index = 0; index < 12; index++)
+          (index.isEven ? storage : other).appendMessage(
+            userId: _userId,
+            characterId: _characterId,
+            isFromCharacter: index.isOdd,
+            content: 'message-$index',
+            timestamp: DateTime.parse('2026-07-15T09:00:00+08:00')
+                .add(Duration(seconds: index)),
+            messageType: PersonaChatMessageTypes.text,
+            origin: PersonaChatMessageOrigin.conversation,
+            isRead: index.isEven,
+          ),
+      ]);
+
+      final messages = await storage.loadMessages(
+        userId: _userId,
+        characterId: _characterId,
+        limit: 20,
+      );
+      expect(messages, hasLength(12));
+      expect(messages.map((record) => record.seq).toSet(), hasLength(12));
       expect(
-        () => fileSystem.getCharacterConversationPath('wujia', '../outside'),
-        throwsArgumentError,
-      );
+          (await storage.loadMetadata(
+            userId: _userId,
+            characterId: _characterId,
+          ))
+              .nextSeq,
+          13);
     });
 
-    test('truncates a tail ending inside a UTF-8 code point', () async {
-      await storage.appendMessage(
-        userId: 'wujia',
-        characterId: 'yaoyao',
-        isFromCharacter: false,
-        content: '保留中文',
-        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+    test('repairs metadata after a crash between JSONL append and metadata',
+        () async {
+      await _appendUser(storage, content: '第一句');
+      final file = _messagesFile(fileSystem);
+      final second = PersonaChatConversationRecord(
+        id: 'crash-gap',
+        seq: 2,
+        characterId: _characterId,
+        isFromCharacter: true,
+        content: '写入后崩溃',
+        isRead: false,
+        timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
         messageType: PersonaChatMessageTypes.text,
         origin: PersonaChatMessageOrigin.conversation,
-        isRead: true,
-        stableId: 'utf8-keep',
       );
-      final file = File(
-        fileSystem.getCharacterConversationMessagesPath('wujia', 'yaoyao'),
+      await file.writeAsString(
+        '${jsonEncode(second.toJson())}\n',
+        mode: FileMode.append,
+        flush: true,
       );
+
+      final messages = await storage.loadMessages(
+        userId: _userId,
+        characterId: _characterId,
+      );
+      final metadata = await storage.loadMetadata(
+        userId: _userId,
+        characterId: _characterId,
+      );
+      expect(messages.map((record) => record.content), ['写入后崩溃', '第一句']);
+      expect(metadata.nextSeq, 3);
+      expect(metadata.messageCount, 2);
+      expect(metadata.unreadCount, 1);
+      expect(metadata.messagesByteLength, await file.length());
+    });
+
+    test('truncates an incomplete UTF-8 tail without losing valid history',
+        () async {
+      await _appendUser(storage, content: '保留中文');
+      final file = _messagesFile(fileSystem);
       await file.writeAsBytes(
         [...await file.readAsBytes(), 0xF0, 0x9F],
         flush: true,
       );
 
-      final records = await storage.loadMessages(
-        userId: 'wujia',
-        characterId: 'yaoyao',
+      final first = await storage.loadMessages(
+        userId: _userId,
+        characterId: _characterId,
       );
-      expect(records.map((record) => record.id), ['utf8-keep']);
+      final second = await storage.loadMessages(
+        userId: _userId,
+        characterId: _characterId,
+      );
+      expect(first.single.content, '保留中文');
+      expect(second.single.content, '保留中文');
+    });
+
+    test('read and reply boundaries rebuild from the authoritative log',
+        () async {
+      await _appendUser(storage, content: '用户消息');
+      await storage.appendMessage(
+        userId: _userId,
+        characterId: _characterId,
+        isFromCharacter: true,
+        content: '未读消息',
+        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+        messageType: PersonaChatMessageTypes.text,
+        origin: PersonaChatMessageOrigin.initiative,
+      );
+      final file = _messagesFile(fileSystem);
+      final before = await file.readAsBytes();
+
+      await storage.advanceCursor(
+        userId: _userId,
+        characterId: _characterId,
+        consumedThroughSeq: 1,
+      );
       expect(
-        await storage.loadMessages(
-          userId: 'wujia',
-          characterId: 'yaoyao',
+        await storage.markAllRead(
+          userId: _userId,
+          characterId: _characterId,
         ),
-        hasLength(1),
+        1,
+      );
+      final after = await file.readAsBytes();
+      expect(after.sublist(0, before.length), before);
+
+      final metadataFile = File(
+        fileSystem.getCharacterConversationMetadataPath(
+          _userId,
+          _characterId,
+        ),
+      );
+      await metadataFile.writeAsString('{}\n', flush: true);
+      final repaired = await storage.loadMetadata(
+        userId: _userId,
+        characterId: _characterId,
+      );
+      expect(repaired.consumedThroughSeq, 1);
+      expect(repaired.readThroughSeq, 2);
+      expect(repaired.unreadCount, 0);
+      expect(
+        (await storage.loadMessages(
+          userId: _userId,
+          characterId: _characterId,
+        ))
+            .first
+            .isRead,
+        isTrue,
       );
     });
 
-    test('clearing a conversation survives a later projection rebuild',
-        () async {
-      await storage.appendMessage(
-        userId: 'wujia',
-        characterId: 'yaoyao',
-        isFromCharacter: false,
-        content: '稍后删掉',
-        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
-        messageType: PersonaChatMessageTypes.text,
-        origin: PersonaChatMessageOrigin.conversation,
-        isRead: true,
+    test('rejects character ids that escape the workspace', () {
+      expect(
+        () => fileSystem.getCharacterConversationPath(_userId, '../outside'),
+        throwsArgumentError,
       );
-      await storage.clearConversation(
-        userId: 'wujia',
-        characterId: 'yaoyao',
-        clearedAt: DateTime.parse('2026-07-15T10:00:00+08:00'),
-      );
-
-      final db = AppDatabase.forTesting(NativeDatabase.memory());
-      addTearDown(db.close);
-      await storage.rebuildSqliteProjection(
-        userId: 'wujia',
-        characterId: 'yaoyao',
-        db: db,
-      );
-      final rows = await db.select(db.personaChatMessages).get();
-      expect(rows, isEmpty);
-      final state = await storage.loadState(
-        userId: 'wujia',
-        characterId: 'yaoyao',
-      );
-      expect(state.clearedAt, isNotNull);
-      expect(state.consumedThroughMessageId, isNull);
     });
   });
 }
+
+PersonaChatConversationRecord _record(
+  int seq,
+  String content, {
+  required String id,
+}) {
+  return PersonaChatConversationRecord(
+    id: id,
+    seq: seq,
+    characterId: _characterId,
+    isFromCharacter: true,
+    content: content,
+    isRead: false,
+    timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
+    messageType: PersonaChatMessageTypes.text,
+    origin: PersonaChatMessageOrigin.conversation,
+    contactEpisodeId: 'character_conversation:task-1',
+  );
+}
+
+Future<void> _appendUser(
+  PersonaChatConversationStorage target, {
+  required String content,
+}) async {
+  await target.appendMessage(
+    userId: _userId,
+    characterId: _characterId,
+    isFromCharacter: false,
+    content: content,
+    timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+    messageType: PersonaChatMessageTypes.text,
+    origin: PersonaChatMessageOrigin.conversation,
+    isRead: true,
+  );
+}
+
+File _messagesFile(FileSystemService fs) => File(
+      fs.getCharacterConversationMessagesPath(_userId, _characterId),
+    );

--- a/test/data/services/persona_chat_workspace_recovery_test.dart
+++ b/test/data/services/persona_chat_workspace_recovery_test.dart
@@ -1,0 +1,179 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/local_asset_server.dart';
+import 'package:memex/data/services/persona_chat_conversation_storage.dart';
+import 'package:memex/data/services/persona_chat_service.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/character_message.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('persona chat workspace recovery', () {
+    const userId = 'wujia';
+    const characterId = 'yaoyao';
+    late Directory tempRoot;
+    late AppDatabase db;
+    late PersonaChatConversationStorage storage;
+    late PersonaChatService chat;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      tempRoot = await Directory.systemTemp.createTemp(
+        'memex_persona_chat_recovery_',
+      );
+      await FileSystemService.init(tempRoot.path);
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      storage = PersonaChatConversationStorage(
+        fileSystem: FileSystemService.instance,
+      );
+      chat = PersonaChatService.forTesting(
+        db,
+        userId: userId,
+        storage: storage,
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+      await LocalAssetServer.stopServer();
+      if (await tempRoot.exists()) {
+        await tempRoot.delete(recursive: true);
+      }
+    });
+
+    test('exports existing SQLite history once into the character workspace',
+        () async {
+      final sqliteOnly = PersonaChatService.forTesting(db);
+      final first = await sqliteOnly.addUserMessage(
+        characterId,
+        '旧的一句',
+        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+      );
+      await sqliteOnly.addCharacterMessages(
+        characterId,
+        [CharacterOutgoingMessage.text('我还在。')],
+        timestamp: DateTime.parse('2026-07-15T09:00:02+08:00'),
+        contactEpisodeId: 'character_conversation:old',
+      );
+      await sqliteOnly.advanceReplyCursor(
+        characterId: characterId,
+        consumedThroughMessageId: first,
+      );
+
+      await storage.ensureMigrated(userId: userId, db: db);
+      await storage.ensureMigrated(userId: userId, db: db);
+
+      final records = await storage.loadMessages(
+        userId: userId,
+        characterId: characterId,
+      );
+      expect(records.map((record) => record.content), ['旧的一句', '我还在。']);
+      final exportedUser = records.first;
+      final sqliteUser = await (db.select(db.personaChatMessages)
+            ..where((row) => row.id.equals(first)))
+          .getSingle();
+      expect(exportedUser.id, sqliteUser.stableId);
+      final state = await storage.loadState(
+        userId: userId,
+        characterId: characterId,
+      );
+      expect(state.consumedThroughMessageId, sqliteUser.stableId);
+    });
+
+    test('rebuilds SQLite from workspace after the database is wiped',
+        () async {
+      final userMessageId = await chat.addUserMessage(
+        characterId,
+        '我刚下楼',
+        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+      );
+      await chat.completeConversationEpisode(
+        characterId: characterId,
+        consumedThroughMessageId: userMessageId,
+        characterMessages: [
+          CharacterOutgoingMessage.text('是有点热。'),
+          CharacterOutgoingMessage.text('那就买一杯。'),
+        ],
+        episodeId: 'character_conversation:task-9',
+        timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
+      );
+
+      await db.delete(db.personaChatMessages).go();
+      await db.delete(db.personaChatReplyCursors).go();
+
+      await chat.reconcileFromWorkspace(userId);
+
+      final restored = await chat.getMessages(characterId);
+      expect(
+        restored.map((message) => message.content).toList().reversed,
+        ['我刚下楼', '是有点热。', '那就买一杯。'],
+      );
+      expect(await chat.getPendingUserMessages(characterId), isEmpty);
+      expect(
+        restored.where((message) => message.isFromCharacter).map(
+              (message) => message.contactEpisodeId,
+            ),
+        everyElement('character_conversation:task-9'),
+      );
+    });
+
+    test('does not re-answer historical user messages after a crash gap',
+        () async {
+      final userMessageId = await chat.addUserMessage(
+        characterId,
+        '在吗',
+        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+      );
+      final userRow = await (db.select(db.personaChatMessages)
+            ..where((row) => row.id.equals(userMessageId)))
+          .getSingle();
+      await storage.advanceCursor(
+        userId: userId,
+        characterId: characterId,
+        consumedThroughMessageId: userRow.stableId!,
+      );
+
+      await db.delete(db.personaChatReplyCursors).go();
+      await chat.reconcileFromWorkspace(userId);
+
+      expect(await chat.getPendingUserMessages(characterId), isEmpty);
+    });
+
+    test('retried episodes do not duplicate workspace or SQLite rows',
+        () async {
+      final userMessageId = await chat.addUserMessage(
+        characterId,
+        '你好',
+        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+      );
+      Future<void> speak() {
+        return chat.completeConversationEpisode(
+          characterId: characterId,
+          consumedThroughMessageId: userMessageId,
+          characterMessages: [CharacterOutgoingMessage.text('嗯。')],
+          episodeId: 'character_conversation:task-retry',
+          timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
+        );
+      }
+
+      await speak();
+      await speak();
+
+      final rows = await db.select(db.personaChatMessages).get();
+      expect(rows.where((row) => row.isFromCharacter), hasLength(1));
+      final records = await storage.loadMessages(
+        userId: userId,
+        characterId: characterId,
+      );
+      expect(
+        records.where((record) => record.isFromCharacter),
+        hasLength(1),
+      );
+    });
+  });
+}

--- a/test/data/services/persona_chat_workspace_recovery_test.dart
+++ b/test/data/services/persona_chat_workspace_recovery_test.dart
@@ -175,5 +175,43 @@ void main() {
         hasLength(1),
       );
     });
+
+    test('repairs an episode interrupted after its first bubble', () async {
+      final userMessageId = await chat.addUserMessage(characterId, '你好');
+      await storage.appendMessage(
+        userId: userId,
+        characterId: characterId,
+        isFromCharacter: true,
+        content: '第一句',
+        timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
+        messageType: PersonaChatMessageTypes.text,
+        origin: PersonaChatMessageOrigin.conversation,
+        contactEpisodeId: 'character_conversation:partial',
+      );
+
+      final ids = await chat.completeConversationEpisode(
+        characterId: characterId,
+        consumedThroughMessageId: userMessageId,
+        characterMessages: [
+          CharacterOutgoingMessage.text('第一句'),
+          CharacterOutgoingMessage.text('第二句'),
+        ],
+        episodeId: 'character_conversation:partial',
+        timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
+      );
+
+      expect(ids, hasLength(2));
+      final records = await storage.loadMessages(
+        userId: userId,
+        characterId: characterId,
+      );
+      final episode = records
+          .where(
+            (record) =>
+                record.contactEpisodeId == 'character_conversation:partial',
+          )
+          .toList();
+      expect(episode.map((record) => record.content), ['第一句', '第二句']);
+    });
   });
 }

--- a/test/data/services/persona_chat_workspace_recovery_test.dart
+++ b/test/data/services/persona_chat_workspace_recovery_test.dart
@@ -1,10 +1,12 @@
 import 'dart:io';
 
+import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_asset_server.dart';
 import 'package:memex/data/services/persona_chat_conversation_storage.dart';
+import 'package:memex/data/services/persona_chat_legacy_migration_service.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/domain/models/character_message.dart';
@@ -23,75 +25,64 @@ void main() {
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      tempRoot = await Directory.systemTemp.createTemp(
-        'memex_persona_chat_recovery_',
-      );
+      tempRoot = await Directory.systemTemp.createTemp('persona_recovery_');
       await FileSystemService.init(tempRoot.path);
       db = AppDatabase.forTesting(NativeDatabase.memory());
       storage = PersonaChatConversationStorage(
         fileSystem: FileSystemService.instance,
       );
-      chat = PersonaChatService.forTesting(
-        db,
-        userId: userId,
-        storage: storage,
-      );
+      chat = PersonaChatService.forTesting(storage: storage, userId: userId);
     });
 
     tearDown(() async {
       await db.close();
       await LocalAssetServer.stopServer();
-      if (await tempRoot.exists()) {
-        await tempRoot.delete(recursive: true);
-      }
+      if (await tempRoot.exists()) await tempRoot.delete(recursive: true);
     });
 
-    test('exports existing SQLite history once into the character workspace',
-        () async {
-      final sqliteOnly = PersonaChatService.forTesting(db);
-      final first = await sqliteOnly.addUserMessage(
-        characterId,
-        '旧的一句',
-        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
-      );
-      await sqliteOnly.addCharacterMessages(
-        characterId,
-        [CharacterOutgoingMessage.text('我还在。')],
-        timestamp: DateTime.parse('2026-07-15T09:00:02+08:00'),
-        contactEpisodeId: 'character_conversation:old',
-      );
-      await sqliteOnly.advanceReplyCursor(
-        characterId: characterId,
-        consumedThroughMessageId: first,
-      );
+    test('imports legacy SQLite once, including its reply cursor', () async {
+      final first = await db.into(db.personaChatMessages).insert(
+            PersonaChatMessagesCompanion.insert(
+              characterId: characterId,
+              isFromCharacter: false,
+              content: '旧的一句',
+              isRead: const Value(true),
+              timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
+            ),
+          );
+      await db.into(db.personaChatMessages).insert(
+            PersonaChatMessagesCompanion.insert(
+              characterId: characterId,
+              isFromCharacter: true,
+              content: '我还在。',
+              timestamp: DateTime.parse('2026-07-15T09:00:02+08:00'),
+              contactEpisodeId: const Value('character_conversation:old'),
+            ),
+          );
+      await db.into(db.personaChatReplyCursors).insert(
+            PersonaChatReplyCursorsCompanion.insert(
+              characterId: characterId,
+              consumedThroughMessageId: Value(first),
+              updatedAt: 1,
+            ),
+          );
 
-      await storage.ensureMigrated(userId: userId, db: db);
-      await storage.ensureMigrated(userId: userId, db: db);
+      final migration = PersonaChatLegacyMigrationService(storage: storage);
+      await migration.ensureMigrated(userId: userId, database: db);
+      await migration.ensureMigrated(userId: userId, database: db);
 
-      final records = await storage.loadMessages(
-        userId: userId,
-        characterId: characterId,
+      final messages = await chat.getMessages(characterId);
+      expect(
+        messages.reversed.map((message) => message.content),
+        ['旧的一句', '我还在。'],
       );
-      expect(records.map((record) => record.content), ['旧的一句', '我还在。']);
-      final exportedUser = records.first;
-      final sqliteUser = await (db.select(db.personaChatMessages)
-            ..where((row) => row.id.equals(first)))
-          .getSingle();
-      expect(exportedUser.id, sqliteUser.stableId);
-      final state = await storage.loadState(
-        userId: userId,
-        characterId: characterId,
-      );
-      expect(state.consumedThroughMessageId, sqliteUser.stableId);
+      expect(await chat.getReplyCursor(characterId), 1);
+      expect(await chat.getPendingUserMessages(characterId), isEmpty);
     });
 
-    test('rebuilds SQLite from workspace after the database is wiped',
+    test('runtime conversation remains available after SQLite is wiped',
         () async {
-      final userMessageId = await chat.addUserMessage(
-        characterId,
-        '我刚下楼',
-        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
-      );
+      final userMessageId = await chat.addUserMessage(characterId, '我刚下楼');
       await chat.completeConversationEpisode(
         characterId: characterId,
         consumedThroughMessageId: userMessageId,
@@ -102,116 +93,36 @@ void main() {
         episodeId: 'character_conversation:task-9',
         timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
       );
-
       await db.delete(db.personaChatMessages).go();
       await db.delete(db.personaChatReplyCursors).go();
 
-      await chat.reconcileFromWorkspace(userId);
-
       final restored = await chat.getMessages(characterId);
       expect(
-        restored.map((message) => message.content).toList().reversed,
+        restored.reversed.map((message) => message.content),
         ['我刚下楼', '是有点热。', '那就买一杯。'],
       );
       expect(await chat.getPendingUserMessages(characterId), isEmpty);
-      expect(
-        restored.where((message) => message.isFromCharacter).map(
-              (message) => message.contactEpisodeId,
-            ),
-        everyElement('character_conversation:task-9'),
-      );
     });
 
-    test('does not re-answer historical user messages after a crash gap',
-        () async {
-      final userMessageId = await chat.addUserMessage(
-        characterId,
-        '在吗',
-        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
-      );
-      final userRow = await (db.select(db.personaChatMessages)
-            ..where((row) => row.id.equals(userMessageId)))
-          .getSingle();
-      await storage.advanceCursor(
-        userId: userId,
-        characterId: characterId,
-        consumedThroughMessageId: userRow.stableId!,
-      );
-
-      await db.delete(db.personaChatReplyCursors).go();
-      await chat.reconcileFromWorkspace(userId);
-
-      expect(await chat.getPendingUserMessages(characterId), isEmpty);
-    });
-
-    test('retried episodes do not duplicate workspace or SQLite rows',
-        () async {
-      final userMessageId = await chat.addUserMessage(
-        characterId,
-        '你好',
-        timestamp: DateTime.parse('2026-07-15T09:00:00+08:00'),
-      );
-      Future<void> speak() {
-        return chat.completeConversationEpisode(
-          characterId: characterId,
-          consumedThroughMessageId: userMessageId,
-          characterMessages: [CharacterOutgoingMessage.text('嗯。')],
-          episodeId: 'character_conversation:task-retry',
-          timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
-        );
-      }
-
-      await speak();
-      await speak();
-
-      final rows = await db.select(db.personaChatMessages).get();
-      expect(rows.where((row) => row.isFromCharacter), hasLength(1));
-      final records = await storage.loadMessages(
-        userId: userId,
-        characterId: characterId,
-      );
-      expect(
-        records.where((record) => record.isFromCharacter),
-        hasLength(1),
-      );
-    });
-
-    test('repairs an episode interrupted after its first bubble', () async {
+    test('retried multi-bubble episodes are idempotent', () async {
       final userMessageId = await chat.addUserMessage(characterId, '你好');
-      await storage.appendMessage(
-        userId: userId,
-        characterId: characterId,
-        isFromCharacter: true,
-        content: '第一句',
-        timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
-        messageType: PersonaChatMessageTypes.text,
-        origin: PersonaChatMessageOrigin.conversation,
-        contactEpisodeId: 'character_conversation:partial',
-      );
+      Future<List<int>> speak() => chat.completeConversationEpisode(
+            characterId: characterId,
+            consumedThroughMessageId: userMessageId,
+            characterMessages: [
+              CharacterOutgoingMessage.text('第一句'),
+              CharacterOutgoingMessage.text('第二句'),
+            ],
+            episodeId: 'character_conversation:task-retry',
+            timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
+          );
 
-      final ids = await chat.completeConversationEpisode(
-        characterId: characterId,
-        consumedThroughMessageId: userMessageId,
-        characterMessages: [
-          CharacterOutgoingMessage.text('第一句'),
-          CharacterOutgoingMessage.text('第二句'),
-        ],
-        episodeId: 'character_conversation:partial',
-        timestamp: DateTime.parse('2026-07-15T09:00:05+08:00'),
-      );
-
-      expect(ids, hasLength(2));
-      final records = await storage.loadMessages(
-        userId: userId,
-        characterId: characterId,
-      );
-      final episode = records
-          .where(
-            (record) =>
-                record.contactEpisodeId == 'character_conversation:partial',
-          )
-          .toList();
-      expect(episode.map((record) => record.content), ['第一句', '第二句']);
+      expect(await speak(), [2, 3]);
+      expect(await speak(), [2, 3]);
+      final messages = await chat.getMessages(characterId);
+      expect(
+          messages.where((message) => message.isFromCharacter), hasLength(2));
+      expect(await db.select(db.personaChatMessages).get(), isEmpty);
     });
   });
 }

--- a/test/data/services/persona_chat_workspace_recovery_test.dart
+++ b/test/data/services/persona_chat_workspace_recovery_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:drift/drift.dart';
@@ -78,6 +79,27 @@ void main() {
       );
       expect(await chat.getReplyCursor(characterId), 1);
       expect(await chat.getPendingUserMessages(characterId), isEmpty);
+      final lines = await File(
+        FileSystemService.instance.getCharacterConversationMessagesPath(
+          userId,
+          characterId,
+        ),
+      ).readAsLines();
+      expect(lines, hasLength(2));
+      expect(jsonDecode(lines.first), containsPair('id', 1));
+      expect(jsonDecode(lines.first), isNot(contains('seq')));
+      expect(jsonDecode(lines.last)['turn_id'], 'character_conversation:old');
+      final migrationState = jsonDecode(
+        await File(
+          '${FileSystemService.instance.getSystemPath(userId)}/'
+          'migration_state.json',
+        ).readAsString(),
+      ) as Map<String, dynamic>;
+      expect(
+        migrationState[PersonaChatConversationStorage.storageMigrationKey],
+        isTrue,
+      );
+      expect(migrationState, isNot(contains('persona_chat_workspace_v2')));
     });
 
     test('runtime conversation remains available after SQLite is wiped',
@@ -104,7 +126,7 @@ void main() {
       expect(await chat.getPendingUserMessages(characterId), isEmpty);
     });
 
-    test('retried multi-bubble episodes are idempotent', () async {
+    test('retried multi-bubble turns are idempotent', () async {
       final userMessageId = await chat.addUserMessage(characterId, '你好');
       Future<List<int>> speak() => chat.completeConversationEpisode(
             characterId: characterId,

--- a/test/db/app_database_migration_test.dart
+++ b/test/db/app_database_migration_test.dart
@@ -1,14 +1,14 @@
 import 'dart:io';
 
+import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:sqlite3/sqlite3.dart' as sqlite;
 
 void main() {
   group('AppDatabase migrations', () {
-    test('upgrades schema 14 to 20 with a reply cursor baseline', () async {
+    test('upgrades schema 14 to 19 with a reply cursor baseline', () async {
       final tempDir = await Directory.systemTemp.createTemp(
         'memex_app_database_migration_',
       );
@@ -18,7 +18,7 @@ void main() {
       final db = AppDatabase.forTesting(NativeDatabase(dbFile));
       try {
         final schemaVersion = await _userVersion(db);
-        expect(schemaVersion, 20);
+        expect(schemaVersion, 19);
 
         final taskColumns = await _columnNames(db, 'tasks');
         expect(taskColumns, contains('run_id'));
@@ -37,21 +37,17 @@ void main() {
         final chatColumns = await _columnNames(db, 'persona_chat_messages');
         expect(
           chatColumns,
-          containsAll(['origin', 'contact_episode_id', 'stable_id']),
+          containsAll(['origin', 'contact_episode_id']),
         );
         expect(chatColumns, isNot(contains('handled_by_episode_id')));
 
         final chatIndices = await _indexNames(db, 'persona_chat_messages');
         expect(chatIndices, contains('idx_persona_chat_episode'));
-        expect(chatIndices, contains('idx_persona_chat_stable_id'));
         expect(chatIndices, isNot(contains('idx_persona_chat_unhandled')));
 
         final cursor = await db.select(db.personaChatReplyCursors).getSingle();
         expect(cursor.characterId, 'legacy-character');
         expect(cursor.consumedThroughMessageId, 1);
-
-        final migrated = await db.select(db.personaChatMessages).getSingle();
-        expect(migrated.stableId, 'legacy-1');
       } finally {
         await db.close();
         await tempDir.delete(recursive: true);
@@ -68,12 +64,18 @@ void main() {
 
       final db = AppDatabase.forTesting(NativeDatabase(dbFile));
       try {
-        expect(await _userVersion(db), 20);
+        expect(await _userVersion(db), 19);
         final cursor = await db.select(db.personaChatReplyCursors).getSingle();
         expect(cursor.consumedThroughMessageId, 2);
 
-        final pending = await PersonaChatService.forTesting(db)
-            .getPendingUserMessages('legacy-character');
+        final pending = await (db.select(db.personaChatMessages)
+              ..where((message) =>
+                  message.characterId.equals('legacy-character') &
+                  message.isFromCharacter.equals(false) &
+                  message.id.isBiggerThanValue(
+                    cursor.consumedThroughMessageId,
+                  )))
+            .get();
         expect(pending.map((message) => message.content), [
           'pending user message',
         ]);

--- a/test/db/app_database_migration_test.dart
+++ b/test/db/app_database_migration_test.dart
@@ -8,7 +8,7 @@ import 'package:sqlite3/sqlite3.dart' as sqlite;
 
 void main() {
   group('AppDatabase migrations', () {
-    test('upgrades schema 14 to 19 with a reply cursor baseline', () async {
+    test('upgrades schema 14 to 20 with a reply cursor baseline', () async {
       final tempDir = await Directory.systemTemp.createTemp(
         'memex_app_database_migration_',
       );
@@ -18,7 +18,7 @@ void main() {
       final db = AppDatabase.forTesting(NativeDatabase(dbFile));
       try {
         final schemaVersion = await _userVersion(db);
-        expect(schemaVersion, 19);
+        expect(schemaVersion, 20);
 
         final taskColumns = await _columnNames(db, 'tasks');
         expect(taskColumns, contains('run_id'));
@@ -37,17 +37,21 @@ void main() {
         final chatColumns = await _columnNames(db, 'persona_chat_messages');
         expect(
           chatColumns,
-          containsAll(['origin', 'contact_episode_id']),
+          containsAll(['origin', 'contact_episode_id', 'stable_id']),
         );
         expect(chatColumns, isNot(contains('handled_by_episode_id')));
 
         final chatIndices = await _indexNames(db, 'persona_chat_messages');
         expect(chatIndices, contains('idx_persona_chat_episode'));
+        expect(chatIndices, contains('idx_persona_chat_stable_id'));
         expect(chatIndices, isNot(contains('idx_persona_chat_unhandled')));
 
         final cursor = await db.select(db.personaChatReplyCursors).getSingle();
         expect(cursor.characterId, 'legacy-character');
         expect(cursor.consumedThroughMessageId, 1);
+
+        final migrated = await db.select(db.personaChatMessages).getSingle();
+        expect(migrated.stableId, 'legacy-1');
       } finally {
         await db.close();
         await tempDir.delete(recursive: true);
@@ -64,7 +68,7 @@ void main() {
 
       final db = AppDatabase.forTesting(NativeDatabase(dbFile));
       try {
-        expect(await _userVersion(db), 19);
+        expect(await _userVersion(db), 20);
         final cursor = await db.select(db.personaChatReplyCursors).getSingle();
         expect(cursor.consumedThroughMessageId, 2);
 

--- a/test/helpers/persona_chat_test_harness.dart
+++ b/test/helpers/persona_chat_test_harness.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/persona_chat_conversation_storage.dart';
+import 'package:memex/data/services/persona_chat_service.dart';
+
+class PersonaChatTestHarness {
+  PersonaChatTestHarness._({
+    required this.root,
+    required this.storage,
+    required this.service,
+    required this.userId,
+  });
+
+  final Directory root;
+  final PersonaChatConversationStorage storage;
+  final PersonaChatService service;
+  final String userId;
+
+  static Future<PersonaChatTestHarness> create({
+    String userId = 'test-user',
+  }) async {
+    final root = await Directory.systemTemp.createTemp('memex_persona_chat_');
+    final storage = PersonaChatConversationStorage(
+      fileSystem: FileSystemService.detached(dataRoot: root.path),
+    );
+    return PersonaChatTestHarness._(
+      root: root,
+      storage: storage,
+      service: PersonaChatService.forTesting(
+        storage: storage,
+        userId: userId,
+      ),
+      userId: userId,
+    );
+  }
+
+  Future<void> dispose() async {
+    if (await root.exists()) await root.delete(recursive: true);
+  }
+}

--- a/test/integration/character_companion_pipeline_test.dart
+++ b/test/integration/character_companion_pipeline_test.dart
@@ -7,6 +7,7 @@ import 'package:memex/data/services/character_initiative_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/global_event_bus.dart';
 import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/data/services/persona_chat_conversation_storage.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/data/services/task_handlers/character_initiative_handler.dart';
 import 'package:memex/data/services/task_handlers/character_perception_handler.dart';
@@ -27,7 +28,10 @@ void main() {
     AppDatabase.setTestInstance(db);
     final executor = LocalTaskExecutor.forTesting(db: db);
     final eventBus = GlobalEventBus.forTesting(executor);
-    final chatService = PersonaChatService.forTesting(db);
+    final chatService = PersonaChatService.forTesting(
+      storage: PersonaChatConversationStorage(fileSystem: fileSystem),
+      userId: 'user-1',
+    );
     final initiativeService = CharacterInitiativeService.forTesting(
       taskExecutor: executor,
     );

--- a/test/integration/character_companion_pipeline_test.dart
+++ b/test/integration/character_companion_pipeline_test.dart
@@ -115,6 +115,7 @@ void main() {
         required messages,
         required timestamp,
         required contactEpisodeId,
+        required expectedGeneration,
         factId,
       }) async {
         await chatService.addCharacterMessages(

--- a/test/integration/character_conversation_pipeline_test.dart
+++ b/test/integration/character_conversation_pipeline_test.dart
@@ -9,6 +9,7 @@ import 'package:memex/data/services/character_workspace_service.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/data/services/persona_chat_conversation_storage.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/data/services/task_handlers/character_conversation_handler.dart';
 import 'package:memex/data/services/task_handlers/character_initiative_handler.dart';
@@ -26,9 +27,14 @@ void main() {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     AppDatabase.setTestInstance(db);
     final executor = LocalTaskExecutor.forTesting(db: db);
-    final chatService = PersonaChatService.forTesting(db);
     final tempRoot =
         await Directory.systemTemp.createTemp('conversation_pipeline_');
+    final chatService = PersonaChatService.forTesting(
+      storage: PersonaChatConversationStorage(
+        fileSystem: FileSystemService.detached(dataRoot: tempRoot.path),
+      ),
+      userId: 'user-1',
+    );
     final workspace = CharacterWorkspaceService(
       fileSystem: FileSystemService.detached(dataRoot: tempRoot.path),
     );
@@ -132,9 +138,14 @@ void main() {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     AppDatabase.setTestInstance(db);
     final executor = LocalTaskExecutor.forTesting(db: db);
-    final chatService = PersonaChatService.forTesting(db);
     final tempRoot =
         await Directory.systemTemp.createTemp('conversation_ownership_');
+    final chatService = PersonaChatService.forTesting(
+      storage: PersonaChatConversationStorage(
+        fileSystem: FileSystemService.detached(dataRoot: tempRoot.path),
+      ),
+      userId: 'user-1',
+    );
     final workspace = CharacterWorkspaceService(
       fileSystem: FileSystemService.detached(dataRoot: tempRoot.path),
     );
@@ -349,9 +360,15 @@ void main() {
   });
 
   test('initiative commit cannot overtake a pending direct message', () async {
-    final db = AppDatabase.forTesting(NativeDatabase.memory());
-    final chatService = PersonaChatService.forTesting(db);
-    addTearDown(db.close);
+    final tempRoot =
+        await Directory.systemTemp.createTemp('initiative_commit_');
+    final chatService = PersonaChatService.forTesting(
+      storage: PersonaChatConversationStorage(
+        fileSystem: FileSystemService.detached(dataRoot: tempRoot.path),
+      ),
+      userId: 'user-1',
+    );
+    addTearDown(() => tempRoot.delete(recursive: true));
     final now = DateTime.parse('2026-07-25T16:25:00+08:00');
     final userMessageId = await chatService.addUserMessage(
       'auntie',

--- a/test/integration/character_conversation_pipeline_test.dart
+++ b/test/integration/character_conversation_pipeline_test.dart
@@ -133,7 +133,7 @@ void main() {
     expect(tasks.single.status, 'completed');
   });
 
-  test('initiative yields one pending user turn to the conversation episode',
+  test('initiative yields one pending user turn to the direct reply task',
       () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     AppDatabase.setTestInstance(db);
@@ -244,6 +244,7 @@ void main() {
         required messages,
         required timestamp,
         required contactEpisodeId,
+        required expectedGeneration,
         factId,
       }) async {
         initiativeMessages += messages.length;
@@ -355,7 +356,7 @@ void main() {
     );
     expect(
       characterMessages.single.contactEpisodeId,
-      'character_conversation:conversation-task',
+      'character_conversation:1-1',
     );
   });
 

--- a/test/ui/character/view_models/persona_chat_viewmodel_test.dart
+++ b/test/ui/character/view_models/persona_chat_viewmodel_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/domain/models/character_model.dart';
 import 'package:memex/domain/models/persona_chat.dart';
 import 'package:memex/ui/character/view_models/persona_chat_viewmodel.dart';
 import 'package:memex/utils/result.dart';
@@ -70,6 +71,33 @@ void main() {
 
     expect(viewModel.isReplying, isTrue);
   });
+
+  test('history and live updates use cursors without reloading visible rows',
+      () async {
+    final router = _PagingMemexRouter();
+    final viewModel = PersonaChatViewModel(
+      router: router,
+      initialCharacterId: 'character-1',
+      eventBus: eventBus,
+    );
+    addTearDown(viewModel.dispose);
+
+    await viewModel.init();
+    expect(viewModel.messages.map((message) => message.id), [3, 2]);
+    expect(router.historyCalls, 0);
+
+    await viewModel.loadMoreHistory();
+    expect(viewModel.messages.map((message) => message.id), [3, 2, 1]);
+    expect(viewModel.hasMoreHistory, isFalse);
+    expect(router.historyCalls, 1);
+    expect(router.lastBeforeCursor, 100);
+
+    await viewModel.refreshLatest();
+    expect(viewModel.messages.map((message) => message.id), [4, 3, 2, 1]);
+    expect(router.liveCalls, 1);
+    expect(router.lastAfterCursor, 200);
+    expect(router.historyCalls, 1);
+  });
 }
 
 class _FakeMemexRouter implements MemexRouter {
@@ -84,14 +112,97 @@ class _FakeMemexRouter implements MemexRouter {
   }
 
   @override
-  Future<Result<List<PersonaChatMessageModel>>> fetchPersonaChatMessages(
+  Future<Result<PersonaChatMessagePageModel>> fetchNewPersonaChatMessages(
     String characterId, {
-    required int limit,
-    int offset = 0,
+    required int afterCursor,
   }) async {
-    return const Ok([]);
+    return Ok(
+      PersonaChatMessagePageModel(
+        messages: const [],
+        olderCursor: null,
+        newestCursor: afterCursor,
+      ),
+    );
   }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _PagingMemexRouter implements MemexRouter {
+  int historyCalls = 0;
+  int liveCalls = 0;
+  int? lastBeforeCursor;
+  int? lastAfterCursor;
+
+  @override
+  Future<Result<PersonaChatThreadModel>> loadPersonaChatThread(
+    String characterId, {
+    int limit = 30,
+  }) async {
+    return Ok(
+      PersonaChatThreadModel(
+        character: CharacterModel(
+          id: characterId,
+          name: '角色',
+          tags: const [],
+          persona: '测试角色',
+          enabled: true,
+        ),
+        userId: 'user-1',
+        messages: [_message(3), _message(2)],
+        olderCursor: 100,
+        newestCursor: 200,
+      ),
+    );
+  }
+
+  @override
+  Future<Result<PersonaChatMessagePageModel>> fetchPersonaChatMessagePage(
+    String characterId, {
+    required int limit,
+    int? beforeCursor,
+  }) async {
+    historyCalls += 1;
+    lastBeforeCursor = beforeCursor;
+    return Ok(
+      PersonaChatMessagePageModel(
+        messages: [_message(1)],
+        olderCursor: null,
+        newestCursor: 200,
+      ),
+    );
+  }
+
+  @override
+  Future<Result<PersonaChatMessagePageModel>> fetchNewPersonaChatMessages(
+    String characterId, {
+    required int afterCursor,
+  }) async {
+    liveCalls += 1;
+    lastAfterCursor = afterCursor;
+    return Ok(
+      PersonaChatMessagePageModel(
+        messages: [_message(4)],
+        olderCursor: null,
+        newestCursor: 250,
+      ),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+PersonaChatMessageModel _message(int id) {
+  return PersonaChatMessageModel(
+    id: id,
+    characterId: 'character-1',
+    isFromCharacter: id.isEven,
+    content: 'message-$id',
+    isRead: true,
+    timestamp: DateTime.fromMillisecondsSinceEpoch(id * 1000),
+    messageType: 'chat',
+    origin: 'conversation',
+  );
 }


### PR DESCRIPTION
## Summary

- Make each character workspace the sole runtime source of truth for persona-chat history, following the same file-first direction as the home-page Memex Agent chat.
- Store one immutable chat message per line in `Conversation/messages.jsonl`, using a normal message shape with `id`, `role`, content blocks, timestamps, origin, and optional `turn_id` / `fact_id`.
- Keep mutable read state, agent processing progress, generation, and rebuildable O(1) summaries in `metadata.json` instead of writing control records into the message log.
- Commit multi-bubble character turns with a transient `.pending_commit.json` write-ahead file. Recovery rewinds to the recorded byte offset and replays the exact message rows, so a crash cannot expose half a turn or duplicate it.
- Use `turn_id` in the authoritative message rows for retry idempotency. Metadata only caches the most recent committed turn; older retries fall back to the message log, so there is no receipt directory or second idempotency fact.
- Import the released SQLite persona-chat rows and reply cursor once through the existing unified `MigrationStateService` marker. The unreleased episode-based workspace format is intentionally not a migration source or runtime compatibility branch.
- Rebuild missing durable conversation tasks from workspace processing state at startup, closing the crash window between appending a user message and enqueueing its SQLite task.
- Load older history and live additions with JSONL byte cursors. The persona chat ViewModel merges incremental pages by message ID instead of repeatedly loading all visible messages.

## Workspace layout

```text
character_workspaces/<characterId>/Conversation/
  messages.jsonl         # authoritative immutable message history
  metadata.json          # mutable boundaries + rebuildable summary/cache
  .pending_commit.json   # transient WAL; absent outside an in-flight commit
  .write.lock            # cross-isolate/process writer lock
```

All workspace paths remain centralized in `FileSystemService`, and character IDs are validated before becoming path components.

## Consistency and performance

- User-message append is O(1): append one JSONL row and atomically replace the small metadata file. If the process stops between those writes, metadata is repaired from the log.
- Multi-bubble replies, SQLite snapshot import, and conversation clear use the same crash-recoverable WAL protocol.
- Writers are serialized by a process path lock plus an OS file lock; tests cover independent storage instances writing concurrently.
- Message IDs are the single durable ordering identity; byte offsets are ephemeral paging cursors and are not stored on messages.
- Unread count, latest message, reply progress, and pending-reply discovery normally read metadata without scanning history.
- Older-turn scans occur only on idempotency fallback; initiative delivery is infrequent, while direct conversation retries use the processed-message boundary to avoid scanning on normal writes.
- Clearing increments a conversation generation and never reuses message IDs, so stale agent output cannot reappear after reset.

Fixes #347

## Test plan

- [x] Storage tests cover flat message schema, byte-cursor paging, concurrent ID allocation, UTF-8 tail repair, read/processing boundaries, older-turn idempotency, and path safety.
- [x] Fault injection covers interruption after WAL creation, message append, and metadata replacement, including partial batches, clear, and legacy SQLite import.
- [x] Migration/recovery tests verify one-way SQLite import, the unified v1 migration marker, runtime independence after SQLite is wiped, and multi-bubble retry idempotency.
- [x] Character conversation, initiative, startup reconciliation, UI ViewModel, widget, and integration pipeline tests pass.
- [x] `flutter test`: 851 passed, 5 skipped live/environment-dependent tests, 0 failed.
- [x] `flutter analyze`: no errors or warnings; 158 pre-existing info-level lints remain outside the changed files.
