### PR TITLE
fix: make Timeline and Library tabs tappable above the home indicator

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,8 @@ import 'dart:async';
 import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:memex/l10n/app_localizations.dart';
@@ -48,7 +46,7 @@ import 'package:health/health.dart';
 import 'package:memex/utils/logger.dart';
 import 'package:memex/utils/toast_helper.dart';
 import 'package:memex/ui/agent_activity/widgets/agent_activity_widget.dart';
-import 'package:memex/ui/main_screen/widgets/ai_core_button.dart';
+import 'package:memex/ui/main_screen/widgets/main_bottom_bar.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/data/services/local_server_service.dart';
 import 'package:memex/data/services/app_update_service.dart';
@@ -1907,160 +1905,25 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       bottom: 0,
       left: 0,
       right: 0,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // The 393x120.5 Figma Canvas scaled flawlessly to screen width
-          FittedBox(
-            fit: BoxFit.fitWidth,
-            alignment: Alignment.bottomCenter,
-            child: SizedBox(
-              width: 393,
-              // PNG bounding box height: 120.5 (includes 20px top shadow + 80.5px white shape)
-              height: 120.5,
-              child: Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  // Painted Native Vector Overlay
-                  // Completely removing dependencies on Figma PNG/SVG transparent paddings!
-                  Positioned.fill(
-                    child: CustomPaint(painter: _NavBarPainter()),
-                  ),
-
-                  // Shadow occluder mask
-                  // The Figma export's shadow has a giant blur that leaks downward.
-                  // Placed OVER the image at exactly y=100.0 (where the white shape ends)
-                  // It completely masks out the grey blur and extends solidly into the Safe Area.
-                  Positioned(
-                    top: 100.0,
-                    bottom: -100.0,
-                    left: 0,
-                    right: 0,
-                    child: Container(color: Colors.white),
-                  ),
-
-                  // Center Action Button (88x88 widget, 68x68 nested circle)
-                  // Dialed down to -16.0 for a more subdued hover gap.
-                  Positioned(
-                    top: -16.0,
-                    left: 156.0,
-                    child: AICoreButton(
-                      key: DemoService.instance.isActive
-                          ? DemoService.instance.addButtonKey
-                          : _aiButtonKey,
-                      onTap: () {
-                        // Advance first so _handleAICoreButtonTap sees tapSend step for prefill
-                        DemoService.instance.tryAdvance(DemoStep.tapAddButton);
-                        _handleAICoreButtonTap();
-                      },
-                      onLongPress: _handleAICoreButtonLongPressStart,
-                      onLongPressMoveUpdate:
-                          _handleAICoreButtonLongPressMoveUpdate,
-                      onLongPressEnd: _handleAICoreButtonLongPressEnd,
-                    ),
-                  ),
-
-                  // Timeline Icon
-                  Positioned(
-                    top: 46.63, // 26.63 local + 20px shadow
-                    left: 64.17,
-                    child: GestureDetector(
-                      behavior: HitTestBehavior.opaque,
-                      onTap: _handleTimelineTabTap,
-                      child: SvgPicture.asset(
-                        'assets/icons/tab_timeline_active.svg',
-                        width: 22,
-                        height: 23,
-                        colorFilter: ColorFilter.mode(
-                          _currentTab == 0
-                              ? const Color(0xFF1F1F1F)
-                              : const Color(0xFF99A1AF),
-                          BlendMode.srcIn,
-                        ),
-                      ),
-                    ),
-                  ),
-
-                  // Timeline Text
-                  Positioned(
-                    top: 76.0,
-                    left: 25.17,
-                    child: GestureDetector(
-                      behavior: HitTestBehavior.opaque,
-                      onTap: _handleTimelineTabTap,
-                      child: SizedBox(
-                        width:
-                            100, // Widened from strict 58 to permit iOS text expansion
-                        // Removed strict height boundary to prevent vertical ascender clipping
-                        child: Text(
-                          UserStorage.l10n.bottomNavTimeline,
-                          textAlign: TextAlign.center,
-                          style: GoogleFonts.inter(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w400,
-                            color: _currentTab == 0
-                                ? const Color(0xFF1F1F1F)
-                                : const Color(0xFF99A1AF),
-                            letterSpacing: 0.14,
-                            height: 1.0,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-
-                  // Library — single widget for both icon + text so the
-                  // demo spotlight key covers the whole tab area.
-                  Positioned(
-                    top: 47.02,
-                    left: 299.58,
-                    child: GestureDetector(
-                      key: DemoService.instance.knowledgeTabKey,
-                      behavior: HitTestBehavior.opaque,
-                      onTap: () {
-                        _handleLibraryTabTap();
-                        DemoService.instance.tryAdvance(
-                          DemoStep.tapKnowledgeTab,
-                        );
-                      },
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          SvgPicture.asset(
-                            'assets/icons/tab_library_inactive.svg',
-                            width: 25.06,
-                            height: 21.15,
-                            colorFilter: ColorFilter.mode(
-                              _currentTab == 1
-                                  ? const Color(0xFF1F1F1F)
-                                  : const Color(0xFF99A1AF),
-                              BlendMode.srcIn,
-                            ),
-                          ),
-                          const SizedBox(height: 76.0 - 47.02 - 21.15),
-                          Text(
-                            UserStorage.l10n.bottomNavLibrary,
-                            textAlign: TextAlign.center,
-                            style: GoogleFonts.inter(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w400,
-                              color: _currentTab == 1
-                                  ? const Color(0xFF1F1F1F)
-                                  : const Color(0xFF99A1AF),
-                              letterSpacing: 0.14,
-                              height: 1.0,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
+      child: MainBottomBar(
+        currentTab: _currentTab,
+        onTimelineTap: _handleTimelineTabTap,
+        onLibraryTap: () {
+          _handleLibraryTabTap();
+          DemoService.instance.tryAdvance(DemoStep.tapKnowledgeTab);
+        },
+        onCenterTap: () {
+          // Advance first so _handleAICoreButtonTap sees tapSend step for prefill
+          DemoService.instance.tryAdvance(DemoStep.tapAddButton);
+          _handleAICoreButtonTap();
+        },
+        onCenterLongPress: _handleAICoreButtonLongPressStart,
+        onCenterLongPressMoveUpdate: _handleAICoreButtonLongPressMoveUpdate,
+        onCenterLongPressEnd: _handleAICoreButtonLongPressEnd,
+        centerButtonKey: DemoService.instance.isActive
+            ? DemoService.instance.addButtonKey
+            : _aiButtonKey,
+        libraryTabKey: DemoService.instance.knowledgeTabKey,
       ),
     );
   }
@@ -2101,42 +1964,4 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       }
     }
   }
-}
-
-class _NavBarPainter extends CustomPainter {
-  @override
-  void paint(Canvas canvas, Size size) {
-    final Path path = Path();
-    path.moveTo(0, 20);
-    path.lineTo(142.528, 20);
-    path.cubicTo(148.501, 20, 153.977, 23.3275, 156.729, 28.6293);
-    path.lineTo(164.497, 43.5965);
-    path.cubicTo(179.426, 72.3609, 220.574, 72.3609, 235.503, 43.5966);
-    path.lineTo(243.271, 28.6293);
-    path.cubicTo(246.023, 23.3275, 251.499, 20, 257.472, 20);
-    path.lineTo(size.width, 20);
-    path.lineTo(size.width, size.height);
-    path.lineTo(0, size.height);
-    path.lineTo(0, 20);
-    path.close();
-
-    // Custom drop shadow that doesn't bleed weirdly
-    // We clip the bottom so the shadow never goes below the nav bar visually
-    canvas.save();
-    canvas.clipRect(
-      Rect.fromLTWH(-50, -50, size.width + 100, size.height + 50),
-    );
-    canvas.drawPath(
-      path,
-      Paint()
-        ..color = Colors.black.withValues(alpha: 0.08)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 10.0),
-    );
-    canvas.restore();
-
-    canvas.drawPath(path, Paint()..color = Colors.white);
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/lib/ui/main_screen/widgets/main_bottom_bar.dart
+++ b/lib/ui/main_screen/widgets/main_bottom_bar.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:memex/ui/main_screen/widgets/ai_core_button.dart';
+import 'package:memex/utils/user_storage.dart';
+
+/// Home bottom bar: Timeline / capture / Library, scaled from the 393-wide
+/// Figma canvas. Tab hit targets are enlarged and lifted above the system
+/// gesture inset so taps still switch pages on phones with a home indicator.
+class MainBottomBar extends StatelessWidget {
+  const MainBottomBar({
+    super.key,
+    required this.currentTab,
+    required this.onTimelineTap,
+    required this.onLibraryTap,
+    required this.onCenterTap,
+    required this.onCenterLongPress,
+    this.onCenterLongPressMoveUpdate,
+    this.onCenterLongPressEnd,
+    this.centerButtonKey,
+    this.timelineTabKey,
+    this.libraryTabKey,
+  });
+
+  final int currentTab;
+  final VoidCallback onTimelineTap;
+  final VoidCallback onLibraryTap;
+  final VoidCallback onCenterTap;
+  final VoidCallback onCenterLongPress;
+  final GestureLongPressMoveUpdateCallback? onCenterLongPressMoveUpdate;
+  final GestureLongPressEndCallback? onCenterLongPressEnd;
+  final Key? centerButtonKey;
+  final Key? timelineTabKey;
+  final Key? libraryTabKey;
+
+  static const double designWidth = 393;
+  static const double designHeight = 120.5;
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.paddingOf(context).bottom;
+    const selectedColor = Color(0xFF1F1F1F);
+    const idleColor = Color(0xFF99A1AF);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FittedBox(
+          fit: BoxFit.fitWidth,
+          alignment: Alignment.bottomCenter,
+          child: SizedBox(
+            width: designWidth,
+            height: designHeight,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                const Positioned.fill(
+                  child: CustomPaint(painter: _NavBarPainter()),
+                ),
+                const Positioned(
+                  top: 100.0,
+                  bottom: -100.0,
+                  left: 0,
+                  right: 0,
+                  child: ColoredBox(color: Colors.white),
+                ),
+                Positioned(
+                  top: -16.0,
+                  left: 156.0,
+                  child: AICoreButton(
+                    key: centerButtonKey,
+                    onTap: onCenterTap,
+                    onLongPress: onCenterLongPress,
+                    onLongPressMoveUpdate: onCenterLongPressMoveUpdate,
+                    onLongPressEnd: onCenterLongPressEnd,
+                  ),
+                ),
+                _NavTab(
+                  key: timelineTabKey,
+                  top: 40,
+                  left: 16,
+                  width: 118,
+                  height: 56,
+                  selected: currentTab == 0,
+                  label: UserStorage.l10n.bottomNavTimeline,
+                  onTap: onTimelineTap,
+                  icon: SvgPicture.asset(
+                    'assets/icons/tab_timeline_active.svg',
+                    width: 22,
+                    height: 23,
+                    colorFilter: ColorFilter.mode(
+                      currentTab == 0 ? selectedColor : idleColor,
+                      BlendMode.srcIn,
+                    ),
+                  ),
+                ),
+                _NavTab(
+                  key: libraryTabKey,
+                  top: 40,
+                  left: 259,
+                  width: 118,
+                  height: 56,
+                  selected: currentTab == 1,
+                  label: UserStorage.l10n.bottomNavLibrary,
+                  onTap: onLibraryTap,
+                  icon: SvgPicture.asset(
+                    'assets/icons/tab_library_inactive.svg',
+                    width: 25.06,
+                    height: 21.15,
+                    colorFilter: ColorFilter.mode(
+                      currentTab == 1 ? selectedColor : idleColor,
+                      BlendMode.srcIn,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (bottomInset > 0)
+          ColoredBox(
+            color: Colors.white,
+            child: SizedBox(height: bottomInset),
+          ),
+      ],
+    );
+  }
+}
+
+class _NavTab extends StatelessWidget {
+  const _NavTab({
+    super.key,
+    required this.top,
+    required this.left,
+    required this.width,
+    required this.height,
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final double top;
+  final double left;
+  final double width;
+  final double height;
+  final Widget icon;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      top: top,
+      left: left,
+      width: width,
+      height: height,
+      child: Semantics(
+        button: true,
+        selected: selected,
+        label: label,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              icon,
+              const SizedBox(height: 6),
+              Text(
+                label,
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: GoogleFonts.inter(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w400,
+                  color: selected
+                      ? const Color(0xFF1F1F1F)
+                      : const Color(0xFF99A1AF),
+                  letterSpacing: 0.14,
+                  height: 1.0,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NavBarPainter extends CustomPainter {
+  const _NavBarPainter();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final path = Path();
+    path.moveTo(0, 20);
+    path.lineTo(142.528, 20);
+    path.cubicTo(148.501, 20, 153.977, 23.3275, 156.729, 28.6293);
+    path.lineTo(164.497, 43.5965);
+    path.cubicTo(179.426, 72.3609, 220.574, 72.3609, 235.503, 43.5966);
+    path.lineTo(243.271, 28.6293);
+    path.cubicTo(246.023, 23.3275, 251.499, 20, 257.472, 20);
+    path.lineTo(size.width, 20);
+    path.lineTo(size.width, size.height);
+    path.lineTo(0, size.height);
+    path.lineTo(0, 20);
+    path.close();
+
+    canvas.save();
+    canvas.clipRect(
+      Rect.fromLTWH(-50, -50, size.width + 100, size.height + 50),
+    );
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = Colors.black.withValues(alpha: 0.08)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 10.0),
+    );
+    canvas.restore();
+
+    canvas.drawPath(path, Paint()..color = Colors.white);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/test/ui/main_screen/widgets/main_bottom_bar_test.dart
+++ b/test/ui/main_screen/widgets/main_bottom_bar_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/main_screen/widgets/main_bottom_bar.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const timelineKey = ValueKey('test-timeline-tab');
+  const libraryKey = ValueKey('test-library-tab');
+
+  setUpAll(() async {
+    GoogleFonts.config.allowRuntimeFetching = false;
+    SharedPreferences.setMockInitialValues({
+      'user_id': 'bottom-bar-test',
+      'language': 'en',
+    });
+    await UserStorage.initL10n();
+  });
+
+  Future<void> pumpBar(
+    WidgetTester tester, {
+    required int currentTab,
+    required VoidCallback onTimelineTap,
+    required VoidCallback onLibraryTap,
+    double bottomInset = 0,
+  }) async {
+    tester.view.physicalSize = const Size(393, 852);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = FakeViewPadding(bottom: bottomInset);
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Stack(
+            children: [
+              Positioned(
+                bottom: 0,
+                left: 0,
+                right: 0,
+                child: MainBottomBar(
+                  currentTab: currentTab,
+                  onTimelineTap: onTimelineTap,
+                  onLibraryTap: onLibraryTap,
+                  onCenterTap: () {},
+                  onCenterLongPress: () {},
+                  timelineTabKey: timelineKey,
+                  libraryTabKey: libraryKey,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('tapping the Timeline label or icon area switches the tab', (
+    tester,
+  ) async {
+    var timelineTaps = 0;
+    var libraryTaps = 0;
+
+    await pumpBar(
+      tester,
+      currentTab: 1,
+      onTimelineTap: () => timelineTaps += 1,
+      onLibraryTap: () => libraryTaps += 1,
+    );
+
+    await tester.tap(find.text(UserStorage.l10n.bottomNavTimeline));
+    await tester.pump();
+    expect(timelineTaps, 1);
+
+    final tabBox = tester.getRect(find.byKey(timelineKey));
+    await tester.tapAt(tabBox.topLeft + const Offset(8, 8));
+    await tester.pump();
+    expect(timelineTaps, 2);
+    expect(libraryTaps, 0);
+  });
+
+  testWidgets('tapping the Library tab area switches the tab', (tester) async {
+    var libraryTaps = 0;
+
+    await pumpBar(
+      tester,
+      currentTab: 0,
+      onTimelineTap: () {},
+      onLibraryTap: () => libraryTaps += 1,
+    );
+
+    await tester.tap(find.text(UserStorage.l10n.bottomNavLibrary));
+    await tester.pump();
+    expect(libraryTaps, 1);
+  });
+
+  testWidgets('home-indicator inset keeps tab labels above the gesture zone', (
+    tester,
+  ) async {
+    const inset = 34.0;
+    await pumpBar(
+      tester,
+      currentTab: 0,
+      onTimelineTap: () {},
+      onLibraryTap: () {},
+      bottomInset: inset,
+    );
+
+    final labelBottom =
+        tester.getBottomLeft(find.text(UserStorage.l10n.bottomNavTimeline)).dy;
+    expect(labelBottom, lessThan(852 - inset));
+    expect(tester.getSize(find.byType(MainBottomBar)).height, 120.5 + inset);
+  });
+}


### PR DESCRIPTION
## Summary
- Timeline and Library sat on ~22×23 SVG hit targets, and Timeline split the icon and label into two detectors with a dead zone between them.
- The bar was pinned to `bottom: 0` with `extendBody: true`, so labels sat in the home-indicator / gesture zone and taps failed to switch tabs.
- Each tab is now one 118×56 target covering icon and label. A white fill matches the system bottom inset so the Figma bar stays above it.

Fixes #350

## Test plan
- [x] `flutter test test/ui/main_screen/widgets/main_bottom_bar_test.dart`
- [x] On a phone with a home indicator, tap Timeline and Library on the icon, the label, and the space around them
- [x] Confirm the center capture button and long-press radial menu still work
- [x] Confirm demo spotlight still highlights the Library tab