### PR TITLE
Refresh recommended LLM model catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,20 +96,20 @@ https://github.com/user-attachments/assets/5048a9b1-47b2-462a-99f3-6a178e183861
 
 | Provider | API Type | Notes |
 |----------|----------|-------|
-| Google Gemini | Gemini API | gemini-3.5-flash, gemini-3.1-pro-preview, etc. |
+| Google Gemini | Gemini API | gemini-3.6-flash, gemini-3.1-pro-preview, etc. |
 | Google Gemini | OAuth (no API key required) | Sign in with Google account. Unofficial — use at your own risk |
-| OpenAI | Chat Completions / Responses API | gpt-5.5, gpt-5.4, etc. |
+| OpenAI | Chat Completions / Responses API | gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, etc. |
 | ChatGPT | OAuth (no API key required) | Sign in with OpenAI account. Unofficial — use at your own risk |
-| Anthropic Claude | Claude API | Direct API access |
-| AWS Bedrock | Bedrock Claude | For AWS users |
+| Anthropic Claude | Claude API | claude-fable-5, claude-opus-5, claude-sonnet-5 |
+| AWS Bedrock | Bedrock Claude | anthropic.claude-fable-5, anthropic.claude-opus-5, etc. |
 | Memex AI | Managed model access | Optional account-based model access; journal data remains local |
-| Kimi (Moonshot) | OpenAI-compatible | kimi-k2.5, kimi-k2, etc. |
-| Aliyun (Qwen) | OpenAI-compatible | qwen3.5-plus, qwen3-coder, etc. |
-| Volcengine (Doubao) | OpenAI / Responses-compatible | doubao-seed-2-0-pro-260215, doubao-seed-1-8-251228, etc. |
-| Zhipu GLM | OpenAI-compatible | glm-5v-turbo, glm-4.6v |
+| Kimi (Moonshot) | OpenAI-compatible | kimi-k3, kimi-k2.7-code, etc. |
+| Aliyun (Qwen) | OpenAI-compatible | qwen3.8-max, qwen3.7-plus, qwen3.7-flash |
+| Volcengine (Doubao) | OpenAI / Responses-compatible | doubao-seed-2-0-pro-260215, doubao-seed-2-0-mini-260428, etc. |
+| Zhipu GLM | OpenAI-compatible | glm-5.2, glm-5v-turbo, glm-4.6v |
 | DeepSeek | OpenAI-compatible | deepseek-v4-flash, deepseek-v4-pro |
-| MiniMax | Anthropic-compatible | MiniMax-M2.5, MiniMax-M1 |
-| Xiaomi MIMO | Anthropic-compatible | mimo-v2.5, mimo-v2-omni, etc. |
+| MiniMax | Anthropic-compatible | MiniMax-M3, MiniMax-M2.7, etc. |
+| Xiaomi MIMO | Anthropic-compatible | mimo-v2.5-pro, mimo-v2.5 |
 | OpenRouter | OpenAI-compatible | Access multiple providers via one API |
 | Ollama | OpenAI-compatible (local) | Run models locally on your device |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -96,20 +96,20 @@ https://github.com/user-attachments/assets/37e59089-9f94-44dc-8265-269045ce982f
 
 | 提供商 | API 类型 | 备注 |
 |--------|----------|------|
-| Google Gemini | Gemini API | gemini-3.5-flash、gemini-3.1-pro-preview 等 |
+| Google Gemini | Gemini API | gemini-3.6-flash、gemini-3.1-pro-preview 等 |
 | Google Gemini | OAuth（无需 API Key） | 使用 Google 账号登录，非官方支持，风险自负 |
-| OpenAI | Chat Completions / Responses API | gpt-5.5、gpt-5.4 等 |
+| OpenAI | Chat Completions / Responses API | gpt-5.6-sol、gpt-5.6-terra、gpt-5.6-luna 等 |
 | ChatGPT | OAuth（无需 API Key） | 使用 OpenAI 账号登录，非官方支持，风险自负 |
-| Anthropic Claude | Claude API | 直接 API 访问 |
-| AWS Bedrock | Bedrock Claude | 适合 AWS 用户 |
+| Anthropic Claude | Claude API | claude-fable-5、claude-opus-5、claude-sonnet-5 |
+| AWS Bedrock | Bedrock Claude | anthropic.claude-fable-5、anthropic.claude-opus-5 等 |
 | Memex AI | 托管模型访问 | 可选账号制模型访问；日记数据仍保存在本地 |
-| Kimi（月之暗面） | OpenAI 兼容 | kimi-k2.5、kimi-k2 等 |
-| 阿里云（通义千问） | OpenAI 兼容 | qwen3.5-plus、qwen3-coder 等 |
-| 火山引擎（豆包） | OpenAI / Responses 兼容 | doubao-seed-2-0-pro-260215、doubao-seed-1-8-251228 等 |
-| 智谱 GLM | OpenAI 兼容 | glm-5v-turbo、glm-4.6v |
+| Kimi（月之暗面） | OpenAI 兼容 | kimi-k3、kimi-k2.7-code 等 |
+| 阿里云（通义千问） | OpenAI 兼容 | qwen3.8-max、qwen3.7-plus、qwen3.7-flash |
+| 火山引擎（豆包） | OpenAI / Responses 兼容 | doubao-seed-2-0-pro-260215、doubao-seed-2-0-mini-260428 等 |
+| 智谱 GLM | OpenAI 兼容 | glm-5.2、glm-5v-turbo、glm-4.6v |
 | DeepSeek | OpenAI 兼容 | deepseek-v4-flash、deepseek-v4-pro |
-| MiniMax | Anthropic 兼容 | MiniMax-M2.5、MiniMax-M1 |
-| 小米 MIMO | Anthropic 兼容 | mimo-v2.5、mimo-v2-omni 等 |
+| MiniMax | Anthropic 兼容 | MiniMax-M3、MiniMax-M2.7 等 |
+| 小米 MIMO | Anthropic 兼容 | mimo-v2.5-pro、mimo-v2.5 |
 | OpenRouter | OpenAI 兼容 | 通过一个 API 访问多个提供商 |
 | Ollama | OpenAI 兼容（本地） | 在本地设备上运行模型 |
 

--- a/lib/data/services/openai_auth_service.dart
+++ b/lib/data/services/openai_auth_service.dart
@@ -356,6 +356,10 @@ class OpenAiAuthService {
 
     // Allowed models whitelist (from opencode codex.ts)
     const allowedModels = {
+      'gpt-5.6',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
       'gpt-5.5',
       'gpt-5.4-mini',
       'gpt-5.3-codex',

--- a/lib/domain/models/llm_config.dart
+++ b/lib/domain/models/llm_config.dart
@@ -133,6 +133,10 @@ class LLMConfig {
 
   /// Models that require a ChatGPT Pro/Plus subscription (OpenAI OAuth only).
   static const Set<String> chatgptProOnlyModels = {
+    'gpt-5.6',
+    'gpt-5.6-sol',
+    'gpt-5.6-terra',
+    'gpt-5.6-luna',
     'gpt-5.5',
     'gpt-5.4',
     'gpt-5.3-codex',
@@ -147,84 +151,110 @@ class LLMConfig {
     switch (type) {
       case typeChatCompletion:
       case typeResponses:
-        return const {'gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'o3'};
+        return const {
+          'gpt-5.6-sol',
+          'gpt-5.6-terra',
+          'gpt-5.6-luna',
+        };
       case typeOpenAiOauth:
-        return const {'gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini'};
+        return const {
+          'gpt-5.6-sol',
+          'gpt-5.6-terra',
+          'gpt-5.6-luna',
+        };
       case typeClaude:
         return const {
-          'claude-opus-4-8',
-          'claude-opus-4-7',
-          'claude-opus-4-6',
-          'claude-sonnet-4-6',
+          'claude-fable-5',
+          'claude-opus-5',
+          'claude-sonnet-5',
         };
       case typeBedrockClaude:
         return const {
-          'anthropic.claude-opus-4-8',
-          'anthropic.claude-opus-4-7',
-          'us.anthropic.claude-opus-4-6-v1',
-          'us.anthropic.claude-sonnet-4-6',
+          'anthropic.claude-fable-5',
+          'anthropic.claude-opus-5',
+          'anthropic.claude-sonnet-5',
         };
       case typeGemini:
       case typeGeminiOauth:
-        return const {'gemini-3.5-flash', 'gemini-3.1-pro-preview'};
+        return const {'gemini-3.6-flash', 'gemini-3.1-pro-preview'};
       case typeKimi:
-        return const {'kimi-k2.5'};
+        return const {'kimi-k3', 'kimi-k2.7-code'};
       case typeQwen:
-        return const {'qwen3.5-plus'};
+        return const {'qwen3.8-max', 'qwen3.7-plus', 'qwen3.7-flash'};
       case typeSeed:
-        return const {'doubao-seed-2-0-pro-260215', 'doubao-seed-1-8-251228'};
+        return const {
+          'doubao-seed-2-0-pro-260215',
+          'doubao-seed-2-0-code-preview-260215',
+        };
       case typeZhipu:
-        return const {'glm-5v-turbo', 'glm-4.6v'};
+        return const {'glm-5.2', 'glm-5v-turbo'};
       case typeDeepSeek:
         return const {'deepseek-v4-flash', 'deepseek-v4-pro'};
+      case typeMinimax:
+        return const {'MiniMax-M3', 'MiniMax-M2.7'};
       case typeMimo:
-        return const {'mimo-v2-pro'};
+        return const {'mimo-v2.5-pro', 'mimo-v2.5'};
       case typeOpenRouter:
         return const {
-          'openai/gpt-5.5',
-          'anthropic/claude-opus-4.8',
-          'anthropic/claude-opus-4.7',
-          'google/gemini-3.5-flash',
-          'anthropic/claude-opus-4.6',
-          'anthropic/claude-sonnet-4.6',
+          'anthropic/claude-fable-5',
+          'anthropic/claude-opus-5',
+          'anthropic/claude-sonnet-5',
+          'openai/gpt-5.6-sol',
+          'openai/gpt-5.6-terra',
+          'openai/gpt-5.6-luna',
+          'google/gemini-3.6-flash',
           'google/gemini-3.1-pro-preview',
-          'openai/gpt-5.4',
-          'openai/o3',
-          'qwen/qwen-plus',
-          'qwen/qwen-max',
-          'x-ai/grok-4',
-          'z-ai/glm-4.6v',
-          'z-ai/glm-5v-turbo',
+          'qwen/qwen3.8-max',
+          'deepseek/deepseek-v4-pro',
+          'minimax/minimax-m3',
+          'z-ai/glm-5.2',
+          'xiaomi/mimo-v2.5-pro',
+          'moonshotai/kimi-k2.7-code',
         };
+      case typeOllama:
+        return const {'qwen3.5:9b', 'gemma4:12b', 'llama4:scout'};
       default:
         return const {};
     }
   }
 
   /// Recommended model IDs per provider type.
+  ///
+  /// This is a curated starter list rather than an exhaustive compatibility
+  /// list. Prefer the current model family plus its immediate predecessor,
+  /// retain distinct price/performance tiers within those families, and keep
+  /// endpoint-specific models out of providers that cannot invoke them. Users
+  /// can still enter older supported model IDs manually.
   static List<String> recommendedModels(String type) {
     switch (type) {
       case typeGemini:
       case typeGeminiOauth:
         return const [
-          'gemini-3.5-flash',
+          'gemini-3.6-flash',
           'gemini-3.1-pro-preview',
-          'gemini-3-flash-preview',
-          'gemini-3.1-flash-lite-preview',
+          'gemini-3.5-flash',
+          'gemini-3.5-flash-lite',
         ];
       case typeChatCompletion:
+        return const [
+          'gpt-5.6-sol',
+          'gpt-5.6-terra',
+          'gpt-5.6-luna',
+          'gpt-5.5',
+        ];
       case typeResponses:
         return const [
+          'gpt-5.6-sol',
+          'gpt-5.6-terra',
+          'gpt-5.6-luna',
           'gpt-5.5',
-          'gpt-5.4',
-          'gpt-5.4-mini',
-          'gpt-5.4-nano',
-          'o3',
-          'gpt-5.4-pro',
-          'gpt-5.3-codex',
+          'gpt-5.5-pro',
         ];
       case typeOpenAiOauth:
         return const [
+          'gpt-5.6-sol',
+          'gpt-5.6-terra',
+          'gpt-5.6-luna',
           'gpt-5.5',
           'gpt-5.4',
           'gpt-5.4-mini',
@@ -232,70 +262,82 @@ class LLMConfig {
         ];
       case typeClaude:
         return const [
+          'claude-fable-5',
+          'claude-opus-5',
+          'claude-sonnet-5',
           'claude-opus-4-8',
-          'claude-opus-4-7',
-          'claude-opus-4-6',
-          'claude-sonnet-4-6',
           'claude-haiku-4-5-20251001',
         ];
       case typeBedrockClaude:
         return const [
+          'anthropic.claude-fable-5',
+          'anthropic.claude-opus-5',
+          'anthropic.claude-sonnet-5',
           'anthropic.claude-opus-4-8',
           'global.anthropic.claude-opus-4-8',
           'us.anthropic.claude-opus-4-8',
-          'anthropic.claude-opus-4-7',
-          'global.anthropic.claude-opus-4-7',
-          'us.anthropic.claude-opus-4-7',
-          'us.anthropic.claude-opus-4-6-v1',
-          'global.anthropic.claude-opus-4-6-v1',
-          'us.anthropic.claude-sonnet-4-6',
-          'global.anthropic.claude-sonnet-4-6',
           'us.anthropic.claude-haiku-4-5-20251001-v1:0',
           'global.anthropic.claude-haiku-4-5-20251001-v1:0',
         ];
       case typeKimi:
         return const [
+          'kimi-k3',
+          'kimi-k2.7-code',
+          'kimi-k2.6',
           'kimi-k2.5',
-          'kimi-k2',
-          'kimi-k2-thinking',
-          'kimi-k2-thinking-turbo',
-          'kimi-k2-turbo-preview',
         ];
       case typeQwen:
         return const [
+          'qwen3.8-max',
+          'qwen3.7-plus',
+          'qwen3.7-flash',
           'qwen3.5-plus',
-          'qwen3-coder',
-          'qwen3-235b-a22b',
-          'qwen-max',
         ];
       case typeSeed:
-        return const ['doubao-seed-1-8-251228', 'doubao-1.5-pro-256k'];
+        return const [
+          'doubao-seed-2-0-pro-260215',
+          'doubao-seed-2-0-code-preview-260215',
+          'doubao-seed-2-0-mini-260428',
+          'doubao-seed-2-0-lite-260428',
+        ];
       case typeZhipu:
-        return const ['glm-5v-turbo', 'glm-4.6v'];
+        return const ['glm-5.2', 'glm-5v-turbo', 'glm-4.6v'];
       case typeDeepSeek:
         return const ['deepseek-v4-flash', 'deepseek-v4-pro'];
       case typeMinimax:
-        return const ['MiniMax-M2.5', 'MiniMax-M1'];
+        return const [
+          'MiniMax-M3',
+          'MiniMax-M2.7',
+          'MiniMax-M2.7-highspeed',
+          'MiniMax-M2.5',
+        ];
       case typeOpenRouter:
         return const [
-          'openai/gpt-5.5',
-          'anthropic/claude-opus-4.8',
-          'anthropic/claude-opus-4.7',
-          'google/gemini-3.5-flash',
-          'anthropic/claude-opus-4.6',
-          'anthropic/claude-sonnet-4.6',
-          'openai/gpt-5.4',
+          'anthropic/claude-fable-5',
+          'anthropic/claude-opus-5',
+          'anthropic/claude-sonnet-5',
+          'openai/gpt-5.6-sol',
+          'openai/gpt-5.6-terra',
+          'openai/gpt-5.6-luna',
+          'google/gemini-3.6-flash',
+          'google/gemini-3.1-pro-preview',
+          'qwen/qwen3.8-max',
+          'deepseek/deepseek-v4-pro',
+          'minimax/minimax-m3',
+          'z-ai/glm-5.2',
+          'xiaomi/mimo-v2.5-pro',
+          'moonshotai/kimi-k2.7-code',
         ];
       case typeOllama:
-        return const ['qwen2.5:7b', 'llama3.1:8b', 'gemma3:12b'];
-      case typeMimo:
         return const [
-          'mimo-v2.5',
-          'mimo-v2-omni',
-          'mimo-v2.5-pro',
-          'mimo-v2-pro',
-          'mimo-v2-flash',
+          'qwen3.5:9b',
+          'qwen3.5:4b',
+          'gemma4:12b',
+          'gemma4:e4b',
+          'llama4:scout',
         ];
+      case typeMimo:
+        return const ['mimo-v2.5-pro', 'mimo-v2.5'];
       default:
         return const [];
     }
@@ -369,6 +411,7 @@ class LLMConfig {
       case typeClaude:
       case typeBedrockClaude:
         return id.contains('claude-3') ||
+            id.contains('claude-fable') ||
             id.contains('claude-sonnet') ||
             id.contains('claude-opus') ||
             id.contains('claude-haiku');
@@ -381,14 +424,35 @@ class LLMConfig {
             id.contains('o3');
       case typeZhipu:
         return id.contains('glm-') && id.contains('v');
+      case typeKimi:
+        return id.startsWith('kimi-k3') ||
+            id.startsWith('kimi-k2.7') ||
+            id.startsWith('kimi-k2.6') ||
+            id.startsWith('kimi-k2.5');
       case typeMimo:
         return id == 'mimo-v2.5' || id == 'mimo-v2-omni' || id.contains('omni');
       case typeQwen:
-      case typeSeed:
-      case typeMinimax:
-        return id.contains('vl') ||
+        return id.startsWith('qwen3.8-') ||
+            id.startsWith('qwen3.7-plus') ||
+            id.startsWith('qwen3.7-flash') ||
+            id.startsWith('qwen3.6-') ||
+            id.startsWith('qwen3.5-') ||
+            id.contains('vl') ||
             id.contains('vision') ||
             id.contains('omni');
+      case typeSeed:
+        return id.startsWith('doubao-seed-2-0') ||
+            id.contains('vision') ||
+            id.contains('omni');
+      case typeMinimax:
+        return id == 'minimax-m3' ||
+            id.contains('vl') ||
+            id.contains('vision') ||
+            id.contains('omni');
+      case typeOllama:
+        return id.startsWith('qwen3.5') ||
+            id.startsWith('gemma4') ||
+            id.startsWith('llama4');
       case typeOpenRouter:
       case typeMemex:
         return id.contains('gemini') ||
@@ -627,7 +691,7 @@ class LLMConfig {
       key: defaultClientKey,
       baseUrl: "https://api.openai.com/v1",
       type: typeChatCompletion,
-      modelId: 'gpt-5.4',
+      modelId: 'gpt-5.6-sol',
       maxTokens: 65536,
       apiKey: '',
       extra: {},

--- a/test/domain/models/llm_config_test.dart
+++ b/test/domain/models/llm_config_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/config/app_flavor.dart';
 import 'package:memex/domain/models/llm_config.dart';
 
 void main() {
@@ -114,6 +115,98 @@ void main() {
       expect(validConfig.isValid, isTrue);
       expect(validConfig.copyWith(apiKey: '').isValid, isFalse);
       expect(validConfig.copyWith(baseUrl: '').isValid, isFalse);
+    });
+  });
+
+  group('current model recommendations', () {
+    test('uses the canonical GPT-5.6 Sol ID for new global configurations', () {
+      AppFlavor.init('global');
+
+      expect(LLMConfig.createDefaultClientConfig().modelId, 'gpt-5.6-sol');
+      expect(
+        LLMConfig.recommendedModels(LLMConfig.typeChatCompletion).take(3),
+        ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'],
+      );
+      expect(
+        LLMConfig.featuredModels(LLMConfig.typeResponses),
+        containsAll(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']),
+      );
+    });
+
+    test('keeps OpenAI recommendations current and endpoint-specific', () {
+      final chatModels = LLMConfig.recommendedModels(
+        LLMConfig.typeChatCompletion,
+      );
+      final responseModels = LLMConfig.recommendedModels(
+        LLMConfig.typeResponses,
+      );
+
+      expect(chatModels, [
+        'gpt-5.6-sol',
+        'gpt-5.6-terra',
+        'gpt-5.6-luna',
+        'gpt-5.5',
+      ]);
+      expect(responseModels, [...chatModels, 'gpt-5.5-pro']);
+      expect(chatModels, isNot(contains('gpt-5.5-pro')));
+      expect(
+        [...chatModels, ...responseModels],
+        isNot(contains(startsWith('gpt-5.4'))),
+      );
+    });
+
+    test('includes the latest frontier models for hosted providers', () {
+      final expectedFirstModel = <String, String>{
+        LLMConfig.typeClaude: 'claude-fable-5',
+        LLMConfig.typeBedrockClaude: 'anthropic.claude-fable-5',
+        LLMConfig.typeGemini: 'gemini-3.6-flash',
+        LLMConfig.typeKimi: 'kimi-k3',
+        LLMConfig.typeQwen: 'qwen3.8-max',
+        LLMConfig.typeSeed: 'doubao-seed-2-0-pro-260215',
+        LLMConfig.typeZhipu: 'glm-5.2',
+        LLMConfig.typeDeepSeek: 'deepseek-v4-flash',
+        LLMConfig.typeMinimax: 'MiniMax-M3',
+        LLMConfig.typeMimo: 'mimo-v2.5-pro',
+        LLMConfig.typeOpenRouter: 'anthropic/claude-fable-5',
+        LLMConfig.typeOllama: 'qwen3.5:9b',
+      };
+
+      for (final entry in expectedFirstModel.entries) {
+        expect(
+          LLMConfig.recommendedModels(entry.key).first,
+          entry.value,
+          reason: '${entry.key} should lead with its current recommendation',
+        );
+        expect(
+          LLMConfig.featuredModels(entry.key),
+          contains(entry.value),
+          reason: '${entry.key} should badge its current recommendation',
+        );
+      }
+    });
+
+    test('recognizes multimodal models added to the recommendations', () {
+      const multimodalModels = <(String, String)>[
+        (LLMConfig.typeClaude, 'claude-fable-5'),
+        (LLMConfig.typeKimi, 'kimi-k3'),
+        (LLMConfig.typeQwen, 'qwen3.8-max'),
+        (LLMConfig.typeSeed, 'doubao-seed-2-0-pro-260215'),
+        (LLMConfig.typeMinimax, 'MiniMax-M3'),
+        (LLMConfig.typeMimo, 'mimo-v2.5'),
+        (LLMConfig.typeOllama, 'gemma4:12b'),
+      ];
+
+      for (final (provider, model) in multimodalModels) {
+        expect(
+          LLMConfig.isKnownMultimodal(provider, model),
+          isTrue,
+          reason: '$model should be marked as multimodal',
+        );
+      }
+      expect(
+        LLMConfig.isKnownMultimodal(LLMConfig.typeZhipu, 'glm-5.2'),
+        isFalse,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- refresh featured and recommended model IDs across OpenAI, Claude/Bedrock, Gemini, Kimi, Qwen, Doubao, GLM, DeepSeek, MiniMax, MiMo, OpenRouter, and Ollama
- define recommendations as a curated starter list: current family plus its immediate predecessor, with distinct current price/performance tiers and endpoint-specific filtering
- default new global OpenAI configurations to the canonical GPT-5.6 Sol ID; keep the GPT-5.6 alias only for OAuth compatibility
- recommend GPT-5.6 Sol/Terra/Luna and GPT-5.5 for Chat Completions; add GPT-5.5 Pro only for Responses
- update Qwen and OpenRouter to Qwen3.8 Max and remove an unverified Kimi high-speed variant
- update multimodal capability recognition for newly recommended models
- synchronize the English and Chinese provider tables with the current recommendations
- add regression coverage for provider ordering, endpoint filtering, featured models, the new default, and multimodal detection

## Verification notes
- `gpt-5.6` is an official OpenAI alias for `gpt-5.6-sol`; it is intentionally not shown as a second recommendation
- GPT-5.4 remains manually configurable but is no longer recommended because GPT-5.6 and GPT-5.5 are the two retained OpenAI generations
- exact provider and aggregator IDs were checked against current official catalogs before the follow-up commit

## Test plan
- `flutter test test/domain/models/llm_config_test.dart test/ui/settings/widgets/model_config_edit_page_test.dart`
- `flutter analyze lib/domain/models/llm_config.dart lib/data/services/openai_auth_service.dart test/domain/models/llm_config_test.dart`
- `flutter test` (826 passed, 5 environment-dependent tests skipped)
- `flutter analyze` (reports 158 existing info-level lints in unrelated files; no findings in changed Dart files)
- `git diff --check origin/main...HEAD`