### PR TITLE
Fix extensionless network image previews

### DIFF
--- a/lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart
+++ b/lib/agent/memex_skill_host_agent/memex_skill_host_agent.dart
@@ -67,7 +67,7 @@ class MemexSkillHostAgent {
       modelConfig: modelConfig,
       state: state,
       tools: tools,
-      skillDirectoryPath: skillDirectoryPath,
+      skillDirectoryPaths: [skillDirectoryPath],
       javaScriptRuntime: FlutterJavaScriptRuntime(),
       skills: null,
       systemPrompts: systemPrompts,

--- a/lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart
+++ b/lib/agent/pure_skill_host_agent/pure_skill_host_agent.dart
@@ -71,7 +71,7 @@ class PureSkillHostAgent {
       modelConfig: modelConfig,
       state: state,
       tools: tools,
-      skillDirectoryPath: skillDirectoryPath,
+      skillDirectoryPaths: [skillDirectoryPath],
       javaScriptRuntime: FlutterJavaScriptRuntime(),
       skills: null,
       systemPrompts: systemPrompts,

--- a/lib/data/services/image_preview_cache_service.dart
+++ b/lib/data/services/image_preview_cache_service.dart
@@ -13,6 +13,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:synchronized/synchronized.dart';
 
 typedef TempDirectoryProvider = Future<Directory> Function();
+typedef NetworkImageFetcher = Future<http.Response> Function(Uri uri);
 
 typedef ImageFileCompressor = Future<String?> Function({
   required String sourcePath,
@@ -47,8 +48,10 @@ class ImagePreviewCacheService {
   ImagePreviewCacheService({
     TempDirectoryProvider? tempDirectoryProvider,
     ImageFileCompressor? compressor,
+    NetworkImageFetcher? networkImageFetcher,
   })  : _tempDirectoryProvider = tempDirectoryProvider ?? getTemporaryDirectory,
-        _compressor = compressor ?? _defaultCompressor;
+        _compressor = compressor ?? _defaultCompressor,
+        _networkImageFetcher = networkImageFetcher ?? http.get;
 
   static final ImagePreviewCacheService instance = ImagePreviewCacheService();
 
@@ -62,6 +65,7 @@ class ImagePreviewCacheService {
 
   final TempDirectoryProvider _tempDirectoryProvider;
   final ImageFileCompressor _compressor;
+  final NetworkImageFetcher _networkImageFetcher;
   final Lock _previewLock = Lock();
   final Logger _logger = getLogger('ImagePreviewCacheService');
 
@@ -155,8 +159,7 @@ class ImagePreviewCacheService {
         _logger.info('Downloading network image preview source: $source');
         final http.Response response;
         try {
-          response = await http
-              .get(Uri.parse(source))
+          response = await _networkImageFetcher(Uri.parse(source))
               .timeout(const Duration(seconds: 20));
         } on TimeoutException {
           throw const ImagePreviewUnavailable('image download timed out');
@@ -168,10 +171,11 @@ class ImagePreviewCacheService {
         }
 
         final cacheDir = await _cacheDirectory();
+        final extension = _networkImageExtension(response, source);
         tempDownloadFile = File(
           path.join(
             cacheDir.path,
-            'temp_${DateTime.now().microsecondsSinceEpoch}',
+            'temp_${DateTime.now().microsecondsSinceEpoch}$extension',
           ),
         );
         await tempDownloadFile.writeAsBytes(response.bodyBytes);
@@ -227,6 +231,30 @@ class ImagePreviewCacheService {
         await tempDownloadFile.delete();
       }
     }
+  }
+
+  static String _networkImageExtension(http.Response response, String source) {
+    final mimeType =
+        response.headers['content-type']?.split(';').first.trim().toLowerCase();
+    final fromMime = switch (mimeType) {
+      'image/jpeg' || 'image/jpg' => '.jpg',
+      'image/png' => '.png',
+      'image/gif' => '.gif',
+      'image/webp' => '.webp',
+      'image/bmp' => '.bmp',
+      'image/heic' => '.heic',
+      'image/heif' => '.heif',
+      'image/tiff' => '.tiff',
+      _ => null,
+    };
+    if (fromMime != null) return fromMime;
+
+    final sourceExtension =
+        path.extension(Uri.parse(source).path).toLowerCase();
+    if (AssetSafetyService.imageExtensions.contains(sourceExtension)) {
+      return sourceExtension;
+    }
+    throw const ImagePreviewUnavailable('unsupported network image type');
   }
 
   Future<Directory> _cacheDirectory() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -364,10 +364,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_agent_core
-      sha256: dc6772a2b169da9748eee18d0b45b666e2ec17496118c274981203f726772895
+      sha256: d04522612390bcdde7828651b0e475cef56da87dfa728cd6efff73ad8348625c
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.1.2"
   dart_jsonwebtoken:
     dependency: "direct main"
     description:
@@ -1132,6 +1132,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  mcp_dart:
+    dependency: transitive
+    description:
+      name: mcp_dart
+      sha256: "777201efc190421e1c86502143379842ed42e16dc8b0ca1c4e8046dc7f7ee5f0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,7 +67,7 @@ dependencies:
   health: ^13.2.1
   pedometer: ^4.0.0
   workmanager: ^0.9.0
-  dart_agent_core: ^2.0.4
+  dart_agent_core: ^2.1.2
   flutter_js: ^0.8.7
   drift: ^2.30.0
   sqlite3_flutter_libs: ^0.5.41

--- a/test/data/services/image_preview_cache_service_test.dart
+++ b/test/data/services/image_preview_cache_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:memex/data/services/image_preview_cache_service.dart';
 
 void main() {
@@ -92,6 +93,68 @@ void main() {
     expect(preview.file.path, cachedAgain.file.path);
     expect(preview.contentType, 'image/jpeg');
     expect(cachedAgain.cacheHit, isTrue);
+  });
+
+  test('uses response content type for extensionless network images', () async {
+    String? downloadedPath;
+    final service = ImagePreviewCacheService(
+      tempDirectoryProvider: () async => tempDir,
+      networkImageFetcher: (uri) async {
+        expect(uri.toString(), 'https://picsum.photos/300/300?random=10');
+        return http.Response.bytes(
+          _jpegHeader(),
+          200,
+          headers: {'content-type': 'image/jpeg; charset=binary'},
+        );
+      },
+      compressor: ({
+        required sourcePath,
+        required targetPath,
+        required maxWidth,
+        required maxHeight,
+        required quality,
+      }) async {
+        downloadedPath = sourcePath;
+        await File(targetPath).writeAsBytes(_jpegHeader());
+        return targetPath;
+      },
+    );
+
+    final preview = await service.getOrCreatePreview(
+      source: 'https://picsum.photos/300/300?random=10',
+      isLocalFile: false,
+    );
+
+    expect(downloadedPath, endsWith('.jpg'));
+    expect(preview.contentType, 'image/jpeg');
+    expect(preview.file.existsSync(), isTrue);
+    expect(File(downloadedPath!).existsSync(), isFalse);
+  });
+
+  test('rejects extensionless network responses without an image MIME type',
+      () async {
+    final service = ImagePreviewCacheService(
+      tempDirectoryProvider: () async => tempDir,
+      networkImageFetcher: (_) async => http.Response.bytes(
+        _jpegHeader(),
+        200,
+        headers: {'content-type': 'application/octet-stream'},
+      ),
+    );
+
+    expect(
+      () => service.getOrCreatePreview(
+        source: 'https://example.test/image',
+        isLocalFile: false,
+      ),
+      throwsA(
+        isA<ImagePreviewUnavailable>().having(
+          (error) => error.reason,
+          'reason',
+          'unsupported network image type',
+        ),
+      ),
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

- infer downloaded network image extensions from the HTTP Content-Type, with URL-extension fallback
- reject extensionless responses that do not identify a supported image type
- clear derived image preview files after backup restore so reused asset paths cannot show pre-restore images
- upgrade dart_agent_core from 2.0.4 to the latest published 2.1.2 and migrate skill host construction to skillDirectoryPaths

The separately reported model 400 error is intentionally out of scope.

## Testing

- flutter test: 870 passed, 5 credential-dependent live tests skipped
- backup restore and image preview targeted tests: 31 passed
- targeted dart analyze: no issues
- full flutter analyze: no errors or warnings; 158 existing info-level findings
- git diff --check