### PR TITLE
Clear stale image previews after backup restore

### DIFF
--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -11,6 +11,7 @@ import 'package:memex/data/services/agent_activity_service.dart';
 import 'package:memex/data/services/agent_background_coordinator.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/image_preview_cache_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/data/services/persona_chat_service.dart';
 import 'package:memex/db/app_database.dart';
@@ -431,6 +432,14 @@ class BackupService {
           appSupportPath: supportDir.path,
         ),
       );
+      try {
+        await ImagePreviewCacheService.instance.clear();
+      } catch (e) {
+        // Preview files are derived data. A cleanup failure must not turn an
+        // already-applied workspace restore into a reported restore failure.
+        _logger
+            .warning('Failed to clear image preview cache after restore: $e');
+      }
 
       // Re-init DB
       await AppDatabase.init(restoredUserId);

--- a/lib/data/services/image_preview_cache_service.dart
+++ b/lib/data/services/image_preview_cache_service.dart
@@ -97,6 +97,19 @@ class ImagePreviewCacheService {
     return File(path.join(cacheDir.path, '$filenameHash$cacheFileSuffix'));
   }
 
+  /// Removes previews derived from workspace files or downloaded image URLs.
+  ///
+  /// Backup restore replaces the workspace wholesale, so path-based cache
+  /// entries cannot be trusted afterward. Normal reads remain path-only and
+  /// pay no file-version lookup cost.
+  Future<void> clear() => _previewLock.synchronized(() async {
+        final tempDir = await _tempDirectoryProvider();
+        final cacheDir = Directory(path.join(tempDir.path, cacheDirectoryName));
+        if (await cacheDir.exists()) {
+          await cacheDir.delete(recursive: true);
+        }
+      });
+
   Future<ImagePreviewFile> getOrCreatePreview({
     required String source,
     required bool isLocalFile,
@@ -130,6 +143,9 @@ class ImagePreviewCacheService {
     }
 
     return _previewLock.synchronized(() async {
+      if (!await cacheFile.parent.exists()) {
+        await cacheFile.parent.create(recursive: true);
+      }
       if (await cacheFile.exists()) {
         return ImagePreviewFile(
           file: cacheFile,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: memex
 description: A personal knowledge management and insights app
 publish_to: "none"
-version: 1.0.38+123
+version: 1.0.39+124
 
 environment:
   sdk: ">=3.6.0 <4.0.0"

--- a/test/data/services/backup_service_test.dart
+++ b/test/data/services/backup_service_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/data/services/backup_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/data/services/image_preview_cache_service.dart';
 import 'package:memex/data/services/local_task_executor.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -510,6 +511,11 @@ void main() {
     );
     final cardFile = File(p.join(workspace.path, 'Cards', 'card.md'));
     await cardFile.writeAsString('local changes after backup');
+    final stalePreview =
+        await ImagePreviewCacheService.instance.cacheFileForSource(
+      p.join(workspace.path, 'Facts', 'assets', 'reused.png'),
+    );
+    await stalePreview.writeAsBytes([0xff, 0xd8, 0xff, 0xd9]);
 
     try {
       await BackupService.restoreBackup(backupPath);
@@ -520,6 +526,7 @@ void main() {
     }
 
     expect(await cardFile.readAsString(), 'hello backup');
+    expect(await stalePreview.exists(), isFalse);
   });
 
   test('restore ignores device-local state contained in an old backup',

--- a/test/data/services/image_preview_cache_service_test.dart
+++ b/test/data/services/image_preview_cache_service_test.dart
@@ -95,6 +95,35 @@ void main() {
     expect(cachedAgain.cacheHit, isTrue);
   });
 
+  test('clear removes every generated preview', () async {
+    final image = File('${tempDir.path}/cached.png');
+    await image.writeAsBytes(_pngHeader(width: 320, height: 240));
+    final service = ImagePreviewCacheService(
+      tempDirectoryProvider: () async => tempDir,
+    );
+    final preview = await service.getOrCreatePreview(
+      source: image.path,
+      isLocalFile: true,
+    );
+
+    await service.clear();
+
+    expect(await preview.file.exists(), isFalse);
+    expect(
+      await Directory(
+        '${tempDir.path}/${ImagePreviewCacheService.cacheDirectoryName}',
+      ).exists(),
+      isFalse,
+    );
+
+    final regenerated = await service.getOrCreatePreview(
+      source: image.path,
+      isLocalFile: true,
+    );
+    expect(regenerated.cacheHit, isFalse);
+    expect(await regenerated.file.exists(), isTrue);
+  });
+
   test('uses response content type for extensionless network images', () async {
     String? downloadedPath;
     final service = ImagePreviewCacheService(


### PR DESCRIPTION
## Summary

- clear path-based image preview files after a backup replaces the workspace
- keep normal image cache reads path-only with no added stat or hashing overhead
- recreate the cache directory safely when preview generation follows cleanup
- treat cache cleanup as best-effort so it cannot turn an already-applied restore into a reported restore failure
- bump the app version from 1.0.38+123 to 1.0.39+124

## Testing

- flutter test: 870 passed, 5 credential-dependent live tests skipped
- flutter test test/data/services/image_preview_cache_service_test.dart test/data/services/backup_service_test.dart: 31 passed
- targeted dart analyze: no issues
- git diff --check