### PR TITLE
Fix task dependency completion semantics

### DIFF
--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -195,7 +195,7 @@ class MemexRouter {
       subscription: EventTaskSubscription(
         subscriptionId: 'comment_agent',
         taskType: 'comment_agent_task',
-        dependsOn: const ['character_perception'],
+        requiresSuccessOf: const ['character_perception'],
         payloadBuilder: (_, event) {
           final p = event.payload as UserInputSubmittedPayload;
           return Future.value({
@@ -233,7 +233,7 @@ class MemexRouter {
       subscription: EventTaskSubscription(
         subscriptionId: 'character_initiative',
         taskType: CharacterInitiativeService.taskType,
-        dependsOn: const ['comment_agent', 'character_perception'],
+        requiresSuccessOf: const ['comment_agent', 'character_perception'],
         maxRetries: 3,
         payloadBuilder: (_, event) {
           final p = event.payload as UserInputSubmittedPayload;
@@ -325,6 +325,7 @@ class MemexRouter {
     executor.registerHandler(
       'comment_agent_task',
       handleCommentAgentImpl,
+      legacyDependenciesRequireSuccess: true,
     );
     executor.registerHandler(
       'character_perception_task',
@@ -340,6 +341,7 @@ class MemexRouter {
       CharacterInitiativeService.taskType,
       handleCharacterInitiativeImpl,
       concurrencyPolicy: TaskConcurrencyPolicy.byUser(),
+      legacyDependenciesRequireSuccess: true,
     );
     executor.registerHandler(
       CharacterConversationService.taskType,

--- a/lib/data/services/chat_service.dart
+++ b/lib/data/services/chat_service.dart
@@ -507,7 +507,10 @@ class ChatService {
         // below system maintenance work that may use higher explicit priority.
         priority: 10,
         bizId: 'chat_turn:$finalSessionId:$turnId',
-        dependencies: previousTaskId == null ? null : [previousTaskId],
+        // Super Agent turns form one global sequence. This is an ordering
+        // barrier, not a hard dependency: a failed turn must not poison every
+        // later user message.
+        waitFor: previousTaskId == null ? null : [previousTaskId],
       );
       try {
         await AgentForegroundTaskTracker.instance.trackTask(taskId);

--- a/lib/data/services/global_event_bus.dart
+++ b/lib/data/services/global_event_bus.dart
@@ -34,20 +34,40 @@ class EventTaskSubscription {
     required this.taskType,
     required this.payloadBuilder,
     this.dependsOn = const [],
+    this.requiresSuccessOf = const [],
     this.priority = 0,
     this.maxRetries = 5,
     this.dependenciesBuilder,
+    this.successDependenciesBuilder,
     this.shouldEnqueue,
   });
 
   final String subscriptionId;
   final String taskType;
+
+  /// Ordering predecessors. The task waits until these subscriptions reach a
+  /// terminal state, then runs even if one of them failed. This preserves the
+  /// dependency behavior that EventTaskSubscription had before hard
+  /// dependencies were introduced.
   final List<String> dependsOn;
+
+  /// Hard predecessors whose tasks must complete successfully.
+  final List<String> requiresSuccessOf;
   final int priority;
   final int maxRetries;
   final EventTaskPayloadBuilder payloadBuilder;
+
+  /// Dynamically resolved ordering barriers that only need to finish.
   final EventTaskDependencyBuilder? dependenciesBuilder;
+
+  /// Dynamically resolved hard dependencies that must succeed.
+  final EventTaskDependencyBuilder? successDependenciesBuilder;
   final EventTaskShouldEnqueue? shouldEnqueue;
+
+  Iterable<String> get predecessorSubscriptionIds sync* {
+    yield* dependsOn;
+    yield* requiresSuccessOf;
+  }
 }
 
 /// 同步订阅：publish 时直接 await 执行 handler，而非入队任务。
@@ -209,7 +229,8 @@ class GlobalEventBus {
     final skippedSubscriptionIds = <String>{};
 
     for (final subscription in orderedSubscriptions) {
-      if (subscription.dependsOn.any(skippedSubscriptionIds.contains)) {
+      if (subscription.predecessorSubscriptionIds
+          .any(skippedSubscriptionIds.contains)) {
         skippedSubscriptionIds.add(subscription.subscriptionId);
         continue;
       }
@@ -221,16 +242,26 @@ class GlobalEventBus {
       }
 
       final payload = await subscription.payloadBuilder(userId, event);
-      final dependencies = <String>[
+      final waitFor = <String>[
         ...(baseDependencies ?? const []),
         ...subscription.dependsOn
             .map((id) => enqueuedTaskIdsBySubscription[id])
             .whereType<String>(),
       ];
 
+      final dependencies = <String>[
+        ...subscription.requiresSuccessOf
+            .map((id) => enqueuedTaskIdsBySubscription[id])
+            .whereType<String>(),
+      ];
+
       if (subscription.dependenciesBuilder != null) {
-        dependencies
-            .addAll(await subscription.dependenciesBuilder!(userId, event));
+        waitFor.addAll(await subscription.dependenciesBuilder!(userId, event));
+      }
+      if (subscription.successDependenciesBuilder != null) {
+        dependencies.addAll(
+          await subscription.successDependenciesBuilder!(userId, event),
+        );
       }
 
       final taskId = await _taskExecutor.enqueueTask(
@@ -244,6 +275,7 @@ class GlobalEventBus {
         // correlation id across subscriptions.
         bizId: 'event:${event.type}:${event.eventId}',
         dependencies: dependencies.isEmpty ? null : dependencies,
+        waitFor: waitFor.isEmpty ? null : waitFor,
       );
 
       enqueuedTaskIds.add(taskId);
@@ -266,7 +298,7 @@ class GlobalEventBus {
     final dependents = <String, Set<String>>{};
     for (final subscription in subscriptions) {
       indegree.putIfAbsent(subscription.subscriptionId, () => 0);
-      for (final depId in subscription.dependsOn) {
+      for (final depId in subscription.predecessorSubscriptionIds) {
         if (!byId.containsKey(depId)) {
           throw StateError(
             'Subscription ${subscription.subscriptionId} depends on unknown subscription $depId',

--- a/lib/data/services/local_task_executor.dart
+++ b/lib/data/services/local_task_executor.dart
@@ -78,6 +78,74 @@ class TaskQueueDrainResult {
 
 enum TaskQueueOwnerKind { foreground, background }
 
+/// Defines what a downstream task needs from one upstream task.
+///
+/// [requiresSuccess] is a hard dependency: the downstream task may run only
+/// after the upstream task completed successfully. [waitForCompletion] is an
+/// ordering barrier: the downstream task waits for the upstream task to reach
+/// a terminal state, then runs whether that state is completed or failed.
+enum TaskDependencyCondition {
+  requiresSuccess('requires_success'),
+  waitForCompletion('wait_for_completion');
+
+  const TaskDependencyCondition(this.wireName);
+
+  final String wireName;
+
+  static TaskDependencyCondition fromWireName(String value) {
+    return TaskDependencyCondition.values.firstWhere(
+      (condition) => condition.wireName == value,
+      orElse: () => throw FormatException(
+        'Unknown task dependency condition: $value',
+      ),
+    );
+  }
+}
+
+class TaskDependency {
+  const TaskDependency.requiresSuccess(this.taskId)
+      : condition = TaskDependencyCondition.requiresSuccess;
+
+  const TaskDependency.waitForCompletion(this.taskId)
+      : condition = TaskDependencyCondition.waitForCompletion;
+
+  const TaskDependency({required this.taskId, required this.condition});
+
+  final String taskId;
+  final TaskDependencyCondition condition;
+
+  Map<String, dynamic> toJson() => {
+        'task_id': taskId,
+        'condition': condition.wireName,
+      };
+
+  /// Legacy dependency arrays stored task IDs as strings without recording
+  /// their condition. Callers supply the task type's historical behavior.
+  factory TaskDependency.fromJson(
+    dynamic value, {
+    required TaskDependencyCondition legacyCondition,
+  }) {
+    if (value is String && value.isNotEmpty) {
+      return TaskDependency(taskId: value, condition: legacyCondition);
+    }
+    if (value is! Map) {
+      throw const FormatException('Task dependency must be a string or object');
+    }
+
+    final taskId = value['task_id'];
+    final condition = value['condition'];
+    if (taskId is! String || taskId.isEmpty || condition is! String) {
+      throw const FormatException(
+        'Task dependency requires task_id and condition',
+      );
+    }
+    return TaskDependency(
+      taskId: taskId,
+      condition: TaskDependencyCondition.fromWireName(condition),
+    );
+  }
+}
+
 /// Handler function type
 typedef TaskHandler = Future<void> Function(
   String userId,
@@ -155,6 +223,7 @@ class LocalTaskExecutor {
   // Handlers registry
   final Map<String, TaskHandler> _handlers = {};
   final Map<String, TaskConcurrencyPolicy> _concurrencyPolicies = {};
+  final Set<String> _legacyHardDependencyTaskTypes = <String>{};
   final Set<String> _activeConcurrencyKeys = <String>{};
   final Set<Future<void>> _activeExecutions = <Future<void>>{};
   final Map<String, Timer> _taskHeartbeatTimers = {};
@@ -384,12 +453,18 @@ class LocalTaskExecutor {
     String taskType,
     TaskHandler handler, {
     TaskConcurrencyPolicy? concurrencyPolicy,
+    bool legacyDependenciesRequireSuccess = false,
   }) {
     _handlers[taskType] = handler;
     if (concurrencyPolicy == null) {
       _concurrencyPolicies.remove(taskType);
     } else {
       _concurrencyPolicies[taskType] = concurrencyPolicy;
+    }
+    if (legacyDependenciesRequireSuccess) {
+      _legacyHardDependencyTaskTypes.add(taskType);
+    } else {
+      _legacyHardDependencyTaskTypes.remove(taskType);
     }
   }
 
@@ -738,10 +813,22 @@ class LocalTaskExecutor {
     int? scheduledAt,
     int maxRetries = 5,
     String? bizId,
+
+    /// Hard dependencies that must complete successfully before this task.
     List<String>? dependencies,
+
+    /// Ordering barriers that only need to reach a terminal state. A failed
+    /// predecessor does not fail this task.
+    List<String>? waitFor,
     String? runId,
   }) async {
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final taskDependencies = <TaskDependency>[
+      for (final taskId in dependencies ?? const <String>[])
+        TaskDependency.requiresSuccess(taskId),
+      for (final taskId in waitFor ?? const <String>[])
+        TaskDependency.waitForCompletion(taskId),
+    ];
 
     // We use a manual UUID or let Drift handle it?
     // Our schema defined ID as Text. Drift doesn't auto-generate Text IDs usually.
@@ -762,8 +849,12 @@ class LocalTaskExecutor {
             maxRetries: Value(maxRetries),
             bizId: Value(bizId),
             dependencies: Value(
-              dependencies != null && dependencies.isNotEmpty
-                  ? jsonEncode(dependencies)
+              taskDependencies.isNotEmpty
+                  ? jsonEncode(
+                      taskDependencies
+                          .map((dependency) => dependency.toJson())
+                          .toList(),
+                    )
                   : null,
             ),
           ),
@@ -1147,16 +1238,34 @@ class LocalTaskExecutor {
     if (task.dependencies == null) return true;
 
     try {
-      final deps = (jsonDecode(task.dependencies!) as List).cast<String>();
+      final decoded = jsonDecode(task.dependencies!);
+      if (decoded is! List) {
+        throw const FormatException('Task dependencies must be a list');
+      }
+      final legacyCondition = _legacyHardDependencyTaskTypes.contains(task.type)
+          ? TaskDependencyCondition.requiresSuccess
+          : TaskDependencyCondition.waitForCompletion;
+      final deps = decoded
+          .map(
+            (value) => TaskDependency.fromJson(
+              value,
+              legacyCondition: legacyCondition,
+            ),
+          )
+          .toList();
       if (deps.isEmpty) return true;
+
+      final dependencyIds =
+          deps.map((dependency) => dependency.taskId).toList();
 
       final dependenciesQuery = _db.selectOnly(_db.tasks)
         ..addColumns([_db.tasks.id, _db.tasks.status])
-        ..where(_db.tasks.id.isIn(deps));
+        ..where(_db.tasks.id.isIn(dependencyIds));
       final rows = await dependenciesQuery.get();
       final foundIds =
           rows.map((row) => row.read(_db.tasks.id)).whereType<String>().toSet();
-      final missingIds = deps.where((id) => !foundIds.contains(id)).toList();
+      final missingIds =
+          dependencyIds.where((id) => !foundIds.contains(id)).toList();
       if (missingIds.isNotEmpty) {
         await _failTask(
           task,
@@ -1165,10 +1274,19 @@ class LocalTaskExecutor {
         return false;
       }
 
-      final failedIds = rows
-          .where((row) => row.read(_db.tasks.status) == 'failed')
-          .map((row) => row.read(_db.tasks.id))
-          .whereType<String>()
+      final statusById = {
+        for (final row in rows)
+          if (row.read(_db.tasks.id) case final String id)
+            id: row.read(_db.tasks.status),
+      };
+      final failedIds = deps
+          .where(
+            (dependency) =>
+                dependency.condition ==
+                    TaskDependencyCondition.requiresSuccess &&
+                statusById[dependency.taskId] == 'failed',
+          )
+          .map((dependency) => dependency.taskId)
           .toList();
       if (failedIds.isNotEmpty) {
         await _failTask(
@@ -1178,7 +1296,14 @@ class LocalTaskExecutor {
         return false;
       }
 
-      return rows.every((row) => row.read(_db.tasks.status) == 'completed');
+      return deps.every((dependency) {
+        final status = statusById[dependency.taskId];
+        return switch (dependency.condition) {
+          TaskDependencyCondition.requiresSuccess => status == 'completed',
+          TaskDependencyCondition.waitForCompletion =>
+            status == 'completed' || status == 'failed',
+        };
+      });
     } catch (e) {
       _logger.warning('Failed to parse dependencies for task ${task.id}: $e');
       await _failTask(task, 'Invalid task dependencies: $e');

--- a/test/data/services/chat_service_test.dart
+++ b/test/data/services/chat_service_test.dart
@@ -279,6 +279,50 @@ void main() {
       }
     });
 
+    test('queues a later Super Agent turn behind the previous terminal state',
+        () async {
+      const queuedSessionId = '${sessionId}_ordered';
+      await _writeSession(
+        userId: userId,
+        sessionId: queuedSessionId,
+        data: _sessionData(sessionId: queuedSessionId),
+      );
+      await db.into(db.tasks).insert(
+            TasksCompanion.insert(
+              id: 'failed-super-agent-turn',
+              type: 'super_agent_chat_turn_task',
+              payload: Value(jsonEncode({
+                'session_id': 'another-session',
+                'turn_id': 'failed-turn',
+              })),
+              status: 'failed',
+              createdAt: const Value(1700000000),
+            ),
+          );
+
+      final subscription = ChatService.instance
+          .sendMessage(
+            'continue after failure',
+            sessionId: queuedSessionId,
+            agentName: 'memex_agent',
+            scene: 'super_agent_home',
+          )
+          .listen((_) {});
+      try {
+        final task = await _waitForQueuedChatTask(db, queuedSessionId);
+        final dependencies = jsonDecode(task.dependencies!) as List<dynamic>;
+
+        expect(dependencies, [
+          {
+            'task_id': 'failed-super-agent-turn',
+            'condition': 'wait_for_completion',
+          },
+        ]);
+      } finally {
+        await subscription.cancel();
+      }
+    });
+
     test('replaces a missing session id and persists the new turn', () async {
       const missingSessionId = 'memex_agent_missing_session';
       final createdSession = Completer<String>();

--- a/test/data/services/global_event_bus_dependency_test.dart
+++ b/test/data/services/global_event_bus_dependency_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/global_event_bus.dart';
+import 'package:memex/data/services/local_task_executor.dart';
+import 'package:memex/db/app_database.dart';
+import 'package:memex/domain/models/system_event.dart';
+
+void main() {
+  late AppDatabase db;
+  late LocalTaskExecutor executor;
+  late GlobalEventBus eventBus;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    AppDatabase.setTestInstance(db);
+    executor = LocalTaskExecutor.forTesting(db: db);
+    eventBus = GlobalEventBus.forTesting(executor);
+  });
+
+  tearDown(() async {
+    await executor.stop();
+    await db.close();
+  });
+
+  test('maps legacy EventBus dependencies to wait-for-completion barriers',
+      () async {
+    eventBus.subscribe(
+      eventType: 'dependency-test',
+      subscription: EventTaskSubscription(
+        subscriptionId: 'source',
+        taskType: 'source-task',
+        payloadBuilder: (_, __) async => const {},
+      ),
+    );
+    eventBus.subscribe(
+      eventType: 'dependency-test',
+      subscription: EventTaskSubscription(
+        subscriptionId: 'legacy-waiter',
+        taskType: 'legacy-waiter-task',
+        dependsOn: const ['source'],
+        dependenciesBuilder: (_, __) async => const ['dynamic-wait'],
+        payloadBuilder: (_, __) async => const {},
+      ),
+    );
+    eventBus.subscribe(
+      eventType: 'dependency-test',
+      subscription: EventTaskSubscription(
+        subscriptionId: 'hard-dependent',
+        taskType: 'hard-dependent-task',
+        requiresSuccessOf: const ['source'],
+        successDependenciesBuilder: (_, __) async => const ['dynamic-hard'],
+        payloadBuilder: (_, __) async => const {},
+      ),
+    );
+
+    await eventBus.publish(
+      userId: 'user-a',
+      event: SystemEvent<void>(
+        type: 'dependency-test',
+        payload: null,
+        source: 'test',
+        eventId: 'event-dependency-semantics',
+      ),
+      baseDependencies: const ['base-wait'],
+    );
+
+    final tasks = await db.select(db.tasks).get();
+    final sourceTask = tasks.singleWhere((task) => task.type == 'source-task');
+    final legacyWaiter =
+        tasks.singleWhere((task) => task.type == 'legacy-waiter-task');
+    final hardDependent =
+        tasks.singleWhere((task) => task.type == 'hard-dependent-task');
+
+    expect(
+      _dependencyConditions(sourceTask.dependencies),
+      {'base-wait': 'wait_for_completion'},
+    );
+    expect(
+      _dependencyConditions(legacyWaiter.dependencies),
+      {
+        sourceTask.id: 'wait_for_completion',
+        'dynamic-wait': 'wait_for_completion',
+        'base-wait': 'wait_for_completion',
+      },
+    );
+    expect(
+      _dependencyConditions(hardDependent.dependencies),
+      {
+        sourceTask.id: 'requires_success',
+        'dynamic-hard': 'requires_success',
+        'base-wait': 'wait_for_completion',
+      },
+    );
+  });
+}
+
+Map<String, String> _dependencyConditions(String? encoded) {
+  final dependencies = jsonDecode(encoded!) as List<dynamic>;
+  return {
+    for (final dependency in dependencies.cast<Map<String, dynamic>>())
+      dependency['task_id'] as String: dependency['condition'] as String,
+  };
+}

--- a/test/data/services/local_task_executor_test.dart
+++ b/test/data/services/local_task_executor_test.dart
@@ -148,23 +148,122 @@ void main() {
               createdAt: Value(now),
             ),
           );
-      await db.into(db.tasks).insert(
-            TasksCompanion.insert(
-              id: 'dependent',
-              type: 'dependent_task',
-              payload: const Value('{}'),
-              status: 'pending',
-              createdAt: Value(now + 1),
-              dependencies: Value(jsonEncode(['failed-prerequisite'])),
-            ),
-          );
+      final dependentId = await executor.enqueueTask(
+        userId: 'user-a',
+        taskType: 'dependent_task',
+        payload: const {},
+        dependencies: const ['failed-prerequisite'],
+      );
 
       await executor.start(userId: 'user-a');
-      final dependent = await _waitForTaskStatus(db, 'dependent', 'failed');
+      final dependent = await _waitForTaskStatus(db, dependentId, 'failed');
 
       expect(dependentRan, isFalse);
       expect(dependent.error, contains('Dependency tasks failed'));
       expect(dependent.error, contains('failed-prerequisite'));
+      expect(
+        jsonDecode(dependent.dependencies!),
+        [
+          {
+            'task_id': 'failed-prerequisite',
+            'condition': 'requires_success',
+          },
+        ],
+      );
+    });
+
+    test('runs a wait-for-completion task after its predecessor failed',
+        () async {
+      final executionOrder = <String>[];
+      executor.registerHandler('failing_predecessor', (_, __, ___) async {
+        executionOrder.add('predecessor');
+        throw StateError('expected predecessor failure');
+      });
+      executor.registerHandler('waiting_task', (_, __, ___) async {
+        executionOrder.add('waiting');
+      });
+      final predecessorId = await executor.enqueueTask(
+        userId: 'user-a',
+        taskType: 'failing_predecessor',
+        payload: const {},
+        maxRetries: 0,
+      );
+      final waitingTaskId = await executor.enqueueTask(
+        userId: 'user-a',
+        taskType: 'waiting_task',
+        payload: const {},
+        waitFor: [predecessorId],
+      );
+
+      await executor.start(userId: 'user-a');
+      final waitingTask =
+          await _waitForTaskStatus(db, waitingTaskId, 'completed');
+      final predecessor = await _getTask(db, predecessorId);
+
+      expect(predecessor.status, 'failed');
+      expect(executionOrder, ['predecessor', 'waiting']);
+      expect(waitingTask.error, isNull);
+      expect(
+        jsonDecode(waitingTask.dependencies!),
+        [
+          {
+            'task_id': predecessorId,
+            'condition': 'wait_for_completion',
+          },
+        ],
+      );
+    });
+
+    test(
+        'preserves legacy wait semantics unless a task type opts into hard dependencies',
+        () async {
+      var legacyWaiterRan = false;
+      var legacyHardTaskRan = false;
+      executor.registerHandler('legacy_waiter', (_, __, ___) async {
+        legacyWaiterRan = true;
+      });
+      executor.registerHandler(
+        'legacy_hard_task',
+        (_, __, ___) async {
+          legacyHardTaskRan = true;
+        },
+        legacyDependenciesRequireSuccess: true,
+      );
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await db.into(db.tasks).insert(
+            TasksCompanion.insert(
+              id: 'legacy-failed-predecessor',
+              type: 'predecessor_task',
+              payload: const Value('{}'),
+              status: 'failed',
+              createdAt: Value(now),
+            ),
+          );
+      for (final entry in const [
+        (id: 'legacy-waiter', type: 'legacy_waiter'),
+        (id: 'legacy-hard', type: 'legacy_hard_task'),
+      ]) {
+        await db.into(db.tasks).insert(
+              TasksCompanion.insert(
+                id: entry.id,
+                type: entry.type,
+                payload: const Value('{}'),
+                status: 'pending',
+                createdAt: Value(now + 1),
+                dependencies: Value(
+                  jsonEncode(['legacy-failed-predecessor']),
+                ),
+              ),
+            );
+      }
+
+      await executor.start(userId: 'user-a');
+      await _waitForTaskStatus(db, 'legacy-waiter', 'completed');
+      final legacyHard = await _waitForTaskStatus(db, 'legacy-hard', 'failed');
+
+      expect(legacyWaiterRan, isTrue);
+      expect(legacyHardTaskRan, isFalse);
+      expect(legacyHard.error, contains('Dependency tasks failed'));
     });
 
     test('uses only available concurrency slots while backlog remains queued',

--- a/test/integration/character_companion_pipeline_test.dart
+++ b/test/integration/character_companion_pipeline_test.dart
@@ -170,7 +170,7 @@ void main() {
       subscription: EventTaskSubscription(
         subscriptionId: 'character_initiative',
         taskType: 'character_initiative_task',
-        dependsOn: const ['comment_agent', 'character_perception'],
+        requiresSuccessOf: const ['comment_agent', 'character_perception'],
         payloadBuilder: (_, event) async {
           final payload = event.payload as UserInputSubmittedPayload;
           return {


### PR DESCRIPTION
## Summary

- distinguish hard success dependencies from terminal-state ordering barriers without changing the database schema
- keep SuperAgent turns globally ordered while allowing later turns to proceed after an earlier failure
- restore the original terminal-only behavior for pre-character EventBus/custom-agent dependencies, while retaining hard success requirements for the character pipeline
- preserve compatibility for persisted legacy dependency payloads and add regression coverage

## Test plan

- `flutter test test/data/services/global_event_bus_dependency_test.dart test/data/services/local_task_executor_test.dart test/data/services/chat_service_test.dart test/integration/character_companion_pipeline_test.dart -r compact --concurrency=1` (42 passed)
- `flutter analyze --no-fatal-infos` (completed successfully; 158 existing info diagnostics)
- full `flutter test -r compact` was sampled to 81 passing tests, then stopped because of suite duration