### PR TITLE
fix: keep manage_memory out of Quick Query

### DIFF
--- a/lib/agent/super_agent/super_agent.dart
+++ b/lib/agent/super_agent/super_agent.dart
@@ -48,6 +48,7 @@ const _quickQueryExcludedSkills = {
   'dynamic_timeline_ui',
   'timeline_diagnostics',
   'manage_pkm',
+  'manage_memory',
   'update_knowledge_insight',
   'manage_calendar_and_reminders',
 };

--- a/test/agent/super_agent_permissions_test.dart
+++ b/test/agent/super_agent_permissions_test.dart
@@ -118,6 +118,14 @@ void main() {
         isFalse,
       );
     });
+
+    test('excludes the memory write skill', () {
+      expect(SuperAgent.isQuickQuerySkillAllowed('manage_memory'), isFalse);
+    });
+
+    test('excludes the mutating PKM skill', () {
+      expect(SuperAgent.isQuickQuerySkillAllowed('manage_pkm'), isFalse);
+    });
   });
 
   group('SuperAgent run limits', () {


### PR DESCRIPTION
## What changed

Quick Query already blocks write skills like `manage_pkm` because skill tools skip the read-only whitelist. `manage_memory` was missing from that list, so a read-only chat could still write profile memory.

Closes #360

## Test plan

- [x] `flutter test test/agent/super_agent_permissions_test.dart`
- [x] Manual: Quick Query cannot activate `manage_memory`
