### PR TITLE
fix: mark persona chat read even if the list is not attached

### DIFF
--- a/lib/ui/character/widgets/persona_chat_screen.dart
+++ b/lib/ui/character/widgets/persona_chat_screen.dart
@@ -160,16 +160,19 @@ class _PersonaChatScreenState extends State<PersonaChatScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await Future<void>.delayed(const Duration(milliseconds: 16));
       if (!mounted) return;
-      if (_scrollController.hasClients) {
-        await _scrollController.animateTo(
+      await markPersonaChatReadAfterOpen(
+        hasScrollClients: _scrollController.hasClients,
+        scrollToLatest: () => _scrollController.animateTo(
           _scrollController.position.minScrollExtent,
           duration: const Duration(milliseconds: 260),
           curve: Curves.easeOut,
-        );
-        if (mounted) {
-          await _viewModel.markVisibleMessagesRead();
-        }
-      }
+        ),
+        markRead: () async {
+          if (mounted) {
+            await _viewModel.markVisibleMessagesRead();
+          }
+        },
+      );
     });
   }
 
@@ -866,6 +869,18 @@ bool shouldAutoScrollPersonaChat({
 }) {
   return previousCharacterId != currentCharacterId ||
       previousNewestMessageId != currentNewestMessageId;
+}
+
+@visibleForTesting
+Future<void> markPersonaChatReadAfterOpen({
+  required bool hasScrollClients,
+  required Future<void> Function() scrollToLatest,
+  required Future<void> Function() markRead,
+}) async {
+  if (hasScrollClients) {
+    await scrollToLatest();
+  }
+  await markRead();
 }
 
 class _ChatAtmosphereBackground extends StatelessWidget {

--- a/test/ui/character/widgets/persona_chat_screen_test.dart
+++ b/test/ui/character/widgets/persona_chat_screen_test.dart
@@ -235,4 +235,29 @@ void main() {
       0,
     );
   });
+
+  test('marks chat read after open even without a scroll client', () async {
+    final events = <String>[];
+
+    await markPersonaChatReadAfterOpen(
+      hasScrollClients: false,
+      scrollToLatest: () async => events.add('scroll'),
+      markRead: () async => events.add('read'),
+    );
+
+    expect(events, ['read']);
+  });
+
+  test('scrolls to latest then marks chat read when a client is attached',
+      () async {
+    final events = <String>[];
+
+    await markPersonaChatReadAfterOpen(
+      hasScrollClients: true,
+      scrollToLatest: () async => events.add('scroll'),
+      markRead: () async => events.add('read'),
+    );
+
+    expect(events, ['scroll', 'read']);
+  });
 }


### PR DESCRIPTION
## What changed

Opening a persona chat only marked messages read after a successful scroll. If the list had no scroll client yet, the unread badge could stick. Mark-read now always runs after open.

Closes #361

## Test plan

- [x] `flutter test test/ui/character/widgets/persona_chat_screen_test.dart`
- [x] Manual: open a character with unread messages and confirm the badge clears
