### PR TITLE
fix: stop character comments from replying to themselves

### DIFF
--- a/lib/agent/skills/comment_agent/tools/comment_tools.dart
+++ b/lib/agent/skills/comment_agent/tools/comment_tools.dart
@@ -51,20 +51,32 @@ class CommentToolFactory {
           final fileSystemService = FileSystemService.instance;
           final commentId = const Uuid().v4();
           final now = DateTime.now();
-          final resolvedReplyToId =
-              fixedReplyTarget ?? _normalizedReplyToId(reply_to_id);
 
           final updatedCardData = await fileSystemService.updateCardFile(
             userId,
             cardId,
             (card) {
+              var replyToId =
+                  fixedReplyTarget ?? _normalizedReplyToId(reply_to_id);
+              if (fixedReplyTarget == null &&
+                  replyToId != null &&
+                  characterId != null) {
+                for (final existing in card.comments) {
+                  if (existing.id == replyToId &&
+                      existing.isAi &&
+                      existing.characterId == characterId) {
+                    replyToId = null;
+                    break;
+                  }
+                }
+              }
               final newComment = CardComment(
                 id: commentId,
                 content: content,
                 isAi: true,
                 timestamp: now.millisecondsSinceEpoch ~/ 1000,
                 characterId: characterId,
-                replyToId: resolvedReplyToId,
+                replyToId: replyToId,
               );
               return card.copyWith(comments: [...card.comments, newComment]);
             },

--- a/test/agent/comment_tool_factory_test.dart
+++ b/test/agent/comment_tool_factory_test.dart
@@ -51,6 +51,13 @@ void main() {
             timestamp: 1001,
             replyToId: 'char-comment',
           ),
+          CardComment(
+            id: 'other-char-comment',
+            content: 'I am a different character.',
+            isAi: true,
+            timestamp: 1002,
+            characterId: 'char-b',
+          ),
         ],
       );
     });
@@ -103,6 +110,25 @@ void main() {
     });
 
     test(
+      'without forcedReplyToId, SaveComment treats a self-reply as top-level',
+      () async {
+        final tool = CommentToolFactory(
+          userId: userId,
+          cardId: cardId,
+          characterId: characterId,
+        ).buildSaveCommentTool();
+
+        await Function.apply(tool.executable!, [
+          'Character comments on own previous comment.',
+          'char-comment',
+        ]);
+
+        final latest = await _latestComment(userId, cardId);
+        expect(latest.replyToId, isNull);
+      },
+    );
+
+    test(
       'without forcedReplyToId, SaveComment preserves a valid model-supplied '
       'reply target for character-to-character interactions',
       () async {
@@ -114,11 +140,11 @@ void main() {
 
         await Function.apply(tool.executable!, [
           'Character builds on another character.',
-          'char-comment',
+          'other-char-comment',
         ]);
 
         final latest = await _latestComment(userId, cardId);
-        expect(latest.replyToId, 'char-comment');
+        expect(latest.replyToId, 'other-char-comment');
       },
     );
 


### PR DESCRIPTION
## What changed

User replies already pin `reply_to_id` to the user comment. On auto-comments, SaveComment still accepted whatever id the model sent, including the same character's earlier comment. Those self-replies are now dropped. Replies to a different character are unchanged.

Closes #362

## Test plan

- [x] `flutter test test/agent/comment_tool_factory_test.dart`
- [x] Manual: same character leaving two auto-comments should not show as a self-reply
