### PR TITLE
fix: show You on comment reply chips instead of the user id

### DIFF
--- a/lib/data/repositories/card.dart
+++ b/lib/data/repositories/card.dart
@@ -166,7 +166,7 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
     rawContent = (assetsAndText['rawText'] as String?) ?? rawContent;
 
     // Read comments (from card file comments field if present)
-    final comments = <Comment>[];
+    final builtComments = <Comment>[];
     // First pass: build comments with character info
     for (final commentData in cardData.comments) {
       try {
@@ -192,7 +192,7 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
           }
         }
 
-        comments.add(
+        builtComments.add(
           Comment(
             id: commentData.id,
             content: commentData.content,
@@ -208,35 +208,10 @@ Future<CardDetailModel> getCardDetail(String cardId) async {
       }
     }
 
-    // Second pass: resolve replyToName from the comment list
-    // Build a lookup: commentId -> display name
-    final commentNameMap = <String, String>{};
-    for (final c in comments) {
-      if (!c.isAi) {
-        // User comment — use the userId as display name
-        commentNameMap[c.id] = userId;
-      } else {
-        commentNameMap[c.id] = c.character?.name ?? 'AI';
-      }
-    }
-    // Resolve replyToName for each comment that has a replyToId
-    for (var i = 0; i < comments.length; i++) {
-      final c = comments[i];
-      if (c.replyToId != null && c.replyToName == null) {
-        final resolvedName = commentNameMap[c.replyToId];
-        if (resolvedName != null) {
-          comments[i] = Comment(
-            id: c.id,
-            content: c.content,
-            isAi: c.isAi,
-            timestamp: c.timestamp,
-            character: c.character,
-            replyToId: c.replyToId,
-            replyToName: resolvedName,
-          );
-        }
-      }
-    }
+    final comments = withResolvedReplyNames(
+      builtComments,
+      userDisplayName: UserStorage.l10n.commentReplyToYou,
+    );
 
     // Get LLM call stats
     LLMStats? llmStats;
@@ -519,4 +494,47 @@ Future<bool> updateCardLocationEndpoint(
     _logger.severe('Failed to update card location for $cardId: $e');
     return false;
   }
+}
+
+String replyDisplayNameFor(Comment c, String userDisplayName) =>
+    c.isAi ? (c.character?.name ?? 'AI') : userDisplayName;
+
+Map<String, String> commentReplyNameMap(
+  Iterable<Comment> comments, {
+  required String userDisplayName,
+}) {
+  final commentNameMap = <String, String>{};
+  for (final c in comments) {
+    commentNameMap[c.id] = replyDisplayNameFor(c, userDisplayName);
+  }
+  return commentNameMap;
+}
+
+List<Comment> withResolvedReplyNames(
+  List<Comment> comments, {
+  required String userDisplayName,
+}) {
+  final commentNameMap = commentReplyNameMap(
+    comments,
+    userDisplayName: userDisplayName,
+  );
+  final resolved = List<Comment>.from(comments);
+  for (var i = 0; i < resolved.length; i++) {
+    final c = resolved[i];
+    if (c.replyToId != null && c.replyToName == null) {
+      final resolvedName = commentNameMap[c.replyToId];
+      if (resolvedName != null) {
+        resolved[i] = Comment(
+          id: c.id,
+          content: c.content,
+          isAi: c.isAi,
+          timestamp: c.timestamp,
+          character: c.character,
+          replyToId: c.replyToId,
+          replyToName: resolvedName,
+        );
+      }
+    }
+  }
+  return resolved;
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "فشل التسجيل",
   "loginFailed": "فشل تسجيل الدخول",
   "paymentCreationFailed": "تعذر بدء الدفع",
-  "completePayment": "إكمال الدفع"
+  "completePayment": "إكمال الدفع",
+  "commentReplyToYou": "أنت"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "Registrierung fehlgeschlagen",
   "loginFailed": "Anmeldung fehlgeschlagen",
   "paymentCreationFailed": "Zahlung konnte nicht gestartet werden",
-  "completePayment": "Zahlung abschließen"
+  "completePayment": "Zahlung abschließen",
+  "commentReplyToYou": "Du"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "Registration failed",
   "loginFailed": "Login failed",
   "paymentCreationFailed": "Could not start payment",
-  "completePayment": "Complete payment"
+  "completePayment": "Complete payment",
+  "commentReplyToYou": "You"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "Error al registrarse",
   "loginFailed": "Error al iniciar sesión",
   "paymentCreationFailed": "No se pudo iniciar el pago",
-  "completePayment": "Completar pago"
+  "completePayment": "Completar pago",
+  "commentReplyToYou": "Tú"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "Échec de l’inscription",
   "loginFailed": "Échec de la connexion",
   "paymentCreationFailed": "Impossible de lancer le paiement",
-  "completePayment": "Finaliser le paiement"
+  "completePayment": "Finaliser le paiement",
+  "commentReplyToYou": "Vous"
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "पंजीकरण असफल",
   "loginFailed": "लॉगिन असफल",
   "paymentCreationFailed": "भुगतान शुरू नहीं हो सका",
-  "completePayment": "भुगतान पूरा करें"
+  "completePayment": "भुगतान पूरा करें",
+  "commentReplyToYou": "आप"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "Pendaftaran gagal",
   "loginFailed": "Login gagal",
   "paymentCreationFailed": "Tidak bisa memulai pembayaran",
-  "completePayment": "Selesaikan pembayaran"
+  "completePayment": "Selesaikan pembayaran",
+  "commentReplyToYou": "Anda"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "登録に失敗しました",
   "loginFailed": "ログインに失敗しました",
   "paymentCreationFailed": "支払いを開始できませんでした",
-  "completePayment": "支払いを完了"
+  "completePayment": "支払いを完了",
+  "commentReplyToYou": "あなた"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "가입에 실패했습니다",
   "loginFailed": "로그인에 실패했습니다",
   "paymentCreationFailed": "결제를 시작할 수 없습니다",
-  "completePayment": "결제 완료"
+  "completePayment": "결제 완료",
+  "commentReplyToYou": "나"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5837,6 +5837,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Complete payment'**
   String get completePayment;
+
+  /// No description provided for @commentReplyToYou.
+  ///
+  /// In en, this message translates to:
+  /// **'You'**
+  String get commentReplyToYou;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3221,4 +3221,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get completePayment => 'إكمال الدفع';
+
+  @override
+  String get commentReplyToYou => 'أنت';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3301,4 +3301,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get completePayment => 'Zahlung abschließen';
+
+  @override
+  String get commentReplyToYou => 'Du';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3240,4 +3240,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get completePayment => 'Complete payment';
+
+  @override
+  String get commentReplyToYou => 'You';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3291,4 +3291,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get completePayment => 'Completar pago';
+
+  @override
+  String get commentReplyToYou => 'Tú';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3298,4 +3298,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get completePayment => 'Finaliser le paiement';
+
+  @override
+  String get commentReplyToYou => 'Vous';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -3249,4 +3249,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get completePayment => 'भुगतान पूरा करें';
+
+  @override
+  String get commentReplyToYou => 'आप';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -3259,4 +3259,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get completePayment => 'Selesaikan pembayaran';
+
+  @override
+  String get commentReplyToYou => 'Anda';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3164,4 +3164,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get completePayment => '支払いを完了';
+
+  @override
+  String get commentReplyToYou => 'あなた';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3163,4 +3163,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get completePayment => '결제 완료';
+
+  @override
+  String get commentReplyToYou => '나';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3269,4 +3269,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get completePayment => 'Concluir pagamento';
+
+  @override
+  String get commentReplyToYou => 'Você';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3267,4 +3267,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get completePayment => 'Завершить оплату';
+
+  @override
+  String get commentReplyToYou => 'Вы';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3126,6 +3126,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get completePayment => '完成支付';
+
+  @override
+  String get commentReplyToYou => '你';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -6254,4 +6257,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get completePayment => '完成付款';
+
+  @override
+  String get commentReplyToYou => '你';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "Falha no cadastro",
   "loginFailed": "Falha no login",
   "paymentCreationFailed": "Não foi possível iniciar o pagamento",
-  "completePayment": "Concluir pagamento"
+  "completePayment": "Concluir pagamento",
+  "commentReplyToYou": "Você"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "Не удалось зарегистрироваться",
   "loginFailed": "Не удалось войти",
   "paymentCreationFailed": "Не удалось начать оплату",
-  "completePayment": "Завершить оплату"
+  "completePayment": "Завершить оплату",
+  "commentReplyToYou": "Вы"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1436,5 +1436,6 @@
   "registrationFailed": "注册失败",
   "loginFailed": "登录失败",
   "paymentCreationFailed": "无法发起支付",
-  "completePayment": "完成支付"
+  "completePayment": "完成支付",
+  "commentReplyToYou": "你"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1482,5 +1482,6 @@
   "registrationFailed": "註冊失敗",
   "loginFailed": "登入失敗",
   "paymentCreationFailed": "無法發起付款",
-  "completePayment": "完成付款"
+  "completePayment": "完成付款",
+  "commentReplyToYou": "你"
 }

--- a/test/data/repositories/card_reply_name_test.dart
+++ b/test/data/repositories/card_reply_name_test.dart
@@ -1,0 +1,114 @@
+import 'package:memex/data/repositories/card.dart';
+import 'package:memex/domain/models/card_detail_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('withResolvedReplyNames', () {
+    test('resolves an AI reply to a user comment as the display name', () {
+      const userDisplayName = 'You';
+      final comments = [
+        Comment(
+          id: 'u1',
+          content: 'User comment',
+          isAi: false,
+          timestamp: 1000,
+        ),
+        Comment(
+          id: 'a1',
+          content: 'AI reply',
+          isAi: true,
+          timestamp: 1001,
+          character: CharacterInfo(
+            id: 'char-yaoyao',
+            name: 'YaoYao',
+            tags: const [],
+          ),
+          replyToId: 'u1',
+        ),
+      ];
+
+      final resolved = withResolvedReplyNames(
+        comments,
+        userDisplayName: userDisplayName,
+      );
+
+      expect(resolved[1].replyToName, userDisplayName);
+      expect(resolved[1].replyToName, isNot('raw-user-id'));
+      expect(
+          commentReplyNameMap(comments, userDisplayName: userDisplayName)['u1'],
+          userDisplayName);
+    });
+
+    test('resolves an AI reply to another character by character name', () {
+      final comments = [
+        Comment(
+          id: 'a1',
+          content: 'First character',
+          isAi: true,
+          timestamp: 1000,
+          character: CharacterInfo(
+            id: 'char-yaoyao',
+            name: 'YaoYao',
+            tags: const [],
+          ),
+        ),
+        Comment(
+          id: 'a2',
+          content: 'Second character replies',
+          isAi: true,
+          timestamp: 1001,
+          character: CharacterInfo(
+            id: 'char-other',
+            name: 'Other',
+            tags: const [],
+          ),
+          replyToId: 'a1',
+        ),
+      ];
+
+      final resolved = withResolvedReplyNames(
+        comments,
+        userDisplayName: 'You',
+      );
+
+      expect(resolved[1].replyToName, 'YaoYao');
+    });
+
+    test('does not use a raw userId as the user display name', () {
+      const userDisplayName = 'You';
+      const rawUserId = 'user_abc123';
+      final comments = [
+        Comment(
+          id: 'u1',
+          content: 'User comment',
+          isAi: false,
+          timestamp: 1000,
+        ),
+        Comment(
+          id: 'a1',
+          content: 'AI reply',
+          isAi: true,
+          timestamp: 1001,
+          character: CharacterInfo(
+            id: 'char-yaoyao',
+            name: 'YaoYao',
+            tags: const [],
+          ),
+          replyToId: 'u1',
+        ),
+      ];
+
+      final resolved = withResolvedReplyNames(
+        comments,
+        userDisplayName: userDisplayName,
+      );
+
+      expect(resolved[1].replyToName, 'You');
+      expect(resolved[1].replyToName, isNot(rawUserId));
+      expect(
+        replyDisplayNameFor(comments.first, userDisplayName),
+        userDisplayName,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What changed

When a character replies to a user comment, the "replying to …" chip was filled from the raw user id. It now uses a localized "You", same idea as the name shown on the comment itself.

Closes #363

## Test plan

- [x] `flutter test test/data/repositories/card_reply_name_test.dart`
- [x] Manual: reply chip on a character reply to you says "You"
