### PR TITLE
fix: time out remote URLs in LocalImage.provider

### DIFF
--- a/lib/ui/core/widgets/local_image.dart
+++ b/lib/ui/core/widgets/local_image.dart
@@ -586,15 +586,27 @@ class TimeoutNetworkImage extends ImageProvider<TimeoutNetworkImage> {
     assert(key == this);
 
     final uri = Uri.parse(key.url);
+    final stopwatch = Stopwatch()..start();
     final client = HttpClient()
       ..connectionTimeout = key.timeout
       ..idleTimeout = key.timeout;
 
+    Duration remainingTimeout() {
+      final remaining = key.timeout - stopwatch.elapsed;
+      if (remaining <= Duration.zero) {
+        throw TimeoutException(
+          'Timed out loading network image after ${key.timeout}: $uri',
+          key.timeout,
+        );
+      }
+      return remaining;
+    }
+
     try {
-      final request = await client.getUrl(uri).timeout(key.timeout);
-      final response = await request.close().timeout(key.timeout);
+      final request = await client.getUrl(uri).timeout(remainingTimeout());
+      final response = await request.close().timeout(remainingTimeout());
       if (response.statusCode != HttpStatus.ok) {
-        await response.drain<void>().timeout(key.timeout);
+        await response.drain<void>().timeout(remainingTimeout());
         throw NetworkImageLoadException(
           statusCode: response.statusCode,
           uri: uri,
@@ -611,7 +623,7 @@ class TimeoutNetworkImage extends ImageProvider<TimeoutNetworkImage> {
             ),
           );
         },
-      ).timeout(key.timeout);
+      ).timeout(remainingTimeout());
 
       if (bytes.isEmpty) {
         throw Exception('TimeoutNetworkImage is an empty file: $uri');

--- a/lib/ui/core/widgets/local_image.dart
+++ b/lib/ui/core/widgets/local_image.dart
@@ -617,7 +617,7 @@ class TimeoutNetworkImage extends ImageProvider<TimeoutNetworkImage> {
         throw Exception('TimeoutNetworkImage is an empty file: $uri');
       }
 
-      return decode(await ui.ImmutableBuffer.fromUint8List(bytes));
+      return await decode(await ui.ImmutableBuffer.fromUint8List(bytes));
     } catch (error) {
       scheduleMicrotask(() {
         PaintingBinding.instance.imageCache.evict(key);

--- a/lib/ui/core/widgets/local_image.dart
+++ b/lib/ui/core/widgets/local_image.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
+import 'dart:ui' as ui;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -218,7 +220,7 @@ class LocalImage extends StatefulWidget {
   }
 
   /// Get ImageProvider (for DecorationImage, CircleAvatar, etc.)
-  static ImageProvider provider(String url) {
+  static ImageProvider provider(String url, {Duration? timeout}) {
     // try parse local file path (from http://127.0.0.1 URL)
     final localFilePath = _parseLocalFilePath(url);
 
@@ -236,8 +238,10 @@ class LocalImage extends StatefulWidget {
       }
       return FileImage(File(filePath));
     } else {
-      // use network load
-      return NetworkImage(url);
+      return TimeoutNetworkImage(
+        url,
+        timeout: timeout ?? const Duration(seconds: 20),
+      );
     }
   }
 
@@ -535,4 +539,111 @@ class _LocalImageState extends State<LocalImage> {
       colorBlendMode: widget.colorBlendMode,
     );
   }
+}
+
+/// Remote [ImageProvider] with a download timeout so a bad URL cannot hang
+/// [DecorationImage] / [CircleAvatar] the way [NetworkImage] can.
+class TimeoutNetworkImage extends ImageProvider<TimeoutNetworkImage> {
+  const TimeoutNetworkImage(
+    this.url, {
+    this.scale = 1.0,
+    this.timeout = const Duration(seconds: 20),
+  });
+
+  final String url;
+  final double scale;
+  final Duration timeout;
+
+  @override
+  Future<TimeoutNetworkImage> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<TimeoutNetworkImage>(this);
+  }
+
+  @override
+  ImageStreamCompleter loadImage(
+    TimeoutNetworkImage key,
+    ImageDecoderCallback decode,
+  ) {
+    final chunkEvents = StreamController<ImageChunkEvent>();
+
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(key, chunkEvents, decode),
+      chunkEvents: chunkEvents.stream,
+      scale: key.scale,
+      debugLabel: key.url,
+      informationCollector: () => <DiagnosticsNode>[
+        DiagnosticsProperty<ImageProvider>('Image provider', this),
+        DiagnosticsProperty<TimeoutNetworkImage>('Image key', key),
+      ],
+    );
+  }
+
+  Future<ui.Codec> _loadAsync(
+    TimeoutNetworkImage key,
+    StreamController<ImageChunkEvent> chunkEvents,
+    ImageDecoderCallback decode,
+  ) async {
+    assert(key == this);
+
+    final uri = Uri.parse(key.url);
+    final client = HttpClient()
+      ..connectionTimeout = key.timeout
+      ..idleTimeout = key.timeout;
+
+    try {
+      final request = await client.getUrl(uri).timeout(key.timeout);
+      final response = await request.close().timeout(key.timeout);
+      if (response.statusCode != HttpStatus.ok) {
+        await response.drain<void>().timeout(key.timeout);
+        throw NetworkImageLoadException(
+          statusCode: response.statusCode,
+          uri: uri,
+        );
+      }
+
+      final bytes = await consolidateHttpClientResponseBytes(
+        response,
+        onBytesReceived: (int cumulative, int? total) {
+          chunkEvents.add(
+            ImageChunkEvent(
+              cumulativeBytesLoaded: cumulative,
+              expectedTotalBytes: total,
+            ),
+          );
+        },
+      ).timeout(key.timeout);
+
+      if (bytes.isEmpty) {
+        throw Exception('TimeoutNetworkImage is an empty file: $uri');
+      }
+
+      return decode(await ui.ImmutableBuffer.fromUint8List(bytes));
+    } catch (error) {
+      scheduleMicrotask(() {
+        PaintingBinding.instance.imageCache.evict(key);
+      });
+      rethrow;
+    } finally {
+      chunkEvents.close();
+      client.close(force: true);
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is TimeoutNetworkImage &&
+        other.url == url &&
+        other.scale == scale &&
+        other.timeout == timeout;
+  }
+
+  @override
+  int get hashCode => Object.hash(url, scale, timeout);
+
+  @override
+  String toString() =>
+      '${objectRuntimeType(this, 'TimeoutNetworkImage')}("$url", scale: ${scale.toStringAsFixed(1)}, timeout: $timeout)';
 }

--- a/test/ui/core/widgets/local_image_provider_test.dart
+++ b/test/ui/core/widgets/local_image_provider_test.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('provider does not use NetworkImage for remote URLs', () {
+    final provider = LocalImage.provider('https://example.invalid/x.png');
+
+    expect(provider, isNot(isA<NetworkImage>()));
+  });
+
+  test('provider reports an error instead of hanging on a stalled download',
+      () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((request) {
+      // Accept the request but never send headers or a body.
+    });
+
+    final provider = LocalImage.provider(
+      'http://${server.address.host}:${server.port}/hang.png',
+      timeout: const Duration(milliseconds: 50),
+    );
+
+    expect(provider, isNot(isA<NetworkImage>()));
+
+    final error = await _resolveImageError(provider).timeout(
+      const Duration(seconds: 1),
+    );
+
+    expect(error, isNotNull);
+  });
+}
+
+Future<Object> _resolveImageError(ImageProvider provider) {
+  final completer = Completer<Object>();
+  final stream = provider.resolve(ImageConfiguration.empty);
+  late final ImageStreamListener listener;
+  listener = ImageStreamListener(
+    (ImageInfo image, bool synchronousCall) {
+      image.dispose();
+      if (!completer.isCompleted) {
+        completer.completeError(StateError('image loaded unexpectedly'));
+      }
+    },
+    onError: (Object error, StackTrace? stackTrace) {
+      if (!completer.isCompleted) {
+        completer.complete(error);
+      }
+    },
+  );
+  stream.addListener(listener);
+  return completer.future.whenComplete(() {
+    stream.removeListener(listener);
+  });
+}

--- a/test/ui/core/widgets/local_image_provider_test.dart
+++ b/test/ui/core/widgets/local_image_provider_test.dart
@@ -16,10 +16,16 @@ void main() {
 
   test('provider reports an error instead of hanging on a stalled download',
       () async {
+    final previousHttpOverrides = HttpOverrides.current;
+    HttpOverrides.global = null;
+    addTearDown(() => HttpOverrides.global = previousHttpOverrides);
+
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(() => server.close(force: true));
+    final requestReceived = Completer<void>();
     server.listen((request) {
       // Accept the request but never send headers or a body.
+      requestReceived.complete();
     });
 
     final provider = LocalImage.provider(
@@ -29,11 +35,42 @@ void main() {
 
     expect(provider, isNot(isA<NetworkImage>()));
 
+    final errorFuture = _resolveImageError(provider);
+    await requestReceived.future.timeout(const Duration(seconds: 1));
+    final error = await errorFuture.timeout(
+      const Duration(seconds: 1),
+    );
+
+    expect(error, isA<TimeoutException>());
+  });
+
+  test('provider applies one timeout across response stages', () async {
+    final previousHttpOverrides = HttpOverrides.current;
+    HttpOverrides.global = null;
+    addTearDown(() => HttpOverrides.global = previousHttpOverrides);
+
+    const timeout = Duration(milliseconds: 200);
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((request) async {
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      request.response.contentLength = 2;
+      request.response.add(const [0x89]);
+      await request.response.flush();
+      // Send enough data to start the body phase, then leave it incomplete.
+    });
+
+    final provider = LocalImage.provider(
+      'http://${server.address.host}:${server.port}/slow.png',
+      timeout: timeout,
+    );
+    final stopwatch = Stopwatch()..start();
     final error = await _resolveImageError(provider).timeout(
       const Duration(seconds: 1),
     );
 
-    expect(error, isNotNull);
+    expect(error, isA<TimeoutException>());
+    expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 300)));
   });
 }
 


### PR DESCRIPTION
## What changed

The `LocalImage` widget path already times out downloads at 20s. `LocalImage.provider()` (avatars, decorations) still used `NetworkImage`, which can hang forever on a dead URL. Remote URLs now fail after 20s.

Closes #365

## Test plan

- [x] `flutter test test/ui/core/widgets/local_image_provider_test.dart test/ui/core/widgets/local_image_safety_test.dart`
- [x] Manual: a hanging network avatar/decoration fails instead of spinning forever
