### PR TITLE
fix: walk the reply chain when routing comment replies

### DIFF
--- a/lib/data/services/task_handlers/comment_agent_handler.dart
+++ b/lib/data/services/task_handlers/comment_agent_handler.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/agent/prompts.dart';
 import 'package:memex/data/services/local_task_executor.dart';
@@ -6,6 +7,7 @@ import 'package:memex/data/services/character_selection_service.dart';
 import 'package:memex/data/services/character_service.dart';
 import 'package:memex/data/services/comment_settings_service.dart';
 import 'package:memex/data/services/file_system_service.dart';
+import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/utils/mention_parser.dart';
 import 'package:memex/data/services/task_handlers/llm_error_utils.dart';
 import 'package:memex/utils/user_storage.dart';
@@ -178,14 +180,14 @@ Future<void> handleProcessAiReplyImpl(
         cardId,
       );
       if (cardData != null) {
-        for (final c in cardData.comments) {
-          if (c.id == replyToId && c.isAi && c.characterId != null) {
-            targetCharacterId = c.characterId;
-            _logger.info(
-              'User replied to comment $replyToId, routing to character $targetCharacterId',
-            );
-            break;
-          }
+        targetCharacterId = resolveReplyTargetCharacterId(
+          cardData.comments,
+          replyToId,
+        );
+        if (targetCharacterId != null) {
+          _logger.info(
+            'User replied to comment $replyToId, routing to character $targetCharacterId',
+          );
         }
       }
     } catch (e) {
@@ -247,4 +249,28 @@ Future<String?> _resolveMentionedCharacterId({
     _logger.warning('Failed to resolve character mention: $e');
     return null;
   }
+}
+
+/// Walks `reply_to_id` until it finds an AI comment with a character.
+/// Direct replies to an AI comment still resolve in one hop; a reply to a
+/// user comment in that thread walks up to the character that owns it.
+@visibleForTesting
+String? resolveReplyTargetCharacterId(
+  List<CardComment> comments,
+  String replyToId,
+) {
+  final byId = {for (final comment in comments) comment.id: comment};
+  CardComment? current = byId[replyToId];
+  final seen = <String>{};
+  while (current != null && seen.add(current.id)) {
+    if (current.isAi && current.characterId != null) {
+      return current.characterId;
+    }
+    final nextId = current.replyToId;
+    if (nextId == null || nextId.isEmpty) {
+      break;
+    }
+    current = byId[nextId];
+  }
+  return null;
 }

--- a/test/data/services/task_handlers/comment_reply_target_test.dart
+++ b/test/data/services/task_handlers/comment_reply_target_test.dart
@@ -1,0 +1,74 @@
+import 'package:memex/data/services/task_handlers/comment_agent_handler.dart';
+import 'package:memex/domain/models/card_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('resolveReplyTargetCharacterId', () {
+    const comments = [
+      CardComment(
+        id: 'a1',
+        content: 'Character A first',
+        isAi: true,
+        timestamp: 1,
+        characterId: 'char-a',
+      ),
+      CardComment(
+        id: 'b1',
+        content: 'Character B later',
+        isAi: true,
+        timestamp: 2,
+        characterId: 'char-b',
+      ),
+      CardComment(
+        id: 'u1',
+        content: 'User replied to A',
+        isAi: false,
+        timestamp: 3,
+        replyToId: 'a1',
+      ),
+      CardComment(
+        id: 'u2',
+        content: 'User replied to their own reply',
+        isAi: false,
+        timestamp: 4,
+        replyToId: 'u1',
+      ),
+    ];
+
+    test('direct reply to an AI comment uses that character', () {
+      expect(resolveReplyTargetCharacterId(comments, 'a1'), 'char-a');
+      expect(resolveReplyTargetCharacterId(comments, 'b1'), 'char-b');
+    });
+
+    test('reply to a user comment walks the chain to the thread owner', () {
+      expect(resolveReplyTargetCharacterId(comments, 'u1'), 'char-a');
+      expect(resolveReplyTargetCharacterId(comments, 'u2'), 'char-a');
+    });
+
+    test('unknown or cyclic reply ids return null', () {
+      expect(resolveReplyTargetCharacterId(comments, 'missing'), isNull);
+      expect(
+        resolveReplyTargetCharacterId(
+          const [
+            CardComment(
+              id: 'loop-a',
+              content: 'loop',
+              isAi: false,
+              timestamp: 1,
+              replyToId: 'loop-b',
+            ),
+            CardComment(
+              id: 'loop-b',
+              content: 'loop',
+              isAi: false,
+              timestamp: 2,
+              replyToId: 'loop-a',
+            ),
+          ],
+          'loop-a',
+        ),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What changed

`handleProcessAiReply` only resolved a character when `reply_to_id` pointed at an AI comment. A reply to the user's own comment in that thread fell through to the most recent AI commenter on the card.

It now walks the `reply_to_id` chain.

Closes #372

## Test plan
- [x] `flutter test test/data/services/task_handlers/comment_reply_target_test.dart`
- [x] Two characters on a card: reply to A, then reply to your own message. A still answers, not the later character.
