### PR TITLE
fix: use unknownError for empty ToastHelper messages

### DIFF
--- a/lib/utils/toast_helper.dart
+++ b/lib/utils/toast_helper.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:memex/data/services/api_exception.dart';
+import 'package:memex/utils/user_storage.dart';
 
 /// Helper class for showing toast notifications
 class ToastHelper {
@@ -71,15 +72,6 @@ class ToastHelper {
   }
 
   static SnackBar _buildErrorSnackBar(dynamic error) {
-    String errorMessage = 'Operation failed, please try again later';
-    if (error is ApiException) {
-      errorMessage = error.message;
-    } else if (error is Exception) {
-      errorMessage = error.toString().replaceFirst('Exception: ', '');
-    } else {
-      errorMessage = error.toString();
-    }
-
     return SnackBar(
       content: Row(
         children: [
@@ -87,7 +79,7 @@ class ToastHelper {
           const SizedBox(width: 12),
           Expanded(
             child: Text(
-              errorMessage,
+              formatErrorMessage(error),
               style: const TextStyle(color: Colors.white, fontSize: 14),
             ),
           ),
@@ -103,5 +95,21 @@ class ToastHelper {
       ),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
     );
+  }
+
+  @visibleForTesting
+  static String formatErrorMessage(dynamic error) {
+    String errorMessage;
+    if (error is ApiException) {
+      errorMessage = error.message;
+    } else if (error is Exception) {
+      errorMessage = error.toString().replaceFirst('Exception: ', '');
+    } else {
+      errorMessage = error.toString();
+    }
+    if (errorMessage.trim().isEmpty) {
+      return UserStorage.l10n.unknownError;
+    }
+    return errorMessage;
   }
 }

--- a/test/utils/toast_helper_test.dart
+++ b/test/utils/toast_helper_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/widgets.dart';
+import 'package:memex/data/services/api_exception.dart';
+import 'package:memex/utils/toast_helper.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:test/test.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  test('uses unknownError when the error text is empty', () {
+    expect(
+      ToastHelper.formatErrorMessage(ApiException('  ')),
+      UserStorage.l10n.unknownError,
+    );
+  });
+
+  test('keeps ApiException messages', () {
+    expect(ToastHelper.formatErrorMessage(ApiException('nope')), 'nope');
+  });
+}


### PR DESCRIPTION
## What changed

Empty toast errors now use `unknownError` instead of a blank or leftover English string.

Closes #376

## Test plan
- [x] `flutter test test/utils/toast_helper_test.dart`
