### PR TITLE
fix: use unknownError on character config toasts

### DIFF
--- a/lib/ui/character/widgets/character_config_screen.dart
+++ b/lib/ui/character/widgets/character_config_screen.dart
@@ -40,7 +40,7 @@ class _CharacterConfigScreenState extends State<CharacterConfigScreen> {
         ToastHelper.showError(
           context,
           UserStorage.l10n.loadCharacterFailed(
-            widget.viewModel.errorMessage ?? 'Unknown error',
+            widget.viewModel.errorMessage ?? UserStorage.l10n.unknownError,
           ),
         );
       }
@@ -58,7 +58,7 @@ class _CharacterConfigScreenState extends State<CharacterConfigScreen> {
       ToastHelper.showError(
         context,
         UserStorage.l10n.operationFailed(
-          vm.errorMessage ?? 'Unknown error',
+          vm.errorMessage ?? UserStorage.l10n.unknownError,
         ),
       );
     }
@@ -95,7 +95,7 @@ class _CharacterConfigScreenState extends State<CharacterConfigScreen> {
         ToastHelper.showError(
           context,
           UserStorage.l10n.deleteFailed(
-            vm.errorMessage ?? 'Unknown error',
+            vm.errorMessage ?? UserStorage.l10n.unknownError,
           ),
         );
       }
@@ -406,7 +406,7 @@ class _CharacterEditPageState extends State<CharacterEditPage> {
       ToastHelper.showError(
         context,
         UserStorage.l10n.loadCharacterFailed(
-          widget.viewModel.errorMessage ?? 'Unknown error',
+          widget.viewModel.errorMessage ?? UserStorage.l10n.unknownError,
         ),
       );
     }
@@ -450,7 +450,7 @@ class _CharacterEditPageState extends State<CharacterEditPage> {
       final imported = await widget.viewModel.importImage(pickedPath);
       if (imported == null) {
         throw StateError(
-            widget.viewModel.errorMessage ?? 'Image import failed');
+            widget.viewModel.errorMessage ?? UserStorage.l10n.unknownError);
       }
       if (!mounted) return null;
       setState(() {
@@ -481,7 +481,7 @@ class _CharacterEditPageState extends State<CharacterEditPage> {
       final imported = await widget.viewModel.importImage(picked.path);
       if (imported == null) {
         throw StateError(
-            widget.viewModel.errorMessage ?? 'Image import failed');
+            widget.viewModel.errorMessage ?? UserStorage.l10n.unknownError);
       }
       if (!mounted) return;
       setState(() {
@@ -593,7 +593,7 @@ class _CharacterEditPageState extends State<CharacterEditPage> {
       ToastHelper.showError(
         context,
         UserStorage.l10n.saveFailed(
-          widget.viewModel.errorMessage ?? 'Unknown error',
+          widget.viewModel.errorMessage ?? UserStorage.l10n.unknownError,
         ),
       );
       return;

--- a/lib/ui/character/widgets/character_config_screen.dart
+++ b/lib/ui/character/widgets/character_config_screen.dart
@@ -19,6 +19,12 @@ import 'package:memex/ui/core/widgets/back_button.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/ui/core/widgets/local_image.dart';
 
+@visibleForTesting
+String characterImageImportFailureMessage(String? errorMessage) =>
+    UserStorage.l10n.operationFailed(
+      errorMessage ?? UserStorage.l10n.unknownError,
+    );
+
 /// AI character config screen. Receives [viewModel] from parent (Compass-style).
 class CharacterConfigScreen extends StatefulWidget {
   const CharacterConfigScreen({super.key, required this.viewModel});
@@ -449,8 +455,13 @@ class _CharacterEditPageState extends State<CharacterEditPage> {
 
       final imported = await widget.viewModel.importImage(pickedPath);
       if (imported == null) {
-        throw StateError(
-            widget.viewModel.errorMessage ?? UserStorage.l10n.unknownError);
+        if (mounted) {
+          ToastHelper.showError(
+            context,
+            characterImageImportFailureMessage(widget.viewModel.errorMessage),
+          );
+        }
+        return null;
       }
       if (!mounted) return null;
       setState(() {
@@ -480,8 +491,13 @@ class _CharacterEditPageState extends State<CharacterEditPage> {
 
       final imported = await widget.viewModel.importImage(picked.path);
       if (imported == null) {
-        throw StateError(
-            widget.viewModel.errorMessage ?? UserStorage.l10n.unknownError);
+        if (mounted) {
+          ToastHelper.showError(
+            context,
+            characterImageImportFailureMessage(widget.viewModel.errorMessage),
+          );
+        }
+        return;
       }
       if (!mounted) return;
       setState(() {

--- a/test/ui/character/widgets/character_config_error_test.dart
+++ b/test/ui/character/widgets/character_config_error_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/character/widgets/character_config_screen.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  test('image import fallback has no StateError prefix', () {
+    final message = characterImageImportFailureMessage(null);
+
+    expect(
+      message,
+      UserStorage.l10n.operationFailed(UserStorage.l10n.unknownError),
+    );
+    expect(message, isNot(contains('Bad state:')));
+  });
+
+  test('image import keeps a specific error message', () {
+    expect(
+      characterImageImportFailureMessage('disk full'),
+      UserStorage.l10n.operationFailed('disk full'),
+    );
+  });
+}


### PR DESCRIPTION
## What changed

Character config toasts now use `unknownError` instead of English fallbacks.

Closes #378

## Test plan
- [ ] Character load / image import failure with no errorMessage shows the localized unknown-error string
