### PR TITLE
fix: localize data-import queue failure fallback

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1615,7 +1615,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       ToastHelper.showError(
         context,
         UserStorage.l10n.operationFailed(
-          viewModel.errorMessage ?? 'Failed to queue processing',
+          viewModel.errorMessage ?? UserStorage.l10n.unknownError,
         ),
       );
     }

--- a/lib/ui/settings/widgets/data_import_page.dart
+++ b/lib/ui/settings/widgets/data_import_page.dart
@@ -52,7 +52,7 @@ class _DataImportPageState extends State<DataImportPage> {
       ToastHelper.showError(
         context,
         UserStorage.l10n.operationFailed(
-          widget.viewModel.errorMessage ?? 'Failed to queue processing',
+          widget.viewModel.errorMessage ?? UserStorage.l10n.unknownError,
         ),
       );
     }


### PR DESCRIPTION
## What changed

Import queue failures with no errorMessage now use `unknownError`.

Closes #380

## Test plan
- [ ] Queue processing failure with null errorMessage shows localized unknown-error text
