### PR TITLE
fix: localize classic card audio playback errors

### DIFF
--- a/lib/ui/core/cards/templates/classic_card.dart
+++ b/lib/ui/core/cards/templates/classic_card.dart
@@ -117,7 +117,7 @@ class _ClassicCardState extends State<ClassicCard> {
       debugPrint('Audio playback error: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to play audio: $e')),
+          SnackBar(content: Text(UserStorage.l10n.operationFailed('$e'))),
         );
       }
     }


### PR DESCRIPTION
## What changed

Audio play failures on classic cards now go through `operationFailed`.

Closes #382

## Test plan
- [ ] Broken audio on a classic card shows a localized SnackBar
