### PR TITLE
fix: show memory list timestamps in local time

### DIFF
--- a/lib/ui/memory/widgets/memory_screen.dart
+++ b/lib/ui/memory/widgets/memory_screen.dart
@@ -6,6 +6,17 @@ import 'package:memex/ui/memory/view_models/memory_viewmodel.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 
+@visibleForTesting
+String formatMemoryListDate(dynamic isoValue) {
+  if (isoValue == null) return '';
+  try {
+    final date = DateTime.parse(isoValue.toString()).toLocal();
+    return '${date.month}/${date.day} ${date.hour}:${date.minute.toString().padLeft(2, '0')}';
+  } catch (_) {
+    return '';
+  }
+}
+
 /// Memory screen. Receives [viewModel] from parent (Compass-style).
 class MemoryScreen extends StatefulWidget {
   const MemoryScreen({super.key, required this.viewModel});
@@ -206,13 +217,5 @@ class _MemoryScreenState extends State<MemoryScreen> {
     );
   }
 
-  String _formatDate(dynamic isoValue) {
-    if (isoValue == null) return '';
-    try {
-      final date = DateTime.parse(isoValue.toString());
-      return '${date.month}/${date.day} ${date.hour}:${date.minute.toString().padLeft(2, '0')}';
-    } catch (_) {
-      return '';
-    }
-  }
+  String _formatDate(dynamic isoValue) => formatMemoryListDate(isoValue);
 }

--- a/test/ui/memory/widgets/memory_list_date_test.dart
+++ b/test/ui/memory/widgets/memory_list_date_test.dart
@@ -1,0 +1,18 @@
+import 'package:test/test.dart';
+import 'package:memex/ui/memory/widgets/memory_screen.dart';
+
+void main() {
+  test('formats UTC instants in local time', () {
+    final formatted = formatMemoryListDate('2026-01-02T15:04:00.000Z');
+    final local = DateTime.parse('2026-01-02T15:04:00.000Z').toLocal();
+    expect(
+      formatted,
+      '${local.month}/${local.day} ${local.hour}:${local.minute.toString().padLeft(2, '0')}',
+    );
+  });
+
+  test('returns empty for missing or invalid values', () {
+    expect(formatMemoryListDate(null), '');
+    expect(formatMemoryListDate('not-a-date'), '');
+  });
+}


### PR DESCRIPTION
## What changed

Memory list dates now call `toLocal()` before formatting.

Closes #384

## Test plan
- [x] `flutter test test/ui/memory/widgets/memory_list_date_test.dart`
