### PR TITLE
fix: show chat history timestamps in local time

### DIFF
--- a/lib/ui/chat/widgets/chat_history_screen.dart
+++ b/lib/ui/chat/widgets/chat_history_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:memex/ui/chat/view_models/chat_viewmodel.dart';

--- a/lib/ui/chat/widgets/chat_history_screen.dart
+++ b/lib/ui/chat/widgets/chat_history_screen.dart
@@ -1,12 +1,33 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:memex/ui/chat/view_models/chat_viewmodel.dart';
+import 'package:memex/utils/date_util.dart';
 import 'package:memex/utils/toast_helper.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/ui/core/widgets/back_button.dart';
 import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
+
+@visibleForTesting
+String formatChatHistoryDateTime(String? isoString, {DateTime? now}) {
+  if (isoString == null) return '';
+  final dateTime = parseLocalDateTime(isoString);
+  if (dateTime == null) return isoString;
+  final current = now ?? DateTime.now();
+  final difference = current.difference(dateTime);
+
+  if (difference.inDays == 0) {
+    return DateFormat('HH:mm').format(dateTime);
+  } else if (difference.inDays == 1) {
+    return UserStorage.l10n.yesterdayAt(DateFormat('HH:mm').format(dateTime));
+  } else if (difference.inDays < 7) {
+    return UserStorage.l10n.daysAgo(difference.inDays);
+  } else {
+    return DateFormat('MM-dd HH:mm').format(dateTime);
+  }
+}
 
 /// Chat history list screen. Receives [viewModel] from parent (Compass-style).
 class ChatHistoryScreen extends StatefulWidget {
@@ -91,27 +112,8 @@ class _ChatHistoryScreenState extends State<ChatHistoryScreen> {
     });
   }
 
-  String _formatDateTime(String? isoString) {
-    if (isoString == null) return '';
-    try {
-      final dateTime = DateTime.parse(isoString);
-      final now = DateTime.now();
-      final difference = now.difference(dateTime);
-
-      if (difference.inDays == 0) {
-        return DateFormat('HH:mm').format(dateTime);
-      } else if (difference.inDays == 1) {
-        return UserStorage.l10n
-            .yesterdayAt(DateFormat('HH:mm').format(dateTime));
-      } else if (difference.inDays < 7) {
-        return UserStorage.l10n.daysAgo(difference.inDays);
-      } else {
-        return DateFormat('MM-dd HH:mm').format(dateTime);
-      }
-    } catch (e) {
-      return isoString;
-    }
-  }
+  String _formatDateTime(String? isoString) =>
+      formatChatHistoryDateTime(isoString);
 
   @override
   Widget build(BuildContext context) {

--- a/test/ui/chat/widgets/chat_history_date_test.dart
+++ b/test/ui/chat/widgets/chat_history_date_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:memex/ui/chat/widgets/chat_history_screen.dart';
+
+void main() {
+  test('formats UTC session times in local hours', () {
+    final utc = DateTime.utc(2026, 8, 27, 15, 30);
+    final iso = utc.toIso8601String();
+    final local = utc.toLocal();
+    final formatted = formatChatHistoryDateTime(iso, now: local);
+    expect(formatted, DateFormat('HH:mm').format(local));
+  });
+
+  test('returns empty for null and original for invalid values', () {
+    expect(formatChatHistoryDateTime(null), '');
+    expect(formatChatHistoryDateTime('not-a-date'), 'not-a-date');
+  });
+}


### PR DESCRIPTION
## What changed

Chat history dates now go through `parseLocalDateTime` before formatting.

Closes #388

## Test plan
- [x] `flutter test test/ui/chat/widgets/chat_history_date_test.dart`
