### PR TITLE
fix: localize async task list load errors

### DIFF
--- a/lib/ui/settings/widgets/async_task_list_page.dart
+++ b/lib/ui/settings/widgets/async_task_list_page.dart
@@ -1,9 +1,14 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
+
+@visibleForTesting
+String asyncTaskLoadErrorMessage(Object error) =>
+    UserStorage.l10n.operationFailed('$error');
 
 class AsyncTaskListPage extends StatefulWidget {
   const AsyncTaskListPage({super.key});
@@ -70,7 +75,7 @@ class _AsyncTaskListPageState extends State<AsyncTaskListPage> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Load tasks failed: $e')),
+          SnackBar(content: Text(asyncTaskLoadErrorMessage(e))),
         );
       }
     } finally {

--- a/lib/ui/settings/widgets/async_task_list_page.dart
+++ b/lib/ui/settings/widgets/async_task_list_page.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:memex/db/app_database.dart';

--- a/test/ui/settings/widgets/async_task_load_error_test.dart
+++ b/test/ui/settings/widgets/async_task_load_error_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/settings/widgets/async_task_list_page.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  test('uses localized operationFailed for load errors', () {
+    expect(
+      asyncTaskLoadErrorMessage('timeout'),
+      UserStorage.l10n.operationFailed('timeout'),
+    );
+  });
+}


### PR DESCRIPTION
## What changed

Task-list load failures now use `UserStorage.l10n.operationFailed`.

Closes #390

## Test plan
- [x] `flutter test test/ui/settings/widgets/async_task_load_error_test.dart`
