### PR TITLE
fix: localize insight template gallery build errors

### DIFF
--- a/lib/ui/insight/widgets/insight_template_gallery_page.dart
+++ b/lib/ui/insight/widgets/insight_template_gallery_page.dart
@@ -1,7 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:memex/ui/core/cards/native_widget_factory.dart';
 import 'package:memex/utils/user_storage.dart';
 import 'package:memex/ui/core/widgets/back_button.dart';
+
+@visibleForTesting
+String insightTemplateBuildError(String templateId) =>
+    UserStorage.l10n.operationFailed(templateId);
 
 class InsightTemplateGalleryPage extends StatelessWidget {
   const InsightTemplateGalleryPage({super.key});
@@ -58,7 +63,7 @@ class InsightTemplateGalleryPage extends StatelessWidget {
             Container(
               padding: const EdgeInsets.all(20),
               color: Colors.red.shade50,
-              child: Text('Failed to build $templateId'),
+              child: Text(insightTemplateBuildError(templateId)),
             ),
       ],
     );

--- a/lib/ui/insight/widgets/insight_template_gallery_page.dart
+++ b/lib/ui/insight/widgets/insight_template_gallery_page.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:memex/ui/core/cards/native_widget_factory.dart';
 import 'package:memex/utils/user_storage.dart';

--- a/test/ui/insight/widgets/insight_template_build_error_test.dart
+++ b/test/ui/insight/widgets/insight_template_build_error_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/insight/widgets/insight_template_gallery_page.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  test('uses localized operationFailed when a template fails to build', () {
+    expect(
+      insightTemplateBuildError('classic'),
+      UserStorage.l10n.operationFailed('classic'),
+    );
+  });
+}


### PR DESCRIPTION
## What changed

Template build fallbacks now use `UserStorage.l10n.operationFailed`.

Closes #392

## Test plan
- [x] `flutter test test/ui/insight/widgets/insight_template_build_error_test.dart`
