### PR TITLE
fix: localize OAuth missing-code callback pages

### DIFF
--- a/lib/data/services/gemini_auth_service.dart
+++ b/lib/data/services/gemini_auth_service.dart
@@ -147,7 +147,7 @@ class GeminiAuthService {
         }
 
         completer.completeError('No code in callback');
-        return 'Invalid callback. Missing code.';
+        return oauthMissingCodePage();
       });
 
       if (!await launchUrl(authUrl, mode: LaunchMode.inAppBrowserView)) {

--- a/lib/data/services/local_server_service.dart
+++ b/lib/data/services/local_server_service.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:memex/utils/user_storage.dart';
 
-@visibleForTesting
 String oauthMissingCodePage() => UserStorage.l10n.unknownError;
 
 class LocalServerService {

--- a/lib/data/services/local_server_service.dart
+++ b/lib/data/services/local_server_service.dart
@@ -1,5 +1,10 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
+import 'package:memex/utils/user_storage.dart';
+
+@visibleForTesting
+String oauthMissingCodePage() => UserStorage.l10n.unknownError;
 
 class LocalServerService {
   static final Logger _logger = Logger('LocalServerService');

--- a/lib/data/services/openai_auth_service.dart
+++ b/lib/data/services/openai_auth_service.dart
@@ -146,7 +146,7 @@ class OpenAiAuthService {
         }
 
         completer.completeError('No code found in callback');
-        return 'Invalid callback response. Missing code.';
+        return oauthMissingCodePage();
       });
 
       // 4. Launch In-App Browser (prevents the app from going to the background and being killed by the OS)

--- a/test/data/services/oauth_missing_code_page_test.dart
+++ b/test/data/services/oauth_missing_code_page_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/local_server_service.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  test('OAuth missing-code page uses unknownError', () {
+    expect(oauthMissingCodePage(), UserStorage.l10n.unknownError);
+  });
+}


### PR DESCRIPTION
## What changed

OpenAI and Gemini missing-code callback pages now use `UserStorage.l10n.unknownError`.

Closes #394

## Test plan
- [x] `flutter test test/data/services/oauth_missing_code_page_test.dart`
