### PR TITLE
fix: localize aggregated timeline period labels

### DIFF
--- a/lib/data/repositories/get_aggregated_timeline.dart
+++ b/lib/data/repositories/get_aggregated_timeline.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/utils/logger.dart';
@@ -97,7 +98,7 @@ Future<Map<String, dynamic>> getAggregatedTimeline({
       );
 
       // Generate labels
-      final labels = _getPeriodLabels(periodId, groupBy);
+      final labels = getPeriodLabels(periodId, groupBy);
 
       items.add({
         'periodId': periodId,
@@ -135,14 +136,16 @@ String _getPeriodId(DateTime dt, String groupBy) {
 }
 
 /// Generates display labels for the period.
-(String label, String subLabel) _getPeriodLabels(
+@visibleForTesting
+(String label, String subLabel) getPeriodLabels(
     String periodId, String groupBy) {
+  final locale = UserStorage.l10n.localeName;
   try {
     switch (groupBy) {
       case 'days':
         final dt = DateFormat('yyyy-MM-dd').parse(periodId);
-        final label = DateFormat('MMM d, yyyy').format(dt);
-        final dayName = DateFormat('EEEE').format(dt);
+        final label = DateFormat('MMM d, yyyy', locale).format(dt);
+        final dayName = DateFormat('EEEE', locale).format(dt);
         return (label, dayName);
 
       case 'weeks':
@@ -155,15 +158,15 @@ String _getPeriodId(DateTime dt, String groupBy) {
           final isoWeekStart = jan4.subtract(Duration(days: dayOfWeek - 1));
           final weekStart = isoWeekStart.add(Duration(days: (week - 1) * 7));
           final weekEnd = weekStart.add(const Duration(days: 6));
-          final startStr = DateFormat('MMM d').format(weekStart);
-          final endStr = DateFormat('MMM d, yyyy').format(weekEnd);
+          final startStr = DateFormat('MMM d', locale).format(weekStart);
+          final endStr = DateFormat('MMM d, yyyy', locale).format(weekEnd);
           return ('Week $week', '$startStr - $endStr');
         }
         return ('Week', periodId);
 
       case 'months':
         final dt = DateFormat('yyyy-MM').parse(periodId);
-        final label = DateFormat('MMMM yyyy').format(dt);
+        final label = DateFormat('MMMM yyyy', locale).format(dt);
         return (label, '');
 
       case 'years':

--- a/test/data/repositories/timeline_period_label_locale_test.dart
+++ b/test/data/repositories/timeline_period_label_locale_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:memex/data/repositories/get_aggregated_timeline.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  test('day labels use the active locale weekday name', () async {
+    await initializeDateFormatting('zh');
+    await UserStorage.setLocale(const Locale('zh'));
+
+    final (label, subLabel) = getPeriodLabels('2026-08-27', 'days');
+    expect(subLabel, isNot(equals('Thursday')));
+    expect(label, isNot(contains('Aug')));
+  });
+
+  test('month labels use the active locale month name', () async {
+    await initializeDateFormatting('zh');
+    await UserStorage.setLocale(const Locale('zh'));
+
+    final (label, subLabel) = getPeriodLabels('2026-08', 'months');
+    expect(label, isNot(equals('August 2026')));
+    expect(subLabel, '');
+  });
+}


### PR DESCRIPTION
## What changed

Period labels now pass `UserStorage.l10n.localeName` into `DateFormat`.

Closes #396

## Test plan
- [x] `flutter test test/data/repositories/timeline_period_label_locale_test.dart`
