### PR TITLE
fix: use calendar days in chat history timestamps

### DIFF
--- a/lib/ui/chat/widgets/chat_history_screen.dart
+++ b/lib/ui/chat/widgets/chat_history_screen.dart
@@ -9,23 +9,30 @@ import 'package:memex/ui/core/widgets/back_button.dart';
 import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 
+bool _isSameCalendarDay(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;
+
 @visibleForTesting
 String formatChatHistoryDateTime(String? isoString, {DateTime? now}) {
   if (isoString == null) return '';
   final dateTime = parseLocalDateTime(isoString);
   if (dateTime == null) return isoString;
   final current = now ?? DateTime.now();
-  final difference = current.difference(dateTime);
+  final time = DateFormat('HH:mm').format(dateTime);
 
-  if (difference.inDays == 0) {
-    return DateFormat('HH:mm').format(dateTime);
-  } else if (difference.inDays == 1) {
-    return UserStorage.l10n.yesterdayAt(DateFormat('HH:mm').format(dateTime));
-  } else if (difference.inDays < 7) {
-    return UserStorage.l10n.daysAgo(difference.inDays);
-  } else {
-    return DateFormat('MM-dd HH:mm').format(dateTime);
+  if (_isSameCalendarDay(dateTime, current)) {
+    return time;
   }
+  if (_isSameCalendarDay(dateTime, current.subtract(const Duration(days: 1)))) {
+    return UserStorage.l10n.yesterdayAt(time);
+  }
+  final daysAgo = DateTime(current.year, current.month, current.day)
+      .difference(DateTime(dateTime.year, dateTime.month, dateTime.day))
+      .inDays;
+  if (daysAgo < 7) {
+    return UserStorage.l10n.daysAgo(daysAgo);
+  }
+  return DateFormat('MM-dd HH:mm').format(dateTime);
 }
 
 /// Chat history list screen. Receives [viewModel] from parent (Compass-style).

--- a/test/ui/chat/widgets/chat_history_date_test.dart
+++ b/test/ui/chat/widgets/chat_history_date_test.dart
@@ -1,14 +1,38 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:memex/ui/chat/widgets/chat_history_screen.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
   test('formats UTC session times in local hours', () {
     final utc = DateTime.utc(2026, 8, 27, 15, 30);
     final iso = utc.toIso8601String();
     final local = utc.toLocal();
     final formatted = formatChatHistoryDateTime(iso, now: local);
     expect(formatted, DateFormat('HH:mm').format(local));
+  });
+
+  test('uses calendar days not 24-hour buckets', () {
+    final yesterdayEvening = DateTime(2026, 8, 27, 23, 0);
+    final todayMorning = DateTime(2026, 8, 28, 1, 0);
+    final formatted = formatChatHistoryDateTime(
+      yesterdayEvening.toIso8601String(),
+      now: todayMorning,
+    );
+    expect(
+      formatted,
+      UserStorage.l10n
+          .yesterdayAt(DateFormat('HH:mm').format(yesterdayEvening)),
+    );
   });
 
   test('returns empty for null and original for invalid values', () {


### PR DESCRIPTION
## What changed

Chat history relative labels now use calendar dates, matching Super Agent time dividers.

Closes #398

## Test plan
- [x] `flutter test test/ui/chat/widgets/chat_history_date_test.dart`
