### PR TITLE
fix(l10n): localize remaining hardcoded UI strings

### DIFF
--- a/lib/data/repositories/card.dart
+++ b/lib/data/repositories/card.dart
@@ -497,7 +497,9 @@ Future<bool> updateCardLocationEndpoint(
 }
 
 String replyDisplayNameFor(Comment c, String userDisplayName) =>
-    c.isAi ? (c.character?.name ?? 'AI') : userDisplayName;
+    c.isAi
+        ? (c.character?.name ?? UserStorage.l10n.commentAuthorAi)
+        : userDisplayName;
 
 Map<String, String> commentReplyNameMap(
   Iterable<Comment> comments, {

--- a/lib/data/repositories/get_aggregated_timeline.dart
+++ b/lib/data/repositories/get_aggregated_timeline.dart
@@ -160,9 +160,12 @@ String _getPeriodId(DateTime dt, String groupBy) {
           final weekEnd = weekStart.add(const Duration(days: 6));
           final startStr = DateFormat('MMM d', locale).format(weekStart);
           final endStr = DateFormat('MMM d, yyyy', locale).format(weekEnd);
-          return ('Week $week', '$startStr - $endStr');
+          return (
+            UserStorage.l10n.timelineWeekNumberLabel(week.toString()),
+            '$startStr - $endStr',
+          );
         }
-        return ('Week', periodId);
+        return (UserStorage.l10n.timelineWeekLabel, periodId);
 
       case 'months':
         final dt = DateFormat('yyyy-MM').parse(periodId);

--- a/lib/data/repositories/post_comment.dart
+++ b/lib/data/repositories/post_comment.dart
@@ -227,7 +227,9 @@ Future<void> processAICommentReply({
       final buf = StringBuffer();
       buf.writeln('\n<existing_comments>');
       for (final c in cardData.comments) {
-        final author = c.isAi ? (c.characterId ?? 'AI') : 'User';
+        final author = c.isAi
+            ? (c.characterId ?? UserStorage.l10n.commentAuthorAi)
+            : UserStorage.l10n.commentAuthorUser;
         final replyInfo =
             c.replyToId != null ? ' (replying to ${c.replyToId})' : '';
         final commentTime = formatLocalDateTimeWithZone(

--- a/lib/data/services/gemini_auth_service.dart
+++ b/lib/data/services/gemini_auth_service.dart
@@ -165,7 +165,7 @@ class GeminiAuthService {
       } catch (_) {}
 
       if (result == null) {
-        onError('Authorization cancelled');
+        onError(UserStorage.l10n.authorizationCancelled);
         return;
       }
 

--- a/lib/data/services/openai_auth_service.dart
+++ b/lib/data/services/openai_auth_service.dart
@@ -169,7 +169,7 @@ class OpenAiAuthService {
       } catch (_) {}
 
       if (result == null) {
-        onError('Authorization cancelled by user');
+        onError(UserStorage.l10n.authorizationCancelled);
         return;
       }
 

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "فشل تسجيل الدخول",
   "paymentCreationFailed": "تعذر بدء الدفع",
   "completePayment": "إكمال الدفع",
-  "commentReplyToYou": "أنت"
+  "commentReplyToYou": "أنت",
+  "commentAuthorUser": "المستخدم",
+  "commentAuthorAi": "AI",
+  "authorizationCancelled": "تم إلغاء التفويض",
+  "timelineWeekNumberLabel": "الأسبوع {week}",
+  "timelineWeekLabel": "أسبوع",
+  "eventCardDefaultTitle": "حدث",
+  "memoryNoLongTermYet": "لا توجد ذكريات طويلة المدى بعد.",
+  "memoryNoRecentBuffer": "لا توجد ذكريات حديثة في المخزن المؤقت.",
+  "memoryGeneralSubject": "عام",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "Anmeldung fehlgeschlagen",
   "paymentCreationFailed": "Zahlung konnte nicht gestartet werden",
   "completePayment": "Zahlung abschließen",
-  "commentReplyToYou": "Du"
+  "commentReplyToYou": "Du",
+  "commentAuthorUser": "Benutzer",
+  "commentAuthorAi": "KI",
+  "authorizationCancelled": "Autorisierung abgebrochen",
+  "timelineWeekNumberLabel": "Woche {week}",
+  "timelineWeekLabel": "Woche",
+  "eventCardDefaultTitle": "Ereignis",
+  "memoryNoLongTermYet": "Noch keine Langzeit-Erinnerungen.",
+  "memoryNoRecentBuffer": "Keine recenten Erinnerungen im Puffer.",
+  "memoryGeneralSubject": "Allgemein",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "Login failed",
   "paymentCreationFailed": "Could not start payment",
   "completePayment": "Complete payment",
-  "commentReplyToYou": "You"
+  "commentReplyToYou": "You",
+  "commentAuthorUser": "User",
+  "commentAuthorAi": "AI",
+  "authorizationCancelled": "Authorization cancelled",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  },
+  "timelineWeekNumberLabel": "Week {week}",
+  "timelineWeekLabel": "Week",
+  "eventCardDefaultTitle": "Event",
+  "memoryNoLongTermYet": "No long-term memories yet.",
+  "memoryNoRecentBuffer": "No recent memories in buffer.",
+  "memoryGeneralSubject": "General"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "Error al iniciar sesión",
   "paymentCreationFailed": "No se pudo iniciar el pago",
   "completePayment": "Completar pago",
-  "commentReplyToYou": "Tú"
+  "commentReplyToYou": "Tú",
+  "commentAuthorUser": "Usuario",
+  "commentAuthorAi": "IA",
+  "authorizationCancelled": "Autorización cancelada",
+  "timelineWeekNumberLabel": "Semana {week}",
+  "timelineWeekLabel": "Semana",
+  "eventCardDefaultTitle": "Evento",
+  "memoryNoLongTermYet": "Aún no hay recuerdos a largo plazo.",
+  "memoryNoRecentBuffer": "No hay recuerdos recientes en el búfer.",
+  "memoryGeneralSubject": "General",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "Échec de la connexion",
   "paymentCreationFailed": "Impossible de lancer le paiement",
   "completePayment": "Finaliser le paiement",
-  "commentReplyToYou": "Vous"
+  "commentReplyToYou": "Vous",
+  "commentAuthorUser": "Utilisateur",
+  "commentAuthorAi": "IA",
+  "authorizationCancelled": "Autorisation annulée",
+  "timelineWeekNumberLabel": "Semaine {week}",
+  "timelineWeekLabel": "Semaine",
+  "eventCardDefaultTitle": "Événement",
+  "memoryNoLongTermYet": "Pas encore de souvenirs à long terme.",
+  "memoryNoRecentBuffer": "Aucun souvenir récent dans le tampon.",
+  "memoryGeneralSubject": "Général",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "लॉगिन असफल",
   "paymentCreationFailed": "भुगतान शुरू नहीं हो सका",
   "completePayment": "भुगतान पूरा करें",
-  "commentReplyToYou": "आप"
+  "commentReplyToYou": "आप",
+  "commentAuthorUser": "उपयोगकर्ता",
+  "commentAuthorAi": "AI",
+  "authorizationCancelled": "प्राधिकरण रद्द कर दिया गया",
+  "timelineWeekNumberLabel": "सप्ताह {week}",
+  "timelineWeekLabel": "सप्ताह",
+  "eventCardDefaultTitle": "कार्यक्रम",
+  "memoryNoLongTermYet": "अभी तक कोई दीर्घकालिक स्मृति नहीं है।",
+  "memoryNoRecentBuffer": "बफ़र में कोई हाल की स्मृति नहीं है।",
+  "memoryGeneralSubject": "सामान्य",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "Login gagal",
   "paymentCreationFailed": "Tidak bisa memulai pembayaran",
   "completePayment": "Selesaikan pembayaran",
-  "commentReplyToYou": "Anda"
+  "commentReplyToYou": "Anda",
+  "commentAuthorUser": "Pengguna",
+  "commentAuthorAi": "AI",
+  "authorizationCancelled": "Otorisasi dibatalkan",
+  "timelineWeekNumberLabel": "Minggu {week}",
+  "timelineWeekLabel": "Minggu",
+  "eventCardDefaultTitle": "Acara",
+  "memoryNoLongTermYet": "Belum ada memori jangka panjang.",
+  "memoryNoRecentBuffer": "Tidak ada memori terbaru di buffer.",
+  "memoryGeneralSubject": "Umum",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "ログインに失敗しました",
   "paymentCreationFailed": "支払いを開始できませんでした",
   "completePayment": "支払いを完了",
-  "commentReplyToYou": "あなた"
+  "commentReplyToYou": "あなた",
+  "commentAuthorUser": "ユーザー",
+  "commentAuthorAi": "AI",
+  "authorizationCancelled": "認可がキャンセルされました",
+  "timelineWeekNumberLabel": "第{week}週",
+  "timelineWeekLabel": "週",
+  "eventCardDefaultTitle": "イベント",
+  "memoryNoLongTermYet": "長期記憶はまだありません。",
+  "memoryNoRecentBuffer": "バッファに最近の記憶はありません。",
+  "memoryGeneralSubject": "一般",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "로그인에 실패했습니다",
   "paymentCreationFailed": "결제를 시작할 수 없습니다",
   "completePayment": "결제 완료",
-  "commentReplyToYou": "나"
+  "commentReplyToYou": "나",
+  "commentAuthorUser": "사용자",
+  "commentAuthorAi": "AI",
+  "authorizationCancelled": "인증이 취소되었습니다",
+  "timelineWeekNumberLabel": "{week}주차",
+  "timelineWeekLabel": "주",
+  "eventCardDefaultTitle": "이벤트",
+  "memoryNoLongTermYet": "아직 장기 기억이 없습니다.",
+  "memoryNoRecentBuffer": "버퍼에 최근 기억이 없습니다.",
+  "memoryGeneralSubject": "일반",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5843,6 +5843,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'You'**
   String get commentReplyToYou;
+
+  /// No description provided for @commentAuthorUser.
+  ///
+  /// In en, this message translates to:
+  /// **'User'**
+  String get commentAuthorUser;
+
+  /// No description provided for @commentAuthorAi.
+  ///
+  /// In en, this message translates to:
+  /// **'AI'**
+  String get commentAuthorAi;
+
+  /// No description provided for @authorizationCancelled.
+  ///
+  /// In en, this message translates to:
+  /// **'Authorization cancelled'**
+  String get authorizationCancelled;
+
+  /// No description provided for @timelineWeekNumberLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Week {week}'**
+  String timelineWeekNumberLabel(Object week);
+
+  /// No description provided for @timelineWeekLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Week'**
+  String get timelineWeekLabel;
+
+  /// No description provided for @eventCardDefaultTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Event'**
+  String get eventCardDefaultTitle;
+
+  /// No description provided for @memoryNoLongTermYet.
+  ///
+  /// In en, this message translates to:
+  /// **'No long-term memories yet.'**
+  String get memoryNoLongTermYet;
+
+  /// No description provided for @memoryNoRecentBuffer.
+  ///
+  /// In en, this message translates to:
+  /// **'No recent memories in buffer.'**
+  String get memoryNoRecentBuffer;
+
+  /// No description provided for @memoryGeneralSubject.
+  ///
+  /// In en, this message translates to:
+  /// **'General'**
+  String get memoryGeneralSubject;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3224,4 +3224,33 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'أنت';
+
+  @override
+  String get commentAuthorUser => 'المستخدم';
+
+  @override
+  String get commentAuthorAi => 'AI';
+
+  @override
+  String get authorizationCancelled => 'تم إلغاء التفويض';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'الأسبوع $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'أسبوع';
+
+  @override
+  String get eventCardDefaultTitle => 'حدث';
+
+  @override
+  String get memoryNoLongTermYet => 'لا توجد ذكريات طويلة المدى بعد.';
+
+  @override
+  String get memoryNoRecentBuffer => 'لا توجد ذكريات حديثة في المخزن المؤقت.';
+
+  @override
+  String get memoryGeneralSubject => 'عام';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3304,4 +3304,33 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'Du';
+
+  @override
+  String get commentAuthorUser => 'Benutzer';
+
+  @override
+  String get commentAuthorAi => 'KI';
+
+  @override
+  String get authorizationCancelled => 'Autorisierung abgebrochen';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'Woche $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'Woche';
+
+  @override
+  String get eventCardDefaultTitle => 'Ereignis';
+
+  @override
+  String get memoryNoLongTermYet => 'Noch keine Langzeit-Erinnerungen.';
+
+  @override
+  String get memoryNoRecentBuffer => 'Keine recenten Erinnerungen im Puffer.';
+
+  @override
+  String get memoryGeneralSubject => 'Allgemein';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3243,4 +3243,33 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'You';
+
+  @override
+  String get commentAuthorUser => 'User';
+
+  @override
+  String get commentAuthorAi => 'AI';
+
+  @override
+  String get authorizationCancelled => 'Authorization cancelled';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'Week $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'Week';
+
+  @override
+  String get eventCardDefaultTitle => 'Event';
+
+  @override
+  String get memoryNoLongTermYet => 'No long-term memories yet.';
+
+  @override
+  String get memoryNoRecentBuffer => 'No recent memories in buffer.';
+
+  @override
+  String get memoryGeneralSubject => 'General';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3294,4 +3294,33 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'Tú';
+
+  @override
+  String get commentAuthorUser => 'Usuario';
+
+  @override
+  String get commentAuthorAi => 'IA';
+
+  @override
+  String get authorizationCancelled => 'Autorización cancelada';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'Semana $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'Semana';
+
+  @override
+  String get eventCardDefaultTitle => 'Evento';
+
+  @override
+  String get memoryNoLongTermYet => 'Aún no hay recuerdos a largo plazo.';
+
+  @override
+  String get memoryNoRecentBuffer => 'No hay recuerdos recientes en el búfer.';
+
+  @override
+  String get memoryGeneralSubject => 'General';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3301,4 +3301,33 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'Vous';
+
+  @override
+  String get commentAuthorUser => 'Utilisateur';
+
+  @override
+  String get commentAuthorAi => 'IA';
+
+  @override
+  String get authorizationCancelled => 'Autorisation annulée';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'Semaine $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'Semaine';
+
+  @override
+  String get eventCardDefaultTitle => 'Événement';
+
+  @override
+  String get memoryNoLongTermYet => 'Pas encore de souvenirs à long terme.';
+
+  @override
+  String get memoryNoRecentBuffer => 'Aucun souvenir récent dans le tampon.';
+
+  @override
+  String get memoryGeneralSubject => 'Général';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -3252,4 +3252,33 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'आप';
+
+  @override
+  String get commentAuthorUser => 'उपयोगकर्ता';
+
+  @override
+  String get commentAuthorAi => 'AI';
+
+  @override
+  String get authorizationCancelled => 'प्राधिकरण रद्द कर दिया गया';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'सप्ताह $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'सप्ताह';
+
+  @override
+  String get eventCardDefaultTitle => 'कार्यक्रम';
+
+  @override
+  String get memoryNoLongTermYet => 'अभी तक कोई दीर्घकालिक स्मृति नहीं है।';
+
+  @override
+  String get memoryNoRecentBuffer => 'बफ़र में कोई हाल की स्मृति नहीं है।';
+
+  @override
+  String get memoryGeneralSubject => 'सामान्य';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -3262,4 +3262,33 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'Anda';
+
+  @override
+  String get commentAuthorUser => 'Pengguna';
+
+  @override
+  String get commentAuthorAi => 'AI';
+
+  @override
+  String get authorizationCancelled => 'Otorisasi dibatalkan';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'Minggu $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'Minggu';
+
+  @override
+  String get eventCardDefaultTitle => 'Acara';
+
+  @override
+  String get memoryNoLongTermYet => 'Belum ada memori jangka panjang.';
+
+  @override
+  String get memoryNoRecentBuffer => 'Tidak ada memori terbaru di buffer.';
+
+  @override
+  String get memoryGeneralSubject => 'Umum';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3167,4 +3167,33 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'あなた';
+
+  @override
+  String get commentAuthorUser => 'ユーザー';
+
+  @override
+  String get commentAuthorAi => 'AI';
+
+  @override
+  String get authorizationCancelled => '認可がキャンセルされました';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return '第$week週';
+  }
+
+  @override
+  String get timelineWeekLabel => '週';
+
+  @override
+  String get eventCardDefaultTitle => 'イベント';
+
+  @override
+  String get memoryNoLongTermYet => '長期記憶はまだありません。';
+
+  @override
+  String get memoryNoRecentBuffer => 'バッファに最近の記憶はありません。';
+
+  @override
+  String get memoryGeneralSubject => '一般';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3166,4 +3166,33 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get commentReplyToYou => '나';
+
+  @override
+  String get commentAuthorUser => '사용자';
+
+  @override
+  String get commentAuthorAi => 'AI';
+
+  @override
+  String get authorizationCancelled => '인증이 취소되었습니다';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return '$week주차';
+  }
+
+  @override
+  String get timelineWeekLabel => '주';
+
+  @override
+  String get eventCardDefaultTitle => '이벤트';
+
+  @override
+  String get memoryNoLongTermYet => '아직 장기 기억이 없습니다.';
+
+  @override
+  String get memoryNoRecentBuffer => '버퍼에 최근 기억이 없습니다.';
+
+  @override
+  String get memoryGeneralSubject => '일반';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3272,4 +3272,33 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'Você';
+
+  @override
+  String get commentAuthorUser => 'Usuário';
+
+  @override
+  String get commentAuthorAi => 'IA';
+
+  @override
+  String get authorizationCancelled => 'Autorização cancelada';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'Semana $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'Semana';
+
+  @override
+  String get eventCardDefaultTitle => 'Evento';
+
+  @override
+  String get memoryNoLongTermYet => 'Ainda não há memórias de longo prazo.';
+
+  @override
+  String get memoryNoRecentBuffer => 'Não há memórias recentes no buffer.';
+
+  @override
+  String get memoryGeneralSubject => 'Geral';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3270,4 +3270,33 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get commentReplyToYou => 'Вы';
+
+  @override
+  String get commentAuthorUser => 'Пользователь';
+
+  @override
+  String get commentAuthorAi => 'ИИ';
+
+  @override
+  String get authorizationCancelled => 'Авторизация отменена';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'Неделя $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'Неделя';
+
+  @override
+  String get eventCardDefaultTitle => 'Событие';
+
+  @override
+  String get memoryNoLongTermYet => 'Долговременных воспоминаний пока нет.';
+
+  @override
+  String get memoryNoRecentBuffer => 'В буфере пока нет недавних воспоминаний.';
+
+  @override
+  String get memoryGeneralSubject => 'Общее';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3129,6 +3129,35 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get commentReplyToYou => '你';
+
+  @override
+  String get commentAuthorUser => '用户';
+
+  @override
+  String get commentAuthorAi => 'AI';
+
+  @override
+  String get authorizationCancelled => '授权已取消';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return '第 $week 周';
+  }
+
+  @override
+  String get timelineWeekLabel => '周';
+
+  @override
+  String get eventCardDefaultTitle => '事件';
+
+  @override
+  String get memoryNoLongTermYet => '还没有长期记忆。';
+
+  @override
+  String get memoryNoRecentBuffer => '缓冲区中还没有近期记忆。';
+
+  @override
+  String get memoryGeneralSubject => '通用';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -6260,4 +6289,33 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get commentReplyToYou => '你';
+
+  @override
+  String get commentAuthorUser => '用戶';
+
+  @override
+  String get commentAuthorAi => 'AI';
+
+  @override
+  String get authorizationCancelled => '授權已取消';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return '第 $week 週';
+  }
+
+  @override
+  String get timelineWeekLabel => '週';
+
+  @override
+  String get eventCardDefaultTitle => '事件';
+
+  @override
+  String get memoryNoLongTermYet => '還沒有長期記憶。';
+
+  @override
+  String get memoryNoRecentBuffer => '緩衝區中還沒有近期記憶。';
+
+  @override
+  String get memoryGeneralSubject => '通用';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "Falha no login",
   "paymentCreationFailed": "Não foi possível iniciar o pagamento",
   "completePayment": "Concluir pagamento",
-  "commentReplyToYou": "Você"
+  "commentReplyToYou": "Você",
+  "commentAuthorUser": "Usuário",
+  "commentAuthorAi": "IA",
+  "authorizationCancelled": "Autorização cancelada",
+  "timelineWeekNumberLabel": "Semana {week}",
+  "timelineWeekLabel": "Semana",
+  "eventCardDefaultTitle": "Evento",
+  "memoryNoLongTermYet": "Ainda não há memórias de longo prazo.",
+  "memoryNoRecentBuffer": "Não há memórias recentes no buffer.",
+  "memoryGeneralSubject": "Geral",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "Не удалось войти",
   "paymentCreationFailed": "Не удалось начать оплату",
   "completePayment": "Завершить оплату",
-  "commentReplyToYou": "Вы"
+  "commentReplyToYou": "Вы",
+  "commentAuthorUser": "Пользователь",
+  "commentAuthorAi": "ИИ",
+  "authorizationCancelled": "Авторизация отменена",
+  "timelineWeekNumberLabel": "Неделя {week}",
+  "timelineWeekLabel": "Неделя",
+  "eventCardDefaultTitle": "Событие",
+  "memoryNoLongTermYet": "Долговременных воспоминаний пока нет.",
+  "memoryNoRecentBuffer": "В буфере пока нет недавних воспоминаний.",
+  "memoryGeneralSubject": "Общее",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1437,5 +1437,19 @@
   "loginFailed": "登录失败",
   "paymentCreationFailed": "无法发起支付",
   "completePayment": "完成支付",
-  "commentReplyToYou": "你"
+  "commentReplyToYou": "你",
+  "commentAuthorUser": "用户",
+  "commentAuthorAi": "AI",
+  "authorizationCancelled": "授权已取消",
+  "timelineWeekNumberLabel": "第 {week} 周",
+  "timelineWeekLabel": "周",
+  "eventCardDefaultTitle": "事件",
+  "memoryNoLongTermYet": "还没有长期记忆。",
+  "memoryNoRecentBuffer": "缓冲区中还没有近期记忆。",
+  "memoryGeneralSubject": "通用",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1483,5 +1483,19 @@
   "loginFailed": "登入失敗",
   "paymentCreationFailed": "無法發起付款",
   "completePayment": "完成付款",
-  "commentReplyToYou": "你"
+  "commentReplyToYou": "你",
+  "commentAuthorUser": "用戶",
+  "commentAuthorAi": "AI",
+  "authorizationCancelled": "授權已取消",
+  "timelineWeekNumberLabel": "第 {week} 週",
+  "timelineWeekLabel": "週",
+  "eventCardDefaultTitle": "事件",
+  "memoryNoLongTermYet": "還沒有長期記憶。",
+  "memoryNoRecentBuffer": "緩衝區中還沒有近期記憶。",
+  "memoryGeneralSubject": "通用",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  }
 }

--- a/lib/ui/core/cards/templates/temporal/event_card.dart
+++ b/lib/ui/core/cards/templates/temporal/event_card.dart
@@ -16,7 +16,7 @@ class EventCard extends StatelessWidget {
     final startTime = parseLocalDateTime(data['start_time']);
     final endTime = parseLocalDateTime(data['end_time']);
 
-    final String title = data['title'] ?? 'Event';
+    final String title = data['title'] ?? UserStorage.l10n.eventCardDefaultTitle;
     final String? location = data['location'];
 
     final localeName = UserStorage.l10n.localeName;

--- a/lib/ui/memory/widgets/memory_screen.dart
+++ b/lib/ui/memory/widgets/memory_screen.dart
@@ -111,10 +111,10 @@ class _MemoryScreenState extends State<MemoryScreen> {
 
   Widget _buildArchivedView(String content) {
     if (content.isEmpty) {
-      return const Center(
+      return Center(
         child: Text(
-          'No long-term memories yet.',
-          style: TextStyle(color: Colors.grey),
+          UserStorage.l10n.memoryNoLongTermYet,
+          style: const TextStyle(color: Colors.grey),
         ),
       );
     }
@@ -146,10 +146,10 @@ class _MemoryScreenState extends State<MemoryScreen> {
 
   Widget _buildRecentView(List<Map<String, dynamic>> buffer) {
     if (buffer.isEmpty) {
-      return const Center(
+      return Center(
         child: Text(
-          'No recent memories in buffer.',
-          style: TextStyle(color: Colors.grey),
+          UserStorage.l10n.memoryNoRecentBuffer,
+          style: const TextStyle(color: Colors.grey),
         ),
       );
     }
@@ -182,7 +182,7 @@ class _MemoryScreenState extends State<MemoryScreen> {
                         borderRadius: BorderRadius.circular(6),
                       ),
                       child: Text(
-                        item['subject'] ?? 'General',
+                        item['subject'] ?? UserStorage.l10n.memoryGeneralSubject,
                         style: const TextStyle(
                           fontSize: 12,
                           color: AppColors.primary,

--- a/lib/ui/settings/widgets/model_config_edit_page.dart
+++ b/lib/ui/settings/widgets/model_config_edit_page.dart
@@ -232,7 +232,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
           _dismissAuthDialog();
           ToastHelper.showError(
             context,
-            UserStorage.l10n.authFailed('Authorization cancelled'),
+            UserStorage.l10n.authFailed(UserStorage.l10n.authorizationCancelled),
           );
         }
       });

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -61,7 +61,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
   bool _isLoading = true;
   String? _errorMessage;
   late final MemexRouter _memexRouter;
-  String _userName = 'User';
+  String _userName = '';
   String? _userAvatar;
   double? _firstImageAspectRatio;
   bool _showInsightText = true;
@@ -114,7 +114,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     final settings = await _memexRouter.getCommentSettings();
     if (mounted) {
       setState(() {
-        _userName = name ?? 'User';
+        _userName = name ?? UserStorage.l10n.commentAuthorUser;
         _userAvatar = avatar;
         _showInsightText = settings.showInsightText;
       });
@@ -229,8 +229,9 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     if (detail.insight.comments.isNotEmpty) {
       buffer.writeln('Comments:');
       for (final comment in detail.insight.comments) {
-        final authorName =
-            comment.isAi ? 'AI' : (comment.character?.name ?? 'User');
+        final authorName = comment.isAi
+            ? (comment.character?.name ?? UserStorage.l10n.commentAuthorAi)
+            : (comment.character?.name ?? UserStorage.l10n.commentAuthorUser);
         final time = formatLocalDateTimeWithZone(
           DateTime.fromMillisecondsSinceEpoch(comment.timestamp * 1000),
         );
@@ -809,8 +810,11 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     // Other comments
     for (var comment in detail.insight.comments) {
       final isUser = !comment.isAi;
-      final commentName =
-          isUser ? _userName : (comment.character?.name ?? 'AI');
+      final displayUserName =
+          _userName.isNotEmpty ? _userName : UserStorage.l10n.commentAuthorUser;
+      final commentName = isUser
+          ? displayUserName
+          : (comment.character?.name ?? UserStorage.l10n.commentAuthorAi);
       commentWidgets.add(
         _buildShareSingleComment(
           characterId: isUser ? 'user' : comment.character?.id,
@@ -1408,17 +1412,24 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
     if (detail.insight.character != null) {
       commentNameMap['insight'] = detail.insight.character!.name;
     }
+    final displayUserName =
+        _userName.isNotEmpty ? _userName : UserStorage.l10n.commentAuthorUser;
     for (var comment in detail.insight.comments) {
       final isUser = !comment.isAi;
-      final name = isUser ? _userName : (comment.character?.name ?? 'AI');
+      final name = isUser
+          ? displayUserName
+          : (comment.character?.name ?? UserStorage.l10n.commentAuthorAi);
       commentNameMap[comment.id] = name;
     }
 
     // Add other comments
     for (var comment in detail.insight.comments) {
       final isUser = !comment.isAi;
-      final commentName =
-          isUser ? _userName : (comment.character?.name ?? 'AI');
+      final displayUserName =
+          _userName.isNotEmpty ? _userName : UserStorage.l10n.commentAuthorUser;
+      final commentName = isUser
+          ? displayUserName
+          : (comment.character?.name ?? UserStorage.l10n.commentAuthorAi);
       commentWidgets.add(
         Material(
           color: Colors.transparent,

--- a/test/l10n/hardcoded_ui_strings_test.dart
+++ b/test/l10n/hardcoded_ui_strings_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/card.dart';
+import 'package:memex/domain/models/card_detail_model.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({'language': 'zh'});
+    await UserStorage.initL10n();
+  });
+
+  test('comment author labels resolve from l10n', () {
+    expect(UserStorage.l10n.commentAuthorUser, '用户');
+    expect(UserStorage.l10n.commentAuthorAi, 'AI');
+    expect(UserStorage.l10n.authorizationCancelled, '授权已取消');
+    expect(UserStorage.l10n.timelineWeekNumberLabel('12'), '第 12 周');
+    expect(UserStorage.l10n.eventCardDefaultTitle, '事件');
+    expect(UserStorage.l10n.memoryNoLongTermYet, '还没有长期记忆。');
+  });
+
+  test('replyDisplayNameFor falls back to localized AI label', () {
+    final comment = Comment(
+      id: 'c1',
+      content: 'hello',
+      timestamp: 1,
+      isAi: true,
+    );
+
+    expect(
+      replyDisplayNameFor(comment, UserStorage.l10n.commentAuthorUser),
+      UserStorage.l10n.commentAuthorAi,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Adds ARB keys for comment author labels (`User`/`AI`), OAuth cancellation, timeline week labels, event card default title, and memory empty states.
- Wires `timeline_card_detail_screen`, `memory_screen`, `event_card`, OAuth services, and aggregated timeline grouping to use l10n.
- Translates new keys across all 13 existing locales.

## Test plan
- [x] `flutter gen-l10n`
- [x] `dart analyze` on changed files
- [x] `flutter test test/l10n/hardcoded_ui_strings_test.dart`
- [x] Card detail comments show localized author fallbacks in zh
- [x] Memory screen empty tabs show localized copy

cc @sparkleMing @whbzju for review when convenient.
