### PR TITLE
docs: add English agent prompt/tools code index

### DIFF
--- a/docs/agent_prompt_tools_code_index.en.md
+++ b/docs/agent_prompt_tools_code_index.en.md
@@ -1,16 +1,16 @@
-# Memex Agent Prompt / Tools 代码索引
+# Memex Agent Prompt / Tools Code Index
 
-中文 | [English](agent_prompt_tools_code_index.en.md)
+[中文](agent_prompt_tools_code_index.md) | English
 
-这份索引按“想理解某个 Agent 时应该读哪些代码”的顺序组织。它补充 [agent_overview.md](agent_overview.md)，偏源码入口、类名、函数名和工具名。
+This index is organized in the order of "which code to read when you want to understand a given Agent." It supplements [agent_overview.md](agent_overview.md), focusing on source entry points, class names, function names, and tool names.
 
-## 1. 全局入口
+## 1. Global Entry Points
 
-### Agent ID 和设置页
+### Agent IDs and Settings Page
 
-文件：[`lib/domain/models/agent_definitions.dart`](../lib/domain/models/agent_definitions.dart)
+File: [`lib/domain/models/agent_definitions.dart`](../lib/domain/models/agent_definitions.dart)
 
-关键对象：
+Key objects:
 
 ```dart
 class AgentDefinitions {
@@ -30,21 +30,21 @@ class AgentDefinitions {
 }
 ```
 
-作用：
+Purpose:
 
-- `displayNames` 决定设置页展示。
-- `configurableAgentIds` 决定哪些 Agent 可独立配置模型。
+- `displayNames` controls what appears on the settings page.
+- `configurableAgentIds` determines which Agents can be independently configured with a model.
 
-### Task handler 注册
+### Task Handler Registration
 
-文件：[`lib/data/repositories/memex_router.dart`](../lib/data/repositories/memex_router.dart)
+File: [`lib/data/repositories/memex_router.dart`](../lib/data/repositories/memex_router.dart)
 
-重点读：
+Read these first:
 
 - `_init()`
 - `_registerEventSubscriptions()`
 
-核心 handler：
+Core handlers:
 
 ```text
 handle_analyze_assets              -> handleAnalyzeAssetsImpl
@@ -59,7 +59,7 @@ ask_clarification_task             -> handleAskClarificationTask
 clarification_resolution_task      -> handleClarificationResolution
 ```
 
-核心订阅：
+Core subscriptions:
 
 ```text
 userInputSubmitted
@@ -82,23 +82,23 @@ clarificationAnswered
   -> clarification_resolution_task
 ```
 
-## 2. Agent 构造函数索引
+## 2. Agent Constructor Index
 
 ### CardAgent
 
-文件：
+Files:
 
 - [`lib/agent/card_agent/card_agent.dart`](../lib/agent/card_agent/card_agent.dart)
 - [`lib/data/services/task_handlers/card_agent_handler.dart`](../lib/data/services/task_handlers/card_agent_handler.dart)
 
-优先读：
+Read these first:
 
 1. `processWithCardAgent(...)`
 2. `CardAgent.runWithContent(...)`
 3. `CardAgent._createAgent(...)`
 4. `CardAgent.inspectCardRunCompletion(...)`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'card_agent'
@@ -112,24 +112,24 @@ disableSubAgents: true
 systemCallback: createSystemCallback(userId)
 ```
 
-Prompt 来源：
+Prompt sources:
 
 - `cardAgentSystemPrompt`
 - `Prompts.cardAgentUserMessagePromptForPublishNewContent(...)`
 - `Prompts.timelineCardSkillSystemPrompt(...)`
 
-Tools 来源：
+Tool sources:
 
 - `TimelineCardSkill._buildTools(...)`
 
 ### PkmAgent
 
-文件：
+Files:
 
 - [`lib/agent/pkm_agent/pkm_agent.dart`](../lib/agent/pkm_agent/pkm_agent.dart)
 - [`lib/data/services/task_handlers/pkm_agent_handler.dart`](../lib/data/services/task_handlers/pkm_agent_handler.dart)
 
-优先读：
+Read these first:
 
 1. `PkmAgent.detectNonPersistentInput(...)`
 2. `processWithPkmAgent(...)`
@@ -137,7 +137,7 @@ Tools 来源：
 4. `PkmAgent.createAgent(...)`
 5. `PkmAgent._getPkmOverview(...)`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'pkm_agent'
@@ -160,7 +160,7 @@ disableSubAgents: true
 planMode: PlanMode.none
 ```
 
-权限：
+Permissions:
 
 ```dart
 PermissionRule(
@@ -169,7 +169,7 @@ PermissionRule(
 )
 ```
 
-Prompt 来源：
+Prompt sources:
 
 - `pkmAgentSystemPrompt`
 - `Prompts.pkmAgentInstructionForNewPublishedContent(...)`
@@ -177,27 +177,27 @@ Prompt 来源：
 - dynamic PKM overview
 - read-only user memory reminder
 
-Tools 来源：
+Tool sources:
 
 - `FileToolFactory`
 - `PkmSkill._buildTools(...)`
 
 ### KnowledgeInsightAgent
 
-文件：
+Files:
 
 - [`lib/agent/insight_agent/knowledge_insight_agent.dart`](../lib/agent/insight_agent/knowledge_insight_agent.dart)
 - [`lib/data/services/task_handlers/knowledge_insight_handler.dart`](../lib/data/services/task_handlers/knowledge_insight_handler.dart)
 - [`lib/agent/insight_agent/knowledge_insight_run_context.dart`](../lib/agent/insight_agent/knowledge_insight_run_context.dart)
 
-优先读：
+Read these first:
 
 1. `KnowledgeInsightAgent.updateKnowledgeInsight(...)`
 2. `KnowledgeInsightAgent._createAgent(...)`
 3. `buildKnowledgeInsightRunContext(...)`
 4. `_createInsightSummaryCardIfNeeded(...)`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'knowledge_insight_agent'
@@ -219,21 +219,21 @@ disableSubAgents: false
 planMode: PlanMode.auto
 ```
 
-权限：
+Permissions:
 
 ```text
 Workspace/Facts/Cards/PKM: read
 KnowledgeInsights: write
 ```
 
-Prompt 来源：
+Prompt sources:
 
 - `knowledgeInsightAgentSystemPrompt`
 - `Prompts.knowledgeInsightAgentKnowledgeInsightSkillPrompt(...)`
 - `MemoryManagement.buildMemoryReadOnlyPrompt()`
 - `buildKnowledgeInsightRunContext(...)`
 
-Tools 来源：
+Tool sources:
 
 - `FileToolFactory`
 - `buildSearchEventLogsTool()`
@@ -242,13 +242,13 @@ Tools 来源：
 
 ### CommentAgent
 
-文件：
+Files:
 
 - [`lib/agent/comment_agent/comment_agent.dart`](../lib/agent/comment_agent/comment_agent.dart)
 - [`lib/data/services/task_handlers/comment_agent_handler.dart`](../lib/data/services/task_handlers/comment_agent_handler.dart)
 - [`lib/agent/context/character_context_assembler.dart`](../lib/agent/context/character_context_assembler.dart)
 
-优先读：
+Read these first:
 
 1. `handleCommentAgentImpl(...)`
 2. `handleProcessAiReplyImpl(...)`
@@ -256,7 +256,7 @@ Tools 来源：
 4. `CommentAgent._createAgent(...)`
 5. `CharacterContextAssembler.build(...)`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'comment_agent'
@@ -267,7 +267,7 @@ disableSubAgents: true
 planMode: PlanMode.none
 ```
 
-Prompt 来源：
+Prompt sources:
 
 - `commentAgentSystemPrompt`
 - `Prompts.commentAgentInitialCommentPrompt`
@@ -277,7 +277,7 @@ Prompt 来源：
 - style examples
 - character context reminders
 
-Tools 来源：
+Tool sources:
 
 - `CommentAgentSkill`
 - `CharacterToolsFactory.buildCommentTools(...)`
@@ -285,20 +285,20 @@ Tools 来源：
 
 ### SuperAgent / Chat
 
-文件：
+Files:
 
 - [`lib/data/services/chat_service.dart`](../lib/data/services/chat_service.dart)
 - [`lib/agent/super_agent/super_agent.dart`](../lib/agent/super_agent/super_agent.dart)
 - [`lib/agent/super_agent/prompts.dart`](../lib/agent/super_agent/prompts.dart)
 
-优先读：
+Read these first:
 
 1. `ChatService.sendMessage(...)`
 2. `SuperAgent.createAgent(...)`
 3. `ChatService._setupControllerListeners(...)`
 4. `_createSession(...)` / `_addMessageToSession(...)`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: agentName ?? 'memex_agent'
@@ -320,17 +320,17 @@ planMode: PlanMode.auto
 disableSubAgents: true
 ```
 
-Prompt 来源：
+Prompt sources:
 
 - `superAgentSystemPrompt`
-- `ChatService` 内联 additional prompt
+- inline additional prompt in `ChatService`
 - scene context
 - refs context
 - location context
 - current time
 - memory prompt
 
-Quick Query read-only tools：
+Quick Query read-only tools:
 
 ```text
 LS
@@ -345,20 +345,20 @@ get_pkm_overview
 
 ### CompanionAgent
 
-文件：
+Files:
 
 - [`lib/agent/companion_agent/companion_agent.dart`](../lib/agent/companion_agent/companion_agent.dart)
 - [`lib/agent/skills/companion_agent/companion_agent_skill.dart`](../lib/agent/skills/companion_agent/companion_agent_skill.dart)
 - [`lib/agent/context/character_context_assembler.dart`](../lib/agent/context/character_context_assembler.dart)
 
-优先读：
+Read these first:
 
 1. `CompanionAgent.chat(...)`
 2. `CompanionAgent._createAgent(...)`
 3. `CompanionAgentSkill._buildSystemPrompt(...)`
 4. `CharacterContextCompressor.compressIfNeeded(...)`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'companion_agent'
@@ -369,7 +369,7 @@ disableSubAgents: true
 planMode: PlanMode.none
 ```
 
-Skill tools：
+Skill tools:
 
 ```text
 MemoryRead
@@ -382,13 +382,13 @@ SendActionMessage
 
 ### MemoryAgent / profile_agent
 
-文件：
+Files:
 
 - [`lib/agent/memory_agent/memory_agent.dart`](../lib/agent/memory_agent/memory_agent.dart)
 - [`lib/data/services/memory_sync_service.dart`](../lib/data/services/memory_sync_service.dart)
 - [`lib/agent/memory/memory_management.dart`](../lib/agent/memory/memory_management.dart)
 
-优先读：
+Read these first:
 
 1. `MemorySyncService.enqueueFact(...)`
 2. `MemorySyncService._processQueue(...)`
@@ -396,7 +396,7 @@ SendActionMessage
 4. `MemoryAgent.run(...)`
 5. `MemoryManagement.buildMemoryManagementTools()`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'memory_agent'
@@ -407,20 +407,20 @@ disableSubAgents: true
 planMode: PlanMode.none
 ```
 
-Prompt 来源：
+Prompt sources:
 
-- `MemoryAgent.run(...)` 内联 Strict Memory Curator prompt
+- inline Strict Memory Curator prompt in `MemoryAgent.run(...)`
 - existing memory context
 - batch facts
 
 ### PostCardRouterAgent
 
-文件：
+Files:
 
 - [`lib/agent/post_card_router_agent/post_card_router_agent.dart`](../lib/agent/post_card_router_agent/post_card_router_agent.dart)
 - [`lib/data/services/task_handlers/post_card_router_handler.dart`](../lib/data/services/task_handlers/post_card_router_handler.dart)
 
-优先读：
+Read these first:
 
 1. `handlePostCardRouter(...)`
 2. `runPostCardRouter(...)`
@@ -428,7 +428,7 @@ Prompt 来源：
 4. `_buildActivateTool(...)`
 5. `_enqueueDownstream(...)`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'post_card_router_agent'
@@ -438,7 +438,7 @@ disableSubAgents: true
 planMode: PlanMode.none
 ```
 
-可选 downstream：
+Optional downstream:
 
 ```text
 schedule_aggregator
@@ -447,13 +447,13 @@ ask_clarification
 
 ### ScheduleAggregatorAgent
 
-文件：
+Files:
 
 - [`lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart`](../lib/agent/schedule_aggregator_agent/schedule_aggregator_agent.dart)
 - [`lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart`](../lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart)
 - [`lib/data/services/schedule_state_service.dart`](../lib/data/services/schedule_state_service.dart)
 
-优先读：
+Read these first:
 
 1. `ScheduleAggregatorAgent.updateScheduleAggregation(...)`
 2. `ScheduleAggregatorAgent._createAgent(...)`
@@ -461,7 +461,7 @@ ask_clarification
 4. `ScheduleAggregationSkill`
 5. `ScheduleStateService`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'schedule_aggregator_agent'
@@ -477,7 +477,7 @@ disableSubAgents: true
 planMode: PlanMode.none
 ```
 
-Skill tools：
+Skill tools:
 
 ```text
 get_schedule_state
@@ -491,20 +491,20 @@ search_completed
 
 ### AskClarificationAgent
 
-文件：
+Files:
 
 - [`lib/agent/ask_clarification_agent/ask_clarification_agent.dart`](../lib/agent/ask_clarification_agent/ask_clarification_agent.dart)
 - [`lib/agent/skills/ask_clarification/ask_clarification_skill.dart`](../lib/agent/skills/ask_clarification/ask_clarification_skill.dart)
 - [`lib/data/services/clarification_request_service.dart`](../lib/data/services/clarification_request_service.dart)
 
-优先读：
+Read these first:
 
 1. `handleAskClarificationTask(...)`
 2. `AskClarificationAgent.run(...)`
 3. `AskClarificationSkill._buildSystemPrompt()`
 4. `AskClarificationSkill._buildTools()`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'ask_clarification_agent'
@@ -515,7 +515,7 @@ disableSubAgents: true
 planMode: PlanMode.none
 ```
 
-Skill tools：
+Skill tools:
 
 ```text
 create_clarification_request
@@ -525,18 +525,18 @@ get_recent_clarification_requests
 
 ### ClarificationResolutionAgent
 
-文件：
+Files:
 
 - [`lib/agent/clarification_resolution_agent/clarification_resolution_agent.dart`](../lib/agent/clarification_resolution_agent/clarification_resolution_agent.dart)
 - [`lib/data/services/task_handlers/clarification_resolution_handler.dart`](../lib/data/services/task_handlers/clarification_resolution_handler.dart)
 
-优先读：
+Read these first:
 
 1. `handleClarificationResolution(...)`
 2. `ClarificationResolutionAgent.run(...)`
 3. `_buildFallbackMemory(...)`
 
-`StatefulAgent` 关键参数：
+Key `StatefulAgent` parameters:
 
 ```dart
 name: 'clarification_resolution_agent'
@@ -546,63 +546,63 @@ disableSubAgents: true
 planMode: PlanMode.none
 ```
 
-关键工具：
+Key tools:
 
 ```text
 append_memories
 ```
 
-## 3. Skill / Tool 代码索引
+## 3. Skill / Tool Code Index
 
 ### TimelineCardSkill
 
-文件：[`lib/agent/skills/manage_timeline_card/timeline_card_skill.dart`](../lib/agent/skills/manage_timeline_card/timeline_card_skill.dart)
+File: [`lib/agent/skills/manage_timeline_card/timeline_card_skill.dart`](../lib/agent/skills/manage_timeline_card/timeline_card_skill.dart)
 
-Prompt：
+Prompts:
 
 - `Prompts.timelineCardSkillSystemPrompt(...)`
-- 模板来源：[`timeline_templates.dart`](../lib/agent/skills/manage_timeline_card/timeline_templates.dart)
+- Template source: [`timeline_templates.dart`](../lib/agent/skills/manage_timeline_card/timeline_templates.dart)
 
-Tools：
+Tools:
 
 ```text
 get_card_metadata
 save_timeline_card
 ```
 
-写入路径：
+Write paths:
 
 - `FileSystemService.updateCardFile(...)`
 - `EventBusService.emitEvent(CardDetailUpdatedMessage(...))`
 
 ### PkmSkill
 
-文件：[`lib/agent/skills/manage_pkm/pkm_skill.dart`](../lib/agent/skills/manage_pkm/pkm_skill.dart)
+File: [`lib/agent/skills/manage_pkm/pkm_skill.dart`](../lib/agent/skills/manage_pkm/pkm_skill.dart)
 
-Prompt：
+Prompts:
 
 - `Prompts.pkmSkillSystemPrompt(...)`
 
-Tools：
+Tools:
 
 ```text
 update_timeline_card_insight
 skip_pkm_organization
 ```
 
-写入路径：
+Write paths:
 
 - `FileSystemService.updateCardFile(...)`
 
 ### KnowledgeInsightSkill
 
-文件：[`lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart`](../lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart)
+File: [`lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart`](../lib/agent/skills/knowledge_insight/knowledge_insight_skill.dart)
 
-Prompt：
+Prompts:
 
 - `Prompts.knowledgeInsightAgentKnowledgeInsightSkillPrompt(...)`
 
-Tools：
+Tools:
 
 ```text
 get_exists_knowledge_insight_cards
@@ -613,19 +613,19 @@ get_available_insight_card_templates
 get_user_activity_stats
 ```
 
-模板：
+Templates:
 
 - [`lib/agent/skills/knowledge_insight/native_widgets.dart`](../lib/agent/skills/knowledge_insight/native_widgets.dart)
 
 ### ScheduleAggregationSkill
 
-文件：[`lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart`](../lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart)
+File: [`lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart`](../lib/agent/skills/schedule_aggregation/schedule_aggregation_skill.dart)
 
-Prompt：
+Prompts:
 
 - `Prompts.scheduleAggregatorSkillPrompt(...)`
 
-Tools：
+Tools:
 
 ```text
 get_schedule_state
@@ -637,15 +637,15 @@ set_presentation
 search_completed
 ```
 
-服务：
+Services:
 
 - `ScheduleStateService`
 
 ### AskClarificationSkill
 
-文件：[`lib/agent/skills/ask_clarification/ask_clarification_skill.dart`](../lib/agent/skills/ask_clarification/ask_clarification_skill.dart)
+File: [`lib/agent/skills/ask_clarification/ask_clarification_skill.dart`](../lib/agent/skills/ask_clarification/ask_clarification_skill.dart)
 
-Tools：
+Tools:
 
 ```text
 create_clarification_request
@@ -653,42 +653,42 @@ get_pending_clarification_requests
 get_recent_clarification_requests
 ```
 
-服务：
+Services:
 
 - `ClarificationRequestService`
 
 ### CommentAgentSkill
 
-文件：[`lib/agent/skills/comment_agent/comment_agent_skill.dart`](../lib/agent/skills/comment_agent/comment_agent_skill.dart)
+File: [`lib/agent/skills/comment_agent/comment_agent_skill.dart`](../lib/agent/skills/comment_agent/comment_agent_skill.dart)
 
-Prompt：
+Prompts:
 
 - `Prompts.commentSkillSystemPrompt(...)`
 - character persona
 - character memory
 - style examples
 
-Tools 来源：
+Tool sources:
 
 - `CharacterToolsFactory.buildCommentTools(...)`
 
 ### CompanionAgentSkill
 
-文件：[`lib/agent/skills/companion_agent/companion_agent_skill.dart`](../lib/agent/skills/companion_agent/companion_agent_skill.dart)
+File: [`lib/agent/skills/companion_agent/companion_agent_skill.dart`](../lib/agent/skills/companion_agent/companion_agent_skill.dart)
 
-Prompt：
+Prompts:
 
 - `CompanionAgentSkill._buildSystemPrompt(...)`
 
-Tools 来源：
+Tool sources:
 
 - `CharacterToolsFactory.buildCompanionTools(...)`
 
 ### CharacterToolsFactory
 
-文件：[`lib/agent/skills/character_tools_factory.dart`](../lib/agent/skills/character_tools_factory.dart)
+File: [`lib/agent/skills/character_tools_factory.dart`](../lib/agent/skills/character_tools_factory.dart)
 
-Comment tools：
+Comment tools:
 
 ```text
 Read
@@ -702,7 +702,7 @@ MemoryRemove
 HistorySearch
 ```
 
-Companion tools：
+Companion tools:
 
 ```text
 MemoryRead
@@ -715,9 +715,9 @@ SendActionMessage
 
 ### SystemActionSkill
 
-文件：[`lib/agent/skills/manage_system_action/system_action_skill.dart`](../lib/agent/skills/manage_system_action/system_action_skill.dart)
+File: [`lib/agent/skills/manage_system_action/system_action_skill.dart`](../lib/agent/skills/manage_system_action/system_action_skill.dart)
 
-Tools：
+Tools:
 
 ```text
 create_calendar_event
@@ -726,15 +726,15 @@ get_recent_actions
 cancel_action
 ```
 
-服务：
+Services:
 
 - `SystemActionService`
 
 ### FileToolFactory
 
-文件：[`lib/agent/built_in_tools/file_tools.dart`](../lib/agent/built_in_tools/file_tools.dart)
+File: [`lib/agent/built_in_tools/file_tools.dart`](../lib/agent/built_in_tools/file_tools.dart)
 
-Tools：
+Tools:
 
 ```text
 Read
@@ -748,16 +748,16 @@ Glob
 Grep
 ```
 
-权限：
+Permissions:
 
 - `FilePermissionManager.checkPermission(...)`
 - `PermissionRule(rootPath, access)`
 
 ### Common Tools
 
-文件：[`lib/agent/common_tools.dart`](../lib/agent/common_tools.dart)
+File: [`lib/agent/common_tools.dart`](../lib/agent/common_tools.dart)
 
-Tools：
+Tools:
 
 ```text
 getCurrentTime
@@ -766,34 +766,34 @@ get_pkm_overview
 
 ### Event Log Tool
 
-文件：[`lib/agent/built_in_tools/search_event_logs_tool.dart`](../lib/agent/built_in_tools/search_event_logs_tool.dart)
+File: [`lib/agent/built_in_tools/search_event_logs_tool.dart`](../lib/agent/built_in_tools/search_event_logs_tool.dart)
 
-Tool：
+Tool:
 
 ```text
 search_workspace_event_logs
 ```
 
-注意：
+Note:
 
-- event logging 从 2026-01-23 开始。
-- 早于该日期的数据必须查文件。
+- Event logging started on 2026-01-23.
+- Data before that date must be looked up in files.
 
 ### AssetAnalysisTool
 
-文件：[`lib/agent/built_in_tools/asset_analysis_tool.dart`](../lib/agent/built_in_tools/asset_analysis_tool.dart)
+File: [`lib/agent/built_in_tools/asset_analysis_tool.dart`](../lib/agent/built_in_tools/asset_analysis_tool.dart)
 
-调用者：
+Callers:
 
 - `analyze_assets_handler.dart`
 
-Prompt：
+Prompt:
 
 - `Prompts.assetAnalysisPrompt(...)`
 
-## 4. Prompt 文件索引
+## 4. Prompt File Index
 
-| 文件 | 主要内容 | 使用者 |
+| File | Main Content | Used By |
 | --- | --- | --- |
 | [`lib/agent/card_agent/prompts.dart`](../lib/agent/card_agent/prompts.dart) | `cardAgentSystemPrompt` | CardAgent |
 | [`lib/agent/pkm_agent/prompts.dart`](../lib/agent/pkm_agent/prompts.dart) | `pkmAgentSystemPrompt` | PkmAgent |
@@ -804,62 +804,62 @@ Prompt：
 | [`lib/agent/ask_clarification_agent/prompt.dart`](../lib/agent/ask_clarification_agent/prompt.dart) | `askClarificationAgentSystemPrompt` | AskClarificationAgent |
 | [`lib/agent/super_agent/prompts.dart`](../lib/agent/super_agent/prompts.dart) | `superAgentSystemPrompt` | Chat / SuperAgent |
 | [`lib/agent/memex_skill_host_agent/prompts.dart`](../lib/agent/memex_skill_host_agent/prompts.dart) | `memexSkillHostAgentSystemPrompt` | MemexSkillHostAgent |
-| [`lib/agent/prompts.dart`](../lib/agent/prompts.dart) | shared skill prompts, tool descriptions, asset prompt, file tool descriptions | 多数 Agent / Skill |
+| [`lib/agent/prompts.dart`](../lib/agent/prompts.dart) | shared skill prompts, tool descriptions, asset prompt, file tool descriptions | Most Agents / Skills |
 
-## 5. 常用搜索命令
+## 5. Common Search Commands
 
-查所有 StatefulAgent 构造：
+Find all `StatefulAgent` constructions:
 
 ```bash
 rg -n "StatefulAgent\\(" lib/agent lib/data/services
 ```
 
-查所有 Tool 名：
+Find all tool names:
 
 ```bash
 rg -n "Tool\\(|name:\\s*['\\\"]" lib/agent/skills lib/agent/built_in_tools lib/agent/common_tools.dart
 ```
 
-查所有 Skill 名：
+Find all skill names:
 
 ```bash
 rg -n "class .*Skill|name:\\s*['\\\"]" lib/agent/skills
 ```
 
-查所有事件订阅：
+Find all event subscriptions:
 
 ```bash
 rg -n "subscribe\\(|subscribeSync|registerHandler" lib/data/repositories/memex_router.dart lib/data/services
 ```
 
-查某个 Agent 的模型配置使用：
+Find model configuration usage for a given Agent:
 
 ```bash
 rg -n "AgentDefinitions\\.(cardAgent|pkmAgent|knowledgeInsightAgent|commentAgent|chatAgent|companionAgent|profileAgent|postCardRouterAgent|scheduleAggregatorAgent|askClarificationAgent|clarificationResolutionAgent)" lib
 ```
 
-## 6. 读代码时的判断点
+## 6. Decision Points When Reading Code
 
-读一个 Agent 时，按这个顺序问：
+When reading an Agent, ask in this order:
 
-1. 这个 Agent 是自动任务、聊天入口，还是自定义宿主？
-2. 它在哪里获取 LLM resources？
-3. 它的 sessionId 如何构造，是否复用状态？
-4. 它有没有 resume interrupted run？
-5. 它有无 responseId cache？
-6. 它的 system prompts 是静态还是动态拼接？
-7. dynamic reminders 包含哪些数据？
-8. 它拥有哪些 tools？
-9. tools 是否有 stopFlag？
-10. 文件权限 root 是什么？
-11. 写入是通过工具、service，还是直接文件写入？
-12. handler 是否有前置跳过、兜底或 failure handler？
+1. Is this Agent an automated task, a chat entry point, or a custom host?
+2. Where does it obtain LLM resources?
+3. How is its sessionId constructed, and does it reuse state?
+4. Does it resume an interrupted run?
+5. Does it have a responseId cache?
+6. Are its system prompts static or dynamically assembled?
+7. What data do dynamic reminders include?
+8. Which tools does it own?
+9. Do any tools have a stopFlag?
+10. What is the file permission root?
+11. Are writes done via tools, a service, or direct file writes?
+12. Does the handler have pre-skip logic, fallbacks, or a failure handler?
 
-## 7. 高风险修改点
+## 7. High-Risk Change Points
 
-### 修改 `agent/prompts.dart`
+### Modifying `agent/prompts.dart`
 
-影响范围大。这个文件包含：
+Large blast radius. This file contains:
 
 - Timeline card skill prompt
 - PKM skill prompt
@@ -869,49 +869,48 @@ rg -n "AgentDefinitions\\.(cardAgent|pkmAgent|knowledgeInsightAgent|commentAgent
 - Asset analysis prompt
 - Schedule aggregation skill prompt
 
-改动前先确认调用方。
+Confirm callers before making changes.
 
-### 修改 FileToolFactory
+### Modifying FileToolFactory
 
-影响范围包括：
+Affected areas include:
 
 - PkmAgent
 - SuperAgent
 - KnowledgeInsightAgent
 - Custom Agent Hosts
 - PersonaAgent
-- CommentAgent 的只读文件工具
+- CommentAgent read-only file tools
 
-需要特别小心权限和路径解析。
+Pay special attention to permissions and path resolution.
 
-### 修改 memory tools
+### Modifying memory tools
 
-影响范围包括：
+Affected areas include:
 
 - SuperAgent
 - CompanionAgent
 - MemoryAgent
 - ClarificationResolutionAgent
-- CommentAgent 回复场景
+- CommentAgent reply scenarios
 
-风险是污染长期用户画像。
+Risk: polluting the long-term user profile.
 
-### 修改 CharacterToolsFactory
+### Modifying CharacterToolsFactory
 
-影响范围：
+Affected areas:
 
 - CommentAgent
 - CompanionAgent
 
-要区分用户级 memory 和角色级 memory。
+Distinguish user-level memory from character-level memory.
 
-### 修改 router / schedule
+### Modifying router / schedule
 
-影响范围：
+Affected areas:
 
-- PostCardRouterAgent 的触发判断。
-- ScheduleAggregatorAgent 的 state mutation。
-- 设备日历/提醒 action 同步。
+- PostCardRouterAgent trigger logic.
+- ScheduleAggregatorAgent state mutation.
+- Device calendar/reminder action sync.
 
-需要关注重复触发、幂等性和 stopFlag。
-
+Watch for duplicate triggers, idempotency, and stopFlag.


### PR DESCRIPTION
## Summary
- Add English translation of the agent prompt/tools code index (`agent_prompt_tools_code_index.en.md`).
- Include the paired source document (`agent_prompt_tools_code_index.md`) for reference and parity with the Chinese docs workflow.

## Test plan
- [ ] Review English index for accuracy against the codebase
- [ ] Confirm links and file paths resolve in the repo