### PR TITLE
fix(l10n): localize OAuth authorize UI and chat history errors

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -255,6 +255,13 @@
   },
   "loadDetailFailedRetry": "فشل تحميل التفاصيل، يرجى المحاولة لاحقا.",
   "loadFailed": "فشل التحميل",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "فشل تحميل السجل: {error}",
+
   "reload": "إعادة التحميل",
   "aiInsightDetail": "تفاصيل الرؤية",
   "relatedRecordsCount": "السجلات المرتبطة ({count})",
@@ -462,6 +469,17 @@
     }
   },
   "authorized": "مفوّض",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "تم التفويض كـ {email}",
+  "authorizedSuccessfully": "تم التفويض بنجاح",
+  "reAuthorize": "إعادة التفويض",
+  "authorizeWithOpenAi": "التفويض عبر OpenAI",
+  "authorizeWithGoogle": "التفويض عبر Google",
+
   "config": "الإعداد",
   "calendar": "التقويم",
   "reminders": "التذكيرات",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -255,6 +255,13 @@
   "retryCount": "Wiederholen: {count}",
   "loadDetailFailedRetry": "Beim Laden der Details ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
   "loadFailed": "Das Laden ist fehlgeschlagen",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "Verlauf konnte nicht geladen werden: {error}",
+
   "reload": "Neu laden",
   "aiInsightDetail": "Insight-Detail",
   "@relatedRecordsCount": {
@@ -462,6 +469,17 @@
   },
   "authFailed": "Authentifizierung fehlgeschlagen: {error}",
   "authorized": "Autorisiert",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "Autorisiert als {email}",
+  "authorizedSuccessfully": "Erfolgreich autorisiert",
+  "reAuthorize": "Erneut autorisieren",
+  "authorizeWithOpenAi": "Mit OpenAI autorisieren",
+  "authorizeWithGoogle": "Mit Google autorisieren",
+
   "config": "Konfig",
   "calendar": "Kalender",
   "reminders": "Erinnerungen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -255,6 +255,13 @@
   "retryCount": "Retry: {count}",
   "loadDetailFailedRetry": "Load detail failed, please retry later.",
   "loadFailed": "Load failed",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "Failed to load history: {error}",
+
   "reload": "Reload",
   "aiInsightDetail": "Insight Detail",
   "@relatedRecordsCount": {
@@ -462,6 +469,17 @@
   },
   "authFailed": "Auth failed: {error}",
   "authorized": "Authorized",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "Authorized as {email}",
+  "authorizedSuccessfully": "Authorized successfully",
+  "reAuthorize": "Re-authorize",
+  "authorizeWithOpenAi": "Authorize with OpenAI",
+  "authorizeWithGoogle": "Authorize with Google",
+
   "config": "Config",
   "calendar": "Calendar",
   "reminders": "Reminders",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -255,6 +255,13 @@
   },
   "loadDetailFailedRetry": "No se pudo cargar el detalle; inténtalo de nuevo más tarde.",
   "loadFailed": "Carga fallida",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "No se pudo cargar el historial: {error}",
+
   "reload": "Recargar",
   "aiInsightDetail": "Detalle del insight",
   "relatedRecordsCount": "Registros relacionados ({count})",
@@ -462,6 +469,17 @@
     }
   },
   "authorized": "Autorizado",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "Autorizado como {email}",
+  "authorizedSuccessfully": "Autorizado correctamente",
+  "reAuthorize": "Volver a autorizar",
+  "authorizeWithOpenAi": "Autorizar con OpenAI",
+  "authorizeWithGoogle": "Autorizar con Google",
+
   "config": "Configuración",
   "calendar": "Calendario",
   "reminders": "Recordatorios",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -255,6 +255,13 @@
   "retryCount": "تلاش مجدد: {count}",
   "loadDetailFailedRetry": "بارگذاری جزئیات ناموفق بود، لطفاً بعداً دوباره تلاش کنید.",
   "loadFailed": "بارگذاری ناموفق بود",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "بارگذاری تاریخچه ناموفق بود: {error}",
+
   "reload": "بارگذاری مجدد",
   "aiInsightDetail": "جزئیات بینش",
   "@relatedRecordsCount": {
@@ -462,6 +469,17 @@
   },
   "authFailed": "احراز هویت ناموفق بود: {error}",
   "authorized": "احراز هویت شده",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "احراز هویت شده به عنوان {email}",
+  "authorizedSuccessfully": "احراز هویت با موفقیت انجام شد",
+  "reAuthorize": "احراز هویت مجدد",
+  "authorizeWithOpenAi": "احراز هویت با OpenAI",
+  "authorizeWithGoogle": "احراز هویت با Google",
+
   "config": "پیکربندی",
   "calendar": "تقویم",
   "reminders": "یادآورها",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -255,6 +255,13 @@
   },
   "loadDetailFailedRetry": "Échec du chargement des détails, veuillez réessayer plus tard.",
   "loadFailed": "Échec du chargement",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "Échec du chargement de l'historique : {error}",
+
   "reload": "Recharger",
   "aiInsightDetail": "Détail de l'insight",
   "relatedRecordsCount": "Enregistrements liés ({count})",
@@ -462,6 +469,17 @@
     }
   },
   "authorized": "Autorisé",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "Autorisé en tant que {email}",
+  "authorizedSuccessfully": "Autorisation réussie",
+  "reAuthorize": "Ré-autoriser",
+  "authorizeWithOpenAi": "Autoriser avec OpenAI",
+  "authorizeWithGoogle": "Autoriser avec Google",
+
   "config": "Configuration",
   "calendar": "Calendrier",
   "reminders": "Rappels",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -255,6 +255,13 @@
   },
   "loadDetailFailedRetry": "विवरण लोड नहीं हो सका, कृपया बाद में फिर कोशिश करें।",
   "loadFailed": "लोड विफल",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "इतिहास लोड करने में विफल: {error}",
+
   "reload": "फिर लोड करें",
   "aiInsightDetail": "अंतर्दृष्टि विवरण",
   "relatedRecordsCount": "संबंधित रिकॉर्ड ({count})",
@@ -462,6 +469,17 @@
     }
   },
   "authorized": "अधिकृत",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "{email} के रूप में प्राधिकृत",
+  "authorizedSuccessfully": "सफलतापूर्वक प्राधिकृत",
+  "reAuthorize": "पुनः प्राधिकृत करें",
+  "authorizeWithOpenAi": "OpenAI के साथ प्राधिकृत करें",
+  "authorizeWithGoogle": "Google के साथ प्राधिकृत करें",
+
   "config": "कॉन्फ़िग",
   "calendar": "कैलेंडर",
   "reminders": "रिमाइंडर",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -255,6 +255,13 @@
   "retryCount": "Coba lagi: {count}",
   "loadDetailFailedRetry": "Gagal memuat detail, coba lagi nanti.",
   "loadFailed": "Gagal memuat",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "Gagal memuat riwayat: {error}",
+
   "reload": "Muat ulang",
   "aiInsightDetail": "Detail insight",
   "@relatedRecordsCount": {
@@ -462,6 +469,17 @@
   },
   "authFailed": "Otorisasi gagal: {error}",
   "authorized": "Terotorisasi",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "Diotorisasi sebagai {email}",
+  "authorizedSuccessfully": "Berhasil diotorisasi",
+  "reAuthorize": "Otorisasi ulang",
+  "authorizeWithOpenAi": "Otorisasi dengan OpenAI",
+  "authorizeWithGoogle": "Otorisasi dengan Google",
+
   "config": "Konfigurasi",
   "calendar": "Kalender",
   "reminders": "Pengingat",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -255,6 +255,13 @@
   },
   "loadDetailFailedRetry": "詳細の読み込みに失敗しました。後でもう一度お試しください。",
   "loadFailed": "読み込みに失敗しました",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "履歴の読み込みに失敗しました: {error}",
+
   "reload": "再読み込み",
   "aiInsightDetail": "インサイト詳細",
   "relatedRecordsCount": "関連記録（{count}）",
@@ -462,6 +469,17 @@
     }
   },
   "authorized": "認証済み",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "{email} として認証しました",
+  "authorizedSuccessfully": "認証に成功しました",
+  "reAuthorize": "再認証",
+  "authorizeWithOpenAi": "OpenAI で認証",
+  "authorizeWithGoogle": "Google で認証",
+
   "config": "設定",
   "calendar": "カレンダー",
   "reminders": "リマインダー",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -255,6 +255,13 @@
   },
   "loadDetailFailedRetry": "세부 정보를 불러오지 못했습니다. 나중에 다시 시도해 주세요.",
   "loadFailed": "불러오기 실패",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "기록을 불러오지 못했습니다: {error}",
+
   "reload": "다시 불러오기",
   "aiInsightDetail": "인사이트 세부 정보",
   "relatedRecordsCount": "관련 기록({count})",
@@ -462,6 +469,17 @@
     }
   },
   "authorized": "인증됨",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "{email}(으)로 인증됨",
+  "authorizedSuccessfully": "인증되었습니다",
+  "reAuthorize": "다시 인증",
+  "authorizeWithOpenAi": "OpenAI로 인증",
+  "authorizeWithGoogle": "Google로 인증",
+
   "config": "설정",
   "calendar": "캘린더",
   "reminders": "미리 알림",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -75,7 +75,7 @@ import 'app_localizations_zh.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -98,11 +98,11 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -120,7 +120,7 @@ abstract class AppLocalizations {
     Locale('ru'),
     Locale('vi'),
     Locale('zh'),
-    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant')
+    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
   ];
 
   /// No description provided for @timesLabel.
@@ -1023,6 +1023,12 @@ abstract class AppLocalizations {
   /// **'Load failed'**
   String get loadFailed;
 
+  /// No description provided for @loadHistoryFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to load history: {error}'**
+  String loadHistoryFailed(Object error);
+
   /// No description provided for @reload.
   ///
   /// In en, this message translates to:
@@ -1352,7 +1358,10 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Running {running}, Pending {pending}, Retry {retrying}'**
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying);
+    Object running,
+    Object pending,
+    Object retrying,
+  );
 
   /// No description provided for @agentBackgroundTaskDetail.
   ///
@@ -1917,6 +1926,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Authorized'**
   String get authorized;
+
+  /// No description provided for @authorizedAs.
+  ///
+  /// In en, this message translates to:
+  /// **'Authorized as {email}'**
+  String authorizedAs(Object email);
+
+  /// No description provided for @authorizedSuccessfully.
+  ///
+  /// In en, this message translates to:
+  /// **'Authorized successfully'**
+  String get authorizedSuccessfully;
+
+  /// No description provided for @reAuthorize.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-authorize'**
+  String get reAuthorize;
+
+  /// No description provided for @authorizeWithOpenAi.
+  ///
+  /// In en, this message translates to:
+  /// **'Authorize with OpenAI'**
+  String get authorizeWithOpenAi;
+
+  /// No description provided for @authorizeWithGoogle.
+  ///
+  /// In en, this message translates to:
+  /// **'Authorize with Google'**
+  String get authorizeWithGoogle;
 
   /// No description provided for @config.
   ///
@@ -5914,21 +5953,21 @@ class _AppLocalizationsDelegate
 
   @override
   bool isSupported(Locale locale) => <String>[
-        'ar',
-        'de',
-        'en',
-        'es',
-        'fa',
-        'fr',
-        'hi',
-        'id',
-        'ja',
-        'ko',
-        'pt',
-        'ru',
-        'vi',
-        'zh'
-      ].contains(locale.languageCode);
+    'ar',
+    'de',
+    'en',
+    'es',
+    'fa',
+    'fr',
+    'hi',
+    'id',
+    'ja',
+    'ko',
+    'pt',
+    'ru',
+    'vi',
+    'zh',
+  ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -5980,8 +6019,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -517,6 +517,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get loadFailed => 'فشل التحميل';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'فشل تحميل السجل: $error';
+  }
+
+  @override
   String get reload => 'إعادة التحميل';
 
   @override
@@ -689,7 +694,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return 'قيد التشغيل $running، معلق $pending، إعادة محاولة $retrying';
   }
 
@@ -1017,6 +1025,23 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get authorized => 'مفوّض';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'تم التفويض كـ $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'تم التفويض بنجاح';
+
+  @override
+  String get reAuthorize => 'إعادة التفويض';
+
+  @override
+  String get authorizeWithOpenAi => 'التفويض عبر OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'التفويض عبر Google';
 
   @override
   String get config => 'الإعداد';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -526,6 +526,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get loadFailed => 'Das Laden ist fehlgeschlagen';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'Verlauf konnte nicht geladen werden: $error';
+  }
+
+  @override
   String get reload => 'Neu laden';
 
   @override
@@ -704,7 +709,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return '$running wird ausgeführt, $pending steht aus, $retrying erneut versuchen';
   }
 
@@ -1041,6 +1049,23 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get authorized => 'Autorisiert';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'Autorisiert als $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'Erfolgreich autorisiert';
+
+  @override
+  String get reAuthorize => 'Erneut autorisieren';
+
+  @override
+  String get authorizeWithOpenAi => 'Mit OpenAI autorisieren';
+
+  @override
+  String get authorizeWithGoogle => 'Mit Google autorisieren';
 
   @override
   String get config => 'Konfig';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -515,6 +515,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loadFailed => 'Load failed';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'Failed to load history: $error';
+  }
+
+  @override
   String get reload => 'Reload';
 
   @override
@@ -690,7 +695,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return 'Running $running, Pending $pending, Retry $retrying';
   }
 
@@ -1018,6 +1026,23 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get authorized => 'Authorized';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'Authorized as $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'Authorized successfully';
+
+  @override
+  String get reAuthorize => 'Re-authorize';
+
+  @override
+  String get authorizeWithOpenAi => 'Authorize with OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'Authorize with Google';
 
   @override
   String get config => 'Config';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -524,6 +524,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get loadFailed => 'Carga fallida';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'No se pudo cargar el historial: $error';
+  }
+
+  @override
   String get reload => 'Recargar';
 
   @override
@@ -699,7 +704,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return 'En ejecución $running, pendientes $pending, reintentos $retrying';
   }
 
@@ -1035,6 +1043,23 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get authorized => 'Autorizado';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'Autorizado como $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'Autorizado correctamente';
+
+  @override
+  String get reAuthorize => 'Volver a autorizar';
+
+  @override
+  String get authorizeWithOpenAi => 'Autorizar con OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'Autorizar con Google';
 
   @override
   String get config => 'Configuración';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -518,6 +518,11 @@ class AppLocalizationsFa extends AppLocalizations {
   String get loadFailed => 'بارگذاری ناموفق بود';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'بارگذاری تاریخچه ناموفق بود: $error';
+  }
+
+  @override
   String get reload => 'بارگذاری مجدد';
 
   @override
@@ -1024,6 +1029,23 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get authorized => 'احراز هویت شده';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'احراز هویت شده به عنوان $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'احراز هویت با موفقیت انجام شد';
+
+  @override
+  String get reAuthorize => 'احراز هویت مجدد';
+
+  @override
+  String get authorizeWithOpenAi => 'احراز هویت با OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'احراز هویت با Google';
 
   @override
   String get config => 'پیکربندی';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -523,6 +523,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get loadFailed => 'Échec du chargement';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'Échec du chargement de l\'historique : $error';
+  }
+
+  @override
   String get reload => 'Recharger';
 
   @override
@@ -701,7 +706,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return 'En cours $running, en attente $pending, nouvelle tentative $retrying';
   }
 
@@ -1034,6 +1042,23 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get authorized => 'Autorisé';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'Autorisé en tant que $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'Autorisation réussie';
+
+  @override
+  String get reAuthorize => 'Ré-autoriser';
+
+  @override
+  String get authorizeWithOpenAi => 'Autoriser avec OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'Autoriser avec Google';
 
   @override
   String get config => 'Configuration';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -517,6 +517,11 @@ class AppLocalizationsHi extends AppLocalizations {
   String get loadFailed => 'लोड विफल';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'इतिहास लोड करने में विफल: $error';
+  }
+
+  @override
   String get reload => 'फिर लोड करें';
 
   @override
@@ -692,7 +697,10 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return 'चल रहे $running, लंबित $pending, पुनः प्रयास $retrying';
   }
 
@@ -1021,6 +1029,23 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get authorized => 'अधिकृत';
+
+  @override
+  String authorizedAs(Object email) {
+    return '$email के रूप में प्राधिकृत';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'सफलतापूर्वक प्राधिकृत';
+
+  @override
+  String get reAuthorize => 'पुनः प्राधिकृत करें';
+
+  @override
+  String get authorizeWithOpenAi => 'OpenAI के साथ प्राधिकृत करें';
+
+  @override
+  String get authorizeWithGoogle => 'Google के साथ प्राधिकृत करें';
 
   @override
   String get config => 'कॉन्फ़िग';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -520,6 +520,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get loadFailed => 'Gagal memuat';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'Gagal memuat riwayat: $error';
+  }
+
+  @override
   String get reload => 'Muat ulang';
 
   @override
@@ -695,7 +700,10 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return 'Berjalan $running, Tertunda $pending, Coba ulang $retrying';
   }
 
@@ -1027,6 +1035,23 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get authorized => 'Terotorisasi';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'Diotorisasi sebagai $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'Berhasil diotorisasi';
+
+  @override
+  String get reAuthorize => 'Otorisasi ulang';
+
+  @override
+  String get authorizeWithOpenAi => 'Otorisasi dengan OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'Otorisasi dengan Google';
 
   @override
   String get config => 'Konfigurasi';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -510,6 +510,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get loadFailed => '読み込みに失敗しました';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return '履歴の読み込みに失敗しました: $error';
+  }
+
+  @override
   String get reload => '再読み込み';
 
   @override
@@ -681,7 +686,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return '実行中 $running、保留中 $pending、再試行 $retrying';
   }
 
@@ -1000,6 +1008,23 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get authorized => '認証済み';
+
+  @override
+  String authorizedAs(Object email) {
+    return '$email として認証しました';
+  }
+
+  @override
+  String get authorizedSuccessfully => '認証に成功しました';
+
+  @override
+  String get reAuthorize => '再認証';
+
+  @override
+  String get authorizeWithOpenAi => 'OpenAI で認証';
+
+  @override
+  String get authorizeWithGoogle => 'Google で認証';
 
   @override
   String get config => '設定';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -510,6 +510,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get loadFailed => '불러오기 실패';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return '기록을 불러오지 못했습니다: $error';
+  }
+
+  @override
   String get reload => '다시 불러오기';
 
   @override
@@ -681,7 +686,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return '실행 중 $running, 대기 중 $pending, 재시도 $retrying';
   }
 
@@ -999,6 +1007,23 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get authorized => '인증됨';
+
+  @override
+  String authorizedAs(Object email) {
+    return '$email(으)로 인증됨';
+  }
+
+  @override
+  String get authorizedSuccessfully => '인증되었습니다';
+
+  @override
+  String get reAuthorize => '다시 인증';
+
+  @override
+  String get authorizeWithOpenAi => 'OpenAI로 인증';
+
+  @override
+  String get authorizeWithGoogle => 'Google로 인증';
 
   @override
   String get config => '설정';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -523,6 +523,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get loadFailed => 'Falha ao carregar';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'Falha ao carregar o histórico: $error';
+  }
+
+  @override
   String get reload => 'Recarregar';
 
   @override
@@ -699,7 +704,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return 'Executando $running, pendentes $pending, nova tentativa $retrying';
   }
 
@@ -1033,6 +1041,23 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get authorized => 'Autorizado';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'Autorizado como $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'Autorizado com sucesso';
+
+  @override
+  String get reAuthorize => 'Reautorizar';
+
+  @override
+  String get authorizeWithOpenAi => 'Autorizar com OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'Autorizar com Google';
 
   @override
   String get config => 'Configuração';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -523,6 +523,11 @@ class AppLocalizationsRu extends AppLocalizations {
   String get loadFailed => 'Загрузка не удалась';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'Не удалось загрузить историю: $error';
+  }
+
+  @override
   String get reload => 'Перезагрузить';
 
   @override
@@ -698,7 +703,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return 'Выполняется $running, ожидает $pending, повтор $retrying';
   }
 
@@ -1030,6 +1038,23 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get authorized => 'Авторизовано';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'Авторизован как $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'Авторизация успешна';
+
+  @override
+  String get reAuthorize => 'Повторная авторизация';
+
+  @override
+  String get authorizeWithOpenAi => 'Авторизовать через OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'Авторизовать через Google';
 
   @override
   String get config => 'Конфигурация';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -520,6 +520,11 @@ class AppLocalizationsVi extends AppLocalizations {
   String get loadFailed => 'Tải thất bại';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return 'Không thể tải lịch sử: $error';
+  }
+
+  @override
   String get reload => 'Tải lại';
 
   @override
@@ -691,7 +696,10 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return 'Đang chạy $running, Chờ $pending, Thử lại $retrying';
   }
 
@@ -1019,6 +1027,23 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get authorized => 'Đã ủy quyền';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'Đã ủy quyền dưới tên $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'Ủy quyền thành công';
+
+  @override
+  String get reAuthorize => 'Ủy quyền lại';
+
+  @override
+  String get authorizeWithOpenAi => 'Ủy quyền với OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'Ủy quyền với Google';
 
   @override
   String get config => 'Cấu hình';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -505,6 +505,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get loadFailed => '加载失败';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return '加载历史记录失败：$error';
+  }
+
+  @override
   String get reload => '重新加载';
 
   @override
@@ -676,7 +681,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return '执行中 $running，排队中 $pending，重试中 $retrying';
   }
 
@@ -991,6 +999,23 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get authorized => '已授权';
+
+  @override
+  String authorizedAs(Object email) {
+    return '已授权为 $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => '授权成功';
+
+  @override
+  String get reAuthorize => '重新授权';
+
+  @override
+  String get authorizeWithOpenAi => '使用 OpenAI 授权';
+
+  @override
+  String get authorizeWithGoogle => '使用 Google 授权';
 
   @override
   String get config => '配置';
@@ -3661,6 +3686,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get loadFailed => '載入失敗';
 
   @override
+  String loadHistoryFailed(Object error) {
+    return '載入歷史記錄失敗：$error';
+  }
+
+  @override
   String get reload => '重新載入';
 
   @override
@@ -3832,7 +3862,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String agentBackgroundTaskSummary(
-      Object running, Object pending, Object retrying) {
+    Object running,
+    Object pending,
+    Object retrying,
+  ) {
     return '執行中 $running，排隊中 $pending，重試中 $retrying';
   }
 
@@ -4146,6 +4179,23 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get authorized => '已授權';
+
+  @override
+  String authorizedAs(Object email) {
+    return '已授權為 $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => '授權成功';
+
+  @override
+  String get reAuthorize => '重新授權';
+
+  @override
+  String get authorizeWithOpenAi => '使用 OpenAI 授權';
+
+  @override
+  String get authorizeWithGoogle => '使用 Google 授權';
 
   @override
   String get config => '設定';

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -255,6 +255,13 @@
   },
   "loadDetailFailedRetry": "Falha ao carregar detalhes, tente novamente mais tarde.",
   "loadFailed": "Falha ao carregar",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "Falha ao carregar o histórico: {error}",
+
   "reload": "Recarregar",
   "aiInsightDetail": "Detalhe do insight",
   "relatedRecordsCount": "Registros relacionados ({count})",
@@ -462,6 +469,17 @@
     }
   },
   "authorized": "Autorizado",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "Autorizado como {email}",
+  "authorizedSuccessfully": "Autorizado com sucesso",
+  "reAuthorize": "Reautorizar",
+  "authorizeWithOpenAi": "Autorizar com OpenAI",
+  "authorizeWithGoogle": "Autorizar com Google",
+
   "config": "Configuração",
   "calendar": "Calendário",
   "reminders": "Lembretes",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -255,6 +255,13 @@
   "retryCount": "Повтор: {count}",
   "loadDetailFailedRetry": "Не удалось загрузить детали, повторите позже.",
   "loadFailed": "Загрузка не удалась",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "Не удалось загрузить историю: {error}",
+
   "reload": "Перезагрузить",
   "aiInsightDetail": "Детали инсайта",
   "@relatedRecordsCount": {
@@ -462,6 +469,17 @@
   },
   "authFailed": "Авторизация не удалась: {error}",
   "authorized": "Авторизовано",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "Авторизован как {email}",
+  "authorizedSuccessfully": "Авторизация успешна",
+  "reAuthorize": "Повторная авторизация",
+  "authorizeWithOpenAi": "Авторизовать через OpenAI",
+  "authorizeWithGoogle": "Авторизовать через Google",
+
   "config": "Конфигурация",
   "calendar": "Календарь",
   "reminders": "Напоминания",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -255,6 +255,13 @@
   "retryCount": "Thử lại: {count}",
   "loadDetailFailedRetry": "Tải chi tiết thất bại, vui lòng thử lại sau.",
   "loadFailed": "Tải thất bại",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "Không thể tải lịch sử: {error}",
+
   "reload": "Tải lại",
   "aiInsightDetail": "Chi tiết insight",
   "@relatedRecordsCount": {
@@ -462,6 +469,17 @@
   },
   "authFailed": "Ủy quyền thất bại: {error}",
   "authorized": "Đã ủy quyền",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "Đã ủy quyền dưới tên {email}",
+  "authorizedSuccessfully": "Ủy quyền thành công",
+  "reAuthorize": "Ủy quyền lại",
+  "authorizeWithOpenAi": "Ủy quyền với OpenAI",
+  "authorizeWithGoogle": "Ủy quyền với Google",
+
   "config": "Cấu hình",
   "calendar": "Lịch",
   "reminders": "Nhắc nhở",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -255,6 +255,13 @@
   "retryCount": "重试: {count}",
   "loadDetailFailedRetry": "加载详情失败，请稍后重试",
   "loadFailed": "加载失败",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "加载历史记录失败：{error}",
+
   "reload": "重新加载",
   "aiInsightDetail": "洞察详情",
   "@relatedRecordsCount": {
@@ -462,6 +469,17 @@
   },
   "authFailed": "授权失败: {error}",
   "authorized": "已授权",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "已授权为 {email}",
+  "authorizedSuccessfully": "授权成功",
+  "reAuthorize": "重新授权",
+  "authorizeWithOpenAi": "使用 OpenAI 授权",
+  "authorizeWithGoogle": "使用 Google 授权",
+
   "config": "配置",
   "calendar": "日历",
   "reminders": "提醒事项",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -255,6 +255,13 @@
   },
   "loadDetailFailedRetry": "載入詳情失敗，請稍後重試",
   "loadFailed": "載入失敗",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "載入歷史記錄失敗：{error}",
+
   "reload": "重新載入",
   "aiInsightDetail": "洞察詳情",
   "relatedRecordsCount": "關聯記錄（{count}）",
@@ -462,6 +469,17 @@
     }
   },
   "authorized": "已授權",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "已授權為 {email}",
+  "authorizedSuccessfully": "授權成功",
+  "reAuthorize": "重新授權",
+  "authorizeWithOpenAi": "使用 OpenAI 授權",
+  "authorizeWithGoogle": "使用 Google 授權",
+
   "config": "設定",
   "calendar": "行事曆",
   "reminders": "提醒事項",

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -666,7 +666,12 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       _logger.severe('Error loading history', e);
       unawaited(_clearLatestSuperAgentHomeSessionIdIfCurrent());
       setState(() => _isLoading = false);
-      if (mounted) ToastHelper.showError(context, 'Failed to load history: $e');
+      if (mounted) {
+        ToastHelper.showError(
+          context,
+          UserStorage.l10n.loadHistoryFailed('$e'),
+        );
+      }
     }
     // After history is on screen, resume following an in-flight run if the
     // dialog was closed mid-reply.

--- a/lib/ui/settings/widgets/model_config_edit_page.dart
+++ b/lib/ui/settings/widgets/model_config_edit_page.dart
@@ -313,7 +313,10 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
         _authFlowCompleted = true;
         _dismissAuthDialog();
         if (mounted) {
-          ToastHelper.showSuccess(context, 'Authorized successfully');
+          ToastHelper.showSuccess(
+            context,
+            UserStorage.l10n.authorizedSuccessfully,
+          );
           _loadOpenAiTokens();
         }
       },
@@ -373,7 +376,10 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
         _authFlowCompleted = true;
         _dismissAuthDialog();
         if (mounted) {
-          ToastHelper.showSuccess(context, 'Authorized as $email');
+          ToastHelper.showSuccess(
+            context,
+            UserStorage.l10n.authorizedAs(email),
+          );
           _loadGeminiTokens();
         }
       },
@@ -391,6 +397,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
   }
 
   Widget _buildOpenAiAuthSection() {
+    final l10n = UserStorage.l10n;
     final bool isAuthorized = _openAiTokens != null;
 
     return Container(
@@ -412,7 +419,8 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
               ),
               const SizedBox(width: 8),
               Text(
-                isAuthorized ? 'Authorized' : 'Not authorized',
+                // OAuth status: reuse authorized / unauthorized
+                isAuthorized ? l10n.authorized : l10n.unauthorized,
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   color: isAuthorized ? Colors.green : Colors.orange,
@@ -427,7 +435,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
               onPressed: _startOpenAiAuth,
               icon: const Icon(Icons.login),
               label: Text(
-                isAuthorized ? 'Re-authorize' : 'Authorize with OpenAI',
+                isAuthorized ? l10n.reAuthorize : l10n.authorizeWithOpenAi,
               ),
             ),
           ),
@@ -455,6 +463,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
   }
 
   Widget _buildGeminiAuthSection() {
+    final l10n = UserStorage.l10n;
     final bool isAuthorized = _geminiTokens != null;
 
     return Container(
@@ -476,7 +485,8 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
               ),
               const SizedBox(width: 8),
               Text(
-                isAuthorized ? 'Authorized' : 'Not authorized',
+                // OAuth status: reuse authorized / unauthorized
+                isAuthorized ? l10n.authorized : l10n.unauthorized,
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   color: isAuthorized ? Colors.green : Colors.orange,
@@ -491,7 +501,7 @@ class _ModelConfigEditPageState extends State<ModelConfigEditPage>
               onPressed: _startGeminiAuth,
               icon: const Icon(Icons.login),
               label: Text(
-                isAuthorized ? 'Re-authorize' : 'Authorize with Google',
+                isAuthorized ? l10n.reAuthorize : l10n.authorizeWithGoogle,
               ),
             ),
           ),

--- a/test/ui/settings/oauth_authorize_l10n_test.dart
+++ b/test/ui/settings/oauth_authorize_l10n_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  test('OAuth authorize UI strings are localized', () {
+    final l10n = UserStorage.l10n;
+
+    expect(l10n.authorizedSuccessfully, isNotEmpty);
+    expect(l10n.authorizedAs('user@example.com'), contains('user@example.com'));
+    expect(l10n.reAuthorize, isNotEmpty);
+    expect(l10n.authorizeWithOpenAi, isNotEmpty);
+    expect(l10n.authorizeWithGoogle, isNotEmpty);
+    expect(l10n.authorized, isNotEmpty);
+    expect(l10n.unauthorized, isNotEmpty);
+    expect(l10n.loadHistoryFailed('timeout'), contains('timeout'));
+  });
+}


### PR DESCRIPTION
## Summary
- Localize OAuth authorize toasts, status labels, and action buttons in `model_config_edit_page.dart` (reuses existing `authorized` / `unauthorized` keys for status)
- Localize chat history load failure toast in `agent_chat_dialog.dart` via new `loadHistoryFailed` key
- Add ARB translations across all 15 locales and a small l10n unit test

## Test plan
- [x] `flutter gen-l10n`
- [x] `dart analyze` on changed Dart files
- [x] `flutter test test/ui/settings/oauth_authorize_l10n_test.dart`
- [x] Manually verify OAuth authorize UI toasts and labels in model config settings
- [x] Manually trigger chat history load failure and confirm localized error toast