### PR TITLE
fix: register Thai and Turkish on iOS and Android

### DIFF
--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
+    <string name="shortcut_quick_note">ملاحظة سريعة</string>
+    <string name="shortcut_quick_note_long">ملاحظة سريعة</string>
+</resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
-    <string name="shortcut_quick_note">Quick Note</string>
-    <string name="shortcut_quick_note_long">Quick Note</string>
+    <string name="shortcut_quick_note">Schnellnotiz</string>
+    <string name="shortcut_quick_note_long">Schnellnotiz</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
-    <string name="shortcut_quick_note">Quick Note</string>
-    <string name="shortcut_quick_note_long">Quick Note</string>
+    <string name="shortcut_quick_note">Nota rápida</string>
+    <string name="shortcut_quick_note_long">Nota rápida</string>
 </resources>

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
+    <string name="shortcut_quick_note">یادداشت سریع</string>
+    <string name="shortcut_quick_note_long">یادداشت سریع</string>
+</resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
-    <string name="shortcut_quick_note">Quick Note</string>
-    <string name="shortcut_quick_note_long">Quick Note</string>
+    <string name="shortcut_quick_note">Note rapide</string>
+    <string name="shortcut_quick_note_long">Note rapide</string>
 </resources>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
+    <string name="shortcut_quick_note">त्वरित नोट</string>
+    <string name="shortcut_quick_note_long">त्वरित नोट</string>
+</resources>

--- a/android/app/src/main/res/values-id/strings.xml
+++ b/android/app/src/main/res/values-id/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
+    <!-- Indonesian (id): duplicate for devices that resolve id rather than in. -->
+    <string name="shortcut_quick_note">Catatan cepat</string>
+    <string name="shortcut_quick_note_long">Catatan cepat</string>
+</resources>

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
+    <!-- Indonesian: Android res uses values-in (language code in); Flutter locale is id. -->
+    <string name="shortcut_quick_note">Catatan cepat</string>
+    <string name="shortcut_quick_note_long">Catatan cepat</string>
+</resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
+    <string name="shortcut_quick_note">クイックメモ</string>
+    <string name="shortcut_quick_note_long">クイックメモ</string>
+</resources>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
-    <string name="shortcut_quick_note">Quick Note</string>
-    <string name="shortcut_quick_note_long">Quick Note</string>
+    <string name="shortcut_quick_note">빠른 메모</string>
+    <string name="shortcut_quick_note_long">빠른 메모</string>
 </resources>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
-    <string name="shortcut_quick_note">Quick Note</string>
-    <string name="shortcut_quick_note_long">Quick Note</string>
+    <string name="shortcut_quick_note">Nota rápida</string>
+    <string name="shortcut_quick_note_long">Nota rápida</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
+    <string name="shortcut_quick_note">Быстрая заметка</string>
+    <string name="shortcut_quick_note_long">Быстрая заметка</string>
+</resources>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). Thai locale. -->
+    <string name="shortcut_quick_note">บันทึกด่วน</string>
+    <string name="shortcut_quick_note_long">บันทึกด่วน</string>
+</resources>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). Turkish locale. -->
+    <string name="shortcut_quick_note">Hızlı Not</string>
+    <string name="shortcut_quick_note_long">Hızlı Not</string>
+</resources>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
-    <string name="shortcut_quick_note">Quick Note</string>
-    <string name="shortcut_quick_note_long">Quick Note</string>
+    <string name="shortcut_quick_note">Ghi chú nhanh</string>
+    <string name="shortcut_quick_note_long">Ghi chú nhanh</string>
 </resources>

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
+    <!-- Mirrors default values/ (Simplified Chinese). -->
+    <string name="shortcut_quick_note">记一下</string>
+    <string name="shortcut_quick_note_long">记一下</string>
+</resources>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App shortcut labels for Quick Note (home-screen shortcut). -->
-    <string name="shortcut_quick_note">Quick Note</string>
-    <string name="shortcut_quick_note_long">Quick Note</string>
+    <string name="shortcut_quick_note">記一下</string>
+    <string name="shortcut_quick_note_long">記一下</string>
 </resources>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -24,10 +24,24 @@
 		<true/>
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
+		<!-- Matches lib/l10n/supported_languages.dart (Flutter UI locales). -->
 		<key>CFBundleLocalizations</key>
 		<array>
-			<string>en</string>
-			<string>zh-Hans</string>
+			<string>en</string><!-- English -->
+			<string>zh-Hans</string><!-- Simplified Chinese (zh) -->
+			<string>zh-Hant</string><!-- Traditional Chinese (zh_Hant) -->
+			<string>de</string><!-- German -->
+			<string>ja</string><!-- Japanese -->
+			<string>ko</string><!-- Korean -->
+			<string>es</string><!-- Spanish -->
+			<string>hi</string><!-- Hindi -->
+			<string>ar</string><!-- Arabic -->
+			<string>pt</string><!-- Portuguese -->
+			<string>fr</string><!-- French -->
+			<string>id</string><!-- Indonesian -->
+			<string>fa</string><!-- Persian -->
+			<string>vi</string><!-- Vietnamese -->
+			<string>ru</string><!-- Russian -->
 		</array>
 		<key>CFBundleAllowMixedLocalizations</key>
 		<true/>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,6 +41,8 @@
 			<string>id</string><!-- Indonesian -->
 			<string>fa</string><!-- Persian -->
 			<string>vi</string><!-- Vietnamese -->
+			<string>th</string><!-- Thai (i18n wishlist) -->
+			<string>tr</string><!-- Turkish (extra UI locale) -->
 			<string>ru</string><!-- Russian -->
 		</array>
 		<key>CFBundleAllowMixedLocalizations</key>


### PR DESCRIPTION
## Summary
- Extends platform locale registration with Thai (`th`) and Turkish (`tr`).
- Updates iOS `CFBundleLocalizations` and Android `values-th` / `values-tr` Quick Note shortcuts.
- Builds on #421 (includes those commits until #421 merges; reviewers can merge #421 first).

## Test plan
- [ ] Confirm Info.plist lists `th` and `tr`
- [ ] Confirm Android shortcut strings exist under `values-th` and `values-tr`

Depends on / stacks with #421.
cc @sparkleMing @whbzju for review when convenient.

