### PR TITLE
ci(l10n): fail PRs when locale ARB keys drift from English

### DIFF
--- a/.github/i18n_issue_body.en.md
+++ b/.github/i18n_issue_body.en.md
@@ -56,5 +56,5 @@ Arabic is already shipped. Keep verifying layouts under `TextDirection.rtl`.
 - [x] iOS `Info.plist` locales beyond `en` / `zh-Hans`
 - [x] Android `values-<locale>/strings.xml` per locale
 - [ ] Arabic RTL layout pass
-- [ ] Missing-key CI lint
+- [ ] Missing-key CI lint (checked in PR Flutter Quality via `scripts/check_arb_key_parity.py`)
 - [ ] Native review per language

--- a/.github/workflows/pr-flutter-quality.yml
+++ b/.github/workflows/pr-flutter-quality.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Run preflight script unit tests
         run: python3 scripts/compare_flutter_analyze_test.py
 
+      - name: Check ARB key parity across locales
+        run: python3 scripts/check_arb_key_parity.py
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/scripts/check_arb_key_parity.py
+++ b/scripts/check_arb_key_parity.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Fail when locale ARB key sets drift from app_en.arb."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+L10N = ROOT / "lib" / "l10n"
+
+
+def message_keys(path: Path) -> set[str]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {key for key in data if not key.startswith("@")}
+
+
+def main() -> int:
+    template = L10N / "app_en.arb"
+    if not template.exists():
+        print(f"missing template ARB: {template}", file=sys.stderr)
+        return 1
+
+    expected = message_keys(template)
+    failures: list[str] = []
+
+    for path in sorted(L10N.glob("app_*.arb")):
+        if path.name == "app_en.arb":
+            continue
+        actual = message_keys(path)
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        if missing or extra:
+            failures.append(path.name)
+            if missing:
+                preview = ", ".join(missing[:8])
+                suffix = "..." if len(missing) > 8 else ""
+                print(f"{path.name}: missing {len(missing)} keys ({preview}{suffix})")
+            if extra:
+                preview = ", ".join(extra[:8])
+                suffix = "..." if len(extra) > 8 else ""
+                print(f"{path.name}: extra {len(extra)} keys ({preview}{suffix})")
+
+    if failures:
+        print(
+            f"ARB key parity check failed for {len(failures)} locale(s). "
+            "Sync keys with lib/l10n/app_en.arb.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"ARB key parity OK across {len(list(L10N.glob('app_*.arb'))) - 1} locales.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/l10n/arb_key_parity_test.dart
+++ b/test/l10n/arb_key_parity_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('locale ARB files stay in key parity with app_en.arb', () {
+    final result = Process.runSync(
+      'python3',
+      ['scripts/check_arb_key_parity.py'],
+      runInShell: true,
+    );
+    expect(
+      result.exitCode,
+      0,
+      reason: String.fromCharCodes(result.stderr + result.stdout),
+    );
+  });
+}

--- a/test/l10n/arb_key_parity_test.dart
+++ b/test/l10n/arb_key_parity_test.dart
@@ -12,7 +12,7 @@ void main() {
     expect(
       result.exitCode,
       0,
-      reason: String.fromCharCodes(result.stderr + result.stdout),
+      reason: '${result.stderr}${result.stdout}',
     );
   });
 }


### PR DESCRIPTION
## Summary

Adds `scripts/check_arb_key_parity.py` and runs it in PR Flutter Quality so any locale ARB that misses keys from `app_en.arb` fails CI.

## Commits

- ARB key parity checker script
- Flutter test wrapper
- CI workflow + i18n wishlist note

## Test plan

- [x] `python3 scripts/check_arb_key_parity.py`
- [x] `flutter test test/l10n/arb_key_parity_test.dart`
