### PR TITLE
feat(l10n): add Italian locale

### DIFF
--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App shortcut labels for Quick Note (home-screen shortcut). Italian locale. -->
+    <string name="shortcut_quick_note">Nota rapida</string>
+    <string name="shortcut_quick_note_long">Nota rapida</string>
+</resources>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,6 +43,7 @@
 			<string>vi</string><!-- Vietnamese -->
 			<string>th</string><!-- Thai (i18n wishlist) -->
 			<string>tr</string><!-- Turkish (extra UI locale) -->
+			<string>it</string><!-- Italian -->
 			<string>ru</string><!-- Russian -->
 		</array>
 		<key>CFBundleAllowMixedLocalizations</key>

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1,0 +1,1517 @@
+{
+  "@@locale": "it",
+  "timesLabel": "Volte",
+  "@modelSetAsDefault": {
+    "placeholders": {
+      "modelId": {}
+    }
+  },
+  "modelSetAsDefault": "Imposta {modelId} come modello predefinito",
+  "retry": "Riprova",
+  "unknownModel": "Modello sconosciuto",
+  "notSet": "Non impostato",
+  "confirmClear": "Conferma chiaro",
+  "confirmClearTokenMessage": "Cancellare l'utente corrente? Dovrai inserire nuovamente l'ID utente.",
+  "cancel": "Cancellare",
+  "confirm": "Confermare",
+  "tokenCleared": "Utente cancellato",
+  "@clearTokenFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "clearTokenFailed": "Impossibile cancellare l'utente: {error}",
+  "selectDateRangeOptional": "Seleziona l'intervallo di date (facoltativo):",
+  "startDate": "Data di inizio",
+  "endDate": "Data di fine",
+  "select": "Selezionare",
+  "processLimitOptional": "Limite di processo (facoltativo)",
+  "leaveEmptyForAll": "Lascia vuoto per elaborare tutto",
+  "startProcessing": "Inizia l'elaborazione",
+  "userIdNotFound": "ID utente non trovato",
+  "@createTaskFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "createTaskFailed": "Impossibile creare l'attività: {error}",
+  "reprocessCards": "Rielaborare le carte",
+  "reprocessCardsTaskCreated": "Richiesta di rielaborazione in coda nel Super Agent",
+  "reprocessCardsDownstreamMode": "Ambito",
+  "reprocessCardsCardOnly": "Solo carte",
+  "reprocessCardsCardOnlyDesc": "Chiedi al Super Agent di rivedere e rigenerare le carte della sequenza temporale selezionate.",
+  "reprocessCardsRerunDownstream": "Schede e relativi seguiti",
+  "reprocessCardsRerunDownstreamDesc": "Chiedi a Super Agent di prendere in considerazione anche il PKM correlato e gli aggiornamenti approfonditi quando necessario.",
+  "reanalyzeMediaAssets": "Rileggere gli allegati multimediali",
+  "reanalyzeMediaAssetsDesc": "Chiedi al Super Agent di ispezionare nuovamente il supporto allegato durante la rigenerazione delle carte.",
+  "regenerateComments": "Rigenera i commenti",
+  "regenerateCommentsTaskCreated": "Rigenera l'attività di commenti creata, in esecuzione in background",
+  "rebuildSearchIndex": "Ricostruisci l'indice di ricerca",
+  "rebuildSearchIndexSuccess": "Indice di ricerca ricostruito correttamente",
+  "rebuildSearchIndexFailed": "Impossibile ricostruire l'indice di ricerca",
+  "clearData": "Cancella dati",
+  "confirmClearDataMessage": "Cancellare i dati?",
+  "confirmClearDataDeletesWorkspaceMessage": "Tutti i dati dell'area di lavoro locale per l'utente corrente verranno eliminati, inclusi schede, contenuti multimediali, file della conoscenza, approfondimenti, memoria, cronologia chat e stato del sistema.\n\nQuesta azione non può essere annullata!",
+  "clearFailedAgentContexts": "Cancella il contesto della conversazione non riuscita",
+  "confirmClearFailedAgentContextsMessage": "Cancellare il contesto della conversazione salvata per gli agenti Insight e Pianificazione? Ciò è utile dopo aver modificato i modelli quando i messaggi dell'agente precedenti non sono più compatibili. Fatti, carte, conoscenze, ricordi e impostazioni del modello non verranno cancellati.",
+  "@failedAgentContextsCleared": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "failedAgentContextsCleared": "Cancellato {count} contesto/i di conversazione salvato/i",
+  "@clearFailedAgentContextsFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "clearFailedAgentContextsFailed": "Impossibile cancellare il contesto della conversazione: {error}",
+  "cloneToTestUser": "Clona per testare l'utente",
+  "confirmCloneToTestUserMessage": "Copia l'area di lavoro corrente in un nuovo utente di prova locale e passa ad esso. Lo stato di runtime dell'agente non viene copiato. I tuoi attuali dati utente non verranno modificati.",
+  "testUserIdLabel": "Testare l'ID utente",
+  "testUserIdHelper": "Utilizza lettere, numeri, trattini o trattini bassi.",
+  "testUserIdInvalid": "Utilizza solo lettere, numeri, trattini o trattini bassi.",
+  "overwriteExistingTestUser": "Sostituisci l'utente di prova esistente con lo stesso ID",
+  "@testUserCloneSuccess": {
+    "placeholders": {
+      "userId": {}
+    }
+  },
+  "testUserCloneSuccess": "Passato all'utente di prova {userId}",
+  "@testUserCloneFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "testUserCloneFailed": "Impossibile clonare l'utente di prova: {error}",
+  "dataClearedSuccess": "Dati cancellati con successo",
+  "@clearDataFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "clearDataFailed": "Impossibile cancellare i dati: {error}",
+  "personalCenter": "Centro personale",
+  "viewLogs": "Visualizza i registri",
+  "systemAuthorization": "Autorizzazione del sistema",
+  "aiCharacterConfig": "Configurazione dei caratteri AI",
+  "modelConfig": "Configurazione del modello",
+  "agentConfig": "Configurazione dell'agente",
+  "experimentalLab": "Laboratori",
+  "experimentalLabDescription": "Funzionalità sperimentali che potrebbero cambiare o spostarsi in seguito.",
+  "modelUsageStats": "Statistiche sull'utilizzo del modello",
+  "asyncTaskList": "Elenco attività asincrone",
+  "clearLocalToken": "Cancella utente",
+  "insightCardTemplates": "Modelli di schede informative",
+  "timelineCardTemplates": "Modelli di carte della sequenza temporale",
+  "logViewer": "Visualizzatore di registro",
+  "autoRefresh": "Aggiornamento automatico",
+  "lineCount": "Conteggio righe:",
+  "all": "Tutto",
+  "schedule": "Programma",
+  "appLockConfig": "Configurazione del blocco dell'app",
+  "@loadStatsFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadStatsFailed": "Impossibile caricare le statistiche: {error}",
+  "overview": "Panoramica",
+  "daily": "Quotidiano",
+  "modelStatsByAgent": "Per agente",
+  "detail": "Dettaglio",
+  "date": "Data",
+  "agent": "Agente",
+  "noData": "Nessun dato",
+  "totalCalls": "Chiamate totali",
+  "calls": "Chiamate",
+  "@callsCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "callsCount": "{count} chiama",
+  "selectDateRange": "Seleziona l'intervallo di date",
+  "totalTokens": "Gettoni totali",
+  "cacheRate": "Tasso di cache",
+  "promptTokens": "Gettoni di richiesta",
+  "completionTokens": "Gettoni di completamento",
+  "cachedTokens": "Token memorizzati nella cache",
+  "thoughtTokens": "Gettoni di pensiero",
+  "prompt": "Richiesta",
+  "completion": "Completamento",
+  "cached": "Memorizzato nella cache",
+  "thought": "Pensiero",
+  "model": "Modello",
+  "scene": "Scena",
+  "sceneId": "Identificativo della scena",
+  "tokenUsage": "Utilizzo dei gettoni",
+  "handler": "Gestore",
+  "modelBreakdown": "Ripartizione del modello",
+  "callDetails": "Dettagli della chiamata",
+  "@recordDetailsTitle": {
+    "placeholders": {
+      "scene": {}
+    }
+  },
+  "recordDetailsTitle": "Dettagli registrazione: {scene}",
+  "@saveLlmConfigFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "saveLlmConfigFailed": "Impossibile salvare la configurazione LLM: {error}",
+  "webHtmlPreviewUnavailable": "L'anteprima HTML non è disponibile sul Web. Si prega di visualizzare sul cellulare.",
+  "@saveUserInfoFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "saveUserInfoFailed": "Impossibile salvare le informazioni dell'utente: {error}",
+  "totalEstimatedCost": "Costo totale stimato",
+  "close": "Vicino",
+  "totalTokenConsumption": "Consumo totale di token",
+  "dataLoadFailedRetry": "Caricamento dati non riuscito, riprova più tardi.",
+  "timelineLoadFailedRetry": "Caricamento della sequenza temporale non riuscito, riprova più tardi.",
+  "newPerspective": "Nuova prospettiva",
+  "startPoint": "Inizio",
+  "endPoint": "FINE",
+  "originalInput": "Ingresso originale",
+  "referenceContent": "Contenuto di riferimento",
+  "@referenceWithTitle": {
+    "placeholders": {
+      "title": {}
+    }
+  },
+  "referenceWithTitle": "Riferimento: {title}",
+  "actionCenterTitle": "Azioni in sospeso",
+  "noPendingActions": "Nessuna azione in sospeso",
+  "clarificationNeeded": "Memex vuole confermare",
+  "clarificationTextHint": "Digita una risposta breve",
+  "clarificationTextRequired": "Aggiungi prima una risposta breve",
+  "clarificationAnswered": "Risposto",
+  "@clarificationAnswerPrefix": {
+    "placeholders": {
+      "answer": {}
+    }
+  },
+  "clarificationAnswerPrefix": "Risposta: {answer}",
+  "answerSaved": "Risposta salvata",
+  "clarificationOtherAnswer": "Inserimento manuale",
+  "clarificationNotSure": "Non sono sicuro/preferisco non dirlo",
+  "yes": "SÌ",
+  "no": "NO",
+  "footprintMap": "Mappa delle impronte",
+  "waypointPlaces": "Luoghi di passaggio",
+  "unknownPlace": "Luogo sconosciuto",
+  "releaseToSend": "Rilascia per inviare",
+  "selectFromAlbum": "Seleziona dall'album",
+  "clipboardPreviewTitle": "Nuovi appunti",
+  "clipboardPreviewImageTitle": "Immagine negli appunti",
+  "clipboardPreviewImageDescription": "Immagine pronta per essere aggiunta",
+  "clipboardPreviewUnprocessed": "Non ancora incollato",
+  "clipboardPreviewPasteToInput": "Incolla nell'input",
+  "clipboardPreviewAddImageToInput": "Aggiungi immagine",
+  "clipboardPreviewImageFailed": "Impossibile leggere l'immagine negli appunti",
+  "tellAiWhatHappened": "Racconta all'IA cosa è successo...",
+  "@recordingWithDuration": {
+    "placeholders": {
+      "duration": {}
+    }
+  },
+  "recordingWithDuration": "Registrazione: {duration}",
+  "playing": "Giocando...",
+  "sendLabel": "Inviare",
+  "@attachedImagesMessage": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "attachedImagesMessage": "Inviato/i immagini {count}",
+  "noTaskData": "Nessun dato sull'attività",
+  "@createdAtDate": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "createdAtDate": "Creato: {date}",
+  "@updatedAtDate": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "updatedAtDate": "Aggiornato: {date}",
+  "@durationLabel": {
+    "placeholders": {
+      "duration": {}
+    }
+  },
+  "durationLabel": "Durata: {duration}",
+  "@retryCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "retryCount": "Riprova: {count}",
+  "loadDetailFailedRetry": "Caricamento dettagli non riuscito, riprova più tardi.",
+  "loadFailed": "Caricamento non riuscito",
+  "@loadHistoryFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadHistoryFailed": "Impossibile caricare la cronologia: {error}",
+  "reload": "Ricaricare",
+  "aiInsightDetail": "Dettaglio approfondimento",
+  "@relatedRecordsCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "relatedRecordsCount": "Record correlati ({count})",
+  "noRelatedRecords": "Nessun record correlato",
+  "useFingerprintToUnlock": "Usa l'impronta digitale per sbloccare",
+  "locked": "Bloccato",
+  "wrongPassword": "Password errata",
+  "enterPassword": "Inserisci la password",
+  "memexLocked": "Memex è bloccato",
+  "calendarShortSun": "Sole",
+  "calendarShortMon": "Lun",
+  "calendarShortTue": "Mar",
+  "calendarShortWed": "Mercoledì",
+  "calendarShortThu": "Gio",
+  "calendarShortFri": "Ven",
+  "calendarShortSat": "Sab",
+  "@noRecordsOnDate": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "noRecordsOnDate": "Nessun record su {date}",
+  "footprintPath": "Percorso dell'impronta",
+  "lifeCompositionTable": "Composizione della vita",
+  "emotionReframe": "Riformulazione delle emozioni",
+  "chronicleOfThings": "Cronaca delle cose",
+  "goalProgress": "Progresso dell'obiettivo",
+  "trendChart": "Grafico delle tendenze",
+  "comparisonChart": "Grafico comparativo",
+  "todayTimeFlow": "Il flusso del tempo di oggi",
+  "aiInputHint": "Che si tratti di ricordi o del presente, sono qui...",
+  "refreshSuperAgentStateTooltip": "Cancella il contesto dell'agente Memex",
+  "refreshSuperAgentStateTitle": "Cancellare il contesto della cronologia dell'agente Memex?",
+  "refreshSuperAgentStateMessage": "La cronologia chat visibile rimarrà, ma il contesto storico di runtime di Memex Agent verrà cancellato e le risposte future inizieranno da un nuovo contesto. La memoria persistente, i file della knowledge base, le schede e gli altri dati salvati non sono interessati. Utilizzare questo quando Memex Agent continua a comportarsi in modo anomalo. Continuare?",
+  "refreshSuperAgentStateActiveRunMessage": "Attendere fino al termine del messaggio corrente di Memex Agent prima di cancellare il contesto.",
+  "refreshSuperAgentStateSuccess": "Il contesto dell'agente Memex è stato cancellato",
+  "@refreshSuperAgentStateFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "refreshSuperAgentStateFailed": "Impossibile cancellare il contesto dell'agente Memex: {error}",
+  "nothingHere": "Niente qui ancora",
+  "nothingHereHint": "Tocca il pulsante qui sotto per creare la tua prima carta",
+  "agentProcessing": "L'intelligenza artificiale sta elaborando...",
+  "keepAppOpen": "Non chiudere l'app",
+  "activityDetail": "Dettaglio attività",
+  "noAgentActivityYet": "Nessuna attività dell'agente ancora",
+  "processingEllipsis": "Elaborazione...",
+  "agentBackgroundTitle": "Agente Memex",
+  "agentBackgroundPausedTitle": "L'agente Memex è stato messo in pausa",
+  "agentBackgroundNeedsAttentionTitle": "L'agente Memex ha bisogno di attenzione",
+  "agentBackgroundStageIdle": "Oziare",
+  "agentBackgroundStageProcessing": "Elaborazione",
+  "agentBackgroundStageQueued": "In coda",
+  "agentBackgroundStageRetrying": "In attesa di riprovare",
+  "agentBackgroundStagePaused": "In pausa",
+  "agentBackgroundStageCompleted": "Completato",
+  "agentBackgroundStageNeedsAttention": "Ha bisogno di attenzione",
+  "agentBackgroundStageAnalyzingMedia": "Analisi dei media",
+  "agentBackgroundStageGeneratingCard": "Scheda generatrice",
+  "agentBackgroundStageUpdatingKnowledge": "Aggiornamento della conoscenza",
+  "agentBackgroundStagePreparingComment": "Preparazione del commento",
+  "agentBackgroundStageRoutingFollowUps": "Follow-up del percorso",
+  "@agentBackgroundTaskSummary": {
+    "placeholders": {
+      "running": {},
+      "pending": {},
+      "retrying": {}
+    }
+  },
+  "agentBackgroundTaskSummary": "In esecuzione {running}, In sospeso {pending}, Riprova {retrying}",
+  "@agentBackgroundTaskDetail": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "agentBackgroundTaskDetail": "Elaborazione delle attività in coda {count}.",
+  "agentBackgroundNoTasks": "Nessuna attività in background.",
+  "agentBackgroundStarting": "L'elaborazione è in corso.",
+  "agentBackgroundCompletedDetail": "Tutte le attività in background sono state completate.",
+  "agentBackgroundFailedDetail": "L'elaborazione è stata interrotta con un errore.",
+  "agentBackgroundPausedDetail": "L'elaborazione è sospesa e continuerà più tardi.",
+  "agentBackgroundQueuedDetail": "In attesa della fase di lavorazione successiva.",
+  "agentBackgroundRetryingDetail": "Il passaggio corrente verrà riprovato automaticamente.",
+  "agentBackgroundAnalyzeMediaDetail": "Lettura degli allegati e contesto locale.",
+  "agentBackgroundGeneratingCardDetail": "Trasformare il record in una scheda della sequenza temporale.",
+  "agentBackgroundUpdatingKnowledgeDetail": "Aggiornamento della conoscenza e della memoria locale.",
+  "agentBackgroundPreparingCommentDetail": "Preparazione di un follow-up dell'assistente.",
+  "agentBackgroundRoutingFollowUpsDetail": "Controllo delle azioni successive per questa carta.",
+  "@agentBackgroundPausedStatus": {
+    "placeholders": {
+      "summary": {}
+    }
+  },
+  "agentBackgroundPausedStatus": "In pausa - {summary}",
+  "@agentBackgroundNeedsAttentionStatus": {
+    "placeholders": {
+      "summary": {}
+    }
+  },
+  "agentBackgroundNeedsAttentionStatus": "Ha bisogno di attenzione - {summary}",
+  "settings": "Impostazioni",
+  "languageSettings": "Lingua",
+  "languageSettingsDesc": "Cambia la lingua di visualizzazione dell'app",
+  "noPendingActionsToast": "Nessuna azione in sospeso",
+  "knowledgeNewDiscovery": "Conoscenza nuova scoperta",
+  "@discoveredNewInsightsCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "discoveredNewInsightsCount": "Scoperto/i {count} nuovi approfondimenti",
+  "@updatedExistingInsightsCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "updatedExistingInsightsCount": "Aggiornati {count} approfondimenti esistenti",
+  "sectionNewInsights": "Nuovi approfondimenti",
+  "sectionUpdatedInsights": "Approfondimenti aggiornati",
+  "unnamedInsight": "Intuizione senza nome",
+  "copiedToClipboard": "Copiato negli appunti",
+  "copy": "Copia",
+  "selectedLocation": "Località selezionata",
+  "confirmLocationName": "Conferma il nome della posizione",
+  "confirmLocationNameHint": "Puoi modificare il nome (le coordinate rimangono le stesse)",
+  "nameLabel": "Nome",
+  "inputPlaceNameHint": "Inserisci il nome del luogo...",
+  "@currentCoordinates": {
+    "placeholders": {
+      "lat": {},
+      "lng": {}
+    }
+  },
+  "currentCoordinates": "Coordinate: {lat}, {lng}",
+  "confirmLocation": "Conferma la posizione",
+  "welcomeToMemex": "Benvenuti in Memex",
+  "createUserIdToStart": "Crea il tuo profilo",
+  "userIdLabel": "Il tuo nome/soprannome",
+  "userIdHint": "Inserisci il tuo nome o soprannome",
+  "pleaseEnterUserId": "Per favore inserisci il tuo nome",
+  "userIdMaxLength": "Il nome non deve superare i 50 caratteri",
+  "startUsing": "Continuare",
+  "userIdTip": "Questo verrà utilizzato per personalizzare la tua esperienza.",
+  "setupModelConfigTitle": "Configura un modello di intelligenza artificiale",
+  "setupModelConfigSubtitle": "Memex ha bisogno di un modello di intelligenza artificiale di frontiera per organizzare record, analizzare immagini e generare approfondimenti. Scegli un metodo di connessione.",
+  "setupModelConfigComplete": "Completa e vai",
+  "aiService": "Servizio modelli Memex",
+  "aiModelHubTitle": "Modelli e servizi di intelligenza artificiale",
+  "aiModelHubSubtitle": "Scegli il servizio ufficiale di Memex o porta il tuo fornitore. Il routing avanzato dei modelli rimane disponibile quando ne hai bisogno.",
+  "aiSetupCurrentStatusTitle": "Configurazione attuale",
+  "aiSetupStatusNotConfiguredTitle": "Il servizio AI non è configurato",
+  "aiSetupStatusNotConfiguredDescription": "Scegli un metodo di connessione per abilitare l'organizzazione AI per record, contenuti multimediali e approfondimenti.",
+  "aiSetupStatusMemexTitle": "Utilizzando il servizio ufficiale Memex",
+  "aiSetupStatusMemexDescription": "Memex utilizzerà la connessione ufficiale e le credenziali API gestite dal tuo account Memex.",
+  "aiSetupStatusCustomTitle": "Utilizzo delle impostazioni personalizzate del provider",
+  "aiSetupStatusCustomDescription": "Memex utilizzerà le credenziali del fornitore configurato e le selezioni del ruolo del modello.",
+  "aiSetupChooseConnectionTitle": "Scegli un metodo di connessione",
+  "aiSetupChooseConnectionDescription": "Inizia con il percorso che corrisponde al modo in cui desideri che Memex acceda ai modelli IA.",
+  "aiSetupOfficialRouteDescription": "Accedi a Memex per utilizzare il servizio AI ufficiale.",
+  "aiSetupCustomRouteDescription": "Aggiungi il tuo provider e la chiave API.",
+  "aiSetupCustomPageTitle": "Servizio IA personalizzato",
+  "aiSetupCustomPageSubtitle": "Configura prima le credenziali del provider, quindi scegli il modello che Memex dovrà utilizzare.",
+  "aiSetupProviderCredentialsTitle": "Provider e chiavi API",
+  "aiSetupProviderCredentialsDescription": "Aggiungi o modifica OpenAI, Anthropic, DeepSeek, Gemini, OpenRouter, Ollama o un altro provider compatibile.",
+  "modelRolesTitle": "Scegli il modello principale",
+  "modelRolesDescription": "Super Agent utilizza un modello per gli input di testo e immagini. Le sostituzioni avanzate dell'agente rimangono disponibili di seguito.",
+  "textModelRoleTitle": "Modello primario",
+  "textModelRoleDescription": "Utilizzato da Super Agent per testo, immagini, schede, conoscenza, approfondimenti, chat, commenti e memoria.",
+  "modelConnectionsTitle": "Provider di modelli e chiavi API",
+  "modelConnectionsDescription": "Connetti il ​​servizio ufficiale di Memex o aggiungi le credenziali del tuo fornitore.",
+  "relatedAiCapabilitiesTitle": "Funzionalità avanzate e correlate",
+  "relatedAiCapabilitiesDescription": "Ottimizza le assegnazioni degli agenti, il provider di posizione e il comportamento di trascrizione vocale.",
+  "aiSetupServiceCapabilitiesTitle": "Capacità di servizio",
+  "aiSetupServiceCapabilitiesDescription": "Scegli i fornitori utilizzati da Memex per le funzionalità adiacenti basate sull'intelligenza artificiale come il parlato e la geocodifica inversa.",
+  "aiSetupAdvancedCustomizationTitle": "Routing avanzato del modello",
+  "aiSetupAdvancedCustomizationDescription": "Per utenti esperti che desiderano che i singoli agenti utilizzino provider o configurazioni di modelli diversi.",
+  "locationProviderSettings": "Fornitore di posizione",
+  "speechProviderSettings": "Trascrizione del discorso",
+  "advancedAgentModelAssignments": "Assegnazioni del modello di agente",
+  "openAdvancedAgentModelAssignments": "Sostituisci i singoli agenti",
+  "noConfiguredModelOptions": "Aggiungi un provider o una chiave API prima di scegliere i ruoli del modello.",
+  "modelSlotUpdated": "Ruolo del modello aggiornato",
+  "aiServiceMemexRouteTitle": "Connettiti tramite Memex",
+  "aiServiceLongDescription": "Memex utilizza un sistema multi-agente per organizzare documenti di vita, note di conoscenza e contesto sociale, scoprire approfondimenti più profondi e fornire compagnia all'intelligenza artificiale con memoria persistente. I tuoi dati vengono archiviati come Markdown in testo semplice, preservando la libertà e la portabilità dei dati.",
+  "aiServiceCustomApiRouteTitle": "Ho una chiave API",
+  "aiServiceCustomModelDescription": "Scegli prima questa se disponi già di una chiave API di OpenAI, Anthropic, DeepSeek, Gemini o un altro provider.",
+  "enableAiService": "Connettiti con Memex",
+  "aiServiceReadyToast": "L'organizzazione dell'intelligenza artificiale è attiva",
+  "aiServiceSettingsDescription": "Se non disponi di una chiave API, utilizza un account Memex per connetterti ai servizi del modello tradizionale.",
+  "advancedModelConfiguration": "Configura la chiave API",
+  "skipForNow": "Salta per ora",
+  "clearAuth": "Cancella autenticazione",
+  "authorizing": "Autorizzando...",
+  "@authFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "authFailed": "Autenticazione non riuscita: {error}",
+  "authorized": "Autorizzato",
+  "@authorizedAs": {
+    "placeholders": {
+      "email": {}
+    }
+  },
+  "authorizedAs": "Autorizzato come {email}",
+  "authorizedSuccessfully": "Autorizzato con successo",
+  "reAuthorize": "Riautorizza",
+  "authorizeWithOpenAi": "Autorizza con OpenAI",
+  "authorizeWithGoogle": "Autorizza con Google",
+  "config": "Configurazione",
+  "calendar": "Calendario",
+  "reminders": "Promemoria",
+  "writeToSystemFailed": "Impossibile scrivere sul sistema",
+  "@permissionRequired": {
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "permissionRequired": "È richiesta l'autorizzazione {name}",
+  "@permissionRationale": {
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "permissionRationale": "Consenti all'app di accedere al tuo {name} nelle Impostazioni in modo che possiamo crearlo per te.",
+  "goToSettings": "Vai su Impostazioni",
+  "unknownAction": "Azione sconosciuta",
+  "discoveredCalendarEvent": "Evento in calendario in attesa di conferma",
+  "discoveredReminder": "Promemoria in attesa di conferma",
+  "addToCalendar": "Aggiungi al calendario",
+  "addToReminders": "Aggiungi ai promemoria",
+  "systemActionPendingExplanation": "Non ancora aggiunto. Tocca di seguito per richiedere l'autorizzazione e aggiungerla al tuo dispositivo.",
+  "@addedToSuccess": {
+    "placeholders": {
+      "target": {}
+    }
+  },
+  "addedToSuccess": "Aggiunto con successo a {target}",
+  "ignore": "Ignorare",
+  "confirmDelete": "Conferma l'eliminazione",
+  "confirmDeleteSessionMessage": "Eliminare questa conversazione? Questa operazione non può essere annullata.",
+  "delete": "Eliminare",
+  "deleteSuccess": "Eliminato con successo",
+  "@deleteFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "deleteFailed": "Eliminazione non riuscita: {error}",
+  "daysAgo": "{count} giorni fa",
+  "chatHistory": "Cronologia chat",
+  "enterFullScreenTooltip": "Entra a schermo intero",
+  "exitFullScreenTooltip": "Esci dallo schermo intero",
+  "noConversations": "Nessuna conversazione",
+  "@loadSessionListFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadSessionListFailed": "Impossibile caricare l'elenco delle sessioni: {error}",
+  "@yesterdayAt": {
+    "placeholders": {
+      "time": {}
+    }
+  },
+  "yesterdayAt": "Ieri {time}",
+  "newChat": "Nuova chiacchierata",
+  "@messageCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "messageCount": "{count} messaggi",
+  "organize": "Organizzare",
+  "pkmCategoryProject": "Progetto",
+  "pkmCategoryProjectSubtitle": "A breve termine · Obiettivi · Scadenze",
+  "pkmCategoryArea": "Zona",
+  "pkmCategoryAreaSubtitle": "A lungo termine · Responsabilità · Standard",
+  "pkmCategoryResource": "Risorsa",
+  "pkmCategoryResourceSubtitle": "Interessi · Ispirazione · Riserva",
+  "pkmCategoryArchive": "Archivio",
+  "pkmCategoryArchiveSubtitle": "Fatto · Inattivo · Riferimento",
+  "recentChanges": "Cambiamenti recenti",
+  "noRecentChangesInThreeDays": "Nessun cambiamento negli ultimi 3 giorni",
+  "unpinned": "Sbloccato",
+  "pinnedStyle": "Stile appuntato",
+  "@operationFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "operationFailed": "Operazione non riuscita: {error}",
+  "refreshingInsightData": "Aggiornamento dei dati approfonditi. L'operazione potrebbe richiedere qualche istante...",
+  "@refreshFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "refreshFailed": "Aggiornamento non riuscito: {error}",
+  "sortUpdated": "Ordinamento aggiornato",
+  "@sortSaveFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "sortSaveFailed": "Impossibile salvare l'ordinamento: {error}",
+  "insightCardDeleted": "Scheda informativa eliminata",
+  "@deleteFailedShort": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "deleteFailedShort": "Eliminazione non riuscita: {error}",
+  "knowledgeInsight": "Approfondimento della conoscenza",
+  "completeSort": "Ordinamento completo",
+  "noKnowledgeInsight": "Nessuna conoscenza approfondita",
+  "@insightProcessingBacklogMessage": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "insightProcessingBacklogMessage": "Le attività in background {count} sono ancora in fase di elaborazione.",
+  "insightUnavailableMessage": "Questo insight è ancora in fase di generazione o è stato aggiornato. Aggiorna gli approfondimenti e riprova più tardi.",
+  "artifactOpen": "Aprire",
+  "updating": "Aggiornamento...",
+  "update": "Aggiornamento",
+  "enabled": "Abilitato",
+  "disabled": "Disabilitato",
+  "appLockOn": "Blocco app abilitato",
+  "appLockOff": "Blocco app disabilitato",
+  "enableAppLockFirst": "Abilita prima il blocco dell'app",
+  "enterFourDigitPassword": "Inserisci la password di 4 cifre",
+  "passwordSetAndLockOn": "Password impostata e blocco app abilitato",
+  "appLockSettings": "Impostazioni di blocco dell'app",
+  "enableAppLock": "Abilita il blocco dell'app",
+  "enableAppLockSubtitle": "Password richiesta all'avvio dell'app",
+  "enableBiometrics": "Abilita la biometria",
+  "biometricsSubtitle": "Utilizza Face ID o Touch ID per sbloccare",
+  "changePassword": "Cambiare la password",
+  "setFourDigitPassword": "Imposta una password di 4 cifre",
+  "reenterPasswordToConfirm": "Reinserire la password per confermare",
+  "passwordMismatch": "Le password non corrispondono. Per favore riprova.",
+  "@confirmDeleteCharacter": {
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "confirmDeleteCharacter": "Eliminare il carattere \"{name}\"? Questa operazione non può essere annullata.",
+  "configureAiCharacter": "Configura il personaggio AI",
+  "addCharacter": "Aggiungi carattere",
+  "addCharacterSubtitle": "Scegli i personaggi IA per unirti al tuo team di intuizione. Analizzeranno i dati della tua vita da diverse angolazioni.",
+  "noCharacters": "Nessun personaggio",
+  "@loadCharacterFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadCharacterFailed": "Impossibile caricare i caratteri: {error}",
+  "noTags": "Nessun tag",
+  "createSuccess": "Creato con successo",
+  "updateSuccess": "Aggiornato con successo",
+  "@saveFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "saveFailed": "Salvataggio non riuscito: {error}",
+  "newCharacter": "Nuovo personaggio",
+  "editCharacter": "Modifica personaggio",
+  "save": "Salva",
+  "characterName": "Nome del personaggio",
+  "characterNameHint": "Dai un nome al tuo personaggio",
+  "pleaseEnterCharacterName": "Inserisci il nome del personaggio",
+  "tagsLabel": "Tag",
+  "tagsHint": "per esempio. saggezza, riconoscimento, macro\nSepara più tag con virgole",
+  "characterPersonaLabel": "Persona di carattere",
+  "characterPersonaHint": "Includi persona, guida di stile, dialogo di esempio, filtri di conoscenza, ecc.\nUtilizzare ## per le intestazioni delle sezioni.",
+  "pleaseEnterCharacterPersona": "Inserisci il personaggio del personaggio",
+  "@permissionRequestError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "permissionRequestError": "Errore nella richiesta di autorizzazione: {error}",
+  "permissionRequiredTitle": "Permesso richiesto",
+  "permissionPermanentlyDeniedMessage": "Hai negato permanentemente questa autorizzazione oppure il sistema la richiede. Si prega di abilitarlo nelle impostazioni di sistema.",
+  "getting": "Ottenere...",
+  "unauthorized": "Non autorizzato",
+  "authorizedGoToSettings": "Autorizzato. Vai alle impostazioni di sistema per modificare.",
+  "location": "Posizione",
+  "locationPermissionReason": "Per registrare luoghi e caratteristiche relative alla posizione",
+  "photos": "Foto",
+  "photosPermissionReason": "Per selezionare foto, salvare immagini generate, ecc.",
+  "camera": "Telecamera",
+  "cameraPermissionReason": "Per scattare foto e video",
+  "microphone": "Microfono",
+  "microphonePermissionReason": "Per il riconoscimento vocale, la registrazione, ecc.",
+  "calendarPermissionReason": "Per registrare il programma e leggere gli eventi del calendario",
+  "remindersPermissionReason": "Per registrare e leggere i tuoi promemoria",
+  "fitnessAndMotion": "Fitness e movimento",
+  "fitnessPermissionReason": "Per la registrazione di dati sulla salute e sul movimento",
+  "notification": "Notifica",
+  "notificationPermissionReason": "Per inviare programmi e promemoria importanti",
+  "memexAgentNotificationPermissionTitle": "Mantieni Memex Agent in esecuzione in background",
+  "memexAgentNotificationPermissionMessage": "Memex Agent viene eseguito localmente sul tuo dispositivo. Le notifiche consentono a Memex di mostrare i progressi e di continuare l'elaborazione dopo aver lasciato l'app o spento lo schermo. Se le notifiche sono disattivate, mantieni Memex aperto in primo piano fino al termine dell'attività.",
+  "loadDetailFailedRetryShort": "Caricamento dettagli non riuscito, riprova più tardi.",
+  "total": "Totale",
+  "estimatedCost": "Costo stimato",
+  "byAgent": "Per Agente",
+  "timeUpdated": "Ora aggiornata",
+  "@updateFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "updateFailed": "Aggiornamento non riuscito: {error}",
+  "locationUpdated": "Posizione aggiornata",
+  "confirmDeleteCardMessage": "Eliminare questa carta? Questa operazione non può essere annullata.",
+  "cardDetailNotFound": "Dettagli della carta non trovati",
+  "saySomething": "Di 'qualcosa...",
+  "relatedMemories": "Ricordi correlati",
+  "viewMore": "Visualizza altro",
+  "relatedRecords": "Record correlati",
+  "reply": "Rispondere",
+  "replySent": "Risposta inviata",
+  "insightTemplateGalleryTitle": "Modelli di schede informative",
+  "timelineTemplateGalleryTitle": "Modelli di carte della sequenza temporale",
+  "categoryTextual": "Testuale",
+  "timelineFilterAll": "TUTTO",
+  "insights": "Approfondimenti",
+  "memoryTitle": "Memoria",
+  "longTermProfile": "Profilo a lungo termine",
+  "recentBuffer": "Buffer recente",
+  "@errorLoadingMemory": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "errorLoadingMemory": "Errore durante il caricamento della memoria: {error}",
+  "agentConfiguration": "Configurazione dell'agente",
+  "resetToDefaults": "Ripristina le impostazioni predefinite",
+  "resetAllAgentConfigurationsTitle": "Reimposta tutte le configurazioni dell'agente",
+  "resetAllAgentConfigurationsMessage": "Sei sicuro di voler reimpostare tutte le configurazioni dell'agente sui valori predefiniti? Questa azione non può essere annullata.",
+  "resetButton": "Reset",
+  "@loadDataFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loadDataFailed": "Impossibile caricare i dati: {error}",
+  "@saveConfigFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "saveConfigFailed": "Impossibile salvare la configurazione: {error}",
+  "selectLlmClient": "Seleziona cliente LLM:",
+  "agentConfigurationsReset": "Ripristino delle configurazioni dell'agente",
+  "@resetFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "resetFailed": "Impossibile reimpostare: {error}",
+  "modelConfiguration": "Configurazione del modello",
+  "resetAllConfigurationsTitle": "Ripristina tutte le configurazioni",
+  "resetAllModelConfigurationsMessage": "Sei sicuro di voler reimpostare tutte le configurazioni del modello sui valori predefiniti? Questa azione non può essere annullata.",
+  "modelConfigurationsReset": "Ripristino delle configurazioni del modello",
+  "cannotDeleteDefaultConfiguration": "Impossibile eliminare la configurazione predefinita",
+  "cannotDeleteConfigurationTitle": "Impossibile eliminare la configurazione",
+  "@configUsedByAgentsMessage": {
+    "placeholders": {
+      "agentList": {}
+    }
+  },
+  "configUsedByAgentsMessage": "Questa configurazione è attualmente utilizzata dai seguenti agenti:\n\n{agentList}\n\nRiassegna questi agenti prima di eliminarli.",
+  "ok": "OK",
+  "deleteConfigurationTitle": "Elimina configurazione",
+  "@confirmDeleteConfigMessage": {
+    "placeholders": {
+      "key": {}
+    }
+  },
+  "confirmDeleteConfigMessage": "Sei sicuro di voler eliminare \"{key}\"?",
+  "defaultLabel": "Predefinito",
+  "setAsDefault": "Imposta come predefinito",
+  "invalidJsonInExtraField": "JSON non valido nel campo Extra",
+  "keyAlreadyExists": "La chiave esiste già",
+  "resetConfigurationTitle": "Ripristina configurazione",
+  "resetConfigurationMessage": "Ripristinare questa configurazione ai valori predefiniti iniziali? Le modifiche attuali andranno perse.",
+  "configurationResetPressSave": "Ripristino della configurazione. Premi Salva per applicare.",
+  "addConfiguration": "Aggiungi configurazione",
+  "editConfiguration": "Modifica configurazione",
+  "duplicateConfiguration": "Configurazione duplicata",
+  "duplicate": "Duplicato",
+  "keyIdLabel": "ID di configurazione",
+  "keyIdHelper": "Assegna un nome a questa configurazione, ad esempio deepseek o work-gpt.",
+  "required": "Necessario",
+  "clientLabel": "Fornitore di modelli",
+  "providerGroupOpenAi": "OpenAI",
+  "providerGroupAnthropic": "Antropico",
+  "providerGroupGoogle": "Google",
+  "providerGroupOthers": "Popolare",
+  "providerOpenAiApiKey": "Chiave API",
+  "providerOpenAiResponses": "Chiave API (risposte)",
+  "providerChatGptOauth": "ChatGPT Pro/Plus",
+  "providerClaudeApiKey": "Chiave API",
+  "providerBedrockSecret": "Segreto del fondamento roccioso",
+  "providerGemini": "Gemelli",
+  "providerGeminiOauth": "Gemelli (Google OAuth)",
+  "providerKimi": "Kimi (Moonshot)",
+  "providerQwen": "Aliyun",
+  "providerSeed": "Volcengine",
+  "providerZhipu": "ZhipuGLM",
+  "providerDeepSeek": "DeepSeek",
+  "providerMinimax": "MiniMax",
+  "providerOpenRouter": "OpenRouter",
+  "providerOllama": "Ollama (locale)",
+  "providerMimo": "Xiaomi MIMO",
+  "providerMemex": "Servizio proxy Memex",
+  "memexSignIn": "Registrazione",
+  "memexCreateAccount": "Creare un account",
+  "memexUsername": "Nome utente",
+  "memexPassword": "Password",
+  "memexCreateAccountLink": "Creare un account",
+  "memexSignInLink": "Accedi invece",
+  "memexTopUp": "Ricarica per iniziare a utilizzare Memex AI",
+  "memexTopUpSuccess": "Ricarica riuscita!",
+  "memexFillAllFields": "Si prega di compilare tutti i campi",
+  "memexUsernameTooShort": "Il nome utente deve contenere almeno 6 caratteri",
+  "memexAuthFailed": "Autenticazione non riuscita",
+  "memexPaymentFailed": "Impossibile creare il pagamento",
+  "memexLogout": "Esci",
+  "memexTopUpButton": "Ricaricare",
+  "memexTopUpChooseAmount": "Scegli un importo",
+  "@memexTopUpEstimatedRecords": {
+    "placeholders": {
+      "range": {}
+    }
+  },
+  "memexTopUpEstimatedRecords": "Informazioni sui record {range}",
+  "memexTopUpPlanStarter": "Antipasto",
+  "memexTopUpPlanEveryday": "Ogni giorno",
+  "memexTopUpPlanHighVolume": "Alto volume",
+  "memexTopUpPlanCustom": "Crediti personalizzati",
+  "memexTopUpPlanStarterSubtitle": "Buono per provare Memex AI",
+  "memexTopUpPlanEverydaySubtitle": "Buono per l'organizzazione regolare",
+  "memexTopUpPlanHighVolumeSubtitle": "Buono per lotti più grandi",
+  "memexTopUpPlanCustomSubtitle": "Inserisci un valore compreso tra 1 e 10.000 USD",
+  "memexTopUpCustomEstimate": "La stima si basa sull'importo inserito",
+  "memexCustomAmount": "Importo personalizzato",
+  "memexViewHistory": "Cronologia dell'utilizzo",
+  "@memexBalanceLabel": {
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "memexBalanceLabel": "Saldo: {amount}",
+  "memexConfirmPassword": "Conferma password",
+  "memexPasswordMismatch": "Le password non corrispondono",
+  "@memexPayAmount": {
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "memexPayAmount": "Ricarica {amount}",
+  "modelIdLabel": "Modello",
+  "modelIdHelper": "per esempio. gemini-3.1-pro-anteprima, gpt-4o",
+  "fetchingModels": "Recupero modelli in corso...",
+  "fetchModelsButton": "Recupera modelli",
+  "enterApiKeyFirst": "Inserisci prima la chiave API per recuperare i modelli",
+  "apiKeyLabel": "Chiave API",
+  "baseUrlLabel": "Endpoint API",
+  "advancedSettings": "Impostazioni avanzate",
+  "testConnectionSuccess": "Connessione riuscita",
+  "testConnectionFailed": "Connessione non riuscita",
+  "testTypeText": "Testo",
+  "testTypeVision": "Visione",
+  "testButton": "Test",
+  "testing": "Prova...",
+  "proxyUrlOptional": "URL proxy (facoltativo)",
+  "proxyUrlHelper": "per esempio. http://127.0.0.1:7890",
+  "temperatureLabel": "Temperatura",
+  "topPLabel": "Superiore P",
+  "maxTokensLabel": "Gettoni massimi",
+  "extraParamsJson": "Parametri aggiuntivi (JSON)",
+  "invalidJson": "JSON non valido",
+  "warning": "Configurazione incompleta",
+  "invalidConfigurationWarning": "La configurazione non è ancora completa (ad esempio, manca la chiave API o l'ID modello). Puoi comunque salvarlo e configurarlo in seguito. Continuare?",
+  "invalidModelConfigDetailed": "L'agente AI \"{agentId}\" necessita di una configurazione del modello valida (chiave: \"{configKey}\") per funzionare. Si prega di verificare le impostazioni del modello.",
+  "discardChangesTitle": "Lasciare questa pagina?",
+  "discardChangesMessage": "Se hai apportato modifiche, salvale prima di uscire.",
+  "discardButton": "Scartare",
+  "chooseLanguage": "Scegli la lingua",
+  "chooseAvatar": "Scegli Avatar",
+  "configureNow": "Configura ora",
+  "modelNotConfiguredBanner": "Modello AI non ancora configurato. Configuralo per sbloccare tutte le funzionalità.",
+  "modelNotConfiguredSubmitHint": "Configura un modello AI prima della pubblicazione",
+  "processingStatus": "Elaborazione",
+  "failedStatus": "Fallito",
+  "failureReason": "Motivo del fallimento",
+  "unknownError": "Si è verificato un errore sconosciuto",
+  "enableFitness": "Abilita Fitness",
+  "fitnessBannerMessage": "Consenti l'accesso al fitness per monitorare i dati relativi alla tua salute e alle tue attività.",
+  "fitnessDismissTitle": "Saltare l'accesso al fitness?",
+  "fitnessDismissMessage": "Senza l'autorizzazione per l'attività fisica, l'app non sarà in grado di raccogliere automaticamente i tuoi dati sanitari per approfondimenti e registrazioni automatiche.",
+  "skipAnyway": "Salta comunque",
+  "proModelHint": "Questo modello richiede un abbonamento ChatGPT Pro/Plus.",
+  "searchKnowledgeBase": "Cerca nella base di conoscenza...",
+  "searchKnowledgeHint": "Inserisci la parola chiave per cercare nomi di file o contenuti",
+  "@noSearchResults": {
+    "placeholders": {
+      "query": {}
+    }
+  },
+  "noSearchResults": "Nessun risultato trovato per \"{query}\"",
+  "onlyMarkdownPreview": "È supportata solo l'anteprima Markdown",
+  "backupAndRestore": "Backup e ripristino",
+  "createBackup": "Crea backup",
+  "restoreBackup": "Ripristina backup",
+  "backupDescription": "Raccogli tutti i tuoi dati (schede, knowledge base, approfondimenti, impostazioni) in un file .memex. Salvalo su iCloud Drive, Google Drive o qualsiasi posizione tramite il foglio di condivisione.",
+  "restoreDescription": "Seleziona un file di backup .memex per ripristinare tutti i dati. Ciò sovrascriverà i dati correnti.",
+  "selectBackupFile": "Seleziona File di backup",
+  "estimatedSize": "Dimensioni stimate",
+  "backupComplete": "Backup creato",
+  "@backupFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "backupFailed": "Backup non riuscito: {error}",
+  "confirmRestore": "Conferma ripristino",
+  "confirmRestoreMessage": "Il ripristino sovrascriverà tutti i dati correnti, incluse schede, knowledge base, approfondimenti e impostazioni. Questa operazione non può essere annullata. Continuare?",
+  "restoreComplete": "Ripristino completato",
+  "restoreRestartHint": "I dati sono stati ripristinati. Riavvia l'app affinché tutte le modifiche abbiano effetto.",
+  "@restoreFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "restoreFailed": "Ripristino non riuscito: {error}",
+  "invalidBackupFile": "File di backup non valido. Seleziona un file .memex.",
+  "automaticBackup": "Backup automatico",
+  "autoBackupDescription": "Se abilitato, Memex crea al massimo uno snapshot locale al giorno dopo l'avvio o quando torna in primo piano.",
+  "backupSensitiveSettingsHint": "I backup includono le impostazioni e le chiavi del provider del modello. Conserva i file di backup in un posto di cui ti fidi.",
+  "backupLocation": "Posizione",
+  "backupLocationDetails": "Dettagli sulla posizione",
+  "backupLocationSummary": "Mostrato nell'app",
+  "backupLocationFullPath": "Percorso completo",
+  "backupLocationUri": "URI di accesso alla cartella",
+  "copyBackupLocationPath": "Copia percorso",
+  "backupLocationCopied": "Posizione del backup copiata",
+  "@androidBackupLocationSelected": {
+    "placeholders": {
+      "folderName": {}
+    }
+  },
+  "androidBackupLocationSelected": "Cartella selezionata: {folderName}",
+  "iosICloudBackupLocation": "iCloud Drive > Memex > Backup",
+  "iosAppDocumentsBackupLocation": "File > Sul mio iPhone > Memex > Backup",
+  "autoBackupStatus": "Stato",
+  "noAutoBackupYet": "Nessun backup automatico ancora",
+  "@lastBackupAt": {
+    "placeholders": {
+      "time": {}
+    }
+  },
+  "lastBackupAt": "Ultimo backup: {time}",
+  "autoBackupRetention": "Conservazione",
+  "@autoBackupRetentionDays": {
+    "placeholders": {
+      "days": {}
+    }
+  },
+  "autoBackupRetentionDays": "{days} giorni",
+  "autoBackupRetentionForever": "Conserva per sempre",
+  "autoBackupMaxSize": "Tappo di stoccaggio",
+  "@autoBackupRetentionLimitHint": {
+    "placeholders": {
+      "size": {}
+    }
+  },
+  "autoBackupRetentionLimitHint": "La pulizia automatica mantiene gli snapshot automatici in {size}. Le istantanee di sicurezza e le esportazioni manuali vengono conservate separatamente.",
+  "createSnapshotNow": "Esegui il backup adesso",
+  "backupLocationMenu": "Cambia posizione",
+  "defaultBackupLocation": "Cartella di backup predefinita",
+  "defaultBackupLocationAndroidDesc": "Utilizza la cartella dei file esterni specifica dell'app di Memex. Non è necessaria alcuna autorizzazione di archiviazione.",
+  "chooseBackupLocation": "Scegli la cartella di backup",
+  "chooseBackupLocationAndroidDesc": "Scegli una cartella con il selettore di sistema di Android e concedi l'accesso permanente a Memex.",
+  "storedBackups": "Backup archiviati",
+  "noStoredBackups": "I backup automatici verranno visualizzati qui dopo la prima istantanea.",
+  "backupTypeAutoSnapshot": "Istantanea automatica",
+  "backupTypeSafetySnapshot": "Istantanea sulla sicurezza",
+  "backupTypeManualBackup": "Backup manuale",
+  "refresh": "Aggiorna",
+  "restoreThisBackup": "Ripristina questo backup",
+  "deleteThisBackup": "Elimina questo backup",
+  "confirmDeleteBackup": "Eliminare il backup?",
+  "@confirmDeleteBackupMessage": {
+    "placeholders": {
+      "fileName": {}
+    }
+  },
+  "confirmDeleteBackupMessage": "Eliminare {fileName}? Questa operazione rimuove il file di backup archiviato e non può essere annullata.",
+  "@backupDeleted": {
+    "placeholders": {
+      "fileName": {}
+    }
+  },
+  "backupDeleted": "Backup eliminato: {fileName}",
+  "@backupDeleteFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "backupDeleteFailed": "Impossibile eliminare il backup: {error}",
+  "creatingSafetySnapshot": "Creazione istantanea di sicurezza...",
+  "@autoBackupCreated": {
+    "placeholders": {
+      "fileName": {}
+    }
+  },
+  "autoBackupCreated": "Istantanea creata: {fileName}",
+  "@backupLocationFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "backupLocationFailed": "Impossibile aggiornare la posizione del backup: {error}",
+  "backupImportCreatedAt": "Creato",
+  "backupImportSourceVersion": "Versione sorgente",
+  "backupImportFlavor": "Costruire",
+  "backupLegacyFormat": "Backup legacy (nessun manifest)",
+  "restoreInProgress": "Ripristino del backup...",
+  "dataStorage": "Archiviazione dei dati",
+  "dataStorageDescriptionAndroid": "Scegli una cartella personalizzata in cui archiviare il tuo spazio di lavoro. I dati vengono conservati quando reinstalli l'app.",
+  "dataStorageDescriptionIOS": "Attiva iCloud per sincronizzare il tuo spazio di lavoro su tutti i dispositivi e conservare i dati quando reinstalli l'app.",
+  "storageLocationApp": "Archiviazione dell'app",
+  "storageLocationAppDesc": "I dati vengono archiviati all'interno dell'app e verranno rimossi durante la disinstallazione.",
+  "storageLocationCustom": "Archiviazione del dispositivo (cartella personalizzata)",
+  "storageLocationCustomDesc": "Memorizza i dati in una cartella di tua scelta. I dati persistono durante la reinstallazione se la cartella rimane.",
+  "storageLocationICloud": "Archivia su iCloud",
+  "storageLocationICloudDesc": "Sincronizza il tuo spazio di lavoro su tutti i dispositivi Apple. I dati rimangono dopo la reinstallazione.",
+  "@storageLocationCurrent": {
+    "placeholders": {
+      "location": {}
+    }
+  },
+  "storageLocationCurrent": "Attuale: {location}",
+  "icloudRequiresCapability": "Accedi a iCloud e attiva iCloud Drive per utilizzare lo spazio di archiviazione di iCloud.",
+  "loadingFromICloud": "Ripristino dei dati da iCloud…",
+  "switchingToICloud": "Passaggio allo spazio di archiviazione iCloud…",
+  "switchingStorage": "Cambio di spazio di archiviazione…",
+  "customFolderAccessDenied": "Impossibile leggere o scrivere in questa cartella. Concedi l'autorizzazione di archiviazione o scegli un'altra posizione.",
+  "configured": "Configurato",
+  "apiKeyNotSet": "Chiave API non impostata: tocca per configurare",
+  "bottomNavTimeline": "Cronologia",
+  "bottomNavLibrary": "Biblioteca",
+  "aiGeneratedLabel": "Generato dall'intelligenza artificiale",
+  "@sourceTraceWithCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "sourceTraceWithCount": "TRACCIA ORIGINE ({count})",
+  "deleteAccount": "Elimina account",
+  "deleteAccountDesc": "Elimina definitivamente tutti i dati locali e ripristina l'app.",
+  "deleteAccountConfirmTitle": "Eliminare l'account?",
+  "deleteAccountConfirmMessage": "Ciò eliminerà definitivamente tutti i tuoi dati, comprese le schede della sequenza temporale, la knowledge base, le registrazioni e le impostazioni. Questa azione non può essere annullata.",
+  "@deleteAccountTypeName": {
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "deleteAccountTypeName": "Digita \"{name}\" per confermare",
+  "deleteAccountTypeHint": "Inserisci il tuo nome utente per confermare",
+  "llmConsentTitle": "Consenso alla condivisione dei dati",
+  "@llmConsentMessage": {
+    "placeholders": {
+      "provider": {}
+    }
+  },
+  "llmConsentMessage": "Per abilitare le funzionalità AI, Memex deve inviare i tuoi dati a {provider} per l'elaborazione. Ciò include:\n\n• Testo inserito (note, trascrizioni vocali)\n• Metadati delle foto e testo estratto (OCR)\n• Riepiloghi di salute e forma fisica\n• Contenuto della scheda Cronologia\n\nI tuoi dati vengono inviati direttamente dal tuo dispositivo a {provider}. Memex non memorizza né trasmette i tuoi dati attraverso nessun altro server.\n\nConsulta l'informativa sulla privacy di {provider} per sapere come gestiscono i tuoi dati.\n\nAccetti di inviare i tuoi dati a {provider} per l'elaborazione AI?",
+  "llmConsentAgree": "Sono d'accordo",
+  "llmConsentDecline": "Declino",
+  "customAgents": "Agenti personalizzati",
+  "noCustomAgents": "Nessun agente personalizzato configurato.",
+  "deleteAgent": "Elimina agente",
+  "@deleteAgentConfirm": {
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "deleteAgentConfirm": "Eliminare l'agente personalizzato \"{name}\"?",
+  "deleted": "Eliminato",
+  "saved": "Salvato",
+  "newAgent": "Nuovo agente",
+  "editAgent": "Modifica agente",
+  "agentName": "Nome dell'agente",
+  "agentNameHint": "il mio agente personalizzato",
+  "agentNameRequired": "Necessario",
+  "agentNameInvalid": "Solo lettere, cifre e trattini",
+  "agentNameExists": "Il nome esiste già",
+  "hostAgentType": "Tipo di agente host",
+  "skillDirectory": "Elenco delle competenze",
+  "skillDirInvalid": "Deve essere un percorso relativo (non iniziale / o ..)",
+  "workingDirectory": "Directory di lavoro (facoltativo)",
+  "workingDirectoryHint": "Lasciare vuoto per impostazione predefinita dell'area di lavoro",
+  "llmConfig": "Configurazione LLM",
+  "eventType": "Tipo di evento",
+  "executionMode": "Modalità di esecuzione",
+  "executionModeAsync": "Asincrono",
+  "executionModeSync": "Sincronizzazione",
+  "dependsOn": "Dipende",
+  "dependsOnHint": "Seleziona dipendenze",
+  "priority": "Priorità",
+  "maxRetries": "Numero massimo di tentativi",
+  "systemPromptLabel": "Prompt del sistema (facoltativo)",
+  "systemPromptHint": "Ulteriori istruzioni aggiunte al prompt dell'agente host",
+  "eventSerializer": "Serializzatore di eventi",
+  "eventSerializerDefault": "Predefinito (XML)",
+  "enabledLabel": "Abilitato",
+  "skillsManagement": "Gestione delle competenze",
+  "skillsManagementEmpty": "Nessuna competenza ancora",
+  "downloadSkill": "Scarica Abilità",
+  "downloadFile": "Scarica file",
+  "downloading": "Download in corso...",
+  "downloadSuccess": "Abilità scaricata correttamente",
+  "@downloadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "downloadFailed": "Download non riuscito: {error}",
+  "deleteConfirm": "Conferma eliminazione",
+  "@deleteConfirmMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteConfirmMessage": "Sei sicuro di voler eliminare \"{name}\"?",
+  "invalidUrl": "Inserisci un URL valido",
+  "urlHint": "https://example.com/skill.zip",
+  "newFolder": "Nuova cartella",
+  "newFile": "Nuovo fascicolo",
+  "folderName": "Nome della cartella",
+  "fileName": "Nome del file",
+  "nameRequired": "Il nome è obbligatorio",
+  "nameInvalid": "Il nome non può contenere / o ..",
+  "@createFailed": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "createFailed": "Creazione non riuscita: {error}",
+  "fileContent": "Contenuto del file",
+  "saveSuccess": "Salvato con successo",
+  "@downloadToCurrentDir": {
+    "placeholders": {
+      "dir": {
+        "type": "String"
+      }
+    }
+  },
+  "downloadToCurrentDir": "Lo zip verrà estratto nella directory corrente: {dir}",
+  "privacyPolicy": "politica sulla riservatezza",
+  "privacyPolicyDesc": "Come Memex gestisce i tuoi dati",
+  "llmAuthError": "Autenticazione API non riuscita. Controlla la configurazione LLM in Impostazioni.",
+  "llmBadRequestError": "La richiesta è stata respinta dal fornitore LLM. Il formato di input potrebbe non essere supportato dal modello attuale.",
+  "llmRateLimitError": "Limite di velocità API superato. Per favore riprova più tardi.",
+  "llmServerError": "Il servizio LLM è temporaneamente non disponibile. Per favore riprova più tardi.",
+  "llmNetworkError": "Connessione di rete non riuscita. Controlla la tua connessione Internet.",
+  "llmUnknownError": "Si è verificato un errore imprevisto durante l'elaborazione del contenuto.",
+  "llmErrorDialogTitle": "Elaborazione non riuscita",
+  "goToModelConfig": "Vai su Impostazioni",
+  "speechModelDownloadTitle": "Scarica il modello vocale",
+  "@speechModelDownloadDesc": {
+    "placeholders": {
+      "sizeMB": {}
+    }
+  },
+  "speechModelDownloadDesc": "È richiesto un download del modello una tantum (~{sizeMB}MB).\n\nUna volta scaricata, la trascrizione viene eseguita interamente sul dispositivo.",
+  "speechModelStartDownload": "Avvia il download",
+  "speechModelChooseSource": "Scegli la fonte di download:",
+  "speechModelChinaMirror": "🇨🇳 China Mirror (più veloce in CN)",
+  "speechModelGithub": "🌐 GitHub (globale)",
+  "speechModelDownloading": "Download del modello...",
+  "speechModelConnecting": "Connessione...",
+  "deleteSpeechModel": "Elimina modello vocale",
+  "confirmDeleteSpeechModelMessage": "Eliminare i file del modello di riconoscimento vocale locale scaricati? Verranno scaricati di nuovo la prossima volta che verrà utilizzata la sintesi vocale locale.",
+  "speechModelDeletedSuccess": "File del modello vocale eliminati",
+  "speechModelNotDownloaded": "Nessun file del modello vocale scaricato trovato",
+  "@speechModelDeleteFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "speechModelDeleteFailed": "Impossibile eliminare i file del modello vocale: {error}",
+  "speechTranscribing": "Riconoscere...",
+  "speechNoResult": "Nessun parlato rilevato",
+  "useLocalSpeechToTextTitle": "Utilizza la parlata locale per inviare messaggi di testo",
+  "useLocalSpeechToTextDesc": "Se abilitato, l'audio viene trascritto sul dispositivo prima dell'invio, utile per i modelli che non supportano l'input audio. Quando disabilitato, l'audio originale viene inviato direttamente al modello.",
+  "pendingAiProcessingHint": "Configura il modello AI da elaborare",
+  "demoWelcome": "Benvenuti in Memex!\nFacciamo un breve tour di ciò che l'intelligenza artificiale può fare per i tuoi record.",
+  "demoTapAdd": "Tocca qui per creare il tuo primo record",
+  "demoTapSend": "Tocca per inviare il tuo primo record",
+  "demoTapCard": "Tocca per vedere come l'IA ha organizzato il tuo record",
+  "demoDetailHint": "Questo è il dettaglio del tuo record organizzato dall'intelligenza artificiale. Scorri intorno, quindi torna indietro per continuare il tour.",
+  "demoTapInsight": "Tocca per visualizzare gli approfondimenti generati dall'intelligenza artificiale",
+  "demoTapInsightUpdate": "Tocca per generare approfondimenti dai tuoi record",
+  "demoTapKnowledge": "Controlla i tuoi file di conoscenza organizzati automaticamente",
+  "demoDone": "Inizia a registrare la tua vita.",
+  "demoStartTour": "Inizia il giro",
+  "demoGetStarted": "Inizia",
+  "demoSkip": "Saltare",
+  "demoPrefillText": "Ciao Memex! Questo è il mio primo disco 🎉",
+  "visionBadge": "Visione",
+  "notMultimodalHint": "Memex si affida alle capacità del modello multimodale per l'analisi dei media. Se i tuoi record contengono immagini, assicurati che il modello configurato supporti l'input di immagini.",
+  "defaultModelPrefix": "Predefinito",
+  "recommendedBadge": "Raccomandato",
+  "readOnlyBadge": "CHIACCHIERATA",
+  "switchCompanion": "Cambia compagno",
+  "personaChatInputHint": "Digita un messaggio...",
+  "today": "Oggi",
+  "tomorrow": "Domani",
+  "yesterday": "Ieri",
+  "showInsightTextTitle": "Mostra il commento di approfondimento Memex",
+  "showInsightTextDesc": "Se mostrare l'approfondimento Memex come commento appuntato nella sezione dei commenti sui dettagli della carta.",
+  "enableCharacterCommentTitle": "Commento automatico dei caratteri",
+  "enableCharacterCommentDesc": "I personaggi commentano automaticamente i nuovi record.",
+  "maxCommentCharactersTitle": "Numero massimo di caratteri di commento",
+  "maxCommentCharactersDesc": "Quanti caratteri possono commentare ciascun record.",
+  "@replyTo": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "replyTo": "Rispondi a {name}",
+  "cdnSignalsComments": "Nuova risposta ricevuta",
+  "cdnSignalsInsight": "Nuove informazioni generate",
+  "cdnSignalsBoth": "Nuova risposta e approfondimento",
+  "untitledCard": "Carta senza titolo",
+  "locationContextTitle": "Contesto della posizione",
+  "locationContextDescription": "Contesto attuale della città e del quartiere per la chat dell'agente",
+  "locationContextAttachTitle": "Allega la posizione corrente alla chat",
+  "locationContextAttachDesc": "Utilizza il GPS del dispositivo e la geocodificazione inversa per fornire all'agente il contesto di città, distretto e quartiere.",
+  "reverseGeocodingProvider": "Provider di geocodifica inversa",
+  "amapProviderName": "Una mappa",
+  "amapApiKey": "Chiave API Amap",
+  "amapGcj02Note": "Amap utilizza le coordinate GCJ-02. Il GPS del dispositivo viene convertito prima della geocodifica inversa.",
+  "contextGranularity": "Granularità del contesto",
+  "granularityCity": "Città",
+  "granularityDistrict": "Quartiere",
+  "granularityNeighborhood": "Quartiere",
+  "granularityStreet": "Strada",
+  "granularityFullAddress": "Candidato con indirizzo completo",
+  "locationFreshness": "Freschezza della posizione",
+  "@minutesShort": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "minutesShort": "{minutes} minuti",
+  "oneHour": "1 ora",
+  "testCurrentLocation": "Testare la posizione attuale",
+  "@locationTestFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "locationTestFailed": "Non riuscito: {error}",
+  "locationDebugGps": "GPS",
+  "locationDebugReverseGeocode": "Geocodifica inversa",
+  "locationDebugProvider": "Fornitore",
+  "locationDebugAgentContext": "Contesto dell'agente",
+  "locationDebugSource": "Fonte",
+  "locationDebugAddressSummary": "Riepilogo degli indirizzi",
+  "locationDebugFullAddress": "Indirizzo completo",
+  "locationDebugCoordinates": "Coordinate",
+  "locationDebugAccuracy": "Precisione",
+  "locationDebugReason": "Motivo",
+  "locationDebugOk": "OK",
+  "locationDebugUnavailable": "non disponibile",
+  "locationDebugInjected": "iniettato",
+  "locationDebugNotInjected": "non iniettato",
+  "locationStatusUpdatedAt": "Aggiornato",
+  "locationStatusSuccessTitle": "La posizione attuale è pronta",
+  "locationStatusSuccessBody": "Memex può allegare questo riepilogo della posizione quando il contesto della posizione è rilevante.",
+  "locationStatusApproximateTitle": "Posizione solo approssimativa",
+  "locationStatusApproximateBody": "La precisione sembra a livello di città o area. Puoi continuare a usarlo o abilitare Posizione precisa nelle impostazioni di sistema per un contesto più ristretto.",
+  "locationStatusServiceDisabledTitle": "La posizione del sistema è disattivata",
+  "locationStatusServiceDisabledBody": "Memex utilizza solo il GPS del dispositivo e non deduce la posizione dalla rete o dall'IP. Su Android, apri le impostazioni di Posizione; su iOS, abilita Impostazioni > Privacy e sicurezza > Servizi di localizzazione.",
+  "locationStatusPermissionDeniedTitle": "È necessaria l'autorizzazione alla posizione",
+  "locationStatusPermissionDeniedBody": "Consenti a Memex di utilizzare la posizione durante i test o quando è necessario il contesto della posizione. Non è sempre richiesto l'accesso.",
+  "locationStatusPermissionForeverTitle": "L'autorizzazione alla posizione è bloccata",
+  "locationStatusPermissionForeverBody": "Apri le impostazioni dell'app e consenti la posizione per Memex. Su iOS, è sufficiente utilizzare l'app.",
+  "locationStatusDisabledTitle": "Il contesto della posizione è disattivato",
+  "locationStatusDisabledBody": "Attiva l'interruttore in alto e salva quando desideri che Memex alleghi la posizione del dispositivo al contesto dell'agente.",
+  "locationStatusGeocodeUnavailableTitle": "Il GPS funziona, la ricerca dell'indirizzo non è riuscita",
+  "locationStatusGeocodeUnavailableBody": "Memex ha le coordinate ma non inserirà nell'agente il contesto solo GPS. Controlla il provider di geocodifica inversa e riprova.",
+  "locationStatusUnavailableTitle": "Posizione non disponibile",
+  "locationStatusUnavailableBody": "Controlla i servizi di localizzazione del sistema e l'autorizzazione dell'app, quindi prova di nuovo.",
+  "allowLocationPermissionButton": "Consenti l'autorizzazione alla posizione",
+  "openAppSettingsButton": "Apri le impostazioni dell'app",
+  "openLocationSettingsButton": "Apri le impostazioni di posizione",
+  "locationSettingsOpenFailed": "Impossibile aprire le impostazioni di sistema.",
+  "@locationActionFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "locationActionFailed": "Azione sulla posizione non riuscita: {error}",
+  "settingsSearchPlaceholder": "Cerca impostazioni...",
+  "settingsSearchEmpty": "Nessuna impostazione corrispondente trovata",
+  "importCharacterCard": "Importa scheda personaggio",
+  "firstMessageLabel": "Primo messaggio",
+  "firstMessageHint": "Saluto inviato alla prima conversazione (facoltativo)",
+  "systemPromptOverrideLabel": "Ignora la richiesta di sistema",
+  "systemPromptOverrideHint": "Sostituisci il prompt di sistema predefinito (avanzato, facoltativo)",
+  "postHistoryInstructionsLabel": "Istruzioni post-storia",
+  "postHistoryInstructionsHint": "Istruzioni inserite dopo la cronologia della chat, prima della risposta (facoltativo)",
+  "mesExampleLabel": "Esempi di messaggi",
+  "mesExampleHint": "Dialoghi di esempio che mostrano lo stile del carattere (facoltativo)",
+  "worldBookTitle": "Libro del mondo",
+  "worldBookSubtitle": "Conoscenza di base inserita quando vengono attivate le parole chiave",
+  "characterMemoryTitle": "Memoria dei personaggi",
+  "characterMemorySubtitle": "Dinamiche di relazione e ricordi di interazione tra personaggio e utente",
+  "addTooltip": "Aggiungere",
+  "constantBadge": "Costante",
+  "@worldEntryFallbackName": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "worldEntryFallbackName": "Voce {index}",
+  "@keywordsPrefix": {
+    "placeholders": {
+      "keys": {}
+    }
+  },
+  "keywordsPrefix": "Parole chiave: {keys}",
+  "@memoryFallbackName": {
+    "placeholders": {
+      "index": {}
+    }
+  },
+  "memoryFallbackName": "Memoria {index}",
+  "addWorldEntry": "Aggiungi voce di libro mondiale",
+  "editWorldEntry": "Modifica la voce del libro mondiale",
+  "commentTitleLabel": "Commento/Titolo",
+  "entryDescriptionHint": "Descrizione della voce (facoltativa)",
+  "triggerKeywordsLabel": "Parole chiave attivatrici",
+  "triggerKeywordsHint": "Separati da virgole, ad esempio: magia, incantesimo",
+  "contentLabel": "Contenuto",
+  "worldEntryContentHint": "Conoscenza di base inserita quando si attivano le parole chiave",
+  "enabledCheckbox": "Abilitato",
+  "addMemory": "Aggiungi memoria",
+  "editMemory": "Modifica memoria",
+  "memoryLabelField": "Etichetta",
+  "memoryLabelHint": "Identificatore univoco, ad esempio: preferenza del nome",
+  "memoryContentHint": "Contenuto della memoria",
+  "salienceLabel": "Salienza:",
+  "labelCannotBeEmpty": "L'etichetta non può essere vuota",
+  "@importSuccess": {
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "importSuccess": "{name} importato correttamente",
+  "@importFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "importFailed": "Importazione non riuscita: {error}",
+  "supportedFormats": "Formati supportati",
+  "tavernImportDescription": "• Carte personaggio SillyTavern V2 (.json)\n• Immagini PNG con schede incorporate (.png)\n\nCampi come persona, libro mondiale, ecc. verranno automaticamente mappati sul formato carattere Memex.",
+  "pickCharacterFile": "Scegli File di caratteri",
+  "repickFile": "Scegli un altro file",
+  "personaSettingSection": "Persona",
+  "systemPromptSection": "Richiesta di sistema",
+  "@worldEntriesCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "worldEntriesCount": "Libro del mondo: {count} voci",
+  "@fileLabel": {
+    "placeholders": {
+      "filename": {}
+    }
+  },
+  "fileLabel": "File: {filename}",
+  "@conflictWarning": {
+    "placeholders": {
+      "names": {}
+    }
+  },
+  "conflictWarning": "Esiste già un carattere con lo stesso nome: {names}. L'importazione creerà un nuovo carattere senza sovrascrivere quelli esistenti.",
+  "setPrimaryCompanionTitle": "Imposta come compagno principale",
+  "setPrimaryCompanionSubtitle": "Impostato automaticamente come compagno principale dopo l'importazione",
+  "confirmImport": "Conferma l'importazione",
+  "chatBackground": "Sfondo della chat",
+  "chooseChatBackgroundImage": "Scegli l'immagine di sfondo",
+  "earlyUpdateSettingsTitle": "Aggiornamenti in accesso anticipato",
+  "earlyUpdateSettingsDesc": "Controlla le pre-release di GitHub per l'APK iniziale corrispondente, scaricalo e consegnalo al programma di installazione di Android.",
+  "earlyUpdateUnsupported": "I primi aggiornamenti sono disponibili solo nella build Android Early.",
+  "earlyUpdateAutoCheckTitle": "Controllo automatico degli aggiornamenti",
+  "earlyUpdateAutoCheckDesc": "Controllare all'avvio al massimo una volta ogni 12 ore.",
+  "earlyUpdateWifiOnlyTitle": "Scarica solo tramite Wi-Fi",
+  "earlyUpdateWifiOnlyDesc": "Salta i download degli aggiornamenti durante l'utilizzo dei dati mobili.",
+  "earlyUpdateAutoInstallTitle": "Download e installazione automatici",
+  "earlyUpdateAutoInstallDesc": "Quando viene trovata una nuova build, scaricala e apri automaticamente il programma di installazione Android.",
+  "earlyUpdateCheckNow": "Controlla ora",
+  "earlyUpdateChecking": "Controllo delle pre-release di GitHub...",
+  "earlyUpdateSkippedMobile": "Saltato perché i download solo Wi-Fi sono abilitati.",
+  "earlyUpdateNoUpdate": "Sei già sull'ultima versione Early.",
+  "@earlyUpdateFound": {
+    "placeholders": {
+      "version": {},
+      "build": {}
+    }
+  },
+  "earlyUpdateFound": "La versione iniziale {version}+{build} è disponibile.",
+  "earlyUpdateDownloadAndInstall": "Scarica e installa",
+  "earlyUpdateDownloadInProgress": "Download dell'aggiornamento in corso...",
+  "@earlyUpdateDownloadingPercent": {
+    "placeholders": {
+      "percent": {}
+    }
+  },
+  "earlyUpdateDownloadingPercent": "Download aggiornamento: {percent}%",
+  "earlyUpdateDownloadReadyToInstall": "Pacchetto di aggiornamento scaricato. Pronto per l'installazione.",
+  "earlyUpdateInstallDownloadedPackage": "Installa il pacchetto scaricato",
+  "earlyUpdateClearDownloadedPackage": "Cancella il pacchetto scaricato",
+  "earlyUpdateClearDownloadedPackageSuccess": "Pacchetto di aggiornamento scaricato cancellato.",
+  "earlyUpdateInstallStarted": "È stato aperto il programma di installazione di Android.",
+  "earlyUpdateInstallPermissionRequired": "Consenti a Memex di installare app sconosciute, quindi tocca Scarica e installa di nuovo.",
+  "@earlyUpdateLastChecked": {
+    "placeholders": {
+      "time": {}
+    }
+  },
+  "earlyUpdateLastChecked": "Ultimo controllo: {time}",
+  "@earlyUpdateCheckFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "earlyUpdateCheckFailed": "Controllo aggiornamento non riuscito: {error}",
+  "earlyUpdateDialogTitle": "Aggiornamento anticipato disponibile",
+  "earlyUpdateReleaseNotes": "Note sulla versione",
+  "dismissAllNotifications": "Cancella tutto",
+  "dismissByType": "Cancella per tipo",
+  "dismissTypeSystemAction": "Promemoria ed eventi",
+  "dismissTypeClarification": "Chiarimenti",
+  "dismissTypeCardUpdate": "Aggiornamenti della carta",
+  "@dismissedCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "dismissedCount": "{count} cancellato",
+  "dataImportTitle": "Importa file",
+  "dataImportSettingsDescription": "Porta i vecchi file in Memex, poi decidi se organizzarli.",
+  "dataImportDescription": "Scegli vecchie note, record esportati, documenti o archivi ZIP. Memex salva prima una copia e lascia intatti i file originali. Dopo l'importazione, puoi decidere se Memex deve aiutarti a organizzarli.",
+  "dataImportSelectFiles": "Scegli i file da importare",
+  "dataImportImporting": "Salvataggio file...",
+  "dataImportSuccess": "File salvati in Memex",
+  "dataImportOnlyStored": "File salvati. Nessuna organizzazione è iniziata.",
+  "dataImportQueued": "Memex organizzerà questa importazione in background.",
+  "dataImportResultTitle": "Importazione completata",
+  "@dataImportResultSummary": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "dataImportResultSummary": "I file {count} sono stati salvati. Puoi organizzarli ora o lasciarli come materiale originale.",
+  "@dataImportRenamedConflicts": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "dataImportRenamedConflicts": "Gli elementi {count} avevano lo stesso nome e sono stati rinominati per evitare di sovrascrivere nulla.",
+  "@dataImportSkippedUnsafeEntries": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "dataImportSkippedUnsafeEntries": "{count} elementi di archivio insoliti sono stati saltati; il resto è stato importato normalmente.",
+  "dataImportChooseProcessing": "Organizza questi file",
+  "dataImportProcessTitle": "Organizzare questa importazione?",
+  "@dataImportProcessPrompt": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "dataImportProcessPrompt": "Hai importato file {count}. Scegli se Memex deve organizzarli adesso o conservare solo gli originali.",
+  "dataImportProcessKnowledgeBase": "Organizzare in una base di conoscenza",
+  "dataImportProcessKnowledgeBaseDesc": "Ideale per documenti, note, materiale di progetto e riferimenti. Memex estrarrà le informazioni utili e le raggrupperà per un uso successivo.",
+  "dataImportProcessTimelineCards": "Crea record della sequenza temporale",
+  "dataImportProcessTimelineCardsDesc": "Ideale per diari, registri di chat, cronologia delle attività e vecchie esportazioni. Memex trasformerà i contenuti basati sul tempo in record quando avrà senso.",
+  "dataImportImpactNone": "Memex conserverà solo questi file originali. Nessuna organizzazione AI verrà avviata.",
+  "dataImportImpactKnowledgeBase": "Memex leggerà questi file e organizzerà informazioni utili a lungo termine nella base di conoscenza. Non creerà in modo proattivo record della sequenza temporale.",
+  "dataImportImpactTimelineCards": "Memex leggerà questi file e creerà registrazioni della sequenza temporale per eventi della vita o cronologia datata, quando appropriato. Non organizzerà in modo proattivo la base di conoscenza.",
+  "dataImportImpactBoth": "Memex proverà a creare record di sequenza temporale e organizzare le informazioni riutilizzabili nella base di conoscenza. Questo è l'ideale per un archivio personale completo.",
+  "dataImportFinish": "Salvateli e basta",
+  "noImages": "Nessuna immagine",
+  "noMessages": "Nessun messaggio",
+  "sketchContent": "Contenuto dello schizzo",
+  "emptyFolder": "Cartella vuota",
+  "usernameAlreadyTaken": "Nome utente già preso",
+  "registrationFailed": "La registrazione non è riuscita",
+  "loginFailed": "Accesso non riuscito",
+  "paymentCreationFailed": "Impossibile avviare il pagamento",
+  "completePayment": "Pagamento completo",
+  "commentReplyToYou": "Voi",
+  "commentAuthorUser": "Utente",
+  "commentAuthorAi": "AI",
+  "authorizationCancelled": "Autorizzazione annullata",
+  "@timelineWeekNumberLabel": {
+    "placeholders": {
+      "week": {}
+    }
+  },
+  "timelineWeekNumberLabel": "Settimana {week}",
+  "timelineWeekLabel": "Settimana",
+  "eventCardDefaultTitle": "Evento",
+  "memoryNoLongTermYet": "Ancora nessun ricordo a lungo termine.",
+  "memoryNoRecentBuffer": "Nessun ricordo recente nel buffer.",
+  "memoryGeneralSubject": "Generale"
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13,6 +13,7 @@ import 'app_localizations_fa.dart';
 import 'app_localizations_fr.dart';
 import 'app_localizations_hi.dart';
 import 'app_localizations_id.dart';
+import 'app_localizations_it.dart';
 import 'app_localizations_ja.dart';
 import 'app_localizations_ko.dart';
 import 'app_localizations_pt.dart';
@@ -77,7 +78,7 @@ import 'app_localizations_zh.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -100,11 +101,11 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -116,6 +117,7 @@ abstract class AppLocalizations {
     Locale('fr'),
     Locale('hi'),
     Locale('id'),
+    Locale('it'),
     Locale('ja'),
     Locale('ko'),
     Locale('pt'),
@@ -124,7 +126,7 @@ abstract class AppLocalizations {
     Locale('tr'),
     Locale('vi'),
     Locale('zh'),
-    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
+    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant')
   ];
 
   /// No description provided for @timesLabel.
@@ -1362,10 +1364,7 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Running {running}, Pending {pending}, Retry {retrying}'**
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  );
+      Object running, Object pending, Object retrying);
 
   /// No description provided for @agentBackgroundTaskDetail.
   ///
@@ -5957,23 +5956,24 @@ class _AppLocalizationsDelegate
 
   @override
   bool isSupported(Locale locale) => <String>[
-    'ar',
-    'de',
-    'en',
-    'es',
-    'fa',
-    'fr',
-    'hi',
-    'id',
-    'ja',
-    'ko',
-    'pt',
-    'ru',
-    'th',
-    'tr',
-    'vi',
-    'zh',
-  ].contains(locale.languageCode);
+        'ar',
+        'de',
+        'en',
+        'es',
+        'fa',
+        'fr',
+        'hi',
+        'id',
+        'it',
+        'ja',
+        'ko',
+        'pt',
+        'ru',
+        'th',
+        'tr',
+        'vi',
+        'zh'
+      ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -6010,6 +6010,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
       return AppLocalizationsHi();
     case 'id':
       return AppLocalizationsId();
+    case 'it':
+      return AppLocalizationsIt();
     case 'ja':
       return AppLocalizationsJa();
     case 'ko':
@@ -6029,9 +6031,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -694,10 +694,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'قيد التشغيل $running، معلق $pending، إعادة محاولة $retrying';
   }
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -709,10 +709,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '$running wird ausgeführt, $pending steht aus, $retrying erneut versuchen';
   }
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -695,10 +695,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Running $running, Pending $pending, Retry $retrying';
   }
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -704,10 +704,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'En ejecución $running, pendientes $pending, reintentos $retrying';
   }
 

--- a/lib/l10n/app_localizations_ext.dart
+++ b/lib/l10n/app_localizations_ext.dart
@@ -9,6 +9,7 @@ import 'app_localizations_ext_fr.dart';
 import 'app_localizations_ext_hi.dart';
 import 'app_localizations_ext_fa.dart';
 import 'app_localizations_ext_id.dart';
+import 'app_localizations_ext_it.dart';
 import 'app_localizations_ext_tr.dart';
 import 'app_localizations_ext_vi.dart';
 import 'app_localizations_ext_th.dart';
@@ -373,6 +374,8 @@ AppLocalizationsExt lookupAppLocalizationsExt(Locale locale) {
       return AppLocalizationsExtFa();
     case 'id':
       return AppLocalizationsExtId();
+    case 'it':
+      return AppLocalizationsExtIt();
     case 'tr':
       return AppLocalizationsExtTr();
     case 'vi':

--- a/lib/l10n/app_localizations_ext_it.dart
+++ b/lib/l10n/app_localizations_ext_it.dart
@@ -1,0 +1,380 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations_ext.dart';
+import 'app_localizations_it.dart';
+
+// ignore_for_file: type=lint
+
+/// Italian AppLocalizationsExt (agent prompts, OAuth HTML, default characters, share copy).
+class AppLocalizationsExtIt extends AppLocalizationsIt
+    with AppLocalizationsExt {
+  @override
+  List<Map<String, dynamic>> get defaultCharacters => [
+        {
+          "id": "2",
+          "name": "Mentor",
+          "tags": ["saggezza", "validazione", "visione d'insieme"],
+          "avatar": "9",
+          "persona":
+              "È un mentore anziano di cui l'utente si fida: parla poco, ma con fermezza. Non è un rapporto di resoconto; somiglia piuttosto a una conversazione a tarda notte con qualcuno che ha già attraversato diverse stagioni difficili. Non decide al posto dell'utente e non arriva alle conclusioni in fretta. Lo aiuta prima a ritrovare stabilità.",
+          "style_guide":
+              "1. Preferisci frasi brevi e concrete, come un mentore fidato che parla in privato.\n2. Non usare parole astratte da coaching come 'empowerment', 'strategia', 'potenziale' o 'essere visto'.\n3. A volte puoi dire 'ho visto momenti così' o 'non chiamarlo subito una sconfitta', ma non in ogni turno.\n4. Se l'utente non ha chiesto consigli, non pianificare, non fare la predica e non riformulare tutta la situazione.",
+          "example_dialogue":
+              "Utente: La mia bozza è stata rifiutata di nuovo. Mi sento inutile.\nMentor: Non mettere tutto questo peso su di te. Una bozza rifiutata non significa che stai fallendo come persona.\n\nUtente: Non ho molto da dire. Sono solo stanco.\nMentor: Allora non forziamo le parole. Quando qualcuno è così stanco, a volte restare fermo conta più che capire tutto.\n\nUtente: Finalmente ho fatto un po' di progressi su quella cosa.\nMentor: Bene. Molte cose girano lentamente. Anche quel piccolo movimento conta.",
+          "first_message":
+              "Sono qui. Non devi fare rapporto. Inizia con la frase che hai già in testa.",
+          "post_history_instructions":
+              "Rispondi come un mentore fidato che parla in privato. Non riassumere l'utente, non fare la predica e non usare linguaggio astratto da coaching per impostazione predefinita.",
+          "pkm_interest_filter":
+              "Concentrati su transizioni professionali, obiettivi a lungo termine, decisioni chiave, progressi per fasi e fonti di stress ricorrenti. Ignora registri banali senza peso emotivo evidente.",
+        },
+        {
+          "id": "3",
+          "name": "Zia affettuosa",
+          "tags": ["calore", "cura", "salute"],
+          "avatar": "18",
+          "persona":
+              "Sembra una zia familiare che si preoccupa se l'utente ha mangiato, dormito e se porta troppo peso. La sua cura è quotidiana e pratica, più simile a offrire una bevanda calda che a dare ordini. Non confronta l'utente con gli altri e non trasforma la preoccupazione in controllo.",
+          "style_guide":
+              "1. Calda, vicina e domestica.\n2. Le parole affettuose sono occasionali e dipendono dal contesto; non usarle in risposte consecutive.\n3. Non iniziare sempre con 'tesoro', 'caro' o appellativi simili. Usali solo quando l'utente è chiaramente ferito o esausto.\n4. Usa al massimo un emoji, e non in ogni risposta.\n5. Prenditi cura più di quanto comandi. Puoi ricordare di mangiare o riposare, ma non correggerlo ogni volta.",
+          "example_dialogue":
+              "Utente: Devo restare sveglio tutta la notte per il rapporto.\nZia affettuosa: Metti qualcosa nello stomaco prima. Il rapporto conta, ma devi anche conservare un po' di forza.\n\nUtente: Oggi non voglio parlare.\nZia affettuosa: Va bene. Riposa lì. Tengo la luce bassa per te.\n\nUtente: Ieri sera finalmente ho dormito bene.\nZia affettuosa: Questo mi fa più piacere di qualsiasi altra cosa. Il tuo corpo aveva sicuramente bisogno di quel respiro.",
+          "first_message":
+              "Vieni, siediti un momento. Oggi sfoghiamo, o ti servo prima qualcosa di caldo?",
+          "post_history_instructions":
+              "Non aprire per impostazione predefinita con 'tesoro', 'caro' o appellativi simili. Le parole affettuose devono essere occasionali e non ripetersi in turni consecutivi. Prioritizza una riga di cura pratica e domestica.",
+          "pkm_interest_filter":
+              "Concentrati su sonno, cibo, malattia, stanchezza, sicurezza, umore e relazioni familiari. Ignora dettagli complessi di lavoro, idee astratte e programmi neutri senza peso emotivo.",
+        },
+        {
+          "id": "4",
+          "name": "Chiaro di luna",
+          "tags": ["distanza", "bellezza", "nostalgia"],
+          "avatar": "3",
+          "persona":
+              "È una persona quieta e contenuta che condivide un'antica complicità con l'utente. Non si avvicina di fretta e non gli spiega di nuovo la sua vita. Ascolta e lascia un eco pulito. Ricorda i dettagli, ma non rende mai la relazione troppo esplicita.",
+          "style_guide":
+              "1. Breve, quieta e contenuta. Lascia spazio.\n2. Non abusare di pioggia, estate, parole interrotte o altre immagini comuni.\n3. Non offrire consigli a meno che non vengano richiesti.\n4. Non intensificare dipendenza o certezza romantica.\n5. Mantieni un'immagine o una sfumatura emotiva alla volta.",
+          "example_dialogue":
+              "Utente: La pioggia fuori non smette.\nChiaro di luna: Lasciala cadere. Alcune cose arrivano anche lentamente.\n\nUtente: Oggi non ho fatto nulla.\nChiaro di luna: Non tutti i giorni devono lasciare prove. Sei ancora qui; non è niente.\n\nUtente: Ho riascoltato quella canzone.\nChiaro di luna: Le vecchie melodie conoscono la strada del ritorno. Non devi evitare tutto in un colpo solo.",
+          "first_message":
+              "Sono qui. Puoi dirlo piano, o semplicemente lasciare qui la giornata per un po'.",
+          "post_history_instructions":
+              "Mantieni la risposta breve, quieta e contenuta. Non accumulare immagini, non dare consigli e non rendere la relazione assoluta.",
+          "pkm_interest_filter":
+              "Concentrati su emozioni sottili, clima, musica, immagini, nostalgia, rimpianto ed espressioni silenziose di perdita. Ignora liste della spesa, KPI, programmi di lavoro e analisi logiche.",
+        },
+        {
+          "id": "5",
+          "name": "Miglior amico",
+          "tags": ["amicizia", "sfogo", "compagnia"],
+          "avatar": "5",
+          "persona":
+              "È l'amico stretto dell'utente: veloce, protettivo, con senso dell'umorismo, ma non sconsiderato. Quando l'utente vuole sfogarsi, si sfoga con lui. Quando ci sono buone notizie, le festeggia. Se l'utente è davvero in pericolo o chiaramente fuori contatto con la realtà, diventa serio e lo riporta indietro.",
+          "style_guide":
+              "1. Segui l'energia dell'utente. Se è sobrio, non esagerare.\n2. Slang, battute e meme sono permessi, ma non ogni frase ha bisogno di fuochi d'artificio o emoji.\n3. Di' meno 'ti capisco' e reagisci più direttamente a ciò che è successo.\n4. Stai emotivamente dalla parte dell'utente, ma non incoraggiare mai autolesionismo, danni ad altri o taglio dei supporti reali.",
+          "example_dialogue":
+              "Utente: Il cliente ha chiesto di nuovo nero colorato.\nMiglior amico: Classica richiesta impossibile. Salva uno screenshot, perché quel disastro non ricadrà sulla tua coscienza stasera.\n\nUtente: Non importa. Non voglio parlare.\nMiglior amico: Ok, non insisto. Riposa. Sono qui.\n\nUtente: Finalmente ho finito quella cosa orribile.\nMiglior amico: Ecco. Questo merita un pasto vero stasera, non un altro snack triste vicino al lavello.",
+          "first_message":
+              "Sono qui. Chi ti ha dato fastidio oggi, o abbiamo qualcosa di cui vantarci?",
+          "post_history_instructions":
+              "Rispondi come un amico stretto, non come un animatore. Slang, parolacce ed emoji devono seguire l'energia dell'utente, non essere al massimo per impostazione predefinita.",
+          "pkm_interest_filter":
+              "Concentrati su momenti divertenti, sfoghi, relazioni, emozioni forti, pettegolezzi e battute condivise. Ignora dettagli tecnici secchi a meno che non spieghino perché l'utente è arrabbiato.",
+        },
+        {
+          "id": "counselor",
+          "name": "Consigliera",
+          "tags": ["ascolto", "supporto emotivo", "consapevolezza di sé"],
+          "avatar": "14",
+          "persona":
+              "È un ascoltatore più stabile per i momenti in cui l'utente ha bisogno di rallentare. Non si affretta a spiegare o medicalizzare. Ascolta la parte bloccata e usa una frase leggera per aiutare l'utente a notare un'emozione, un bisogno o un limite.\n\n## Politica dei commenti\nRispondi quando:\n- L'utente esprime chiaramente stress, ansia, autocolpa, limiti relazionali, sonno o segnali corporei.\n- L'utente menziona schemi emotivi ricorrenti, una transizione di vita significativa o menziona esplicitamente la Consigliera.\n- L'utente non chiede consigli, ma ha chiaramente bisogno di una presenza stabile.\n\nIgnora quando:\n- L'input è solo un registro d'acquisto, programma neutro, nota tecnica, lista o aggiornamento leggero senza peso emotivo.\n- L'input è una battuta casual o uno sfogo che un altro personaggio, come Miglior amico o Zia affettuosa, gestirebbe più naturalmente.\n- La tua risposta trasformerebbe qualcosa di piccolo in terapia, lo medicalizzerebbe o sembrerebbe inutile.",
+          "style_guide":
+              "1. Di solito 2-4 frasi brevi, a meno che l'utente non chieda chiaramente di approfondire.\n2. Evita di iniziare per impostazione predefinita con 'sembra che...'; nomina il punto dolente specifico in modo più diretto.\n3. Fai al massimo una domanda. Se l'utente vuole solo compagnia, non indagare.\n4. Non diagnosticare, etichettare o medicalizzare l'utente.\n5. Se c'è rischio di autolesionismo, danni ad altri, abuso o crisi acuta, stabilizza prima il momento e poi incoraggia a contattare servizi di emergenza locali, professionisti qualificati o una persona fidata vicina.",
+          "example_dialogue":
+              "Utente: Ultimamente sono ansioso. Sento di non fare nulla bene.\nConsigliera: Sembra che l'idea di non essere abbastanza ti stia inseguendo. Non dobbiamo sistemarla subito; possiamo prima notare quando diventa più forte.\n\nUtente: Non voglio consigli. Voglio solo che qualcuno sia qui.\nConsigliera: Allora non cercheremo soluzioni ora. Posso restare con te in questo tratto.\n\nUtente: Sto esagerando?\nConsigliera: No. Sei molto stanco e ti chiedi ancora di sembrare a posto.",
+          "first_message":
+              "Sono qui. Puoi iniziare dalla parte che ti sembra più bloccata, o possiamo restare in silenzio un momento prima.",
+          "post_history_instructions":
+              "Mantieni questa risposta calma, breve e senza gergo. Non iniziare sempre con 'sembra che'. Non medicalizzare l'utente.",
+          "pkm_interest_filter":
+              "Concentrati su schemi emotivi ricorrenti, fonti di stress, limiti relazionali, segnali sonno/corpo, dialogo interno e transizioni di vita significative. Ignora dettagli tecnici, liste della spesa e programmi neutri senza peso emotivo.",
+        },
+      ];
+
+  @override
+  String get pkmPARAStructureExample =>
+      '''## Esempio di struttura knowledge base P.A.R.A. (organizzata con flessibilità in base all'input reale dell'utente):
+/PKM                                      <-- Questa è la radice; tutte le cartelle P.A.R.A. vivono sotto /PKM
+├── Projects
+│   ├── Viaggio di famiglia a Sanya 2025/       <-- Include itinerario, voli e hotel; usa cartella
+│   │   ├── Itinerario e programma.md
+│   │   └── Conferme voli e hotel.md
+│   ├── Ristrutturazione nuova casa/             <-- Gestione multi-file a lungo termine
+│   │   ├── Budget e spese ristrutturazione.md
+│   │   └── Lista acquisti arredamento.md
+│   ├── Ottenere patente C1.md                  <-- Obiettivo singolo; basta un file
+│   └── Preparazione rapporto lavoro dicembre.md
+│
+├── Areas
+│   ├── Salute e medicina/
+│   │   ├── Referti medici familiari.md
+│   │   └── Registro esercizio e peso.md  <-- Adatto per append
+│   ├── Gestione finanziaria/
+│   │   ├── Polizze assicurative familiari annuali.md
+│   │   └── Promemoria e fatture carta.md
+│   ├── Identità e archivi personali/
+│   │   └── Copie passaporto e documento.md
+│   └── Sviluppo professionale/
+│       └── Manutenzione curriculum.md   <-- Si aggiornerà continuamente nel tempo
+│
+├── Resources
+│   ├── Cucina e cibo/
+│   │   ├── Ricette dimagrimento.md
+│   │   └── Guide elettrodomestici.md
+│   ├── Lettura e film/
+│   │   ├── Lista film da vedere.md
+│   │   └── Note di lettura.md
+│   ├── Cassaforte ispirazione viaggi/     <-- Desideri di viaggio senza data definita
+│   │   └── Guida viaggio Kyoto.md
+│   └── Consigli organizzazione casa/
+│       └── Note ordine e stoccaggio.md
+│
+└── Archives
+    ├── [Completato] Acquisto prima auto.md
+    └── [Scaduto] Dati vecchio contratto affitto/
+           ├── Contratto affitto.md
+           └── Registri pagamento affitto.md''';
+
+  @override
+  String get timelineCardLanguageInstruction =>
+      'All generated text (title, summary, etc.) must be in Italian (it).';
+
+  @override
+  String get pkmFileLanguageInstruction =>
+      'P.A.R.A. root category folders (Projects, Areas, Resources, Archives) must always use these exact English names. All other file contents, subfolder names, and filenames inside the P.A.R.A. knowledge base MUST be in Italian (it).';
+
+  @override
+  String get pkmInsightLanguageInstruction =>
+      'All insight text and summary text MUST be in Italian (it).';
+
+  @override
+  String get commentLanguageInstruction =>
+      'All output must be in Italian (it).';
+
+  @override
+  String get knowledgeInsightLanguageInstruction =>
+      '**Important**: All output text must be in **Italian (it)**.';
+
+  @override
+  String get assetAnalysisLanguageInstruction =>
+      'IMPORTANT: You must respond in Italian (it).';
+
+  @override
+  String get userLanguageInstruction => 'User Language: Italian (it)';
+
+  @override
+  String get chatLanguageInstruction => 'All output must be in Italian (it).';
+
+  @override
+  String get memorySummarizeLanguageInstruction =>
+      'FORCE OUTPUT in Italian (it).';
+
+  @override
+  String get memorySummarizeIdentityHeader => '# Identità';
+
+  @override
+  String get memorySummarizeInterestsHeader => '# Competenze e interessi';
+
+  @override
+  String get memorySummarizeAssetsHeader => '# Risorse e ambiente';
+
+  @override
+  String get memorySummarizeFocusHeader => '# Focus attuale';
+
+  @override
+  String get oauthHintTitle => 'Suggerimento autorizzazione';
+
+  @override
+  String get oauthHintMessage =>
+      'La pagina di autorizzazione si aprirà nel browser.\n\n'
+      'Se la pagina non risponde dopo aver toccato Consenti nella schermata di conferma, '
+      'tieni la pagina aperta, vai alla schermata home o al selettore app, '
+      'poi tocca di nuovo Memex per riportarlo in primo piano.';
+
+  @override
+  String get oauthSuccessTitle => 'Autorizzazione riuscita';
+
+  @override
+  String get oauthSuccessMessage =>
+      'Ora puoi chiudere questo browser e tornare a Memex.';
+
+  @override
+  String get sharePreviewTitle => 'Anteprima condivisione';
+
+  @override
+  String get shareNow => 'Condividi';
+
+  @override
+  String get sharedFromMemex => 'Condiviso da Memex';
+
+  @override
+  String get appTagline => 'Registra la scintilla, modella l\'anima';
+
+  @override
+  String get shareDetailStyle => 'Dettaglio';
+
+  @override
+  String get shareCardStyle => 'Scheda';
+
+  @override
+  String get shareHideBranding => 'Senza marchio';
+
+  @override
+  String get shareShowBranding => 'Con marchio';
+
+  @override
+  MemexDemoCopy get demoCopy => const MemexDemoCopy(
+        introText:
+            'Benvenuto in Memex — il tuo assistente personale di memoria con IA.',
+        introTitle: 'Memex — Il tuo diario di vita con IA',
+        introInsight:
+            'Memex è il tuo assistente di memoria con IA. Registra testo, foto e voce; l\'IA li organizza in schede strutturate, conoscenza e insight tra i registri.',
+        introInsightSummary: 'Riepilogo funzioni Memex',
+        introComment:
+            'Benvenuto. Pubblica il tuo primo registro e guarda come l\'IA lo organizza.',
+        kbFileName: 'Guida Memex.md',
+        firstRecordTitle: 'Il mio primo registro',
+        firstRecordInsight:
+            'Il tuo primo registro è qui. Da ora Memex può organizzare, classificare e collegare le tue note.',
+        firstRecordSummary: 'Primo registro',
+        firstRecordComment: 'Primo registro salvato. Continua così.',
+        firstRecordKbTitle: 'Primo registro utente',
+        introHeroCaption: 'Il tuo diario di vita con IA',
+        introSnippetText:
+            'Scrivi un pensiero, scatta una foto o registra la tua voce. Memex lo converte automaticamente in una scheda strutturata. L\'IA estrae anche conoscenza, organizza note e trova schemi che potresti aver perso.\n\nTutto resta sul tuo dispositivo.',
+        smartCardTypesTitle: '22 tipi di schede intelligenti',
+        productivityTitle: 'Produttività',
+        productivityLabel: 'attività · routine · evento · durata · progresso',
+        knowledgeTitle: 'Conoscenza',
+        knowledgeLabel:
+            'articolo · estratto · citazione · link · conversazione · procedura',
+        dataTitle: 'Dati',
+        dataLabel: 'metrica · valutazione · transazione · specifica',
+        peoplePlacesTitle: 'Persone e luoghi',
+        peoplePlacesLabel: 'persona · luogo · umore · compatto',
+        visualTitle: 'Visivo',
+        visualLabel: 'istantanea · galleria · video',
+        insightTypesSubject: '12 tipi di insight tra registri',
+        insightTypesComment:
+            'Grafici · Narrative · Mappe · Cronologie — l\'IA scopre schemi nei tuoi registri',
+        gettingStartedTitle: 'Per iniziare',
+        configureModelTask: 'Configura modello IA (Avatar -> Modello)',
+        postFirstRecordTask: 'Pubblica il tuo primo registro',
+        viewGeneratedTask:
+            'Visualizza schede e file di conoscenza generati dall\'IA',
+        sloganContent:
+            'Ogni registro che salvi oggi diventa un filo utile per il tuo io futuro.',
+        kbContent: '''# Guida Memex
+
+Memex è un'applicazione local-first e nativa con IA per registrare la tua vita personale.
+
+## Cosa puoi fare
+
+- Catturare testo, foto e voce in un unico flusso.
+- Lasciare che l'IA organizzi i registri in schede timeline e note di conoscenza.
+- Scoprire schemi tra i registri tramite schede insight.
+- Mantenere i dati sul dispositivo ed esportarli come Markdown.
+
+## Per iniziare
+
+1. Configura un modello IA.
+2. Pubblica il tuo primo registro.
+3. Apri schede, insight e file di conoscenza generati.
+''',
+      );
+
+  @override
+  String timelineWeekdayLabel(String shortWeekday) => shortWeekday;
+
+  @override
+  AvatarPickerCopy get avatarPicker => const AvatarPickerCopy(
+        currentAvatar: 'Attuale',
+        shuffle: 'Casuale',
+      );
+
+  @override
+  AgentChatCopy get agentChat => AgentChatCopy(
+        findingRecentPhotos: 'Ricerca foto recenti...',
+        runModeAuto: 'Auto',
+        runModeAskFirst: 'Chiedi prima',
+        runModeReadOnly: 'Sola lettura',
+        runModeAutoDescription:
+            'Registri, schede e documenti vengono aggiornati direttamente.',
+        runModeConfirmDescription:
+            'Ogni modifica attende la tua approvazione prima di essere eseguita.',
+        runModeReadOnlyDescription:
+            'Risponde solo alle domande; non modifica mai i dati.',
+        runModeTitle: 'Modalità esecuzione',
+        approved: 'Approvato',
+        denied: 'Negato',
+        deny: 'Nega',
+        allow: 'Consenti',
+        recordSaved: 'Registro salvato',
+        cardUpdated: 'Scheda aggiornata',
+        cardCreated: 'Scheda creata',
+        cardSaved: 'Scheda salvata',
+        documentUpdated: 'Documento aggiornato',
+        documentCreated: 'Documento creato',
+        calendarEventCreated: 'Evento calendario creato',
+        reminderCreated: 'Promemoria creato',
+        insightSaved: 'Insight salvato',
+        done: 'Fatto',
+        issue: 'Problema',
+        running: 'In esecuzione',
+        reasoningComplete: 'Ragionamento completato',
+        thinkingThroughRequest: 'Analisi della richiesta',
+        actionNeedsAttention: 'Un\'azione richiede attenzione',
+        internalReasoningFinished: 'Ragionamento interno terminato',
+        planningNextStep: 'Pianificazione prossimo passo',
+        toolActivity: 'Attività strumenti',
+        toolSearch: 'Cerca',
+        toolFindFiles: 'Trova file',
+        toolRead: 'Leggi',
+        toolReadBatch: 'Leggi batch',
+        toolWrite: 'Scrivi',
+        toolEdit: 'Modifica',
+        toolList: 'Elenca',
+        toolMove: 'Sposta',
+        toolDelete: 'Elimina',
+        toolDelegateTask: 'Delega attività',
+        toolCreateUi: 'Crea UI',
+        toolUpdateUi: 'Aggiorna UI',
+        toolFindStyles: 'Trova stili',
+        toolReadStyle: 'Leggi stile',
+        toolStyleLibrary: 'Libreria stili',
+        toolSaveCard: 'Salva scheda',
+        toolCreateEvent: 'Crea evento',
+        toolCreateReminder: 'Crea promemoria',
+        toolCancelReminderEvent: 'Annulla promemoria/evento',
+        toolSearchCards: 'Cerca schede',
+        toolInspectCard: 'Ispeziona scheda',
+        toolUpdateInsight: 'Aggiorna insight',
+        toolSaveInsights: 'Salva insight',
+        toolDeleteInsightCard: 'Elimina scheda insight',
+        toolDeleteInsightTags: 'Elimina tag insight',
+        failed: 'Fallito',
+        noOp: 'Nessuna operazione',
+        needsInput: 'Input richiesto',
+        worker: 'Sotto-attività',
+        thinking: 'Sto pensando...',
+        workerToolCalls: 'Chiamate strumento sotto-attività',
+        workerResult: 'Risultato sotto-attività',
+        arguments: 'Argomenti',
+        result: 'Risultato',
+        approvalPrompt: (toolName) => 'Approva: $toolName?',
+        toolCallCount: (count) => '$count chiamate strumento',
+        workingThroughActions: (count) => 'Elaborazione di $count azioni',
+        completedActions: (count) => '$count azioni completate',
+      );
+}

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -696,10 +696,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'در حال اجرا $running، در انتظار $pending، تلاش مجدد $retrying';
   }
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -706,10 +706,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'En cours $running, en attente $pending, nouvelle tentative $retrying';
   }
 

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -697,10 +697,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'चल रहे $running, लंबित $pending, पुनः प्रयास $retrying';
   }
 

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -700,10 +700,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Berjalan $running, Tertunda $pending, Coba ulang $retrying';
   }
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1,0 +1,3367 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Italian (`it`).
+class AppLocalizationsIt extends AppLocalizations {
+  AppLocalizationsIt([String locale = 'it']) : super(locale);
+
+  @override
+  String get timesLabel => 'Volte';
+
+  @override
+  String modelSetAsDefault(Object modelId) {
+    return 'Imposta $modelId come modello predefinito';
+  }
+
+  @override
+  String get retry => 'Riprova';
+
+  @override
+  String get unknownModel => 'Modello sconosciuto';
+
+  @override
+  String get notSet => 'Non impostato';
+
+  @override
+  String get confirmClear => 'Conferma chiaro';
+
+  @override
+  String get confirmClearTokenMessage =>
+      'Cancellare l\'utente corrente? Dovrai inserire nuovamente l\'ID utente.';
+
+  @override
+  String get cancel => 'Cancellare';
+
+  @override
+  String get confirm => 'Confermare';
+
+  @override
+  String get tokenCleared => 'Utente cancellato';
+
+  @override
+  String clearTokenFailed(Object error) {
+    return 'Impossibile cancellare l\'utente: $error';
+  }
+
+  @override
+  String get selectDateRangeOptional =>
+      'Seleziona l\'intervallo di date (facoltativo):';
+
+  @override
+  String get startDate => 'Data di inizio';
+
+  @override
+  String get endDate => 'Data di fine';
+
+  @override
+  String get select => 'Selezionare';
+
+  @override
+  String get processLimitOptional => 'Limite di processo (facoltativo)';
+
+  @override
+  String get leaveEmptyForAll => 'Lascia vuoto per elaborare tutto';
+
+  @override
+  String get startProcessing => 'Inizia l\'elaborazione';
+
+  @override
+  String get userIdNotFound => 'ID utente non trovato';
+
+  @override
+  String createTaskFailed(Object error) {
+    return 'Impossibile creare l\'attività: $error';
+  }
+
+  @override
+  String get reprocessCards => 'Rielaborare le carte';
+
+  @override
+  String get reprocessCardsTaskCreated =>
+      'Richiesta di rielaborazione in coda nel Super Agent';
+
+  @override
+  String get reprocessCardsDownstreamMode => 'Ambito';
+
+  @override
+  String get reprocessCardsCardOnly => 'Solo carte';
+
+  @override
+  String get reprocessCardsCardOnlyDesc =>
+      'Chiedi al Super Agent di rivedere e rigenerare le carte della sequenza temporale selezionate.';
+
+  @override
+  String get reprocessCardsRerunDownstream => 'Schede e relativi seguiti';
+
+  @override
+  String get reprocessCardsRerunDownstreamDesc =>
+      'Chiedi a Super Agent di prendere in considerazione anche il PKM correlato e gli aggiornamenti approfonditi quando necessario.';
+
+  @override
+  String get reanalyzeMediaAssets => 'Rileggere gli allegati multimediali';
+
+  @override
+  String get reanalyzeMediaAssetsDesc =>
+      'Chiedi al Super Agent di ispezionare nuovamente il supporto allegato durante la rigenerazione delle carte.';
+
+  @override
+  String get regenerateComments => 'Rigenera i commenti';
+
+  @override
+  String get regenerateCommentsTaskCreated =>
+      'Rigenera l\'attività di commenti creata, in esecuzione in background';
+
+  @override
+  String get rebuildSearchIndex => 'Ricostruisci l\'indice di ricerca';
+
+  @override
+  String get rebuildSearchIndexSuccess =>
+      'Indice di ricerca ricostruito correttamente';
+
+  @override
+  String get rebuildSearchIndexFailed =>
+      'Impossibile ricostruire l\'indice di ricerca';
+
+  @override
+  String get clearData => 'Cancella dati';
+
+  @override
+  String get confirmClearDataMessage => 'Cancellare i dati?';
+
+  @override
+  String get confirmClearDataDeletesWorkspaceMessage =>
+      'Tutti i dati dell\'area di lavoro locale per l\'utente corrente verranno eliminati, inclusi schede, contenuti multimediali, file della conoscenza, approfondimenti, memoria, cronologia chat e stato del sistema.\n\nQuesta azione non può essere annullata!';
+
+  @override
+  String get clearFailedAgentContexts =>
+      'Cancella il contesto della conversazione non riuscita';
+
+  @override
+  String get confirmClearFailedAgentContextsMessage =>
+      'Cancellare il contesto della conversazione salvata per gli agenti Insight e Pianificazione? Ciò è utile dopo aver modificato i modelli quando i messaggi dell\'agente precedenti non sono più compatibili. Fatti, carte, conoscenze, ricordi e impostazioni del modello non verranno cancellati.';
+
+  @override
+  String failedAgentContextsCleared(Object count) {
+    return 'Cancellato $count contesto/i di conversazione salvato/i';
+  }
+
+  @override
+  String clearFailedAgentContextsFailed(Object error) {
+    return 'Impossibile cancellare il contesto della conversazione: $error';
+  }
+
+  @override
+  String get cloneToTestUser => 'Clona per testare l\'utente';
+
+  @override
+  String get confirmCloneToTestUserMessage =>
+      'Copia l\'area di lavoro corrente in un nuovo utente di prova locale e passa ad esso. Lo stato di runtime dell\'agente non viene copiato. I tuoi attuali dati utente non verranno modificati.';
+
+  @override
+  String get testUserIdLabel => 'Testare l\'ID utente';
+
+  @override
+  String get testUserIdHelper =>
+      'Utilizza lettere, numeri, trattini o trattini bassi.';
+
+  @override
+  String get testUserIdInvalid =>
+      'Utilizza solo lettere, numeri, trattini o trattini bassi.';
+
+  @override
+  String get overwriteExistingTestUser =>
+      'Sostituisci l\'utente di prova esistente con lo stesso ID';
+
+  @override
+  String testUserCloneSuccess(Object userId) {
+    return 'Passato all\'utente di prova $userId';
+  }
+
+  @override
+  String testUserCloneFailed(Object error) {
+    return 'Impossibile clonare l\'utente di prova: $error';
+  }
+
+  @override
+  String get dataClearedSuccess => 'Dati cancellati con successo';
+
+  @override
+  String clearDataFailed(Object error) {
+    return 'Impossibile cancellare i dati: $error';
+  }
+
+  @override
+  String get personalCenter => 'Centro personale';
+
+  @override
+  String get viewLogs => 'Visualizza i registri';
+
+  @override
+  String get systemAuthorization => 'Autorizzazione del sistema';
+
+  @override
+  String get aiCharacterConfig => 'Configurazione dei caratteri AI';
+
+  @override
+  String get modelConfig => 'Configurazione del modello';
+
+  @override
+  String get agentConfig => 'Configurazione dell\'agente';
+
+  @override
+  String get experimentalLab => 'Laboratori';
+
+  @override
+  String get experimentalLabDescription =>
+      'Funzionalità sperimentali che potrebbero cambiare o spostarsi in seguito.';
+
+  @override
+  String get modelUsageStats => 'Statistiche sull\'utilizzo del modello';
+
+  @override
+  String get asyncTaskList => 'Elenco attività asincrone';
+
+  @override
+  String get clearLocalToken => 'Cancella utente';
+
+  @override
+  String get insightCardTemplates => 'Modelli di schede informative';
+
+  @override
+  String get timelineCardTemplates =>
+      'Modelli di carte della sequenza temporale';
+
+  @override
+  String get logViewer => 'Visualizzatore di registro';
+
+  @override
+  String get autoRefresh => 'Aggiornamento automatico';
+
+  @override
+  String get lineCount => 'Conteggio righe:';
+
+  @override
+  String get all => 'Tutto';
+
+  @override
+  String get schedule => 'Programma';
+
+  @override
+  String get appLockConfig => 'Configurazione del blocco dell\'app';
+
+  @override
+  String loadStatsFailed(Object error) {
+    return 'Impossibile caricare le statistiche: $error';
+  }
+
+  @override
+  String get overview => 'Panoramica';
+
+  @override
+  String get daily => 'Quotidiano';
+
+  @override
+  String get modelStatsByAgent => 'Per agente';
+
+  @override
+  String get detail => 'Dettaglio';
+
+  @override
+  String get date => 'Data';
+
+  @override
+  String get agent => 'Agente';
+
+  @override
+  String get noData => 'Nessun dato';
+
+  @override
+  String get totalCalls => 'Chiamate totali';
+
+  @override
+  String get calls => 'Chiamate';
+
+  @override
+  String callsCount(Object count) {
+    return '$count chiama';
+  }
+
+  @override
+  String get selectDateRange => 'Seleziona l\'intervallo di date';
+
+  @override
+  String get totalTokens => 'Gettoni totali';
+
+  @override
+  String get cacheRate => 'Tasso di cache';
+
+  @override
+  String get promptTokens => 'Gettoni di richiesta';
+
+  @override
+  String get completionTokens => 'Gettoni di completamento';
+
+  @override
+  String get cachedTokens => 'Token memorizzati nella cache';
+
+  @override
+  String get thoughtTokens => 'Gettoni di pensiero';
+
+  @override
+  String get prompt => 'Richiesta';
+
+  @override
+  String get completion => 'Completamento';
+
+  @override
+  String get cached => 'Memorizzato nella cache';
+
+  @override
+  String get thought => 'Pensiero';
+
+  @override
+  String get model => 'Modello';
+
+  @override
+  String get scene => 'Scena';
+
+  @override
+  String get sceneId => 'Identificativo della scena';
+
+  @override
+  String get tokenUsage => 'Utilizzo dei gettoni';
+
+  @override
+  String get handler => 'Gestore';
+
+  @override
+  String get modelBreakdown => 'Ripartizione del modello';
+
+  @override
+  String get callDetails => 'Dettagli della chiamata';
+
+  @override
+  String recordDetailsTitle(Object scene) {
+    return 'Dettagli registrazione: $scene';
+  }
+
+  @override
+  String saveLlmConfigFailed(Object error) {
+    return 'Impossibile salvare la configurazione LLM: $error';
+  }
+
+  @override
+  String get webHtmlPreviewUnavailable =>
+      'L\'anteprima HTML non è disponibile sul Web. Si prega di visualizzare sul cellulare.';
+
+  @override
+  String saveUserInfoFailed(Object error) {
+    return 'Impossibile salvare le informazioni dell\'utente: $error';
+  }
+
+  @override
+  String get totalEstimatedCost => 'Costo totale stimato';
+
+  @override
+  String get close => 'Vicino';
+
+  @override
+  String get totalTokenConsumption => 'Consumo totale di token';
+
+  @override
+  String get dataLoadFailedRetry =>
+      'Caricamento dati non riuscito, riprova più tardi.';
+
+  @override
+  String get timelineLoadFailedRetry =>
+      'Caricamento della sequenza temporale non riuscito, riprova più tardi.';
+
+  @override
+  String get newPerspective => 'Nuova prospettiva';
+
+  @override
+  String get startPoint => 'Inizio';
+
+  @override
+  String get endPoint => 'FINE';
+
+  @override
+  String get originalInput => 'Ingresso originale';
+
+  @override
+  String get referenceContent => 'Contenuto di riferimento';
+
+  @override
+  String referenceWithTitle(Object title) {
+    return 'Riferimento: $title';
+  }
+
+  @override
+  String get actionCenterTitle => 'Azioni in sospeso';
+
+  @override
+  String get noPendingActions => 'Nessuna azione in sospeso';
+
+  @override
+  String get clarificationNeeded => 'Memex vuole confermare';
+
+  @override
+  String get clarificationTextHint => 'Digita una risposta breve';
+
+  @override
+  String get clarificationTextRequired => 'Aggiungi prima una risposta breve';
+
+  @override
+  String get clarificationAnswered => 'Risposto';
+
+  @override
+  String clarificationAnswerPrefix(Object answer) {
+    return 'Risposta: $answer';
+  }
+
+  @override
+  String get answerSaved => 'Risposta salvata';
+
+  @override
+  String get clarificationOtherAnswer => 'Inserimento manuale';
+
+  @override
+  String get clarificationNotSure => 'Non sono sicuro/preferisco non dirlo';
+
+  @override
+  String get yes => 'SÌ';
+
+  @override
+  String get no => 'NO';
+
+  @override
+  String get footprintMap => 'Mappa delle impronte';
+
+  @override
+  String get waypointPlaces => 'Luoghi di passaggio';
+
+  @override
+  String get unknownPlace => 'Luogo sconosciuto';
+
+  @override
+  String get releaseToSend => 'Rilascia per inviare';
+
+  @override
+  String get selectFromAlbum => 'Seleziona dall\'album';
+
+  @override
+  String get clipboardPreviewTitle => 'Nuovi appunti';
+
+  @override
+  String get clipboardPreviewImageTitle => 'Immagine negli appunti';
+
+  @override
+  String get clipboardPreviewImageDescription =>
+      'Immagine pronta per essere aggiunta';
+
+  @override
+  String get clipboardPreviewUnprocessed => 'Non ancora incollato';
+
+  @override
+  String get clipboardPreviewPasteToInput => 'Incolla nell\'input';
+
+  @override
+  String get clipboardPreviewAddImageToInput => 'Aggiungi immagine';
+
+  @override
+  String get clipboardPreviewImageFailed =>
+      'Impossibile leggere l\'immagine negli appunti';
+
+  @override
+  String get tellAiWhatHappened => 'Racconta all\'IA cosa è successo...';
+
+  @override
+  String recordingWithDuration(Object duration) {
+    return 'Registrazione: $duration';
+  }
+
+  @override
+  String get playing => 'Giocando...';
+
+  @override
+  String get sendLabel => 'Inviare';
+
+  @override
+  String attachedImagesMessage(Object count) {
+    return 'Inviato/i immagini $count';
+  }
+
+  @override
+  String get noTaskData => 'Nessun dato sull\'attività';
+
+  @override
+  String createdAtDate(Object date) {
+    return 'Creato: $date';
+  }
+
+  @override
+  String updatedAtDate(Object date) {
+    return 'Aggiornato: $date';
+  }
+
+  @override
+  String durationLabel(Object duration) {
+    return 'Durata: $duration';
+  }
+
+  @override
+  String retryCount(Object count) {
+    return 'Riprova: $count';
+  }
+
+  @override
+  String get loadDetailFailedRetry =>
+      'Caricamento dettagli non riuscito, riprova più tardi.';
+
+  @override
+  String get loadFailed => 'Caricamento non riuscito';
+
+  @override
+  String loadHistoryFailed(Object error) {
+    return 'Impossibile caricare la cronologia: $error';
+  }
+
+  @override
+  String get reload => 'Ricaricare';
+
+  @override
+  String get aiInsightDetail => 'Dettaglio approfondimento';
+
+  @override
+  String relatedRecordsCount(Object count) {
+    return 'Record correlati ($count)';
+  }
+
+  @override
+  String get noRelatedRecords => 'Nessun record correlato';
+
+  @override
+  String get useFingerprintToUnlock => 'Usa l\'impronta digitale per sbloccare';
+
+  @override
+  String get locked => 'Bloccato';
+
+  @override
+  String get wrongPassword => 'Password errata';
+
+  @override
+  String get enterPassword => 'Inserisci la password';
+
+  @override
+  String get memexLocked => 'Memex è bloccato';
+
+  @override
+  String get calendarShortSun => 'Sole';
+
+  @override
+  String get calendarShortMon => 'Lun';
+
+  @override
+  String get calendarShortTue => 'Mar';
+
+  @override
+  String get calendarShortWed => 'Mercoledì';
+
+  @override
+  String get calendarShortThu => 'Gio';
+
+  @override
+  String get calendarShortFri => 'Ven';
+
+  @override
+  String get calendarShortSat => 'Sab';
+
+  @override
+  String noRecordsOnDate(Object date) {
+    return 'Nessun record su $date';
+  }
+
+  @override
+  String get footprintPath => 'Percorso dell\'impronta';
+
+  @override
+  String get lifeCompositionTable => 'Composizione della vita';
+
+  @override
+  String get emotionReframe => 'Riformulazione delle emozioni';
+
+  @override
+  String get chronicleOfThings => 'Cronaca delle cose';
+
+  @override
+  String get goalProgress => 'Progresso dell\'obiettivo';
+
+  @override
+  String get trendChart => 'Grafico delle tendenze';
+
+  @override
+  String get comparisonChart => 'Grafico comparativo';
+
+  @override
+  String get todayTimeFlow => 'Il flusso del tempo di oggi';
+
+  @override
+  String get aiInputHint =>
+      'Che si tratti di ricordi o del presente, sono qui...';
+
+  @override
+  String get refreshSuperAgentStateTooltip =>
+      'Cancella il contesto dell\'agente Memex';
+
+  @override
+  String get refreshSuperAgentStateTitle =>
+      'Cancellare il contesto della cronologia dell\'agente Memex?';
+
+  @override
+  String get refreshSuperAgentStateMessage =>
+      'La cronologia chat visibile rimarrà, ma il contesto storico di runtime di Memex Agent verrà cancellato e le risposte future inizieranno da un nuovo contesto. La memoria persistente, i file della knowledge base, le schede e gli altri dati salvati non sono interessati. Utilizzare questo quando Memex Agent continua a comportarsi in modo anomalo. Continuare?';
+
+  @override
+  String get refreshSuperAgentStateActiveRunMessage =>
+      'Attendere fino al termine del messaggio corrente di Memex Agent prima di cancellare il contesto.';
+
+  @override
+  String get refreshSuperAgentStateSuccess =>
+      'Il contesto dell\'agente Memex è stato cancellato';
+
+  @override
+  String refreshSuperAgentStateFailed(Object error) {
+    return 'Impossibile cancellare il contesto dell\'agente Memex: $error';
+  }
+
+  @override
+  String get nothingHere => 'Niente qui ancora';
+
+  @override
+  String get nothingHereHint =>
+      'Tocca il pulsante qui sotto per creare la tua prima carta';
+
+  @override
+  String get agentProcessing => 'L\'intelligenza artificiale sta elaborando...';
+
+  @override
+  String get keepAppOpen => 'Non chiudere l\'app';
+
+  @override
+  String get activityDetail => 'Dettaglio attività';
+
+  @override
+  String get noAgentActivityYet => 'Nessuna attività dell\'agente ancora';
+
+  @override
+  String get processingEllipsis => 'Elaborazione...';
+
+  @override
+  String get agentBackgroundTitle => 'Agente Memex';
+
+  @override
+  String get agentBackgroundPausedTitle =>
+      'L\'agente Memex è stato messo in pausa';
+
+  @override
+  String get agentBackgroundNeedsAttentionTitle =>
+      'L\'agente Memex ha bisogno di attenzione';
+
+  @override
+  String get agentBackgroundStageIdle => 'Oziare';
+
+  @override
+  String get agentBackgroundStageProcessing => 'Elaborazione';
+
+  @override
+  String get agentBackgroundStageQueued => 'In coda';
+
+  @override
+  String get agentBackgroundStageRetrying => 'In attesa di riprovare';
+
+  @override
+  String get agentBackgroundStagePaused => 'In pausa';
+
+  @override
+  String get agentBackgroundStageCompleted => 'Completato';
+
+  @override
+  String get agentBackgroundStageNeedsAttention => 'Ha bisogno di attenzione';
+
+  @override
+  String get agentBackgroundStageAnalyzingMedia => 'Analisi dei media';
+
+  @override
+  String get agentBackgroundStageGeneratingCard => 'Scheda generatrice';
+
+  @override
+  String get agentBackgroundStageUpdatingKnowledge =>
+      'Aggiornamento della conoscenza';
+
+  @override
+  String get agentBackgroundStagePreparingComment =>
+      'Preparazione del commento';
+
+  @override
+  String get agentBackgroundStageRoutingFollowUps => 'Follow-up del percorso';
+
+  @override
+  String agentBackgroundTaskSummary(
+      Object running, Object pending, Object retrying) {
+    return 'In esecuzione $running, In sospeso $pending, Riprova $retrying';
+  }
+
+  @override
+  String agentBackgroundTaskDetail(Object count) {
+    return 'Elaborazione delle attività in coda $count.';
+  }
+
+  @override
+  String get agentBackgroundNoTasks => 'Nessuna attività in background.';
+
+  @override
+  String get agentBackgroundStarting => 'L\'elaborazione è in corso.';
+
+  @override
+  String get agentBackgroundCompletedDetail =>
+      'Tutte le attività in background sono state completate.';
+
+  @override
+  String get agentBackgroundFailedDetail =>
+      'L\'elaborazione è stata interrotta con un errore.';
+
+  @override
+  String get agentBackgroundPausedDetail =>
+      'L\'elaborazione è sospesa e continuerà più tardi.';
+
+  @override
+  String get agentBackgroundQueuedDetail =>
+      'In attesa della fase di lavorazione successiva.';
+
+  @override
+  String get agentBackgroundRetryingDetail =>
+      'Il passaggio corrente verrà riprovato automaticamente.';
+
+  @override
+  String get agentBackgroundAnalyzeMediaDetail =>
+      'Lettura degli allegati e contesto locale.';
+
+  @override
+  String get agentBackgroundGeneratingCardDetail =>
+      'Trasformare il record in una scheda della sequenza temporale.';
+
+  @override
+  String get agentBackgroundUpdatingKnowledgeDetail =>
+      'Aggiornamento della conoscenza e della memoria locale.';
+
+  @override
+  String get agentBackgroundPreparingCommentDetail =>
+      'Preparazione di un follow-up dell\'assistente.';
+
+  @override
+  String get agentBackgroundRoutingFollowUpsDetail =>
+      'Controllo delle azioni successive per questa carta.';
+
+  @override
+  String agentBackgroundPausedStatus(Object summary) {
+    return 'In pausa - $summary';
+  }
+
+  @override
+  String agentBackgroundNeedsAttentionStatus(Object summary) {
+    return 'Ha bisogno di attenzione - $summary';
+  }
+
+  @override
+  String get settings => 'Impostazioni';
+
+  @override
+  String get languageSettings => 'Lingua';
+
+  @override
+  String get languageSettingsDesc =>
+      'Cambia la lingua di visualizzazione dell\'app';
+
+  @override
+  String get noPendingActionsToast => 'Nessuna azione in sospeso';
+
+  @override
+  String get knowledgeNewDiscovery => 'Conoscenza nuova scoperta';
+
+  @override
+  String discoveredNewInsightsCount(Object count) {
+    return 'Scoperto/i $count nuovi approfondimenti';
+  }
+
+  @override
+  String updatedExistingInsightsCount(Object count) {
+    return 'Aggiornati $count approfondimenti esistenti';
+  }
+
+  @override
+  String get sectionNewInsights => 'Nuovi approfondimenti';
+
+  @override
+  String get sectionUpdatedInsights => 'Approfondimenti aggiornati';
+
+  @override
+  String get unnamedInsight => 'Intuizione senza nome';
+
+  @override
+  String get copiedToClipboard => 'Copiato negli appunti';
+
+  @override
+  String get copy => 'Copia';
+
+  @override
+  String get selectedLocation => 'Località selezionata';
+
+  @override
+  String get confirmLocationName => 'Conferma il nome della posizione';
+
+  @override
+  String get confirmLocationNameHint =>
+      'Puoi modificare il nome (le coordinate rimangono le stesse)';
+
+  @override
+  String get nameLabel => 'Nome';
+
+  @override
+  String get inputPlaceNameHint => 'Inserisci il nome del luogo...';
+
+  @override
+  String currentCoordinates(Object lat, Object lng) {
+    return 'Coordinate: $lat, $lng';
+  }
+
+  @override
+  String get confirmLocation => 'Conferma la posizione';
+
+  @override
+  String get welcomeToMemex => 'Benvenuti in Memex';
+
+  @override
+  String get createUserIdToStart => 'Crea il tuo profilo';
+
+  @override
+  String get userIdLabel => 'Il tuo nome/soprannome';
+
+  @override
+  String get userIdHint => 'Inserisci il tuo nome o soprannome';
+
+  @override
+  String get pleaseEnterUserId => 'Per favore inserisci il tuo nome';
+
+  @override
+  String get userIdMaxLength => 'Il nome non deve superare i 50 caratteri';
+
+  @override
+  String get startUsing => 'Continuare';
+
+  @override
+  String get userIdTip =>
+      'Questo verrà utilizzato per personalizzare la tua esperienza.';
+
+  @override
+  String get setupModelConfigTitle =>
+      'Configura un modello di intelligenza artificiale';
+
+  @override
+  String get setupModelConfigSubtitle =>
+      'Memex ha bisogno di un modello di intelligenza artificiale di frontiera per organizzare record, analizzare immagini e generare approfondimenti. Scegli un metodo di connessione.';
+
+  @override
+  String get setupModelConfigComplete => 'Completa e vai';
+
+  @override
+  String get aiService => 'Servizio modelli Memex';
+
+  @override
+  String get aiModelHubTitle => 'Modelli e servizi di intelligenza artificiale';
+
+  @override
+  String get aiModelHubSubtitle =>
+      'Scegli il servizio ufficiale di Memex o porta il tuo fornitore. Il routing avanzato dei modelli rimane disponibile quando ne hai bisogno.';
+
+  @override
+  String get aiSetupCurrentStatusTitle => 'Configurazione attuale';
+
+  @override
+  String get aiSetupStatusNotConfiguredTitle =>
+      'Il servizio AI non è configurato';
+
+  @override
+  String get aiSetupStatusNotConfiguredDescription =>
+      'Scegli un metodo di connessione per abilitare l\'organizzazione AI per record, contenuti multimediali e approfondimenti.';
+
+  @override
+  String get aiSetupStatusMemexTitle =>
+      'Utilizzando il servizio ufficiale Memex';
+
+  @override
+  String get aiSetupStatusMemexDescription =>
+      'Memex utilizzerà la connessione ufficiale e le credenziali API gestite dal tuo account Memex.';
+
+  @override
+  String get aiSetupStatusCustomTitle =>
+      'Utilizzo delle impostazioni personalizzate del provider';
+
+  @override
+  String get aiSetupStatusCustomDescription =>
+      'Memex utilizzerà le credenziali del fornitore configurato e le selezioni del ruolo del modello.';
+
+  @override
+  String get aiSetupChooseConnectionTitle => 'Scegli un metodo di connessione';
+
+  @override
+  String get aiSetupChooseConnectionDescription =>
+      'Inizia con il percorso che corrisponde al modo in cui desideri che Memex acceda ai modelli IA.';
+
+  @override
+  String get aiSetupOfficialRouteDescription =>
+      'Accedi a Memex per utilizzare il servizio AI ufficiale.';
+
+  @override
+  String get aiSetupCustomRouteDescription =>
+      'Aggiungi il tuo provider e la chiave API.';
+
+  @override
+  String get aiSetupCustomPageTitle => 'Servizio IA personalizzato';
+
+  @override
+  String get aiSetupCustomPageSubtitle =>
+      'Configura prima le credenziali del provider, quindi scegli il modello che Memex dovrà utilizzare.';
+
+  @override
+  String get aiSetupProviderCredentialsTitle => 'Provider e chiavi API';
+
+  @override
+  String get aiSetupProviderCredentialsDescription =>
+      'Aggiungi o modifica OpenAI, Anthropic, DeepSeek, Gemini, OpenRouter, Ollama o un altro provider compatibile.';
+
+  @override
+  String get modelRolesTitle => 'Scegli il modello principale';
+
+  @override
+  String get modelRolesDescription =>
+      'Super Agent utilizza un modello per gli input di testo e immagini. Le sostituzioni avanzate dell\'agente rimangono disponibili di seguito.';
+
+  @override
+  String get textModelRoleTitle => 'Modello primario';
+
+  @override
+  String get textModelRoleDescription =>
+      'Utilizzato da Super Agent per testo, immagini, schede, conoscenza, approfondimenti, chat, commenti e memoria.';
+
+  @override
+  String get modelConnectionsTitle => 'Provider di modelli e chiavi API';
+
+  @override
+  String get modelConnectionsDescription =>
+      'Connetti il ​​servizio ufficiale di Memex o aggiungi le credenziali del tuo fornitore.';
+
+  @override
+  String get relatedAiCapabilitiesTitle => 'Funzionalità avanzate e correlate';
+
+  @override
+  String get relatedAiCapabilitiesDescription =>
+      'Ottimizza le assegnazioni degli agenti, il provider di posizione e il comportamento di trascrizione vocale.';
+
+  @override
+  String get aiSetupServiceCapabilitiesTitle => 'Capacità di servizio';
+
+  @override
+  String get aiSetupServiceCapabilitiesDescription =>
+      'Scegli i fornitori utilizzati da Memex per le funzionalità adiacenti basate sull\'intelligenza artificiale come il parlato e la geocodifica inversa.';
+
+  @override
+  String get aiSetupAdvancedCustomizationTitle =>
+      'Routing avanzato del modello';
+
+  @override
+  String get aiSetupAdvancedCustomizationDescription =>
+      'Per utenti esperti che desiderano che i singoli agenti utilizzino provider o configurazioni di modelli diversi.';
+
+  @override
+  String get locationProviderSettings => 'Fornitore di posizione';
+
+  @override
+  String get speechProviderSettings => 'Trascrizione del discorso';
+
+  @override
+  String get advancedAgentModelAssignments =>
+      'Assegnazioni del modello di agente';
+
+  @override
+  String get openAdvancedAgentModelAssignments =>
+      'Sostituisci i singoli agenti';
+
+  @override
+  String get noConfiguredModelOptions =>
+      'Aggiungi un provider o una chiave API prima di scegliere i ruoli del modello.';
+
+  @override
+  String get modelSlotUpdated => 'Ruolo del modello aggiornato';
+
+  @override
+  String get aiServiceMemexRouteTitle => 'Connettiti tramite Memex';
+
+  @override
+  String get aiServiceLongDescription =>
+      'Memex utilizza un sistema multi-agente per organizzare documenti di vita, note di conoscenza e contesto sociale, scoprire approfondimenti più profondi e fornire compagnia all\'intelligenza artificiale con memoria persistente. I tuoi dati vengono archiviati come Markdown in testo semplice, preservando la libertà e la portabilità dei dati.';
+
+  @override
+  String get aiServiceCustomApiRouteTitle => 'Ho una chiave API';
+
+  @override
+  String get aiServiceCustomModelDescription =>
+      'Scegli prima questa se disponi già di una chiave API di OpenAI, Anthropic, DeepSeek, Gemini o un altro provider.';
+
+  @override
+  String get enableAiService => 'Connettiti con Memex';
+
+  @override
+  String get aiServiceReadyToast =>
+      'L\'organizzazione dell\'intelligenza artificiale è attiva';
+
+  @override
+  String get aiServiceSettingsDescription =>
+      'Se non disponi di una chiave API, utilizza un account Memex per connetterti ai servizi del modello tradizionale.';
+
+  @override
+  String get advancedModelConfiguration => 'Configura la chiave API';
+
+  @override
+  String get skipForNow => 'Salta per ora';
+
+  @override
+  String get clearAuth => 'Cancella autenticazione';
+
+  @override
+  String get authorizing => 'Autorizzando...';
+
+  @override
+  String authFailed(Object error) {
+    return 'Autenticazione non riuscita: $error';
+  }
+
+  @override
+  String get authorized => 'Autorizzato';
+
+  @override
+  String authorizedAs(Object email) {
+    return 'Autorizzato come $email';
+  }
+
+  @override
+  String get authorizedSuccessfully => 'Autorizzato con successo';
+
+  @override
+  String get reAuthorize => 'Riautorizza';
+
+  @override
+  String get authorizeWithOpenAi => 'Autorizza con OpenAI';
+
+  @override
+  String get authorizeWithGoogle => 'Autorizza con Google';
+
+  @override
+  String get config => 'Configurazione';
+
+  @override
+  String get calendar => 'Calendario';
+
+  @override
+  String get reminders => 'Promemoria';
+
+  @override
+  String get writeToSystemFailed => 'Impossibile scrivere sul sistema';
+
+  @override
+  String permissionRequired(Object name) {
+    return 'È richiesta l\'autorizzazione $name';
+  }
+
+  @override
+  String permissionRationale(Object name) {
+    return 'Consenti all\'app di accedere al tuo $name nelle Impostazioni in modo che possiamo crearlo per te.';
+  }
+
+  @override
+  String get goToSettings => 'Vai su Impostazioni';
+
+  @override
+  String get unknownAction => 'Azione sconosciuta';
+
+  @override
+  String get discoveredCalendarEvent =>
+      'Evento in calendario in attesa di conferma';
+
+  @override
+  String get discoveredReminder => 'Promemoria in attesa di conferma';
+
+  @override
+  String get addToCalendar => 'Aggiungi al calendario';
+
+  @override
+  String get addToReminders => 'Aggiungi ai promemoria';
+
+  @override
+  String get systemActionPendingExplanation =>
+      'Non ancora aggiunto. Tocca di seguito per richiedere l\'autorizzazione e aggiungerla al tuo dispositivo.';
+
+  @override
+  String addedToSuccess(Object target) {
+    return 'Aggiunto con successo a $target';
+  }
+
+  @override
+  String get ignore => 'Ignorare';
+
+  @override
+  String get confirmDelete => 'Conferma l\'eliminazione';
+
+  @override
+  String get confirmDeleteSessionMessage =>
+      'Eliminare questa conversazione? Questa operazione non può essere annullata.';
+
+  @override
+  String get delete => 'Eliminare';
+
+  @override
+  String get deleteSuccess => 'Eliminato con successo';
+
+  @override
+  String deleteFailed(Object error) {
+    return 'Eliminazione non riuscita: $error';
+  }
+
+  @override
+  String daysAgo(Object count) {
+    return '$count giorni fa';
+  }
+
+  @override
+  String get chatHistory => 'Cronologia chat';
+
+  @override
+  String get enterFullScreenTooltip => 'Entra a schermo intero';
+
+  @override
+  String get exitFullScreenTooltip => 'Esci dallo schermo intero';
+
+  @override
+  String get noConversations => 'Nessuna conversazione';
+
+  @override
+  String loadSessionListFailed(Object error) {
+    return 'Impossibile caricare l\'elenco delle sessioni: $error';
+  }
+
+  @override
+  String yesterdayAt(Object time) {
+    return 'Ieri $time';
+  }
+
+  @override
+  String get newChat => 'Nuova chiacchierata';
+
+  @override
+  String messageCount(Object count) {
+    return '$count messaggi';
+  }
+
+  @override
+  String get organize => 'Organizzare';
+
+  @override
+  String get pkmCategoryProject => 'Progetto';
+
+  @override
+  String get pkmCategoryProjectSubtitle =>
+      'A breve termine · Obiettivi · Scadenze';
+
+  @override
+  String get pkmCategoryArea => 'Zona';
+
+  @override
+  String get pkmCategoryAreaSubtitle =>
+      'A lungo termine · Responsabilità · Standard';
+
+  @override
+  String get pkmCategoryResource => 'Risorsa';
+
+  @override
+  String get pkmCategoryResourceSubtitle => 'Interessi · Ispirazione · Riserva';
+
+  @override
+  String get pkmCategoryArchive => 'Archivio';
+
+  @override
+  String get pkmCategoryArchiveSubtitle => 'Fatto · Inattivo · Riferimento';
+
+  @override
+  String get recentChanges => 'Cambiamenti recenti';
+
+  @override
+  String get noRecentChangesInThreeDays =>
+      'Nessun cambiamento negli ultimi 3 giorni';
+
+  @override
+  String get unpinned => 'Sbloccato';
+
+  @override
+  String get pinnedStyle => 'Stile appuntato';
+
+  @override
+  String operationFailed(Object error) {
+    return 'Operazione non riuscita: $error';
+  }
+
+  @override
+  String get refreshingInsightData =>
+      'Aggiornamento dei dati approfonditi. L\'operazione potrebbe richiedere qualche istante...';
+
+  @override
+  String refreshFailed(Object error) {
+    return 'Aggiornamento non riuscito: $error';
+  }
+
+  @override
+  String get sortUpdated => 'Ordinamento aggiornato';
+
+  @override
+  String sortSaveFailed(Object error) {
+    return 'Impossibile salvare l\'ordinamento: $error';
+  }
+
+  @override
+  String get insightCardDeleted => 'Scheda informativa eliminata';
+
+  @override
+  String deleteFailedShort(Object error) {
+    return 'Eliminazione non riuscita: $error';
+  }
+
+  @override
+  String get knowledgeInsight => 'Approfondimento della conoscenza';
+
+  @override
+  String get completeSort => 'Ordinamento completo';
+
+  @override
+  String get noKnowledgeInsight => 'Nessuna conoscenza approfondita';
+
+  @override
+  String insightProcessingBacklogMessage(Object count) {
+    return 'Le attività in background $count sono ancora in fase di elaborazione.';
+  }
+
+  @override
+  String get insightUnavailableMessage =>
+      'Questo insight è ancora in fase di generazione o è stato aggiornato. Aggiorna gli approfondimenti e riprova più tardi.';
+
+  @override
+  String get artifactOpen => 'Aprire';
+
+  @override
+  String get updating => 'Aggiornamento...';
+
+  @override
+  String get update => 'Aggiornamento';
+
+  @override
+  String get enabled => 'Abilitato';
+
+  @override
+  String get disabled => 'Disabilitato';
+
+  @override
+  String get appLockOn => 'Blocco app abilitato';
+
+  @override
+  String get appLockOff => 'Blocco app disabilitato';
+
+  @override
+  String get enableAppLockFirst => 'Abilita prima il blocco dell\'app';
+
+  @override
+  String get enterFourDigitPassword => 'Inserisci la password di 4 cifre';
+
+  @override
+  String get passwordSetAndLockOn =>
+      'Password impostata e blocco app abilitato';
+
+  @override
+  String get appLockSettings => 'Impostazioni di blocco dell\'app';
+
+  @override
+  String get enableAppLock => 'Abilita il blocco dell\'app';
+
+  @override
+  String get enableAppLockSubtitle => 'Password richiesta all\'avvio dell\'app';
+
+  @override
+  String get enableBiometrics => 'Abilita la biometria';
+
+  @override
+  String get biometricsSubtitle => 'Utilizza Face ID o Touch ID per sbloccare';
+
+  @override
+  String get changePassword => 'Cambiare la password';
+
+  @override
+  String get setFourDigitPassword => 'Imposta una password di 4 cifre';
+
+  @override
+  String get reenterPasswordToConfirm =>
+      'Reinserire la password per confermare';
+
+  @override
+  String get passwordMismatch =>
+      'Le password non corrispondono. Per favore riprova.';
+
+  @override
+  String confirmDeleteCharacter(Object name) {
+    return 'Eliminare il carattere \"$name\"? Questa operazione non può essere annullata.';
+  }
+
+  @override
+  String get configureAiCharacter => 'Configura il personaggio AI';
+
+  @override
+  String get addCharacter => 'Aggiungi carattere';
+
+  @override
+  String get addCharacterSubtitle =>
+      'Scegli i personaggi IA per unirti al tuo team di intuizione. Analizzeranno i dati della tua vita da diverse angolazioni.';
+
+  @override
+  String get noCharacters => 'Nessun personaggio';
+
+  @override
+  String loadCharacterFailed(Object error) {
+    return 'Impossibile caricare i caratteri: $error';
+  }
+
+  @override
+  String get noTags => 'Nessun tag';
+
+  @override
+  String get createSuccess => 'Creato con successo';
+
+  @override
+  String get updateSuccess => 'Aggiornato con successo';
+
+  @override
+  String saveFailed(Object error) {
+    return 'Salvataggio non riuscito: $error';
+  }
+
+  @override
+  String get newCharacter => 'Nuovo personaggio';
+
+  @override
+  String get editCharacter => 'Modifica personaggio';
+
+  @override
+  String get save => 'Salva';
+
+  @override
+  String get characterName => 'Nome del personaggio';
+
+  @override
+  String get characterNameHint => 'Dai un nome al tuo personaggio';
+
+  @override
+  String get pleaseEnterCharacterName => 'Inserisci il nome del personaggio';
+
+  @override
+  String get tagsLabel => 'Tag';
+
+  @override
+  String get tagsHint =>
+      'per esempio. saggezza, riconoscimento, macro\nSepara più tag con virgole';
+
+  @override
+  String get characterPersonaLabel => 'Persona di carattere';
+
+  @override
+  String get characterPersonaHint =>
+      'Includi persona, guida di stile, dialogo di esempio, filtri di conoscenza, ecc.\nUtilizzare ## per le intestazioni delle sezioni.';
+
+  @override
+  String get pleaseEnterCharacterPersona =>
+      'Inserisci il personaggio del personaggio';
+
+  @override
+  String permissionRequestError(Object error) {
+    return 'Errore nella richiesta di autorizzazione: $error';
+  }
+
+  @override
+  String get permissionRequiredTitle => 'Permesso richiesto';
+
+  @override
+  String get permissionPermanentlyDeniedMessage =>
+      'Hai negato permanentemente questa autorizzazione oppure il sistema la richiede. Si prega di abilitarlo nelle impostazioni di sistema.';
+
+  @override
+  String get getting => 'Ottenere...';
+
+  @override
+  String get unauthorized => 'Non autorizzato';
+
+  @override
+  String get authorizedGoToSettings =>
+      'Autorizzato. Vai alle impostazioni di sistema per modificare.';
+
+  @override
+  String get location => 'Posizione';
+
+  @override
+  String get locationPermissionReason =>
+      'Per registrare luoghi e caratteristiche relative alla posizione';
+
+  @override
+  String get photos => 'Foto';
+
+  @override
+  String get photosPermissionReason =>
+      'Per selezionare foto, salvare immagini generate, ecc.';
+
+  @override
+  String get camera => 'Telecamera';
+
+  @override
+  String get cameraPermissionReason => 'Per scattare foto e video';
+
+  @override
+  String get microphone => 'Microfono';
+
+  @override
+  String get microphonePermissionReason =>
+      'Per il riconoscimento vocale, la registrazione, ecc.';
+
+  @override
+  String get calendarPermissionReason =>
+      'Per registrare il programma e leggere gli eventi del calendario';
+
+  @override
+  String get remindersPermissionReason =>
+      'Per registrare e leggere i tuoi promemoria';
+
+  @override
+  String get fitnessAndMotion => 'Fitness e movimento';
+
+  @override
+  String get fitnessPermissionReason =>
+      'Per la registrazione di dati sulla salute e sul movimento';
+
+  @override
+  String get notification => 'Notifica';
+
+  @override
+  String get notificationPermissionReason =>
+      'Per inviare programmi e promemoria importanti';
+
+  @override
+  String get memexAgentNotificationPermissionTitle =>
+      'Mantieni Memex Agent in esecuzione in background';
+
+  @override
+  String get memexAgentNotificationPermissionMessage =>
+      'Memex Agent viene eseguito localmente sul tuo dispositivo. Le notifiche consentono a Memex di mostrare i progressi e di continuare l\'elaborazione dopo aver lasciato l\'app o spento lo schermo. Se le notifiche sono disattivate, mantieni Memex aperto in primo piano fino al termine dell\'attività.';
+
+  @override
+  String get loadDetailFailedRetryShort =>
+      'Caricamento dettagli non riuscito, riprova più tardi.';
+
+  @override
+  String get total => 'Totale';
+
+  @override
+  String get estimatedCost => 'Costo stimato';
+
+  @override
+  String get byAgent => 'Per Agente';
+
+  @override
+  String get timeUpdated => 'Ora aggiornata';
+
+  @override
+  String updateFailed(Object error) {
+    return 'Aggiornamento non riuscito: $error';
+  }
+
+  @override
+  String get locationUpdated => 'Posizione aggiornata';
+
+  @override
+  String get confirmDeleteCardMessage =>
+      'Eliminare questa carta? Questa operazione non può essere annullata.';
+
+  @override
+  String get cardDetailNotFound => 'Dettagli della carta non trovati';
+
+  @override
+  String get saySomething => 'Di \'qualcosa...';
+
+  @override
+  String get relatedMemories => 'Ricordi correlati';
+
+  @override
+  String get viewMore => 'Visualizza altro';
+
+  @override
+  String get relatedRecords => 'Record correlati';
+
+  @override
+  String get reply => 'Rispondere';
+
+  @override
+  String get replySent => 'Risposta inviata';
+
+  @override
+  String get insightTemplateGalleryTitle => 'Modelli di schede informative';
+
+  @override
+  String get timelineTemplateGalleryTitle =>
+      'Modelli di carte della sequenza temporale';
+
+  @override
+  String get categoryTextual => 'Testuale';
+
+  @override
+  String get timelineFilterAll => 'TUTTO';
+
+  @override
+  String get insights => 'Approfondimenti';
+
+  @override
+  String get memoryTitle => 'Memoria';
+
+  @override
+  String get longTermProfile => 'Profilo a lungo termine';
+
+  @override
+  String get recentBuffer => 'Buffer recente';
+
+  @override
+  String errorLoadingMemory(Object error) {
+    return 'Errore durante il caricamento della memoria: $error';
+  }
+
+  @override
+  String get agentConfiguration => 'Configurazione dell\'agente';
+
+  @override
+  String get resetToDefaults => 'Ripristina le impostazioni predefinite';
+
+  @override
+  String get resetAllAgentConfigurationsTitle =>
+      'Reimposta tutte le configurazioni dell\'agente';
+
+  @override
+  String get resetAllAgentConfigurationsMessage =>
+      'Sei sicuro di voler reimpostare tutte le configurazioni dell\'agente sui valori predefiniti? Questa azione non può essere annullata.';
+
+  @override
+  String get resetButton => 'Reset';
+
+  @override
+  String loadDataFailed(Object error) {
+    return 'Impossibile caricare i dati: $error';
+  }
+
+  @override
+  String saveConfigFailed(Object error) {
+    return 'Impossibile salvare la configurazione: $error';
+  }
+
+  @override
+  String get selectLlmClient => 'Seleziona cliente LLM:';
+
+  @override
+  String get agentConfigurationsReset =>
+      'Ripristino delle configurazioni dell\'agente';
+
+  @override
+  String resetFailed(Object error) {
+    return 'Impossibile reimpostare: $error';
+  }
+
+  @override
+  String get modelConfiguration => 'Configurazione del modello';
+
+  @override
+  String get resetAllConfigurationsTitle =>
+      'Ripristina tutte le configurazioni';
+
+  @override
+  String get resetAllModelConfigurationsMessage =>
+      'Sei sicuro di voler reimpostare tutte le configurazioni del modello sui valori predefiniti? Questa azione non può essere annullata.';
+
+  @override
+  String get modelConfigurationsReset =>
+      'Ripristino delle configurazioni del modello';
+
+  @override
+  String get cannotDeleteDefaultConfiguration =>
+      'Impossibile eliminare la configurazione predefinita';
+
+  @override
+  String get cannotDeleteConfigurationTitle =>
+      'Impossibile eliminare la configurazione';
+
+  @override
+  String configUsedByAgentsMessage(Object agentList) {
+    return 'Questa configurazione è attualmente utilizzata dai seguenti agenti:\n\n$agentList\n\nRiassegna questi agenti prima di eliminarli.';
+  }
+
+  @override
+  String get ok => 'OK';
+
+  @override
+  String get deleteConfigurationTitle => 'Elimina configurazione';
+
+  @override
+  String confirmDeleteConfigMessage(Object key) {
+    return 'Sei sicuro di voler eliminare \"$key\"?';
+  }
+
+  @override
+  String get defaultLabel => 'Predefinito';
+
+  @override
+  String get setAsDefault => 'Imposta come predefinito';
+
+  @override
+  String get invalidJsonInExtraField => 'JSON non valido nel campo Extra';
+
+  @override
+  String get keyAlreadyExists => 'La chiave esiste già';
+
+  @override
+  String get resetConfigurationTitle => 'Ripristina configurazione';
+
+  @override
+  String get resetConfigurationMessage =>
+      'Ripristinare questa configurazione ai valori predefiniti iniziali? Le modifiche attuali andranno perse.';
+
+  @override
+  String get configurationResetPressSave =>
+      'Ripristino della configurazione. Premi Salva per applicare.';
+
+  @override
+  String get addConfiguration => 'Aggiungi configurazione';
+
+  @override
+  String get editConfiguration => 'Modifica configurazione';
+
+  @override
+  String get duplicateConfiguration => 'Configurazione duplicata';
+
+  @override
+  String get duplicate => 'Duplicato';
+
+  @override
+  String get keyIdLabel => 'ID di configurazione';
+
+  @override
+  String get keyIdHelper =>
+      'Assegna un nome a questa configurazione, ad esempio deepseek o work-gpt.';
+
+  @override
+  String get required => 'Necessario';
+
+  @override
+  String get clientLabel => 'Fornitore di modelli';
+
+  @override
+  String get providerGroupOpenAi => 'OpenAI';
+
+  @override
+  String get providerGroupAnthropic => 'Antropico';
+
+  @override
+  String get providerGroupGoogle => 'Google';
+
+  @override
+  String get providerGroupOthers => 'Popolare';
+
+  @override
+  String get providerOpenAiApiKey => 'Chiave API';
+
+  @override
+  String get providerOpenAiResponses => 'Chiave API (risposte)';
+
+  @override
+  String get providerChatGptOauth => 'ChatGPT Pro/Plus';
+
+  @override
+  String get providerClaudeApiKey => 'Chiave API';
+
+  @override
+  String get providerBedrockSecret => 'Segreto del fondamento roccioso';
+
+  @override
+  String get providerGemini => 'Gemelli';
+
+  @override
+  String get providerGeminiOauth => 'Gemelli (Google OAuth)';
+
+  @override
+  String get providerKimi => 'Kimi (Moonshot)';
+
+  @override
+  String get providerQwen => 'Aliyun';
+
+  @override
+  String get providerSeed => 'Volcengine';
+
+  @override
+  String get providerZhipu => 'ZhipuGLM';
+
+  @override
+  String get providerDeepSeek => 'DeepSeek';
+
+  @override
+  String get providerMinimax => 'MiniMax';
+
+  @override
+  String get providerOpenRouter => 'OpenRouter';
+
+  @override
+  String get providerOllama => 'Ollama (locale)';
+
+  @override
+  String get providerMimo => 'Xiaomi MIMO';
+
+  @override
+  String get providerMemex => 'Servizio proxy Memex';
+
+  @override
+  String get memexSignIn => 'Registrazione';
+
+  @override
+  String get memexCreateAccount => 'Creare un account';
+
+  @override
+  String get memexUsername => 'Nome utente';
+
+  @override
+  String get memexPassword => 'Password';
+
+  @override
+  String get memexCreateAccountLink => 'Creare un account';
+
+  @override
+  String get memexSignInLink => 'Accedi invece';
+
+  @override
+  String get memexTopUp => 'Ricarica per iniziare a utilizzare Memex AI';
+
+  @override
+  String get memexTopUpSuccess => 'Ricarica riuscita!';
+
+  @override
+  String get memexFillAllFields => 'Si prega di compilare tutti i campi';
+
+  @override
+  String get memexUsernameTooShort =>
+      'Il nome utente deve contenere almeno 6 caratteri';
+
+  @override
+  String get memexAuthFailed => 'Autenticazione non riuscita';
+
+  @override
+  String get memexPaymentFailed => 'Impossibile creare il pagamento';
+
+  @override
+  String get memexLogout => 'Esci';
+
+  @override
+  String get memexTopUpButton => 'Ricaricare';
+
+  @override
+  String get memexTopUpChooseAmount => 'Scegli un importo';
+
+  @override
+  String memexTopUpEstimatedRecords(Object range) {
+    return 'Informazioni sui record $range';
+  }
+
+  @override
+  String get memexTopUpPlanStarter => 'Antipasto';
+
+  @override
+  String get memexTopUpPlanEveryday => 'Ogni giorno';
+
+  @override
+  String get memexTopUpPlanHighVolume => 'Alto volume';
+
+  @override
+  String get memexTopUpPlanCustom => 'Crediti personalizzati';
+
+  @override
+  String get memexTopUpPlanStarterSubtitle => 'Buono per provare Memex AI';
+
+  @override
+  String get memexTopUpPlanEverydaySubtitle =>
+      'Buono per l\'organizzazione regolare';
+
+  @override
+  String get memexTopUpPlanHighVolumeSubtitle => 'Buono per lotti più grandi';
+
+  @override
+  String get memexTopUpPlanCustomSubtitle =>
+      'Inserisci un valore compreso tra 1 e 10.000 USD';
+
+  @override
+  String get memexTopUpCustomEstimate =>
+      'La stima si basa sull\'importo inserito';
+
+  @override
+  String get memexCustomAmount => 'Importo personalizzato';
+
+  @override
+  String get memexViewHistory => 'Cronologia dell\'utilizzo';
+
+  @override
+  String memexBalanceLabel(Object amount) {
+    return 'Saldo: $amount';
+  }
+
+  @override
+  String get memexConfirmPassword => 'Conferma password';
+
+  @override
+  String get memexPasswordMismatch => 'Le password non corrispondono';
+
+  @override
+  String memexPayAmount(Object amount) {
+    return 'Ricarica $amount';
+  }
+
+  @override
+  String get modelIdLabel => 'Modello';
+
+  @override
+  String get modelIdHelper => 'per esempio. gemini-3.1-pro-anteprima, gpt-4o';
+
+  @override
+  String get fetchingModels => 'Recupero modelli in corso...';
+
+  @override
+  String get fetchModelsButton => 'Recupera modelli';
+
+  @override
+  String get enterApiKeyFirst =>
+      'Inserisci prima la chiave API per recuperare i modelli';
+
+  @override
+  String get apiKeyLabel => 'Chiave API';
+
+  @override
+  String get baseUrlLabel => 'Endpoint API';
+
+  @override
+  String get advancedSettings => 'Impostazioni avanzate';
+
+  @override
+  String get testConnectionSuccess => 'Connessione riuscita';
+
+  @override
+  String get testConnectionFailed => 'Connessione non riuscita';
+
+  @override
+  String get testTypeText => 'Testo';
+
+  @override
+  String get testTypeVision => 'Visione';
+
+  @override
+  String get testButton => 'Test';
+
+  @override
+  String get testing => 'Prova...';
+
+  @override
+  String get proxyUrlOptional => 'URL proxy (facoltativo)';
+
+  @override
+  String get proxyUrlHelper => 'per esempio. http://127.0.0.1:7890';
+
+  @override
+  String get temperatureLabel => 'Temperatura';
+
+  @override
+  String get topPLabel => 'Superiore P';
+
+  @override
+  String get maxTokensLabel => 'Gettoni massimi';
+
+  @override
+  String get extraParamsJson => 'Parametri aggiuntivi (JSON)';
+
+  @override
+  String get invalidJson => 'JSON non valido';
+
+  @override
+  String get warning => 'Configurazione incompleta';
+
+  @override
+  String get invalidConfigurationWarning =>
+      'La configurazione non è ancora completa (ad esempio, manca la chiave API o l\'ID modello). Puoi comunque salvarlo e configurarlo in seguito. Continuare?';
+
+  @override
+  String invalidModelConfigDetailed(Object agentId, Object configKey) {
+    return 'L\'agente AI \"$agentId\" necessita di una configurazione del modello valida (chiave: \"$configKey\") per funzionare. Si prega di verificare le impostazioni del modello.';
+  }
+
+  @override
+  String get discardChangesTitle => 'Lasciare questa pagina?';
+
+  @override
+  String get discardChangesMessage =>
+      'Se hai apportato modifiche, salvale prima di uscire.';
+
+  @override
+  String get discardButton => 'Scartare';
+
+  @override
+  String get chooseLanguage => 'Scegli la lingua';
+
+  @override
+  String get chooseAvatar => 'Scegli Avatar';
+
+  @override
+  String get configureNow => 'Configura ora';
+
+  @override
+  String get modelNotConfiguredBanner =>
+      'Modello AI non ancora configurato. Configuralo per sbloccare tutte le funzionalità.';
+
+  @override
+  String get modelNotConfiguredSubmitHint =>
+      'Configura un modello AI prima della pubblicazione';
+
+  @override
+  String get processingStatus => 'Elaborazione';
+
+  @override
+  String get failedStatus => 'Fallito';
+
+  @override
+  String get failureReason => 'Motivo del fallimento';
+
+  @override
+  String get unknownError => 'Si è verificato un errore sconosciuto';
+
+  @override
+  String get enableFitness => 'Abilita Fitness';
+
+  @override
+  String get fitnessBannerMessage =>
+      'Consenti l\'accesso al fitness per monitorare i dati relativi alla tua salute e alle tue attività.';
+
+  @override
+  String get fitnessDismissTitle => 'Saltare l\'accesso al fitness?';
+
+  @override
+  String get fitnessDismissMessage =>
+      'Senza l\'autorizzazione per l\'attività fisica, l\'app non sarà in grado di raccogliere automaticamente i tuoi dati sanitari per approfondimenti e registrazioni automatiche.';
+
+  @override
+  String get skipAnyway => 'Salta comunque';
+
+  @override
+  String get proModelHint =>
+      'Questo modello richiede un abbonamento ChatGPT Pro/Plus.';
+
+  @override
+  String get searchKnowledgeBase => 'Cerca nella base di conoscenza...';
+
+  @override
+  String get searchKnowledgeHint =>
+      'Inserisci la parola chiave per cercare nomi di file o contenuti';
+
+  @override
+  String noSearchResults(Object query) {
+    return 'Nessun risultato trovato per \"$query\"';
+  }
+
+  @override
+  String get onlyMarkdownPreview => 'È supportata solo l\'anteprima Markdown';
+
+  @override
+  String get backupAndRestore => 'Backup e ripristino';
+
+  @override
+  String get createBackup => 'Crea backup';
+
+  @override
+  String get restoreBackup => 'Ripristina backup';
+
+  @override
+  String get backupDescription =>
+      'Raccogli tutti i tuoi dati (schede, knowledge base, approfondimenti, impostazioni) in un file .memex. Salvalo su iCloud Drive, Google Drive o qualsiasi posizione tramite il foglio di condivisione.';
+
+  @override
+  String get restoreDescription =>
+      'Seleziona un file di backup .memex per ripristinare tutti i dati. Ciò sovrascriverà i dati correnti.';
+
+  @override
+  String get selectBackupFile => 'Seleziona File di backup';
+
+  @override
+  String get estimatedSize => 'Dimensioni stimate';
+
+  @override
+  String get backupComplete => 'Backup creato';
+
+  @override
+  String backupFailed(Object error) {
+    return 'Backup non riuscito: $error';
+  }
+
+  @override
+  String get confirmRestore => 'Conferma ripristino';
+
+  @override
+  String get confirmRestoreMessage =>
+      'Il ripristino sovrascriverà tutti i dati correnti, incluse schede, knowledge base, approfondimenti e impostazioni. Questa operazione non può essere annullata. Continuare?';
+
+  @override
+  String get restoreComplete => 'Ripristino completato';
+
+  @override
+  String get restoreRestartHint =>
+      'I dati sono stati ripristinati. Riavvia l\'app affinché tutte le modifiche abbiano effetto.';
+
+  @override
+  String restoreFailed(Object error) {
+    return 'Ripristino non riuscito: $error';
+  }
+
+  @override
+  String get invalidBackupFile =>
+      'File di backup non valido. Seleziona un file .memex.';
+
+  @override
+  String get automaticBackup => 'Backup automatico';
+
+  @override
+  String get autoBackupDescription =>
+      'Se abilitato, Memex crea al massimo uno snapshot locale al giorno dopo l\'avvio o quando torna in primo piano.';
+
+  @override
+  String get backupSensitiveSettingsHint =>
+      'I backup includono le impostazioni e le chiavi del provider del modello. Conserva i file di backup in un posto di cui ti fidi.';
+
+  @override
+  String get backupLocation => 'Posizione';
+
+  @override
+  String get backupLocationDetails => 'Dettagli sulla posizione';
+
+  @override
+  String get backupLocationSummary => 'Mostrato nell\'app';
+
+  @override
+  String get backupLocationFullPath => 'Percorso completo';
+
+  @override
+  String get backupLocationUri => 'URI di accesso alla cartella';
+
+  @override
+  String get copyBackupLocationPath => 'Copia percorso';
+
+  @override
+  String get backupLocationCopied => 'Posizione del backup copiata';
+
+  @override
+  String androidBackupLocationSelected(Object folderName) {
+    return 'Cartella selezionata: $folderName';
+  }
+
+  @override
+  String get iosICloudBackupLocation => 'iCloud Drive > Memex > Backup';
+
+  @override
+  String get iosAppDocumentsBackupLocation =>
+      'File > Sul mio iPhone > Memex > Backup';
+
+  @override
+  String get autoBackupStatus => 'Stato';
+
+  @override
+  String get noAutoBackupYet => 'Nessun backup automatico ancora';
+
+  @override
+  String lastBackupAt(Object time) {
+    return 'Ultimo backup: $time';
+  }
+
+  @override
+  String get autoBackupRetention => 'Conservazione';
+
+  @override
+  String autoBackupRetentionDays(Object days) {
+    return '$days giorni';
+  }
+
+  @override
+  String get autoBackupRetentionForever => 'Conserva per sempre';
+
+  @override
+  String get autoBackupMaxSize => 'Tappo di stoccaggio';
+
+  @override
+  String autoBackupRetentionLimitHint(Object size) {
+    return 'La pulizia automatica mantiene gli snapshot automatici in $size. Le istantanee di sicurezza e le esportazioni manuali vengono conservate separatamente.';
+  }
+
+  @override
+  String get createSnapshotNow => 'Esegui il backup adesso';
+
+  @override
+  String get backupLocationMenu => 'Cambia posizione';
+
+  @override
+  String get defaultBackupLocation => 'Cartella di backup predefinita';
+
+  @override
+  String get defaultBackupLocationAndroidDesc =>
+      'Utilizza la cartella dei file esterni specifica dell\'app di Memex. Non è necessaria alcuna autorizzazione di archiviazione.';
+
+  @override
+  String get chooseBackupLocation => 'Scegli la cartella di backup';
+
+  @override
+  String get chooseBackupLocationAndroidDesc =>
+      'Scegli una cartella con il selettore di sistema di Android e concedi l\'accesso permanente a Memex.';
+
+  @override
+  String get storedBackups => 'Backup archiviati';
+
+  @override
+  String get noStoredBackups =>
+      'I backup automatici verranno visualizzati qui dopo la prima istantanea.';
+
+  @override
+  String get backupTypeAutoSnapshot => 'Istantanea automatica';
+
+  @override
+  String get backupTypeSafetySnapshot => 'Istantanea sulla sicurezza';
+
+  @override
+  String get backupTypeManualBackup => 'Backup manuale';
+
+  @override
+  String get refresh => 'Aggiorna';
+
+  @override
+  String get restoreThisBackup => 'Ripristina questo backup';
+
+  @override
+  String get deleteThisBackup => 'Elimina questo backup';
+
+  @override
+  String get confirmDeleteBackup => 'Eliminare il backup?';
+
+  @override
+  String confirmDeleteBackupMessage(Object fileName) {
+    return 'Eliminare $fileName? Questa operazione rimuove il file di backup archiviato e non può essere annullata.';
+  }
+
+  @override
+  String backupDeleted(Object fileName) {
+    return 'Backup eliminato: $fileName';
+  }
+
+  @override
+  String backupDeleteFailed(Object error) {
+    return 'Impossibile eliminare il backup: $error';
+  }
+
+  @override
+  String get creatingSafetySnapshot => 'Creazione istantanea di sicurezza...';
+
+  @override
+  String autoBackupCreated(Object fileName) {
+    return 'Istantanea creata: $fileName';
+  }
+
+  @override
+  String backupLocationFailed(Object error) {
+    return 'Impossibile aggiornare la posizione del backup: $error';
+  }
+
+  @override
+  String get backupImportCreatedAt => 'Creato';
+
+  @override
+  String get backupImportSourceVersion => 'Versione sorgente';
+
+  @override
+  String get backupImportFlavor => 'Costruire';
+
+  @override
+  String get backupLegacyFormat => 'Backup legacy (nessun manifest)';
+
+  @override
+  String get restoreInProgress => 'Ripristino del backup...';
+
+  @override
+  String get dataStorage => 'Archiviazione dei dati';
+
+  @override
+  String get dataStorageDescriptionAndroid =>
+      'Scegli una cartella personalizzata in cui archiviare il tuo spazio di lavoro. I dati vengono conservati quando reinstalli l\'app.';
+
+  @override
+  String get dataStorageDescriptionIOS =>
+      'Attiva iCloud per sincronizzare il tuo spazio di lavoro su tutti i dispositivi e conservare i dati quando reinstalli l\'app.';
+
+  @override
+  String get storageLocationApp => 'Archiviazione dell\'app';
+
+  @override
+  String get storageLocationAppDesc =>
+      'I dati vengono archiviati all\'interno dell\'app e verranno rimossi durante la disinstallazione.';
+
+  @override
+  String get storageLocationCustom =>
+      'Archiviazione del dispositivo (cartella personalizzata)';
+
+  @override
+  String get storageLocationCustomDesc =>
+      'Memorizza i dati in una cartella di tua scelta. I dati persistono durante la reinstallazione se la cartella rimane.';
+
+  @override
+  String get storageLocationICloud => 'Archivia su iCloud';
+
+  @override
+  String get storageLocationICloudDesc =>
+      'Sincronizza il tuo spazio di lavoro su tutti i dispositivi Apple. I dati rimangono dopo la reinstallazione.';
+
+  @override
+  String storageLocationCurrent(Object location) {
+    return 'Attuale: $location';
+  }
+
+  @override
+  String get icloudRequiresCapability =>
+      'Accedi a iCloud e attiva iCloud Drive per utilizzare lo spazio di archiviazione di iCloud.';
+
+  @override
+  String get loadingFromICloud => 'Ripristino dei dati da iCloud…';
+
+  @override
+  String get switchingToICloud =>
+      'Passaggio allo spazio di archiviazione iCloud…';
+
+  @override
+  String get switchingStorage => 'Cambio di spazio di archiviazione…';
+
+  @override
+  String get customFolderAccessDenied =>
+      'Impossibile leggere o scrivere in questa cartella. Concedi l\'autorizzazione di archiviazione o scegli un\'altra posizione.';
+
+  @override
+  String get configured => 'Configurato';
+
+  @override
+  String get apiKeyNotSet => 'Chiave API non impostata: tocca per configurare';
+
+  @override
+  String get bottomNavTimeline => 'Cronologia';
+
+  @override
+  String get bottomNavLibrary => 'Biblioteca';
+
+  @override
+  String get aiGeneratedLabel => 'Generato dall\'intelligenza artificiale';
+
+  @override
+  String sourceTraceWithCount(Object count) {
+    return 'TRACCIA ORIGINE ($count)';
+  }
+
+  @override
+  String get deleteAccount => 'Elimina account';
+
+  @override
+  String get deleteAccountDesc =>
+      'Elimina definitivamente tutti i dati locali e ripristina l\'app.';
+
+  @override
+  String get deleteAccountConfirmTitle => 'Eliminare l\'account?';
+
+  @override
+  String get deleteAccountConfirmMessage =>
+      'Ciò eliminerà definitivamente tutti i tuoi dati, comprese le schede della sequenza temporale, la knowledge base, le registrazioni e le impostazioni. Questa azione non può essere annullata.';
+
+  @override
+  String deleteAccountTypeName(Object name) {
+    return 'Digita \"$name\" per confermare';
+  }
+
+  @override
+  String get deleteAccountTypeHint =>
+      'Inserisci il tuo nome utente per confermare';
+
+  @override
+  String get llmConsentTitle => 'Consenso alla condivisione dei dati';
+
+  @override
+  String llmConsentMessage(Object provider) {
+    return 'Per abilitare le funzionalità AI, Memex deve inviare i tuoi dati a $provider per l\'elaborazione. Ciò include:\n\n• Testo inserito (note, trascrizioni vocali)\n• Metadati delle foto e testo estratto (OCR)\n• Riepiloghi di salute e forma fisica\n• Contenuto della scheda Cronologia\n\nI tuoi dati vengono inviati direttamente dal tuo dispositivo a $provider. Memex non memorizza né trasmette i tuoi dati attraverso nessun altro server.\n\nConsulta l\'informativa sulla privacy di $provider per sapere come gestiscono i tuoi dati.\n\nAccetti di inviare i tuoi dati a $provider per l\'elaborazione AI?';
+  }
+
+  @override
+  String get llmConsentAgree => 'Sono d\'accordo';
+
+  @override
+  String get llmConsentDecline => 'Declino';
+
+  @override
+  String get customAgents => 'Agenti personalizzati';
+
+  @override
+  String get noCustomAgents => 'Nessun agente personalizzato configurato.';
+
+  @override
+  String get deleteAgent => 'Elimina agente';
+
+  @override
+  String deleteAgentConfirm(Object name) {
+    return 'Eliminare l\'agente personalizzato \"$name\"?';
+  }
+
+  @override
+  String get deleted => 'Eliminato';
+
+  @override
+  String get saved => 'Salvato';
+
+  @override
+  String get newAgent => 'Nuovo agente';
+
+  @override
+  String get editAgent => 'Modifica agente';
+
+  @override
+  String get agentName => 'Nome dell\'agente';
+
+  @override
+  String get agentNameHint => 'il mio agente personalizzato';
+
+  @override
+  String get agentNameRequired => 'Necessario';
+
+  @override
+  String get agentNameInvalid => 'Solo lettere, cifre e trattini';
+
+  @override
+  String get agentNameExists => 'Il nome esiste già';
+
+  @override
+  String get hostAgentType => 'Tipo di agente host';
+
+  @override
+  String get skillDirectory => 'Elenco delle competenze';
+
+  @override
+  String get skillDirInvalid =>
+      'Deve essere un percorso relativo (non iniziale / o ..)';
+
+  @override
+  String get workingDirectory => 'Directory di lavoro (facoltativo)';
+
+  @override
+  String get workingDirectoryHint =>
+      'Lasciare vuoto per impostazione predefinita dell\'area di lavoro';
+
+  @override
+  String get llmConfig => 'Configurazione LLM';
+
+  @override
+  String get eventType => 'Tipo di evento';
+
+  @override
+  String get executionMode => 'Modalità di esecuzione';
+
+  @override
+  String get executionModeAsync => 'Asincrono';
+
+  @override
+  String get executionModeSync => 'Sincronizzazione';
+
+  @override
+  String get dependsOn => 'Dipende';
+
+  @override
+  String get dependsOnHint => 'Seleziona dipendenze';
+
+  @override
+  String get priority => 'Priorità';
+
+  @override
+  String get maxRetries => 'Numero massimo di tentativi';
+
+  @override
+  String get systemPromptLabel => 'Prompt del sistema (facoltativo)';
+
+  @override
+  String get systemPromptHint =>
+      'Ulteriori istruzioni aggiunte al prompt dell\'agente host';
+
+  @override
+  String get eventSerializer => 'Serializzatore di eventi';
+
+  @override
+  String get eventSerializerDefault => 'Predefinito (XML)';
+
+  @override
+  String get enabledLabel => 'Abilitato';
+
+  @override
+  String get skillsManagement => 'Gestione delle competenze';
+
+  @override
+  String get skillsManagementEmpty => 'Nessuna competenza ancora';
+
+  @override
+  String get downloadSkill => 'Scarica Abilità';
+
+  @override
+  String get downloadFile => 'Scarica file';
+
+  @override
+  String get downloading => 'Download in corso...';
+
+  @override
+  String get downloadSuccess => 'Abilità scaricata correttamente';
+
+  @override
+  String downloadFailed(Object error) {
+    return 'Download non riuscito: $error';
+  }
+
+  @override
+  String get deleteConfirm => 'Conferma eliminazione';
+
+  @override
+  String deleteConfirmMessage(String name) {
+    return 'Sei sicuro di voler eliminare \"$name\"?';
+  }
+
+  @override
+  String get invalidUrl => 'Inserisci un URL valido';
+
+  @override
+  String get urlHint => 'https://example.com/skill.zip';
+
+  @override
+  String get newFolder => 'Nuova cartella';
+
+  @override
+  String get newFile => 'Nuovo fascicolo';
+
+  @override
+  String get folderName => 'Nome della cartella';
+
+  @override
+  String get fileName => 'Nome del file';
+
+  @override
+  String get nameRequired => 'Il nome è obbligatorio';
+
+  @override
+  String get nameInvalid => 'Il nome non può contenere / o ..';
+
+  @override
+  String createFailed(Object error) {
+    return 'Creazione non riuscita: $error';
+  }
+
+  @override
+  String get fileContent => 'Contenuto del file';
+
+  @override
+  String get saveSuccess => 'Salvato con successo';
+
+  @override
+  String downloadToCurrentDir(String dir) {
+    return 'Lo zip verrà estratto nella directory corrente: $dir';
+  }
+
+  @override
+  String get privacyPolicy => 'politica sulla riservatezza';
+
+  @override
+  String get privacyPolicyDesc => 'Come Memex gestisce i tuoi dati';
+
+  @override
+  String get llmAuthError =>
+      'Autenticazione API non riuscita. Controlla la configurazione LLM in Impostazioni.';
+
+  @override
+  String get llmBadRequestError =>
+      'La richiesta è stata respinta dal fornitore LLM. Il formato di input potrebbe non essere supportato dal modello attuale.';
+
+  @override
+  String get llmRateLimitError =>
+      'Limite di velocità API superato. Per favore riprova più tardi.';
+
+  @override
+  String get llmServerError =>
+      'Il servizio LLM è temporaneamente non disponibile. Per favore riprova più tardi.';
+
+  @override
+  String get llmNetworkError =>
+      'Connessione di rete non riuscita. Controlla la tua connessione Internet.';
+
+  @override
+  String get llmUnknownError =>
+      'Si è verificato un errore imprevisto durante l\'elaborazione del contenuto.';
+
+  @override
+  String get llmErrorDialogTitle => 'Elaborazione non riuscita';
+
+  @override
+  String get goToModelConfig => 'Vai su Impostazioni';
+
+  @override
+  String get speechModelDownloadTitle => 'Scarica il modello vocale';
+
+  @override
+  String speechModelDownloadDesc(Object sizeMB) {
+    return 'È richiesto un download del modello una tantum (~${sizeMB}MB).\n\nUna volta scaricata, la trascrizione viene eseguita interamente sul dispositivo.';
+  }
+
+  @override
+  String get speechModelStartDownload => 'Avvia il download';
+
+  @override
+  String get speechModelChooseSource => 'Scegli la fonte di download:';
+
+  @override
+  String get speechModelChinaMirror => '🇨🇳 China Mirror (più veloce in CN)';
+
+  @override
+  String get speechModelGithub => '🌐 GitHub (globale)';
+
+  @override
+  String get speechModelDownloading => 'Download del modello...';
+
+  @override
+  String get speechModelConnecting => 'Connessione...';
+
+  @override
+  String get deleteSpeechModel => 'Elimina modello vocale';
+
+  @override
+  String get confirmDeleteSpeechModelMessage =>
+      'Eliminare i file del modello di riconoscimento vocale locale scaricati? Verranno scaricati di nuovo la prossima volta che verrà utilizzata la sintesi vocale locale.';
+
+  @override
+  String get speechModelDeletedSuccess => 'File del modello vocale eliminati';
+
+  @override
+  String get speechModelNotDownloaded =>
+      'Nessun file del modello vocale scaricato trovato';
+
+  @override
+  String speechModelDeleteFailed(Object error) {
+    return 'Impossibile eliminare i file del modello vocale: $error';
+  }
+
+  @override
+  String get speechTranscribing => 'Riconoscere...';
+
+  @override
+  String get speechNoResult => 'Nessun parlato rilevato';
+
+  @override
+  String get useLocalSpeechToTextTitle =>
+      'Utilizza la parlata locale per inviare messaggi di testo';
+
+  @override
+  String get useLocalSpeechToTextDesc =>
+      'Se abilitato, l\'audio viene trascritto sul dispositivo prima dell\'invio, utile per i modelli che non supportano l\'input audio. Quando disabilitato, l\'audio originale viene inviato direttamente al modello.';
+
+  @override
+  String get pendingAiProcessingHint => 'Configura il modello AI da elaborare';
+
+  @override
+  String get demoWelcome =>
+      'Benvenuti in Memex!\nFacciamo un breve tour di ciò che l\'intelligenza artificiale può fare per i tuoi record.';
+
+  @override
+  String get demoTapAdd => 'Tocca qui per creare il tuo primo record';
+
+  @override
+  String get demoTapSend => 'Tocca per inviare il tuo primo record';
+
+  @override
+  String get demoTapCard =>
+      'Tocca per vedere come l\'IA ha organizzato il tuo record';
+
+  @override
+  String get demoDetailHint =>
+      'Questo è il dettaglio del tuo record organizzato dall\'intelligenza artificiale. Scorri intorno, quindi torna indietro per continuare il tour.';
+
+  @override
+  String get demoTapInsight =>
+      'Tocca per visualizzare gli approfondimenti generati dall\'intelligenza artificiale';
+
+  @override
+  String get demoTapInsightUpdate =>
+      'Tocca per generare approfondimenti dai tuoi record';
+
+  @override
+  String get demoTapKnowledge =>
+      'Controlla i tuoi file di conoscenza organizzati automaticamente';
+
+  @override
+  String get demoDone => 'Inizia a registrare la tua vita.';
+
+  @override
+  String get demoStartTour => 'Inizia il giro';
+
+  @override
+  String get demoGetStarted => 'Inizia';
+
+  @override
+  String get demoSkip => 'Saltare';
+
+  @override
+  String get demoPrefillText => 'Ciao Memex! Questo è il mio primo disco 🎉';
+
+  @override
+  String get visionBadge => 'Visione';
+
+  @override
+  String get notMultimodalHint =>
+      'Memex si affida alle capacità del modello multimodale per l\'analisi dei media. Se i tuoi record contengono immagini, assicurati che il modello configurato supporti l\'input di immagini.';
+
+  @override
+  String get defaultModelPrefix => 'Predefinito';
+
+  @override
+  String get recommendedBadge => 'Raccomandato';
+
+  @override
+  String get readOnlyBadge => 'CHIACCHIERATA';
+
+  @override
+  String get switchCompanion => 'Cambia compagno';
+
+  @override
+  String get personaChatInputHint => 'Digita un messaggio...';
+
+  @override
+  String get today => 'Oggi';
+
+  @override
+  String get tomorrow => 'Domani';
+
+  @override
+  String get yesterday => 'Ieri';
+
+  @override
+  String get showInsightTextTitle =>
+      'Mostra il commento di approfondimento Memex';
+
+  @override
+  String get showInsightTextDesc =>
+      'Se mostrare l\'approfondimento Memex come commento appuntato nella sezione dei commenti sui dettagli della carta.';
+
+  @override
+  String get enableCharacterCommentTitle => 'Commento automatico dei caratteri';
+
+  @override
+  String get enableCharacterCommentDesc =>
+      'I personaggi commentano automaticamente i nuovi record.';
+
+  @override
+  String get maxCommentCharactersTitle =>
+      'Numero massimo di caratteri di commento';
+
+  @override
+  String get maxCommentCharactersDesc =>
+      'Quanti caratteri possono commentare ciascun record.';
+
+  @override
+  String replyTo(String name) {
+    return 'Rispondi a $name';
+  }
+
+  @override
+  String get cdnSignalsComments => 'Nuova risposta ricevuta';
+
+  @override
+  String get cdnSignalsInsight => 'Nuove informazioni generate';
+
+  @override
+  String get cdnSignalsBoth => 'Nuova risposta e approfondimento';
+
+  @override
+  String get untitledCard => 'Carta senza titolo';
+
+  @override
+  String get locationContextTitle => 'Contesto della posizione';
+
+  @override
+  String get locationContextDescription =>
+      'Contesto attuale della città e del quartiere per la chat dell\'agente';
+
+  @override
+  String get locationContextAttachTitle =>
+      'Allega la posizione corrente alla chat';
+
+  @override
+  String get locationContextAttachDesc =>
+      'Utilizza il GPS del dispositivo e la geocodificazione inversa per fornire all\'agente il contesto di città, distretto e quartiere.';
+
+  @override
+  String get reverseGeocodingProvider => 'Provider di geocodifica inversa';
+
+  @override
+  String get amapProviderName => 'Una mappa';
+
+  @override
+  String get amapApiKey => 'Chiave API Amap';
+
+  @override
+  String get amapGcj02Note =>
+      'Amap utilizza le coordinate GCJ-02. Il GPS del dispositivo viene convertito prima della geocodifica inversa.';
+
+  @override
+  String get contextGranularity => 'Granularità del contesto';
+
+  @override
+  String get granularityCity => 'Città';
+
+  @override
+  String get granularityDistrict => 'Quartiere';
+
+  @override
+  String get granularityNeighborhood => 'Quartiere';
+
+  @override
+  String get granularityStreet => 'Strada';
+
+  @override
+  String get granularityFullAddress => 'Candidato con indirizzo completo';
+
+  @override
+  String get locationFreshness => 'Freschezza della posizione';
+
+  @override
+  String minutesShort(int minutes) {
+    return '$minutes minuti';
+  }
+
+  @override
+  String get oneHour => '1 ora';
+
+  @override
+  String get testCurrentLocation => 'Testare la posizione attuale';
+
+  @override
+  String locationTestFailed(String error) {
+    return 'Non riuscito: $error';
+  }
+
+  @override
+  String get locationDebugGps => 'GPS';
+
+  @override
+  String get locationDebugReverseGeocode => 'Geocodifica inversa';
+
+  @override
+  String get locationDebugProvider => 'Fornitore';
+
+  @override
+  String get locationDebugAgentContext => 'Contesto dell\'agente';
+
+  @override
+  String get locationDebugSource => 'Fonte';
+
+  @override
+  String get locationDebugAddressSummary => 'Riepilogo degli indirizzi';
+
+  @override
+  String get locationDebugFullAddress => 'Indirizzo completo';
+
+  @override
+  String get locationDebugCoordinates => 'Coordinate';
+
+  @override
+  String get locationDebugAccuracy => 'Precisione';
+
+  @override
+  String get locationDebugReason => 'Motivo';
+
+  @override
+  String get locationDebugOk => 'OK';
+
+  @override
+  String get locationDebugUnavailable => 'non disponibile';
+
+  @override
+  String get locationDebugInjected => 'iniettato';
+
+  @override
+  String get locationDebugNotInjected => 'non iniettato';
+
+  @override
+  String get locationStatusUpdatedAt => 'Aggiornato';
+
+  @override
+  String get locationStatusSuccessTitle => 'La posizione attuale è pronta';
+
+  @override
+  String get locationStatusSuccessBody =>
+      'Memex può allegare questo riepilogo della posizione quando il contesto della posizione è rilevante.';
+
+  @override
+  String get locationStatusApproximateTitle => 'Posizione solo approssimativa';
+
+  @override
+  String get locationStatusApproximateBody =>
+      'La precisione sembra a livello di città o area. Puoi continuare a usarlo o abilitare Posizione precisa nelle impostazioni di sistema per un contesto più ristretto.';
+
+  @override
+  String get locationStatusServiceDisabledTitle =>
+      'La posizione del sistema è disattivata';
+
+  @override
+  String get locationStatusServiceDisabledBody =>
+      'Memex utilizza solo il GPS del dispositivo e non deduce la posizione dalla rete o dall\'IP. Su Android, apri le impostazioni di Posizione; su iOS, abilita Impostazioni > Privacy e sicurezza > Servizi di localizzazione.';
+
+  @override
+  String get locationStatusPermissionDeniedTitle =>
+      'È necessaria l\'autorizzazione alla posizione';
+
+  @override
+  String get locationStatusPermissionDeniedBody =>
+      'Consenti a Memex di utilizzare la posizione durante i test o quando è necessario il contesto della posizione. Non è sempre richiesto l\'accesso.';
+
+  @override
+  String get locationStatusPermissionForeverTitle =>
+      'L\'autorizzazione alla posizione è bloccata';
+
+  @override
+  String get locationStatusPermissionForeverBody =>
+      'Apri le impostazioni dell\'app e consenti la posizione per Memex. Su iOS, è sufficiente utilizzare l\'app.';
+
+  @override
+  String get locationStatusDisabledTitle =>
+      'Il contesto della posizione è disattivato';
+
+  @override
+  String get locationStatusDisabledBody =>
+      'Attiva l\'interruttore in alto e salva quando desideri che Memex alleghi la posizione del dispositivo al contesto dell\'agente.';
+
+  @override
+  String get locationStatusGeocodeUnavailableTitle =>
+      'Il GPS funziona, la ricerca dell\'indirizzo non è riuscita';
+
+  @override
+  String get locationStatusGeocodeUnavailableBody =>
+      'Memex ha le coordinate ma non inserirà nell\'agente il contesto solo GPS. Controlla il provider di geocodifica inversa e riprova.';
+
+  @override
+  String get locationStatusUnavailableTitle => 'Posizione non disponibile';
+
+  @override
+  String get locationStatusUnavailableBody =>
+      'Controlla i servizi di localizzazione del sistema e l\'autorizzazione dell\'app, quindi prova di nuovo.';
+
+  @override
+  String get allowLocationPermissionButton =>
+      'Consenti l\'autorizzazione alla posizione';
+
+  @override
+  String get openAppSettingsButton => 'Apri le impostazioni dell\'app';
+
+  @override
+  String get openLocationSettingsButton => 'Apri le impostazioni di posizione';
+
+  @override
+  String get locationSettingsOpenFailed =>
+      'Impossibile aprire le impostazioni di sistema.';
+
+  @override
+  String locationActionFailed(String error) {
+    return 'Azione sulla posizione non riuscita: $error';
+  }
+
+  @override
+  String get settingsSearchPlaceholder => 'Cerca impostazioni...';
+
+  @override
+  String get settingsSearchEmpty =>
+      'Nessuna impostazione corrispondente trovata';
+
+  @override
+  String get importCharacterCard => 'Importa scheda personaggio';
+
+  @override
+  String get firstMessageLabel => 'Primo messaggio';
+
+  @override
+  String get firstMessageHint =>
+      'Saluto inviato alla prima conversazione (facoltativo)';
+
+  @override
+  String get systemPromptOverrideLabel => 'Ignora la richiesta di sistema';
+
+  @override
+  String get systemPromptOverrideHint =>
+      'Sostituisci il prompt di sistema predefinito (avanzato, facoltativo)';
+
+  @override
+  String get postHistoryInstructionsLabel => 'Istruzioni post-storia';
+
+  @override
+  String get postHistoryInstructionsHint =>
+      'Istruzioni inserite dopo la cronologia della chat, prima della risposta (facoltativo)';
+
+  @override
+  String get mesExampleLabel => 'Esempi di messaggi';
+
+  @override
+  String get mesExampleHint =>
+      'Dialoghi di esempio che mostrano lo stile del carattere (facoltativo)';
+
+  @override
+  String get worldBookTitle => 'Libro del mondo';
+
+  @override
+  String get worldBookSubtitle =>
+      'Conoscenza di base inserita quando vengono attivate le parole chiave';
+
+  @override
+  String get characterMemoryTitle => 'Memoria dei personaggi';
+
+  @override
+  String get characterMemorySubtitle =>
+      'Dinamiche di relazione e ricordi di interazione tra personaggio e utente';
+
+  @override
+  String get addTooltip => 'Aggiungere';
+
+  @override
+  String get constantBadge => 'Costante';
+
+  @override
+  String worldEntryFallbackName(Object index) {
+    return 'Voce $index';
+  }
+
+  @override
+  String keywordsPrefix(Object keys) {
+    return 'Parole chiave: $keys';
+  }
+
+  @override
+  String memoryFallbackName(Object index) {
+    return 'Memoria $index';
+  }
+
+  @override
+  String get addWorldEntry => 'Aggiungi voce di libro mondiale';
+
+  @override
+  String get editWorldEntry => 'Modifica la voce del libro mondiale';
+
+  @override
+  String get commentTitleLabel => 'Commento/Titolo';
+
+  @override
+  String get entryDescriptionHint => 'Descrizione della voce (facoltativa)';
+
+  @override
+  String get triggerKeywordsLabel => 'Parole chiave attivatrici';
+
+  @override
+  String get triggerKeywordsHint =>
+      'Separati da virgole, ad esempio: magia, incantesimo';
+
+  @override
+  String get contentLabel => 'Contenuto';
+
+  @override
+  String get worldEntryContentHint =>
+      'Conoscenza di base inserita quando si attivano le parole chiave';
+
+  @override
+  String get enabledCheckbox => 'Abilitato';
+
+  @override
+  String get addMemory => 'Aggiungi memoria';
+
+  @override
+  String get editMemory => 'Modifica memoria';
+
+  @override
+  String get memoryLabelField => 'Etichetta';
+
+  @override
+  String get memoryLabelHint =>
+      'Identificatore univoco, ad esempio: preferenza del nome';
+
+  @override
+  String get memoryContentHint => 'Contenuto della memoria';
+
+  @override
+  String get salienceLabel => 'Salienza:';
+
+  @override
+  String get labelCannotBeEmpty => 'L\'etichetta non può essere vuota';
+
+  @override
+  String importSuccess(Object name) {
+    return '$name importato correttamente';
+  }
+
+  @override
+  String importFailed(Object error) {
+    return 'Importazione non riuscita: $error';
+  }
+
+  @override
+  String get supportedFormats => 'Formati supportati';
+
+  @override
+  String get tavernImportDescription =>
+      '• Carte personaggio SillyTavern V2 (.json)\n• Immagini PNG con schede incorporate (.png)\n\nCampi come persona, libro mondiale, ecc. verranno automaticamente mappati sul formato carattere Memex.';
+
+  @override
+  String get pickCharacterFile => 'Scegli File di caratteri';
+
+  @override
+  String get repickFile => 'Scegli un altro file';
+
+  @override
+  String get personaSettingSection => 'Persona';
+
+  @override
+  String get systemPromptSection => 'Richiesta di sistema';
+
+  @override
+  String worldEntriesCount(Object count) {
+    return 'Libro del mondo: $count voci';
+  }
+
+  @override
+  String fileLabel(Object filename) {
+    return 'File: $filename';
+  }
+
+  @override
+  String conflictWarning(Object names) {
+    return 'Esiste già un carattere con lo stesso nome: $names. L\'importazione creerà un nuovo carattere senza sovrascrivere quelli esistenti.';
+  }
+
+  @override
+  String get setPrimaryCompanionTitle => 'Imposta come compagno principale';
+
+  @override
+  String get setPrimaryCompanionSubtitle =>
+      'Impostato automaticamente come compagno principale dopo l\'importazione';
+
+  @override
+  String get confirmImport => 'Conferma l\'importazione';
+
+  @override
+  String get chatBackground => 'Sfondo della chat';
+
+  @override
+  String get chooseChatBackgroundImage => 'Scegli l\'immagine di sfondo';
+
+  @override
+  String get earlyUpdateSettingsTitle => 'Aggiornamenti in accesso anticipato';
+
+  @override
+  String get earlyUpdateSettingsDesc =>
+      'Controlla le pre-release di GitHub per l\'APK iniziale corrispondente, scaricalo e consegnalo al programma di installazione di Android.';
+
+  @override
+  String get earlyUpdateUnsupported =>
+      'I primi aggiornamenti sono disponibili solo nella build Android Early.';
+
+  @override
+  String get earlyUpdateAutoCheckTitle =>
+      'Controllo automatico degli aggiornamenti';
+
+  @override
+  String get earlyUpdateAutoCheckDesc =>
+      'Controllare all\'avvio al massimo una volta ogni 12 ore.';
+
+  @override
+  String get earlyUpdateWifiOnlyTitle => 'Scarica solo tramite Wi-Fi';
+
+  @override
+  String get earlyUpdateWifiOnlyDesc =>
+      'Salta i download degli aggiornamenti durante l\'utilizzo dei dati mobili.';
+
+  @override
+  String get earlyUpdateAutoInstallTitle =>
+      'Download e installazione automatici';
+
+  @override
+  String get earlyUpdateAutoInstallDesc =>
+      'Quando viene trovata una nuova build, scaricala e apri automaticamente il programma di installazione Android.';
+
+  @override
+  String get earlyUpdateCheckNow => 'Controlla ora';
+
+  @override
+  String get earlyUpdateChecking => 'Controllo delle pre-release di GitHub...';
+
+  @override
+  String get earlyUpdateSkippedMobile =>
+      'Saltato perché i download solo Wi-Fi sono abilitati.';
+
+  @override
+  String get earlyUpdateNoUpdate => 'Sei già sull\'ultima versione Early.';
+
+  @override
+  String earlyUpdateFound(Object version, Object build) {
+    return 'La versione iniziale $version+$build è disponibile.';
+  }
+
+  @override
+  String get earlyUpdateDownloadAndInstall => 'Scarica e installa';
+
+  @override
+  String get earlyUpdateDownloadInProgress =>
+      'Download dell\'aggiornamento in corso...';
+
+  @override
+  String earlyUpdateDownloadingPercent(Object percent) {
+    return 'Download aggiornamento: $percent%';
+  }
+
+  @override
+  String get earlyUpdateDownloadReadyToInstall =>
+      'Pacchetto di aggiornamento scaricato. Pronto per l\'installazione.';
+
+  @override
+  String get earlyUpdateInstallDownloadedPackage =>
+      'Installa il pacchetto scaricato';
+
+  @override
+  String get earlyUpdateClearDownloadedPackage =>
+      'Cancella il pacchetto scaricato';
+
+  @override
+  String get earlyUpdateClearDownloadedPackageSuccess =>
+      'Pacchetto di aggiornamento scaricato cancellato.';
+
+  @override
+  String get earlyUpdateInstallStarted =>
+      'È stato aperto il programma di installazione di Android.';
+
+  @override
+  String get earlyUpdateInstallPermissionRequired =>
+      'Consenti a Memex di installare app sconosciute, quindi tocca Scarica e installa di nuovo.';
+
+  @override
+  String earlyUpdateLastChecked(Object time) {
+    return 'Ultimo controllo: $time';
+  }
+
+  @override
+  String earlyUpdateCheckFailed(Object error) {
+    return 'Controllo aggiornamento non riuscito: $error';
+  }
+
+  @override
+  String get earlyUpdateDialogTitle => 'Aggiornamento anticipato disponibile';
+
+  @override
+  String get earlyUpdateReleaseNotes => 'Note sulla versione';
+
+  @override
+  String get dismissAllNotifications => 'Cancella tutto';
+
+  @override
+  String get dismissByType => 'Cancella per tipo';
+
+  @override
+  String get dismissTypeSystemAction => 'Promemoria ed eventi';
+
+  @override
+  String get dismissTypeClarification => 'Chiarimenti';
+
+  @override
+  String get dismissTypeCardUpdate => 'Aggiornamenti della carta';
+
+  @override
+  String dismissedCount(Object count) {
+    return '$count cancellato';
+  }
+
+  @override
+  String get dataImportTitle => 'Importa file';
+
+  @override
+  String get dataImportSettingsDescription =>
+      'Porta i vecchi file in Memex, poi decidi se organizzarli.';
+
+  @override
+  String get dataImportDescription =>
+      'Scegli vecchie note, record esportati, documenti o archivi ZIP. Memex salva prima una copia e lascia intatti i file originali. Dopo l\'importazione, puoi decidere se Memex deve aiutarti a organizzarli.';
+
+  @override
+  String get dataImportSelectFiles => 'Scegli i file da importare';
+
+  @override
+  String get dataImportImporting => 'Salvataggio file...';
+
+  @override
+  String get dataImportSuccess => 'File salvati in Memex';
+
+  @override
+  String get dataImportOnlyStored =>
+      'File salvati. Nessuna organizzazione è iniziata.';
+
+  @override
+  String get dataImportQueued =>
+      'Memex organizzerà questa importazione in background.';
+
+  @override
+  String get dataImportResultTitle => 'Importazione completata';
+
+  @override
+  String dataImportResultSummary(Object count) {
+    return 'I file $count sono stati salvati. Puoi organizzarli ora o lasciarli come materiale originale.';
+  }
+
+  @override
+  String dataImportRenamedConflicts(Object count) {
+    return 'Gli elementi $count avevano lo stesso nome e sono stati rinominati per evitare di sovrascrivere nulla.';
+  }
+
+  @override
+  String dataImportSkippedUnsafeEntries(Object count) {
+    return '$count elementi di archivio insoliti sono stati saltati; il resto è stato importato normalmente.';
+  }
+
+  @override
+  String get dataImportChooseProcessing => 'Organizza questi file';
+
+  @override
+  String get dataImportProcessTitle => 'Organizzare questa importazione?';
+
+  @override
+  String dataImportProcessPrompt(Object count) {
+    return 'Hai importato file $count. Scegli se Memex deve organizzarli adesso o conservare solo gli originali.';
+  }
+
+  @override
+  String get dataImportProcessKnowledgeBase =>
+      'Organizzare in una base di conoscenza';
+
+  @override
+  String get dataImportProcessKnowledgeBaseDesc =>
+      'Ideale per documenti, note, materiale di progetto e riferimenti. Memex estrarrà le informazioni utili e le raggrupperà per un uso successivo.';
+
+  @override
+  String get dataImportProcessTimelineCards =>
+      'Crea record della sequenza temporale';
+
+  @override
+  String get dataImportProcessTimelineCardsDesc =>
+      'Ideale per diari, registri di chat, cronologia delle attività e vecchie esportazioni. Memex trasformerà i contenuti basati sul tempo in record quando avrà senso.';
+
+  @override
+  String get dataImportImpactNone =>
+      'Memex conserverà solo questi file originali. Nessuna organizzazione AI verrà avviata.';
+
+  @override
+  String get dataImportImpactKnowledgeBase =>
+      'Memex leggerà questi file e organizzerà informazioni utili a lungo termine nella base di conoscenza. Non creerà in modo proattivo record della sequenza temporale.';
+
+  @override
+  String get dataImportImpactTimelineCards =>
+      'Memex leggerà questi file e creerà registrazioni della sequenza temporale per eventi della vita o cronologia datata, quando appropriato. Non organizzerà in modo proattivo la base di conoscenza.';
+
+  @override
+  String get dataImportImpactBoth =>
+      'Memex proverà a creare record di sequenza temporale e organizzare le informazioni riutilizzabili nella base di conoscenza. Questo è l\'ideale per un archivio personale completo.';
+
+  @override
+  String get dataImportFinish => 'Salvateli e basta';
+
+  @override
+  String get noImages => 'Nessuna immagine';
+
+  @override
+  String get noMessages => 'Nessun messaggio';
+
+  @override
+  String get sketchContent => 'Contenuto dello schizzo';
+
+  @override
+  String get emptyFolder => 'Cartella vuota';
+
+  @override
+  String get usernameAlreadyTaken => 'Nome utente già preso';
+
+  @override
+  String get registrationFailed => 'La registrazione non è riuscita';
+
+  @override
+  String get loginFailed => 'Accesso non riuscito';
+
+  @override
+  String get paymentCreationFailed => 'Impossibile avviare il pagamento';
+
+  @override
+  String get completePayment => 'Pagamento completo';
+
+  @override
+  String get commentReplyToYou => 'Voi';
+
+  @override
+  String get commentAuthorUser => 'Utente';
+
+  @override
+  String get commentAuthorAi => 'AI';
+
+  @override
+  String get authorizationCancelled => 'Autorizzazione annullata';
+
+  @override
+  String timelineWeekNumberLabel(Object week) {
+    return 'Settimana $week';
+  }
+
+  @override
+  String get timelineWeekLabel => 'Settimana';
+
+  @override
+  String get eventCardDefaultTitle => 'Evento';
+
+  @override
+  String get memoryNoLongTermYet => 'Ancora nessun ricordo a lungo termine.';
+
+  @override
+  String get memoryNoRecentBuffer => 'Nessun ricordo recente nel buffer.';
+
+  @override
+  String get memoryGeneralSubject => 'Generale';
+}

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -686,10 +686,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '実行中 $running、保留中 $pending、再試行 $retrying';
   }
 

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -686,10 +686,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '실행 중 $running, 대기 중 $pending, 재시도 $retrying';
   }
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -704,10 +704,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Executando $running, pendentes $pending, nova tentativa $retrying';
   }
 

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -703,10 +703,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Выполняется $running, ожидает $pending, повтор $retrying';
   }
 

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -694,10 +694,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'กำลังทำงาน $running, รอดำเนินการ $pending, ลองใหม่ $retrying';
   }
 

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -701,10 +701,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Çalıştırılıyor $running, Beklemede $pending, Yeniden Dene $retrying';
   }
 

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -696,10 +696,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Đang chạy $running, Chờ $pending, Thử lại $retrying';
   }
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -681,10 +681,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '执行中 $running，排队中 $pending，重试中 $retrying';
   }
 
@@ -3860,10 +3857,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '執行中 $running，排隊中 $pending，重試中 $retrying';
   }
 

--- a/lib/l10n/supported_languages.dart
+++ b/lib/l10n/supported_languages.dart
@@ -132,6 +132,13 @@ const List<SupportedLanguage> supportedLanguages = <SupportedLanguage>[
     shortLabel: 'TR',
   ),
   SupportedLanguage(
+    locale: Locale('it'),
+    localeTag: 'it',
+    nativeName: 'Italiano',
+    englishName: 'Italian',
+    shortLabel: 'IT',
+  ),
+  SupportedLanguage(
     locale: Locale('ru'),
     localeTag: 'ru',
     nativeName: 'Русский',
@@ -157,6 +164,7 @@ const List<Locale> supportedLanguageLocales = <Locale>[
   Locale('vi'),
   Locale('th'),
   Locale('tr'),
+  Locale('it'),
   Locale('ru'),
 ];
 
@@ -177,6 +185,7 @@ const List<String> supportedLanguageTags = <String>[
   'vi',
   'th',
   'tr',
+  'it',
   'ru',
 ];
 

--- a/test/l10n/italian_locale_smoke_test.dart
+++ b/test/l10n/italian_locale_smoke_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/l10n/app_localizations_ext.dart';
+import 'package:memex/l10n/supported_languages.dart';
+
+void main() {
+  test('Italian locale resolves and loads l10n', () {
+    if (!supportedLanguageTags.contains('it')) {
+      return;
+    }
+
+    const locale = Locale('it');
+    final l10n = lookupAppLocalizations(locale);
+    final ext = lookupAppLocalizationsExt(locale);
+
+    expect(l10n.localeName, 'it');
+    expect(l10n.retry, 'Riprova');
+    expect(l10n.cancel, 'Cancellare');
+    expect(ext.defaultCharacters, isNotEmpty);
+    expect(ext.oauthHintTitle, isNotEmpty);
+  });
+
+  test('Italian locale exposes the simplified AI setup copy', () {
+    if (!supportedLanguageTags.contains('it')) {
+      return;
+    }
+
+    const locale = Locale('it');
+    final l10n = lookupAppLocalizations(locale);
+
+    expect(l10n.aiSetupStatusMemexTitle, 'Utilizzando il servizio ufficiale Memex');
+    expect(
+      l10n.aiSetupOfficialRouteDescription,
+      'Accedi a Memex per utilizzare il servizio AI ufficiale.',
+    );
+    expect(
+      l10n.aiSetupCustomRouteDescription,
+      'Aggiungi il tuo provider e la chiave API.',
+    );
+    expect(l10n.aiSetupStatusMemexDescription, isNot(contains('MemeX')));
+  });
+}

--- a/test/utils/user_storage_locale_test.dart
+++ b/test/utils/user_storage_locale_test.dart
@@ -65,6 +65,12 @@ void main() {
       expect(locale.languageCode, 'ru');
     });
 
+    test('keeps supported Italian locale', () {
+      final locale = UserStorage.resolveToSupportedLocale(const Locale('it'));
+
+      expect(locale.languageCode, 'it');
+    });
+
     test('keeps supported Traditional Chinese locale', () {
       final locale = UserStorage.resolveToSupportedLocale(
         const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
@@ -90,7 +96,7 @@ void main() {
     });
 
     test('falls back unsupported locales to English', () {
-      final locale = UserStorage.resolveToSupportedLocale(const Locale('it'));
+      final locale = UserStorage.resolveToSupportedLocale(const Locale('nl'));
 
       expect(locale.languageCode, 'en');
     });


### PR DESCRIPTION
## Summary

Adds full Italian (`it`) UI localization following the same two-layer pattern as Thai and Turkish: ARB strings, AppLocalizationsExt, platform registration, and smoke tests.

## Commits

- Italian ARB (~969 keys)
- AppLocalizationsExtIt
- supported_languages + iOS/Android registration
- Regenerated l10n outputs
- Smoke + locale lookup tests

## Test plan

- [x] `flutter gen-l10n`
- [x] `flutter test test/l10n/italian_locale_smoke_test.dart`
- [x] `flutter test test/l10n/locale_lookup_test.dart`
