### PR TITLE
fix(l10n): localize debug tools UI and OAuth error paths

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "لا توجد ذكريات طويلة المدى بعد.",
   "memoryNoRecentBuffer": "لا توجد ذكريات حديثة في المخزن المؤقت.",
   "memoryGeneralSubject": "عام",
+  "debugging": "تصحيح الأخطاء",
+  "agentStates": "حالات الوكيل",
+  "logLevel": "المستوى: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "الحالة: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "المجدول: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "مكتمل: {date}",
+  "oauthCouldNotLaunchBrowser": "تعذر تشغيل المتصفح لـ OAuth",
+  "authorizationTimedOut": "انتهت صلاحية التفويض",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "Noch keine Langzeit-Erinnerungen.",
   "memoryNoRecentBuffer": "Keine recenten Erinnerungen im Puffer.",
   "memoryGeneralSubject": "Allgemein",
+  "debugging": "Debugging",
+  "agentStates": "Agentenzustände",
+  "logLevel": "Level: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "Status: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "Geplant: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "Abgeschlossen: {date}",
+  "oauthCouldNotLaunchBrowser": "Browser für OAuth konnte nicht gestartet werden",
+  "authorizationTimedOut": "Autorisierung abgelaufen",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1515,5 +1515,40 @@
   "eventCardDefaultTitle": "Event",
   "memoryNoLongTermYet": "No long-term memories yet.",
   "memoryNoRecentBuffer": "No recent memories in buffer.",
-  "memoryGeneralSubject": "General"
+  "memoryGeneralSubject": "General",
+  "debugging": "Debugging",
+  "agentStates": "Agent States",
+  "logLevel": "Level: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "Status: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "Scheduled: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "Completed: {date}",
+  "oauthCouldNotLaunchBrowser": "Could not launch browser for OAuth",
+  "authorizationTimedOut": "Authorization timed out"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "Aún no hay recuerdos a largo plazo.",
   "memoryNoRecentBuffer": "No hay recuerdos recientes en el búfer.",
   "memoryGeneralSubject": "General",
+  "debugging": "Depuración",
+  "agentStates": "Estados del agente",
+  "logLevel": "Nivel: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "Estado: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "Programado: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "Completado: {date}",
+  "oauthCouldNotLaunchBrowser": "No se pudo abrir el navegador para OAuth",
+  "authorizationTimedOut": "La autorización expiró",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -1515,5 +1515,40 @@
   "eventCardDefaultTitle": "رویداد",
   "memoryNoLongTermYet": "هنوز هیچ خاطره بلندمدتی وجود ندارد.",
   "memoryNoRecentBuffer": "هیچ خاطره جدیدی در بافر وجود ندارد.",
-  "memoryGeneralSubject": "عمومی"
+  "memoryGeneralSubject": "عمومی",
+  "debugging": "اشکال‌زدایی",
+  "agentStates": "وضعیت‌های عامل",
+  "logLevel": "سطح: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "وضعیت: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "زمان‌بندی‌شده: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "تکمیل‌شده: {date}",
+  "oauthCouldNotLaunchBrowser": "امکان راه‌اندازی مرورگر برای OAuth وجود ندارد",
+  "authorizationTimedOut": "مهلت مجوز به پایان رسید"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "Pas encore de souvenirs à long terme.",
   "memoryNoRecentBuffer": "Aucun souvenir récent dans le tampon.",
   "memoryGeneralSubject": "Général",
+  "debugging": "Débogage",
+  "agentStates": "États de l'agent",
+  "logLevel": "Niveau : ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID : {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID : {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "Statut : {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "Planifié : {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "Terminé : {date}",
+  "oauthCouldNotLaunchBrowser": "Impossible de lancer le navigateur pour OAuth",
+  "authorizationTimedOut": "Autorisation expirée",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "अभी तक कोई दीर्घकालिक स्मृति नहीं है।",
   "memoryNoRecentBuffer": "बफ़र में कोई हाल की स्मृति नहीं है।",
   "memoryGeneralSubject": "सामान्य",
+  "debugging": "डीबगिंग",
+  "agentStates": "एजेंट स्थितियाँ",
+  "logLevel": "स्तर: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "स्थिति: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "निर्धारित: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "पूर्ण: {date}",
+  "oauthCouldNotLaunchBrowser": "OAuth के लिए ब्राउज़र लॉन्च नहीं किया जा सका",
+  "authorizationTimedOut": "प्राधिकरण समय समाप्त",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "Belum ada memori jangka panjang.",
   "memoryNoRecentBuffer": "Tidak ada memori terbaru di buffer.",
   "memoryGeneralSubject": "Umum",
+  "debugging": "Debugging",
+  "agentStates": "Status agen",
+  "logLevel": "Level: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "Status: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "Dijadwalkan: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "Selesai: {date}",
+  "oauthCouldNotLaunchBrowser": "Tidak dapat membuka browser untuk OAuth",
+  "authorizationTimedOut": "Otorisasi habis waktu",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "長期記憶はまだありません。",
   "memoryNoRecentBuffer": "バッファに最近の記憶はありません。",
   "memoryGeneralSubject": "一般",
+  "debugging": "デバッグ",
+  "agentStates": "エージェント状態",
+  "logLevel": "レベル: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "ステータス: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "予定: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "完了: {date}",
+  "oauthCouldNotLaunchBrowser": "OAuth用のブラウザを起動できませんでした",
+  "authorizationTimedOut": "認証がタイムアウトしました",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "아직 장기 기억이 없습니다.",
   "memoryNoRecentBuffer": "버퍼에 최근 기억이 없습니다.",
   "memoryGeneralSubject": "일반",
+  "debugging": "디버깅",
+  "agentStates": "에이전트 상태",
+  "logLevel": "레벨: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "상태: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "예정: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "완료: {date}",
+  "oauthCouldNotLaunchBrowser": "OAuth용 브라우저를 실행할 수 없습니다",
+  "authorizationTimedOut": "인증 시간이 초과되었습니다",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -77,7 +77,7 @@ import 'app_localizations_zh.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -100,11 +100,11 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -124,7 +124,7 @@ abstract class AppLocalizations {
     Locale('tr'),
     Locale('vi'),
     Locale('zh'),
-    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
+    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant')
   ];
 
   /// No description provided for @timesLabel.
@@ -1362,10 +1362,7 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Running {running}, Pending {pending}, Retry {retrying}'**
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  );
+      Object running, Object pending, Object retrying);
 
   /// No description provided for @agentBackgroundTaskDetail.
   ///
@@ -5944,6 +5941,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'General'**
   String get memoryGeneralSubject;
+
+  /// No description provided for @debugging.
+  ///
+  /// In en, this message translates to:
+  /// **'Debugging'**
+  String get debugging;
+
+  /// No description provided for @agentStates.
+  ///
+  /// In en, this message translates to:
+  /// **'Agent States'**
+  String get agentStates;
+
+  /// No description provided for @logLevel.
+  ///
+  /// In en, this message translates to:
+  /// **'Level: '**
+  String get logLevel;
+
+  /// No description provided for @taskIdLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'ID: {id}'**
+  String taskIdLabel(Object id);
+
+  /// No description provided for @taskBizIdLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'BizID: {bizId}'**
+  String taskBizIdLabel(Object bizId);
+
+  /// No description provided for @taskStatusLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Status: {status}'**
+  String taskStatusLabel(Object status);
+
+  /// No description provided for @taskScheduledLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled: {date}'**
+  String taskScheduledLabel(Object date);
+
+  /// No description provided for @taskCompletedLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Completed: {date}'**
+  String taskCompletedLabel(Object date);
+
+  /// No description provided for @oauthCouldNotLaunchBrowser.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not launch browser for OAuth'**
+  String get oauthCouldNotLaunchBrowser;
+
+  /// No description provided for @authorizationTimedOut.
+  ///
+  /// In en, this message translates to:
+  /// **'Authorization timed out'**
+  String get authorizationTimedOut;
 }
 
 class _AppLocalizationsDelegate
@@ -5957,23 +6014,23 @@ class _AppLocalizationsDelegate
 
   @override
   bool isSupported(Locale locale) => <String>[
-    'ar',
-    'de',
-    'en',
-    'es',
-    'fa',
-    'fr',
-    'hi',
-    'id',
-    'ja',
-    'ko',
-    'pt',
-    'ru',
-    'th',
-    'tr',
-    'vi',
-    'zh',
-  ].contains(locale.languageCode);
+        'ar',
+        'de',
+        'en',
+        'es',
+        'fa',
+        'fr',
+        'hi',
+        'id',
+        'ja',
+        'ko',
+        'pt',
+        'ru',
+        'th',
+        'tr',
+        'vi',
+        'zh'
+      ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -6029,9 +6086,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -694,10 +694,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'قيد التشغيل $running، معلق $pending، إعادة محاولة $retrying';
   }
 
@@ -3277,4 +3274,44 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'عام';
+
+  @override
+  String get debugging => 'تصحيح الأخطاء';
+
+  @override
+  String get agentStates => 'حالات الوكيل';
+
+  @override
+  String get logLevel => 'المستوى: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'الحالة: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'المجدول: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'مكتمل: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser => 'تعذر تشغيل المتصفح لـ OAuth';
+
+  @override
+  String get authorizationTimedOut => 'انتهت صلاحية التفويض';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -709,10 +709,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '$running wird ausgeführt, $pending steht aus, $retrying erneut versuchen';
   }
 
@@ -3358,4 +3355,45 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'Allgemein';
+
+  @override
+  String get debugging => 'Debugging';
+
+  @override
+  String get agentStates => 'Agentenzustände';
+
+  @override
+  String get logLevel => 'Level: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'Status: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'Geplant: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'Abgeschlossen: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser =>
+      'Browser für OAuth konnte nicht gestartet werden';
+
+  @override
+  String get authorizationTimedOut => 'Autorisierung abgelaufen';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -695,10 +695,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Running $running, Pending $pending, Retry $retrying';
   }
 
@@ -3297,4 +3294,44 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'General';
+
+  @override
+  String get debugging => 'Debugging';
+
+  @override
+  String get agentStates => 'Agent States';
+
+  @override
+  String get logLevel => 'Level: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'Status: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'Scheduled: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'Completed: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser => 'Could not launch browser for OAuth';
+
+  @override
+  String get authorizationTimedOut => 'Authorization timed out';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -704,10 +704,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'En ejecución $running, pendientes $pending, reintentos $retrying';
   }
 
@@ -3348,4 +3345,45 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'General';
+
+  @override
+  String get debugging => 'Depuración';
+
+  @override
+  String get agentStates => 'Estados del agente';
+
+  @override
+  String get logLevel => 'Nivel: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'Estado: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'Programado: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'Completado: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser =>
+      'No se pudo abrir el navegador para OAuth';
+
+  @override
+  String get authorizationTimedOut => 'La autorización expiró';
 }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -696,10 +696,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'در حال اجرا $running، در انتظار $pending، تلاش مجدد $retrying';
   }
 
@@ -3301,4 +3298,45 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'عمومی';
+
+  @override
+  String get debugging => 'اشکال‌زدایی';
+
+  @override
+  String get agentStates => 'وضعیت‌های عامل';
+
+  @override
+  String get logLevel => 'سطح: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'وضعیت: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'زمان‌بندی‌شده: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'تکمیل‌شده: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser =>
+      'امکان راه‌اندازی مرورگر برای OAuth وجود ندارد';
+
+  @override
+  String get authorizationTimedOut => 'مهلت مجوز به پایان رسید';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -706,10 +706,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'En cours $running, en attente $pending, nouvelle tentative $retrying';
   }
 
@@ -3355,4 +3352,45 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'Général';
+
+  @override
+  String get debugging => 'Débogage';
+
+  @override
+  String get agentStates => 'États de l\'agent';
+
+  @override
+  String get logLevel => 'Niveau : ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID : $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID : $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'Statut : $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'Planifié : $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'Terminé : $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser =>
+      'Impossible de lancer le navigateur pour OAuth';
+
+  @override
+  String get authorizationTimedOut => 'Autorisation expirée';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -697,10 +697,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'चल रहे $running, लंबित $pending, पुनः प्रयास $retrying';
   }
 
@@ -3306,4 +3303,45 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'सामान्य';
+
+  @override
+  String get debugging => 'डीबगिंग';
+
+  @override
+  String get agentStates => 'एजेंट स्थितियाँ';
+
+  @override
+  String get logLevel => 'स्तर: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'स्थिति: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'निर्धारित: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'पूर्ण: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser =>
+      'OAuth के लिए ब्राउज़र लॉन्च नहीं किया जा सका';
+
+  @override
+  String get authorizationTimedOut => 'प्राधिकरण समय समाप्त';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -700,10 +700,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Berjalan $running, Tertunda $pending, Coba ulang $retrying';
   }
 
@@ -3316,4 +3313,45 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'Umum';
+
+  @override
+  String get debugging => 'Debugging';
+
+  @override
+  String get agentStates => 'Status agen';
+
+  @override
+  String get logLevel => 'Level: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'Status: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'Dijadwalkan: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'Selesai: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser =>
+      'Tidak dapat membuka browser untuk OAuth';
+
+  @override
+  String get authorizationTimedOut => 'Otorisasi habis waktu';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -686,10 +686,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '実行中 $running、保留中 $pending、再試行 $retrying';
   }
 
@@ -3220,4 +3217,44 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => '一般';
+
+  @override
+  String get debugging => 'デバッグ';
+
+  @override
+  String get agentStates => 'エージェント状態';
+
+  @override
+  String get logLevel => 'レベル: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'ステータス: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return '予定: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return '完了: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser => 'OAuth用のブラウザを起動できませんでした';
+
+  @override
+  String get authorizationTimedOut => '認証がタイムアウトしました';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -686,10 +686,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '실행 중 $running, 대기 중 $pending, 재시도 $retrying';
   }
 
@@ -3219,4 +3216,44 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => '일반';
+
+  @override
+  String get debugging => '디버깅';
+
+  @override
+  String get agentStates => '에이전트 상태';
+
+  @override
+  String get logLevel => '레벨: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return '상태: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return '예정: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return '완료: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser => 'OAuth용 브라우저를 실행할 수 없습니다';
+
+  @override
+  String get authorizationTimedOut => '인증 시간이 초과되었습니다';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -704,10 +704,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Executando $running, pendentes $pending, nova tentativa $retrying';
   }
 
@@ -3326,4 +3323,45 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'Geral';
+
+  @override
+  String get debugging => 'Depuração';
+
+  @override
+  String get agentStates => 'Estados do agente';
+
+  @override
+  String get logLevel => 'Nível: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'Status: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'Agendado: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'Concluído: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser =>
+      'Não foi possível abrir o navegador para OAuth';
+
+  @override
+  String get authorizationTimedOut => 'Autorização expirada';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -703,10 +703,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Выполняется $running, ожидает $pending, повтор $retrying';
   }
 
@@ -3324,4 +3321,45 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'Общее';
+
+  @override
+  String get debugging => 'Отладка';
+
+  @override
+  String get agentStates => 'Состояния агента';
+
+  @override
+  String get logLevel => 'Уровень: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'Статус: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'Запланировано: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'Завершено: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser =>
+      'Не удалось запустить браузер для OAuth';
+
+  @override
+  String get authorizationTimedOut => 'Время авторизации истекло';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -694,10 +694,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'กำลังทำงาน $running, รอดำเนินการ $pending, ลองใหม่ $retrying';
   }
 
@@ -3288,4 +3285,45 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'ทั่วไป';
+
+  @override
+  String get debugging => 'การดีบัก';
+
+  @override
+  String get agentStates => 'สถานะเอเจนต์';
+
+  @override
+  String get logLevel => 'ระดับ: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'สถานะ: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'กำหนดเวลา: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'เสร็จสิ้น: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser =>
+      'ไม่สามารถเปิดเบราว์เซอร์สำหรับ OAuth';
+
+  @override
+  String get authorizationTimedOut => 'การอนุญาตหมดเวลา';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -701,10 +701,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Çalıştırılıyor $running, Beklemede $pending, Yeniden Dene $retrying';
   }
 
@@ -3319,4 +3316,44 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'Genel';
+
+  @override
+  String get debugging => 'Hata Ayıklama';
+
+  @override
+  String get agentStates => 'Ajan Durumları';
+
+  @override
+  String get logLevel => 'Seviye: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'Durum: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'Planlanan: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'Tamamlandı: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser => 'OAuth için tarayıcı başlatılamadı';
+
+  @override
+  String get authorizationTimedOut => 'Yetkilendirme zaman aşımına uğradı';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -696,10 +696,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return 'Đang chạy $running, Chờ $pending, Thử lại $retrying';
   }
 
@@ -3288,4 +3285,44 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => 'Chung';
+
+  @override
+  String get debugging => 'Gỡ lỗi';
+
+  @override
+  String get agentStates => 'Trạng thái tác nhân';
+
+  @override
+  String get logLevel => 'Cấp độ: ';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID: $id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID: $bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return 'Trạng thái: $status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return 'Đã lên lịch: $date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return 'Hoàn thành: $date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser => 'Không thể mở trình duyệt cho OAuth';
+
+  @override
+  String get authorizationTimedOut => 'Ủy quyền đã hết hạn';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -681,10 +681,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '执行中 $running，排队中 $pending，重试中 $retrying';
   }
 
@@ -3181,6 +3178,46 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get memoryGeneralSubject => '通用';
+
+  @override
+  String get debugging => '调试';
+
+  @override
+  String get agentStates => '代理状态';
+
+  @override
+  String get logLevel => '级别：';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID：$id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID：$bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return '状态：$status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return '计划时间：$date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return '完成时间：$date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser => '无法启动浏览器进行 OAuth 授权';
+
+  @override
+  String get authorizationTimedOut => '授权超时';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -3860,10 +3897,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String agentBackgroundTaskSummary(
-    Object running,
-    Object pending,
-    Object retrying,
-  ) {
+      Object running, Object pending, Object retrying) {
     return '執行中 $running，排隊中 $pending，重試中 $retrying';
   }
 
@@ -6364,4 +6398,44 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get memoryGeneralSubject => '通用';
+
+  @override
+  String get debugging => '偵錯';
+
+  @override
+  String get agentStates => '代理狀態';
+
+  @override
+  String get logLevel => '層級：';
+
+  @override
+  String taskIdLabel(Object id) {
+    return 'ID：$id';
+  }
+
+  @override
+  String taskBizIdLabel(Object bizId) {
+    return 'BizID：$bizId';
+  }
+
+  @override
+  String taskStatusLabel(Object status) {
+    return '狀態：$status';
+  }
+
+  @override
+  String taskScheduledLabel(Object date) {
+    return '排程：$date';
+  }
+
+  @override
+  String taskCompletedLabel(Object date) {
+    return '完成：$date';
+  }
+
+  @override
+  String get oauthCouldNotLaunchBrowser => '無法啟動瀏覽器進行 OAuth 授權';
+
+  @override
+  String get authorizationTimedOut => '授權逾時';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "Ainda não há memórias de longo prazo.",
   "memoryNoRecentBuffer": "Não há memórias recentes no buffer.",
   "memoryGeneralSubject": "Geral",
+  "debugging": "Depuração",
+  "agentStates": "Estados do agente",
+  "logLevel": "Nível: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "Status: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "Agendado: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "Concluído: {date}",
+  "oauthCouldNotLaunchBrowser": "Não foi possível abrir o navegador para OAuth",
+  "authorizationTimedOut": "Autorização expirada",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "Долговременных воспоминаний пока нет.",
   "memoryNoRecentBuffer": "В буфере пока нет недавних воспоминаний.",
   "memoryGeneralSubject": "Общее",
+  "debugging": "Отладка",
+  "agentStates": "Состояния агента",
+  "logLevel": "Уровень: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "Статус: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "Запланировано: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "Завершено: {date}",
+  "oauthCouldNotLaunchBrowser": "Не удалось запустить браузер для OAuth",
+  "authorizationTimedOut": "Время авторизации истекло",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -1513,5 +1513,40 @@
   "eventCardDefaultTitle": "กิจกรรม",
   "memoryNoLongTermYet": "ยังไม่มีความทรงจำระยะยาว",
   "memoryNoRecentBuffer": "ไม่มีความทรงจำล่าสุดในบัฟเฟอร์",
-  "memoryGeneralSubject": "ทั่วไป"
+  "memoryGeneralSubject": "ทั่วไป",
+  "debugging": "การดีบัก",
+  "agentStates": "สถานะเอเจนต์",
+  "logLevel": "ระดับ: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "สถานะ: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "กำหนดเวลา: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "เสร็จสิ้น: {date}",
+  "oauthCouldNotLaunchBrowser": "ไม่สามารถเปิดเบราว์เซอร์สำหรับ OAuth",
+  "authorizationTimedOut": "การอนุญาตหมดเวลา"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -1513,5 +1513,40 @@
   "eventCardDefaultTitle": "Etkinlik",
   "memoryNoLongTermYet": "Henüz uzun süreli anılar yok.",
   "memoryNoRecentBuffer": "Ara bellekte yeni anı yok.",
-  "memoryGeneralSubject": "Genel"
+  "memoryGeneralSubject": "Genel",
+  "debugging": "Hata Ayıklama",
+  "agentStates": "Ajan Durumları",
+  "logLevel": "Seviye: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "Durum: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "Planlanan: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "Tamamlandı: {date}",
+  "oauthCouldNotLaunchBrowser": "OAuth için tarayıcı başlatılamadı",
+  "authorizationTimedOut": "Yetkilendirme zaman aşımına uğradı"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -1515,5 +1515,40 @@
   "eventCardDefaultTitle": "Sự kiện",
   "memoryNoLongTermYet": "Chưa có ký ức dài hạn.",
   "memoryNoRecentBuffer": "Không có ký ức gần đây trong bộ đệm.",
-  "memoryGeneralSubject": "Chung"
+  "memoryGeneralSubject": "Chung",
+  "debugging": "Gỡ lỗi",
+  "agentStates": "Trạng thái tác nhân",
+  "logLevel": "Cấp độ: ",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID: {id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID: {bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "Trạng thái: {status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "Đã lên lịch: {date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "Hoàn thành: {date}",
+  "oauthCouldNotLaunchBrowser": "Không thể mở trình duyệt cho OAuth",
+  "authorizationTimedOut": "Ủy quyền đã hết hạn"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1465,6 +1465,41 @@
   "memoryNoLongTermYet": "还没有长期记忆。",
   "memoryNoRecentBuffer": "缓冲区中还没有近期记忆。",
   "memoryGeneralSubject": "通用",
+  "debugging": "调试",
+  "agentStates": "代理状态",
+  "logLevel": "级别：",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID：{id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID：{bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "状态：{status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "计划时间：{date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "完成时间：{date}",
+  "oauthCouldNotLaunchBrowser": "无法启动浏览器进行 OAuth 授权",
+  "authorizationTimedOut": "授权超时",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1511,6 +1511,41 @@
   "memoryNoLongTermYet": "還沒有長期記憶。",
   "memoryNoRecentBuffer": "緩衝區中還沒有近期記憶。",
   "memoryGeneralSubject": "通用",
+  "debugging": "偵錯",
+  "agentStates": "代理狀態",
+  "logLevel": "層級：",
+  "@taskIdLabel": {
+    "placeholders": {
+      "id": {}
+    }
+  },
+  "taskIdLabel": "ID：{id}",
+  "@taskBizIdLabel": {
+    "placeholders": {
+      "bizId": {}
+    }
+  },
+  "taskBizIdLabel": "BizID：{bizId}",
+  "@taskStatusLabel": {
+    "placeholders": {
+      "status": {}
+    }
+  },
+  "taskStatusLabel": "狀態：{status}",
+  "@taskScheduledLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskScheduledLabel": "排程：{date}",
+  "@taskCompletedLabel": {
+    "placeholders": {
+      "date": {}
+    }
+  },
+  "taskCompletedLabel": "完成：{date}",
+  "oauthCouldNotLaunchBrowser": "無法啟動瀏覽器進行 OAuth 授權",
+  "authorizationTimedOut": "授權逾時",
   "@timelineWeekNumberLabel": {
     "placeholders": {
       "week": {}

--- a/lib/ui/settings/widgets/agent_state_viewer_page.dart
+++ b/lib/ui/settings/widgets/agent_state_viewer_page.dart
@@ -159,7 +159,7 @@ class _AgentStateViewerPageState extends State<AgentStateViewerPage> {
     return Scaffold(
       backgroundColor: const Color(0xFFF7F8FA),
       appBar: AppBar(
-        title: const Text('Agent States'),
+        title: Text(UserStorage.l10n.agentStates),
         backgroundColor: AppColors.background,
         surfaceTintColor: AppColors.background,
         foregroundColor: Colors.black,

--- a/lib/ui/settings/widgets/async_task_list_page.dart
+++ b/lib/ui/settings/widgets/async_task_list_page.dart
@@ -219,7 +219,7 @@ class _AsyncTaskListPageState extends State<AsyncTaskListPage> {
                           const SizedBox(height: 8),
                           if (task.bizId != null) ...[
                             Text(
-                              'BizID: ${task.bizId}',
+                              UserStorage.l10n.taskBizIdLabel(task.bizId!),
                               style: TextStyle(
                                 fontSize: 13,
                                 color: Colors.grey[600],
@@ -228,7 +228,7 @@ class _AsyncTaskListPageState extends State<AsyncTaskListPage> {
                             const SizedBox(height: 4),
                           ],
                           Text(
-                            'ID: ${task.id}',
+                            UserStorage.l10n.taskIdLabel(task.id),
                             style: TextStyle(
                               fontSize: 12,
                               color: Colors.grey[500],
@@ -360,16 +360,26 @@ class AsyncTaskDetailDialog extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            SelectableText('ID: ${task.id}'),
+            SelectableText(UserStorage.l10n.taskIdLabel(task.id)),
             const SizedBox(height: 8),
-            SelectableText('BizID: ${task.bizId ?? "N/A"}'),
+            SelectableText(
+              UserStorage.l10n.taskBizIdLabel(task.bizId ?? 'N/A'),
+            ),
             const SizedBox(height: 8),
-            SelectableText('Status: ${task.status}'),
+            SelectableText(UserStorage.l10n.taskStatusLabel(task.status)),
             const SizedBox(height: 8),
-            SelectableText('Created: ${_formatDate(task.createdAt)}'),
-            SelectableText('Scheduled: ${_formatDate(task.scheduledAt)}'),
-            SelectableText('Updated: ${_formatDate(task.updatedAt)}'),
-            SelectableText('Completed: ${_formatDate(task.completedAt)}'),
+            SelectableText(
+              UserStorage.l10n.createdAtDate(_formatDate(task.createdAt)),
+            ),
+            SelectableText(
+              UserStorage.l10n.taskScheduledLabel(_formatDate(task.scheduledAt)),
+            ),
+            SelectableText(
+              UserStorage.l10n.updatedAtDate(_formatDate(task.updatedAt)),
+            ),
+            SelectableText(
+              UserStorage.l10n.taskCompletedLabel(_formatDate(task.completedAt)),
+            ),
             const SizedBox(height: 12),
             const Text(
               'Payload:',
@@ -419,7 +429,7 @@ class AsyncTaskDetailDialog extends StatelessWidget {
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
-          child: const Text('Close'),
+          child: Text(UserStorage.l10n.close),
         ),
       ],
     );

--- a/lib/ui/settings/widgets/debug_settings_page.dart
+++ b/lib/ui/settings/widgets/debug_settings_page.dart
@@ -95,7 +95,7 @@ class DebugSettingsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Debugging'),
+        title: Text(UserStorage.l10n.debugging),
         backgroundColor: AppColors.background,
         surfaceTintColor: AppColors.background,
         foregroundColor: Colors.black,
@@ -274,7 +274,7 @@ class DebugSettingsPage extends StatelessWidget {
           _buildFunctionTab(
             context: context,
             icon: Icons.psychology_alt_outlined,
-            title: 'Agent States',
+            title: UserStorage.l10n.agentStates,
             onTap: () {
               Navigator.push(
                 context,

--- a/lib/ui/settings/widgets/log_viewer_page.dart
+++ b/lib/ui/settings/widgets/log_viewer_page.dart
@@ -397,7 +397,7 @@ class _LogViewerPageState extends State<LogViewerPage> {
             // Level
             Row(
               children: [
-                const Text('Level: ', style: TextStyle(fontSize: 12)),
+                Text(UserStorage.l10n.logLevel, style: const TextStyle(fontSize: 12)),
                 DropdownButton<String>(
                   value: _levelFilter,
                   isDense: true,

--- a/lib/ui/settings/widgets/personal_center_screen.dart
+++ b/lib/ui/settings/widgets/personal_center_screen.dart
@@ -321,7 +321,7 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                           const SizedBox(height: 12),
                           _buildFunctionTab(
                             icon: Icons.bug_report_outlined,
-                            title: 'Debugging',
+                            title: UserStorage.l10n.debugging,
                             onTap: () {
                               Navigator.push(
                                 context,

--- a/test/data/repositories/get_aggregated_timeline_week_test.dart
+++ b/test/data/repositories/get_aggregated_timeline_week_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:memex/data/repositories/get_aggregated_timeline.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  test('week labels use German week label', () async {
+    await initializeDateFormatting('de');
+    await UserStorage.setLocale(const Locale('de'));
+
+    final (label, subLabel) = getPeriodLabels('2026-W10', 'weeks');
+
+    expect(label, contains('Woche'));
+    expect(label, contains('10'));
+    expect(subLabel, isNotEmpty);
+  });
+}

--- a/test/l10n/debug_tools_l10n_test.dart
+++ b/test/l10n/debug_tools_l10n_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await UserStorage.initL10n();
+  });
+
+  test('debug tools strings are localized', () {
+    final l10n = UserStorage.l10n;
+
+    expect(l10n.debugging, isNotEmpty);
+    expect(l10n.agentStates, isNotEmpty);
+    expect(l10n.logLevel, isNotEmpty);
+    expect(l10n.taskIdLabel('42'), contains('42'));
+    expect(l10n.taskBizIdLabel('biz-1'), contains('biz-1'));
+    expect(l10n.taskStatusLabel('pending'), contains('pending'));
+    expect(l10n.taskScheduledLabel('2026-01-01'), contains('2026-01-01'));
+    expect(l10n.taskCompletedLabel('2026-01-02'), contains('2026-01-02'));
+    expect(l10n.oauthCouldNotLaunchBrowser, isNotEmpty);
+    expect(l10n.authorizationTimedOut, isNotEmpty);
+  });
+}

--- a/test/ui/memory/widgets/memory_screen_l10n_test.dart
+++ b/test/ui/memory/widgets/memory_screen_l10n_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/ui/memory/view_models/memory_viewmodel.dart';
+import 'package:memex/ui/memory/widgets/memory_screen.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeMemoryViewModel extends MemoryViewModel {
+  _FakeMemoryViewModel() : super(router: MemexRouter());
+
+  @override
+  Future<void> loadMemory() async {
+    isLoading = false;
+    memoryData = {
+      'archived_memory': '',
+      'recent_buffer': <Map<String, dynamic>>[],
+    };
+    notifyListeners();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'language': 'en'});
+    await UserStorage.initL10n();
+  });
+
+  testWidgets('MemoryScreen shows localized title and empty states', (
+    tester,
+  ) async {
+    final vm = _FakeMemoryViewModel();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MemoryScreen(viewModel: vm),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text(UserStorage.l10n.memoryTitle), findsOneWidget);
+    expect(find.text(UserStorage.l10n.longTermProfile), findsOneWidget);
+    expect(find.text(UserStorage.l10n.recentBuffer), findsOneWidget);
+    expect(find.text(UserStorage.l10n.memoryNoLongTermYet), findsOneWidget);
+  });
+}

--- a/test/ui/settings/widgets/agent_state_viewer_page_test.dart
+++ b/test/ui/settings/widgets/agent_state_viewer_page_test.dart
@@ -3,13 +3,18 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memex/ui/settings/widgets/agent_state_viewer_page.dart';
+import 'package:memex/utils/user_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUp(() {
-    SharedPreferences.setMockInitialValues({'user_id': 'state-user'});
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      'user_id': 'state-user',
+      'language': 'en',
+    });
+    await UserStorage.initL10n();
   });
 
   testWidgets('renders parent state with linked child state ids',
@@ -165,7 +170,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    expect(find.text('Agent States'), findsOneWidget);
+    expect(find.text(UserStorage.l10n.agentStates), findsOneWidget);
     expect(find.text('memex_agent_parent'), findsOneWidget);
     expect(find.textContaining('Linked Child States'), findsOneWidget);
     expect(find.textContaining('manage_card_child_1'), findsOneWidget);


### PR DESCRIPTION
## Summary

Localizes remaining hardcoded English in debug/dev settings pages and OAuth browser launch / timeout errors across all shipped locales.

## Commits

- ARB keys for debug tools and OAuth errors (all locales)
- Wire debug settings, async task list, log viewer, agent state viewer
- Localize gemini/openai auth service errors
- Widget + l10n tests for debug pages
- Timeline week-label and memory screen smoke tests

## Test plan

- [x] `flutter test test/l10n/debug_tools_l10n_test.dart`
- [x] `flutter test test/data/repositories/get_aggregated_timeline_week_test.dart`
- [x] `flutter test test/ui/memory/widgets/memory_screen_l10n_test.dart`
