### PR TITLE
perf(timeline): hydrate page cards in parallel

### DIFF
--- a/lib/data/repositories/get_cards_by_ids.dart
+++ b/lib/data/repositories/get_cards_by_ids.dart
@@ -19,7 +19,7 @@ Future<List<TimelineCardModel>> getCardsByIds(List<String> ids) async {
       return [];
     }
 
-    return hydrateCards(
+    return await hydrateCards(
       userId,
       ids,
       onError: (factId, error) {

--- a/lib/data/repositories/get_cards_by_ids.dart
+++ b/lib/data/repositories/get_cards_by_ids.dart
@@ -19,18 +19,13 @@ Future<List<TimelineCardModel>> getCardsByIds(List<String> ids) async {
       return [];
     }
 
-    final cards = <TimelineCardModel>[];
-
-    for (final id in ids) {
-      try {
-        final card = await hydrateCard(userId, id);
-        if (card != null) cards.add(card);
-      } catch (e) {
-        _logger.warning('Failed to process card id $id: $e');
-      }
-    }
-
-    return cards;
+    return hydrateCards(
+      userId,
+      ids,
+      onError: (factId, error) {
+        _logger.warning('Failed to process card id $factId: $error');
+      },
+    );
   } catch (e) {
     _logger.severe('Failed to get cards by ids: $e');
     return [];

--- a/lib/data/repositories/get_timeline_cards.dart
+++ b/lib/data/repositories/get_timeline_cards.dart
@@ -48,19 +48,21 @@ Future<List<TimelineCardModel>> getTimelineCards({
       dateTo: dateTo,
     );
 
-    // 3. Hydrate Cards
-    final timelineCards = <TimelineCardModel>[];
-    for (final cachedCard in cachedCards) {
-      try {
-        final card = await hydrateCard(userId, cachedCard.factId);
-        if (card != null) timelineCards.add(card);
-      } catch (e) {
-        _logger.warning('Failed to hydrate card ${cachedCard.factId}: $e');
-      }
-    }
+    // 3. Hydrate cards with bounded parallelism. Sequential YAML + render
+    // on the UI isolate made first paint wait on every card in the page.
+    final hydrateStarted = DateTime.now();
+    final timelineCards = await hydrateCards(
+      userId,
+      cachedCards.map((card) => card.factId),
+      onError: (factId, error) {
+        _logger.warning('Failed to hydrate card $factId: $error');
+      },
+    );
 
     _logger.info(
-        'Returned ${timelineCards.length} cards for page $page (cache hit)');
+      'Returned ${timelineCards.length} cards for page $page '
+      'in ${DateTime.now().difference(hydrateStarted).inMilliseconds}ms',
+    );
 
     return timelineCards;
   } catch (e) {

--- a/lib/data/repositories/hydrate_card.dart
+++ b/lib/data/repositories/hydrate_card.dart
@@ -2,6 +2,7 @@ import 'package:memex/domain/models/timeline_card_model.dart';
 import 'package:memex/domain/models/card_detail_model.dart';
 import 'package:memex/data/services/file_system_service.dart';
 import 'package:memex/data/services/card_renderer.dart';
+import 'package:memex/utils/async_pool.dart';
 import 'package:memex/utils/logger.dart';
 
 final _logger = getLogger('HydrateCard');
@@ -50,4 +51,30 @@ Future<TimelineCardModel?> hydrateCard(String userId, String factId) async {
     address: cardData.address,
     failureReason: cardData.failureReason,
   );
+}
+
+/// Hydrate many cards with bounded parallelism. Failed ids are skipped.
+/// Result order matches [factIds], minus nulls.
+Future<List<TimelineCardModel>> hydrateCards(
+  String userId,
+  Iterable<String> factIds, {
+  int concurrency = 6,
+  void Function(String factId, Object error)? onError,
+}) async {
+  final results = await mapWithLimit<String, TimelineCardModel?>(
+    factIds,
+    (factId) async {
+      try {
+        return await hydrateCard(userId, factId);
+      } catch (e) {
+        onError?.call(factId, e);
+        return null;
+      }
+    },
+    limit: concurrency,
+  );
+  return [
+    for (final card in results)
+      if (card != null) card,
+  ];
 }

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -1462,17 +1462,13 @@ class MemexRouter {
         limit: limit,
       );
 
-      final cards = <TimelineCardModel>[];
-      for (final r in ftsResults) {
-        final factId = r['fact_id'] as String;
-        try {
-          final card = await hydrateCard(userId, factId);
-          if (card != null) cards.add(card);
-        } catch (e) {
-          _logger.warning('Failed to hydrate search result: $e');
-        }
-      }
-      return cards;
+      return hydrateCards(
+        userId,
+        ftsResults.map((r) => r['fact_id'] as String),
+        onError: (factId, error) {
+          _logger.warning('Failed to hydrate search result $factId: $error');
+        },
+      );
     });
   }
 

--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -1462,7 +1462,7 @@ class MemexRouter {
         limit: limit,
       );
 
-      return hydrateCards(
+      return await hydrateCards(
         userId,
         ftsResults.map((r) => r['fact_id'] as String),
         onError: (factId, error) {

--- a/lib/utils/async_pool.dart
+++ b/lib/utils/async_pool.dart
@@ -1,0 +1,31 @@
+/// Runs [mapper] over [items] with a bounded number of in-flight futures.
+///
+/// Results stay in input order. Dart is single-threaded, so the cursor bump
+/// between awaits is safe without a lock.
+Future<List<T>> mapWithLimit<S, T>(
+  Iterable<S> items,
+  Future<T> Function(S item) mapper, {
+  int limit = 6,
+}) async {
+  if (limit < 1) {
+    throw ArgumentError.value(limit, 'limit', 'must be >= 1');
+  }
+
+  final source = items.toList(growable: false);
+  if (source.isEmpty) return <T>[];
+
+  final results = List<T?>.filled(source.length, null);
+  var cursor = 0;
+
+  Future<void> worker() async {
+    while (true) {
+      final index = cursor++;
+      if (index >= source.length) return;
+      results[index] = await mapper(source[index]);
+    }
+  }
+
+  final workerCount = limit < source.length ? limit : source.length;
+  await Future.wait(List.generate(workerCount, (_) => worker()));
+  return results.cast<T>();
+}

--- a/test/utils/async_pool_test.dart
+++ b/test/utils/async_pool_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/utils/async_pool.dart';
+
+void main() {
+  test('keeps input order while overlapping work', () async {
+    final started = <int>[];
+    var inFlight = 0;
+    var maxInFlight = 0;
+
+    final values = await mapWithLimit<int, String>(
+      [1, 2, 3, 4, 5],
+      (item) async {
+        started.add(item);
+        inFlight++;
+        if (inFlight > maxInFlight) maxInFlight = inFlight;
+        await Future<void>.delayed(Duration(milliseconds: 20 - item));
+        inFlight--;
+        return 'n$item';
+      },
+      limit: 3,
+    );
+
+    expect(values, ['n1', 'n2', 'n3', 'n4', 'n5']);
+    expect(started.take(3).toSet(), {1, 2, 3});
+    expect(maxInFlight, 3);
+  });
+
+  test('returns an empty list for empty input', () async {
+    final values = await mapWithLimit<int, int>(
+      const [],
+      (item) async => item,
+    );
+    expect(values, isEmpty);
+  });
+
+  test('rejects a non-positive limit', () {
+    expect(
+      () => mapWithLimit<int, int>([1], (item) async => item, limit: 0),
+      throwsArgumentError,
+    );
+  });
+}


### PR DESCRIPTION
Timeline first paint currently hydrates each card one after another (YAML read, render, assets). That is the main wait after router init.

This overlaps up to six hydrations, keeps result order, and uses the same helper for get-by-id and search. Logs hydrate wall time so we can compare before and after on a real journal.

## Test plan
- flutter test test/utils/async_pool_test.dart
- dart analyze on the touched repository files
- On a journal with many cards, open Timeline and confirm the first page still matches previous order