### PR TITLE
perf(startup): defer insight, library, and health loads

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -267,12 +267,10 @@ class RootShellState extends State<RootShell> {
               TimelineViewModel(router: c.read<MemexRouter>())..init(),
         ),
         ChangeNotifierProvider<InsightViewModel>(
-          create: (c) =>
-              InsightViewModel(router: c.read<MemexRouter>())..loadData(),
+          create: (c) => InsightViewModel(router: c.read<MemexRouter>()),
         ),
         ChangeNotifierProvider<KnowledgeBaseViewModel>(
-          create: (c) => KnowledgeBaseViewModel(router: c.read<MemexRouter>())
-            ..fetchData(),
+          create: (c) => KnowledgeBaseViewModel(router: c.read<MemexRouter>()),
         ),
         ChangeNotifierProvider<PersonaAvatarViewModel>(
           create: (c) =>
@@ -545,14 +543,18 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       }
     });
 
-    // Check and report all health data
-    _logger.info('initState: Starting comprehensive health check...');
-    _checkAndReportHealthData().catchError((error, stackTrace) {
-      _logger.severe(
-        '❌ Error in _checkAndReportHealthData: $error',
-        error,
-        stackTrace,
-      );
+    // Health reads compete with Timeline first paint. Wait until the
+    // home shell has had a chance to load cards.
+    Future.delayed(const Duration(seconds: 5), () {
+      if (!mounted) return;
+      _logger.info('initState: Starting comprehensive health check...');
+      _checkAndReportHealthData().catchError((error, stackTrace) {
+        _logger.severe(
+          '❌ Error in _checkAndReportHealthData: $error',
+          error,
+          stackTrace,
+        );
+      });
     });
 
     // Start auto input collection and quantity check
@@ -578,8 +580,9 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
           _openSuperAgentDialog(
             initialDraftText: data.text,
             initialImages: data.images,
-            initialImageOriginalFilenames:
-                _originalFilenamesFromImages(data.images),
+            initialImageOriginalFilenames: _originalFilenamesFromImages(
+              data.images,
+            ),
           );
         });
       },
@@ -1856,9 +1859,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
               bottom: 164,
               left: 0,
               right: 0,
-              child: Center(
-                child: AgentActivityWidget(),
-              ),
+              child: Center(child: AgentActivityWidget()),
             ),
 
             if (_isRadialMenuOpen)
@@ -1949,6 +1950,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     _knowledgeBaseButtonTapCount++;
     if (_knowledgeBaseButtonTapCount == 1) {
       setState(() => _currentTab = 1);
+      unawaited(context.read<KnowledgeBaseViewModel>().ensureLoaded());
       _knowledgeBaseButtonTapTimer?.cancel();
       _knowledgeBaseButtonTapTimer = Timer(
         const Duration(milliseconds: 300),

--- a/lib/ui/insight/view_models/insight_viewmodel.dart
+++ b/lib/ui/insight/view_models/insight_viewmodel.dart
@@ -10,9 +10,7 @@ import 'package:memex/utils/user_storage.dart';
 
 /// ViewModel for the Insight page. Holds insight list, pin/delete/reorder state.
 class InsightViewModel extends ChangeNotifier {
-  InsightViewModel({
-    required MemexRouter router,
-  }) : _router = router {
+  InsightViewModel({required MemexRouter router}) : _router = router {
     EventBusService.instance.addHandler(
       EventBusMessageType.newInsight,
       _handleNewInsightEvent,
@@ -22,7 +20,8 @@ class InsightViewModel extends ChangeNotifier {
   final MemexRouter _router;
 
   List<KnowledgeInsightCard>? insights;
-  bool isLoading = true;
+  bool isLoading = false;
+  bool _hasLoaded = false;
   String? errorMessage;
   String? activeCardId;
   bool isDeleting = false;
@@ -35,6 +34,11 @@ class InsightViewModel extends ChangeNotifier {
   }
 
   Future<void> _reloadAfterInsightUpdated() async {
+    await loadData();
+  }
+
+  Future<void> ensureLoaded() async {
+    if (_hasLoaded || isLoading) return;
     await loadData();
   }
 
@@ -52,6 +56,7 @@ class InsightViewModel extends ChangeNotifier {
         errorMessage = UserStorage.l10n.dataLoadFailedRetry;
       },
     );
+    _hasLoaded = true;
     isLoading = false;
     notifyListeners();
   }

--- a/lib/ui/knowledge/view_models/knowledge_base_viewmodel.dart
+++ b/lib/ui/knowledge/view_models/knowledge_base_viewmodel.dart
@@ -72,12 +72,18 @@ class KnowledgeBaseViewModel extends ChangeNotifier {
   final MemexRouter _router;
 
   bool isLoading = false;
+  bool _hasLoaded = false;
   List<Map<String, dynamic>> recentFiles = [];
   List<Map<String, dynamic>> additionalRootFolders = [];
   List<Map<String, dynamic>> rootLevelFiles = [];
   Map<String, int> categoryCounts = {};
 
   int countItems(String category) => categoryCounts[category] ?? 0;
+
+  Future<void> ensureLoaded() async {
+    if (_hasLoaded || isLoading) return;
+    await fetchData();
+  }
 
   Future<void> fetchData() async {
     isLoading = true;
@@ -95,15 +101,20 @@ class KnowledgeBaseViewModel extends ChangeNotifier {
       ...additionalRootFolders.map((folder) => folder['path'] as String),
     ];
     final countResult = await _router.countPkmItems(countPaths);
-    categoryCounts =
-        countResult.when(onOk: (c) => c, onError: (_, __) => <String, int>{});
+    categoryCounts = countResult.when(
+      onOk: (c) => c,
+      onError: (_, __) => <String, int>{},
+    );
     for (final folder in additionalRootFolders) {
       final path = folder['path'] as String;
       folder['item_count'] = categoryCounts[path] ?? 0;
     }
     final recentResult = await _router.getRecentPkmFiles();
     recentFiles = recentResult.when(
-        onOk: (r) => r, onError: (_, __) => <Map<String, dynamic>>[]);
+      onOk: (r) => r,
+      onError: (_, __) => <Map<String, dynamic>>[],
+    );
+    _hasLoaded = true;
     isLoading = false;
     notifyListeners();
   }

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
@@ -207,6 +209,7 @@ class TimelineScreenState extends State<TimelineScreen> {
     _currentPageIndex = index;
     final filter = _pageIndexToFilter(index, vm);
     if (index == 1) {
+      unawaited(widget.insightViewModel.ensureLoaded());
       vm.setViewMode(TimelineViewMode.insight);
       vm.setActiveFilter('insight');
     } else {
@@ -536,6 +539,9 @@ class TimelineScreenState extends State<TimelineScreen> {
                     vm.setViewMode(action['tag'] == 'insight'
                         ? TimelineViewMode.insight
                         : TimelineViewMode.timeline);
+                    if (action['tag'] == 'insight') {
+                      unawaited(widget.insightViewModel.ensureLoaded());
+                    }
                     final toastContext = context;
                     vm.loadCards(refresh: true).catchError((e) {
                       if (toastContext.mounted) {
@@ -599,6 +605,7 @@ class TimelineScreenState extends State<TimelineScreen> {
       scrollController: _tagScrollController,
       onPageSelected: _jumpToPage,
       onInsightSelected: () {
+        unawaited(widget.insightViewModel.ensureLoaded());
         DemoService.instance.tryAdvance(DemoStep.tapInsightTab);
       },
     );

--- a/test/ui/lazy_secondary_loads_test.dart
+++ b/test/ui/lazy_secondary_loads_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/ui/insight/view_models/insight_viewmodel.dart';
+import 'package:memex/ui/knowledge/view_models/knowledge_base_viewmodel.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    EventBusService.instance.clearHandlers();
+  });
+
+  test('InsightViewModel does not start in a loading state', () {
+    final vm = InsightViewModel(router: MemexRouter());
+    addTearDown(vm.dispose);
+    expect(vm.isLoading, isFalse);
+    expect(vm.insights, isNull);
+  });
+
+  test('KnowledgeBaseViewModel does not start in a loading state', () {
+    final vm = KnowledgeBaseViewModel(router: MemexRouter());
+    addTearDown(vm.dispose);
+    expect(vm.isLoading, isFalse);
+    expect(vm.recentFiles, isEmpty);
+  });
+}


### PR DESCRIPTION
Opening Timeline currently also starts Insight fetch, Library PKM listing, and a full health check. Those compete with first paint on a fresh install.

This keeps Timeline as the only load at home create. Insight and Library load on first open, and the health check waits five seconds.

## Test plan
- `flutter test test/ui/lazy_secondary_loads_test.dart test/ui/insight/widgets/insight_screen_test.dart test/ui/knowledge/knowledge_base_screen_test.dart`
- Open Timeline on a fresh profile and confirm Insight/Library stay idle until tapped
- Tap Insights and Library and confirm each loads once
- Confirm health data still reports after the delay