### PR TITLE
fix(ui): drop duplicate Memex copy and enlarge first-run loaders

### DIFF
--- a/lib/ui/chat/widgets/open_super_agent_dialog.dart
+++ b/lib/ui/chat/widgets/open_super_agent_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:memex/data/repositories/memex_router.dart';
 import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
+import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
 import 'package:memex/utils/result.dart';
 import 'package:memex/utils/user_storage.dart';
 
@@ -139,7 +140,15 @@ Widget buildSuperAgentDialogSessionGate({
     future: sessionIdFuture,
     builder: (context, snapshot) {
       if (snapshot.connectionState != ConnectionState.done) {
-        return const SizedBox.shrink();
+        return const Material(
+          color: Colors.transparent,
+          child: Center(
+            child: AgentLogoLoading(
+              key: ValueKey('super-agent-session-loading'),
+              size: 72,
+            ),
+          ),
+        );
       }
 
       final sessionId = snapshot.data;

--- a/lib/ui/settings/widgets/ai_service_setup_page.dart
+++ b/lib/ui/settings/widgets/ai_service_setup_page.dart
@@ -363,6 +363,7 @@ class _MemexOfficialServicePageState extends State<MemexOfficialServicePage> {
       iconColor: AppColors.primary,
       title: l10n.aiServiceMemexRouteTitle,
       description: l10n.aiServiceSettingsDescription,
+      showIntro: false,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -631,6 +632,7 @@ class _AiServiceOptionCard extends StatelessWidget {
     required this.description,
     required this.child,
     this.trailing,
+    this.showIntro = true,
   });
 
   final IconData icon;
@@ -639,6 +641,7 @@ class _AiServiceOptionCard extends StatelessWidget {
   final String description;
   final Widget child;
   final Widget? trailing;
+  final bool showIntro;
 
   @override
   Widget build(BuildContext context) {
@@ -661,48 +664,48 @@ class _AiServiceOptionCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              Container(
-                width: 38,
-                height: 38,
-                decoration: BoxDecoration(
-                  color: iconColor.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(10),
+          if (showIntro) ...[
+            Row(
+              children: [
+                Container(
+                  width: 38,
+                  height: 38,
+                  decoration: BoxDecoration(
+                    color: iconColor.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(icon, color: iconColor, size: 21),
                 ),
-                child: Icon(icon, color: iconColor, size: 21),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  title,
-                  style: const TextStyle(
-                    fontSize: 18,
-                    height: 1.25,
-                    fontWeight: FontWeight.w800,
-                    color: AppColors.textPrimary,
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      height: 1.25,
+                      fontWeight: FontWeight.w800,
+                      color: AppColors.textPrimary,
+                    ),
                   ),
                 ),
-              ),
-              if (trailing != null) ...[
-                const SizedBox(width: 8),
-                trailing!,
+                if (trailing != null) ...[
+                  const SizedBox(width: 8),
+                  trailing!,
+                ],
               ],
-            ],
-          ),
-          const SizedBox(height: 12),
-          Text(
-            description,
-            style: const TextStyle(
-              fontSize: 14,
-              height: 1.55,
-              color: AppColors.textSecondary,
             ),
-          ),
-          if (hasChild) ...[
-            const SizedBox(height: 16),
-            child,
+            const SizedBox(height: 12),
+            Text(
+              description,
+              style: const TextStyle(
+                fontSize: 14,
+                height: 1.55,
+                color: AppColors.textSecondary,
+              ),
+            ),
+            if (hasChild) const SizedBox(height: 16),
           ],
+          if (hasChild) child,
         ],
       ),
     );

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -606,7 +606,7 @@ class TimelineScreenState extends State<TimelineScreen> {
 
   Widget _buildTimelineBody(TimelineViewModel vm) {
     if ((vm.isLoading || vm.load.running) && vm.cards.isEmpty) {
-      return const Center(child: AgentLogoLoading());
+      return const Center(child: AgentLogoLoading(size: 72));
     }
 
     return _buildTimelineContent(vm);
@@ -655,7 +655,7 @@ class TimelineScreenState extends State<TimelineScreen> {
     }
 
     if (vm.cards.isEmpty && (vm.isLoading || vm.load.running)) {
-      return const Center(child: AgentLogoLoading());
+      return const Center(child: AgentLogoLoading(size: 72));
     }
     return _buildTimelineList(vm);
   }

--- a/test/ui/chat/widgets/open_super_agent_dialog_test.dart
+++ b/test/ui/chat/widgets/open_super_agent_dialog_test.dart
@@ -132,10 +132,18 @@ void main() {
     );
 
     expect(find.byType(AgentChatDialog), findsNothing);
+    expect(
+      find.byKey(const ValueKey('super-agent-session-loading')),
+      findsOneWidget,
+    );
 
     sessionId.complete('session-1');
     await tester.pump();
 
     expect(find.byType(AgentChatDialog), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('super-agent-session-loading')),
+      findsNothing,
+    );
   });
 }

--- a/test/ui/settings/widgets/ai_service_setup_page_test.dart
+++ b/test/ui/settings/widgets/ai_service_setup_page_test.dart
@@ -158,6 +158,10 @@ void main() {
 
     expect(find.byType(MemexOfficialServicePage), findsOneWidget);
     expect(find.text(UserStorage.l10n.aiServiceMemexRouteTitle), findsWidgets);
+    expect(
+      find.text(UserStorage.l10n.aiServiceSettingsDescription),
+      findsOneWidget,
+    );
     expect(find.text(UserStorage.l10n.modelRolesTitle), findsNothing);
 
     await tester.tap(find.text(UserStorage.l10n.enableAiService));

--- a/test/ui/timeline/widgets/timeline_loading_spinner_test.dart
+++ b/test/ui/timeline/widgets/timeline_loading_spinner_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/ui/character/view_models/persona_avatar_viewmodel.dart';
+import 'package:memex/ui/core/widgets/agent_logo_loading.dart';
+import 'package:memex/ui/insight/view_models/insight_viewmodel.dart';
+import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
+import 'package:memex/ui/timeline/widgets/timeline_screen.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    EventBusService.instance.clearHandlers();
+    SharedPreferences.setMockInitialValues({'language': 'en'});
+    await UserStorage.initL10n();
+  });
+
+  tearDown(() {
+    EventBusService.instance.clearHandlers();
+  });
+
+  testWidgets('empty timeline loading uses a larger spinner', (tester) async {
+    final timeline = TimelineViewModel.forTest(autoLoad: false)
+      ..isLoading = true;
+    final insight = InsightViewModel(router: MemexRouter());
+    final persona = PersonaAvatarViewModel(router: MemexRouter());
+    addTearDown(timeline.dispose);
+    addTearDown(insight.dispose);
+    addTearDown(persona.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TimelineScreen(
+            viewModel: timeline,
+            insightViewModel: insight,
+            personaAvatarViewModel: persona,
+            onInputTap: () {},
+          ),
+        ),
+      ),
+    );
+
+    final loading = tester.widget<AgentLogoLoading>(
+      find.byType(AgentLogoLoading),
+    );
+    expect(loading.size, 72);
+  });
+}


### PR DESCRIPTION
A live first-run pass showed three UI problems: the official Memex connection page repeated the same title and description, empty Timeline used a 48px spinner that looked like a leftover, and Super Agent opened as a blank overlay until session lookup finished.

This hides the duplicate intro on the official card, uses a 72px spinner on empty Timeline, and shows the same loader while Super Agent resolves the home session.

## Test plan
- `flutter test test/ui/chat/widgets/open_super_agent_dialog_test.dart test/ui/settings/widgets/ai_service_setup_page_test.dart test/ui/timeline/widgets/timeline_loading_spinner_test.dart`
- Open Connect through Memex and confirm the title and description appear once
- Open Timeline with no cards and confirm the larger spinner
- Open Super Agent and confirm a loader appears before the chat sheet