### PR TITLE
fix(l10n): wire localized OAuth errors

### DIFF
--- a/lib/data/services/gemini_auth_service.dart
+++ b/lib/data/services/gemini_auth_service.dart
@@ -151,12 +151,13 @@ class GeminiAuthService {
       });
 
       if (!await launchUrl(authUrl, mode: LaunchMode.inAppBrowserView)) {
-        throw Exception('Could not launch browser for OAuth');
+        throw Exception(UserStorage.l10n.oauthCouldNotLaunchBrowser);
       }
 
       final result = await completer.future.timeout(
         const Duration(minutes: 5),
-        onTimeout: () => throw TimeoutException('Authorization timed out'),
+        onTimeout: () =>
+            throw TimeoutException(UserStorage.l10n.authorizationTimedOut),
       );
 
       LocalServerService.clearGeminiAuthCallback();

--- a/lib/data/services/openai_auth_service.dart
+++ b/lib/data/services/openai_auth_service.dart
@@ -151,13 +151,13 @@ class OpenAiAuthService {
 
       // 4. Launch In-App Browser (prevents the app from going to the background and being killed by the OS)
       if (!await launchUrl(authUrl, mode: LaunchMode.inAppBrowserView)) {
-        throw Exception('Could not launch browser for OAuth');
+        throw Exception(UserStorage.l10n.oauthCouldNotLaunchBrowser);
       }
 
       // 5. Wait for the Callback (with timeout)
       final result = await completer.future.timeout(const Duration(minutes: 5),
           onTimeout: () {
-        throw TimeoutException('Authorization timed out');
+        throw TimeoutException(UserStorage.l10n.authorizationTimedOut);
       });
 
       // Cleanup listener


### PR DESCRIPTION
## Summary

Completes the OAuth portion of #429 by using the localized browser-launch and authorization-timeout messages in both Gemini and OpenAI authentication services.

## Test plan

- [x] `flutter test test/l10n/debug_tools_l10n_test.dart test/l10n/arb_key_parity_test.dart`
