### PR TITLE
fix(ui): integrate Arabic RTL layout pass

### DIFF
--- a/.github/i18n_issue_body.en.md
+++ b/.github/i18n_issue_body.en.md
@@ -55,6 +55,6 @@ Arabic is already shipped. Keep verifying layouts under `TextDirection.rtl`.
 - [x] Turkish (`tr`) ARB + Ext
 - [x] iOS `Info.plist` locales beyond `en` / `zh-Hans`
 - [x] Android `values-<locale>/strings.xml` per locale
-- [ ] Arabic RTL layout pass
+- [~] Arabic RTL layout pass — directional insets applied to timeline, chat header, bottom bar, personal center, and insight summary cards; smoke test added (`test/ui/rtl/arabic_layout_smoke_test.dart`); remaining screens still need audit
 - [ ] Missing-key CI lint
 - [ ] Native review per language

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -2035,7 +2035,12 @@ class _AgentChatDialogState extends State<AgentChatDialog>
 
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.only(left: 24, right: 4, top: 16, bottom: 16),
+      padding: const EdgeInsetsDirectional.only(
+        start: 24,
+        end: 4,
+        top: 16,
+        bottom: 16,
+      ),
       decoration: BoxDecoration(
         color: Colors.white.withValues(alpha: 0.8),
         border: const Border(bottom: BorderSide(color: Color(0xFFF7F8FA))),
@@ -2044,8 +2049,11 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         height: 36,
         child: Stack(
           children: [
-            Positioned.fill(
-              right: reservedActionWidth,
+            PositionedDirectional(
+              start: 0,
+              end: reservedActionWidth,
+              top: 0,
+              bottom: 0,
               child: Row(
                 children: [
                   _buildAgentMark(size: 22),
@@ -2065,9 +2073,9 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                 ],
               ),
             ),
-            Positioned(
+            PositionedDirectional(
               top: 0,
-              right: 0,
+              end: 0,
               bottom: 0,
               child: Row(mainAxisSize: MainAxisSize.min, children: actions),
             ),
@@ -2196,7 +2204,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           children: [
             ...cluster.take(5).map(
                   (photo) => Padding(
-                    padding: const EdgeInsets.only(right: 6),
+                    padding: const EdgeInsetsDirectional.only(end: 6),
                     child: ClipRRect(
                       borderRadius: BorderRadius.circular(8),
                       child: SizedBox(
@@ -2215,7 +2223,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                 ),
             if (cluster.length > 5)
               Padding(
-                padding: const EdgeInsets.only(right: 6),
+                padding: const EdgeInsetsDirectional.only(end: 6),
                 child: Text(
                   '+${cluster.length - 5}',
                   style: const TextStyle(
@@ -2685,7 +2693,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
-              padding: const EdgeInsets.only(left: 2, bottom: 2),
+              padding: const EdgeInsetsDirectional.only(start: 2, bottom: 2),
               child: Text(
                 _artifactSectionTitle(artifacts.length),
                 style: const TextStyle(
@@ -2901,7 +2909,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
                     _buildAssistantArtifactSection(item.artifacts),
                   if (!item.isStreaming && item.text.trim().isNotEmpty)
                     Padding(
-                      padding: const EdgeInsets.only(left: 2, top: 6),
+                      padding: const EdgeInsetsDirectional.only(start: 2, top: 6),
                       child: _CopyMessageButton(
                         text: item.text,
                         onCopied: () {
@@ -3483,7 +3491,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
               ),
               if (tappable)
                 Container(
-                  padding: const EdgeInsets.only(left: 8),
+                  padding: const EdgeInsetsDirectional.only(start: 8),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [

--- a/lib/ui/insight/widgets/insight_cards/summary_card.dart
+++ b/lib/ui/insight/widgets/insight_cards/summary_card.dart
@@ -197,7 +197,7 @@ class SummaryCard extends StatelessWidget {
 
                   return Expanded(
                     child: Container(
-                      margin: EdgeInsets.only(right: isLast ? 0 : 10),
+                      margin: EdgeInsetsDirectional.only(end: isLast ? 0 : 10),
                       padding: const EdgeInsets.symmetric(vertical: 14),
                       decoration: BoxDecoration(
                         color: const Color(0xFFF7F8FA),

--- a/lib/ui/main_screen/widgets/main_bottom_bar.dart
+++ b/lib/ui/main_screen/widgets/main_bottom_bar.dart
@@ -65,21 +65,24 @@ class MainBottomBar extends StatelessWidget {
                   right: 0,
                   child: ColoredBox(color: Colors.white),
                 ),
-                Positioned(
+                PositionedDirectional(
                   top: -16.0,
-                  left: 156.0,
-                  child: AICoreButton(
-                    key: centerButtonKey,
-                    onTap: onCenterTap,
-                    onLongPress: onCenterLongPress,
-                    onLongPressMoveUpdate: onCenterLongPressMoveUpdate,
-                    onLongPressEnd: onCenterLongPressEnd,
+                  start: 0,
+                  end: 0,
+                  child: Center(
+                    child: AICoreButton(
+                      key: centerButtonKey,
+                      onTap: onCenterTap,
+                      onLongPress: onCenterLongPress,
+                      onLongPressMoveUpdate: onCenterLongPressMoveUpdate,
+                      onLongPressEnd: onCenterLongPressEnd,
+                    ),
                   ),
                 ),
                 _NavTab(
                   key: timelineTabKey,
                   top: 40,
-                  left: 16,
+                  start: 16,
                   width: 118,
                   height: 56,
                   selected: currentTab == 0,
@@ -98,7 +101,7 @@ class MainBottomBar extends StatelessWidget {
                 _NavTab(
                   key: libraryTabKey,
                   top: 40,
-                  left: 259,
+                  end: 16,
                   width: 118,
                   height: 56,
                   selected: currentTab == 1,
@@ -132,17 +135,19 @@ class _NavTab extends StatelessWidget {
   const _NavTab({
     super.key,
     required this.top,
-    required this.left,
+    this.start,
+    this.end,
     required this.width,
     required this.height,
     required this.icon,
     required this.label,
     required this.selected,
     required this.onTap,
-  });
+  }) : assert(start != null || end != null);
 
   final double top;
-  final double left;
+  final double? start;
+  final double? end;
   final double width;
   final double height;
   final Widget icon;
@@ -152,9 +157,10 @@ class _NavTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Positioned(
+    return PositionedDirectional(
       top: top,
-      left: left,
+      start: start,
+      end: end,
       width: width,
       height: height,
       child: Semantics(

--- a/lib/ui/settings/widgets/personal_center_screen.dart
+++ b/lib/ui/settings/widgets/personal_center_screen.dart
@@ -98,9 +98,9 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
             return Container(
               decoration: const BoxDecoration(
                 color: Color(0xFFF7F8FA),
-                borderRadius: BorderRadius.only(
-                  topLeft: Radius.circular(20),
-                  topRight: Radius.circular(20),
+                borderRadius: BorderRadiusDirectional.only(
+                  topStart: Radius.circular(20),
+                  topEnd: Radius.circular(20),
                 ),
               ),
               child: SafeArea(
@@ -108,7 +108,7 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                   children: [
                     // Header
                     Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 16, 12, 0),
+                      padding: const EdgeInsetsDirectional.fromSTEB(20, 16, 12, 0),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.end,
                         children: [
@@ -188,8 +188,8 @@ class _PersonalCenterScreenState extends State<PersonalCenterScreen> {
                                   size: 80,
                                 ),
                               ),
-                              Positioned(
-                                right: 0,
+                              PositionedDirectional(
+                                end: 0,
                                 bottom: 0,
                                 child: Container(
                                   width: 26,

--- a/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_card_detail_screen.dart
@@ -502,7 +502,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
         children: [
           // Timestamp Header mimicking list view
           Padding(
-            padding: const EdgeInsets.only(left: 8, bottom: 12),
+            padding: const EdgeInsetsDirectional.only(start: 8, bottom: 12),
             child: Row(
               children: [
                 Text(
@@ -1241,7 +1241,7 @@ class _TimelineCardDetailScreenState extends State<TimelineCardDetailScreen> {
       key: const ValueKey('demo_detail_hint'),
       color: Colors.transparent,
       child: Container(
-        padding: const EdgeInsets.fromLTRB(14, 12, 10, 12),
+        padding: const EdgeInsetsDirectional.fromSTEB(14, 12, 10, 12),
         decoration: BoxDecoration(
           color: Colors.white.withValues(alpha: 0.96),
           borderRadius: BorderRadius.circular(16),
@@ -2196,9 +2196,9 @@ class _FullScreenGalleryState extends State<_FullScreenGallery> {
               });
             },
           ),
-          Positioned(
+          PositionedDirectional(
             top: 50,
-            left: 16,
+            start: 16,
             child: GestureDetector(
               onTap: () => Navigator.pop(context),
               child: Container(

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -307,9 +307,9 @@ class TimelineScreenState extends State<TimelineScreen> {
                                         ),
                                       ),
                                       if (pendingCount > 0)
-                                        Positioned(
+                                        PositionedDirectional(
                                           top: 6,
-                                          left: 22,
+                                          end: 6,
                                           child: Container(
                                             width: 8,
                                             height: 8,
@@ -833,7 +833,7 @@ class TimelineFilterBar extends StatelessWidget {
     return ListView.separated(
       controller: scrollController,
       scrollDirection: Axis.horizontal,
-      padding: const EdgeInsets.only(left: 20, right: 20),
+      padding: const EdgeInsetsDirectional.only(start: 20, end: 20),
       itemCount: totalCount,
       separatorBuilder: (_, __) => const SizedBox(width: 10),
       itemBuilder: (context, index) {

--- a/test/ui/rtl/arabic_layout_smoke_test.dart
+++ b/test/ui/rtl/arabic_layout_smoke_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/l10n/app_localizations.dart';
+import 'package:memex/ui/insight/widgets/insight_cards/summary_card.dart';
+import 'package:memex/ui/main_screen/widgets/main_bottom_bar.dart';
+import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
+import 'package:memex/ui/timeline/widgets/timeline_screen.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      'user_id': 'rtl-smoke-test',
+      'language': 'ar',
+    });
+    await UserStorage.setLocale(const Locale('ar'));
+    await UserStorage.initL10n();
+  });
+
+  Future<void> pumpArabicRtl(
+    WidgetTester tester,
+    Widget child, {
+    Size viewport = const Size(393, 852),
+  }) async {
+    tester.view.physicalSize = viewport;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('ar'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: child,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  }
+
+  testWidgets('MainBottomBar lays out without overflow in Arabic RTL', (
+    tester,
+  ) async {
+    await pumpArabicRtl(
+      tester,
+      Scaffold(
+        body: Align(
+          alignment: Alignment.bottomCenter,
+          child: MainBottomBar(
+            currentTab: 0,
+            onTimelineTap: () {},
+            onLibraryTap: () {},
+            onCenterTap: () {},
+            onCenterLongPress: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(MainBottomBar), findsOneWidget);
+    expect(find.text(UserStorage.l10n.bottomNavTimeline), findsOneWidget);
+    expect(find.text(UserStorage.l10n.bottomNavLibrary), findsOneWidget);
+  });
+
+  testWidgets('TimelineFilterBar lays out without overflow in Arabic RTL', (
+    tester,
+  ) async {
+    final viewModel = TimelineViewModel(
+      router: MemexRouter(),
+      autoLoad: false,
+    );
+    addTearDown(viewModel.dispose);
+
+    await pumpArabicRtl(
+      tester,
+      SizedBox(
+        height: 44,
+        child: TimelineFilterBar(
+          viewModel: viewModel,
+          onPageSelected: (_) {},
+          onInsightSelected: () {},
+        ),
+      ),
+    );
+
+    expect(find.byType(TimelineFilterBar), findsOneWidget);
+    expect(find.text(UserStorage.l10n.timelineFilterAll), findsOneWidget);
+  });
+
+  testWidgets('SummaryCard metrics lay out without overflow in Arabic RTL', (
+    tester,
+  ) async {
+    await pumpArabicRtl(
+      tester,
+      SingleChildScrollView(
+        child: SummaryCard(
+          tag: 'ملخص',
+          title: 'نشاط الأسبوع',
+          date: '٠٢/٠٩',
+          insightContent: 'هذا نص تجريبي باللغة العربية للتحقق من الاتجاه.',
+          metrics: [
+            SummaryMetric(label: 'الخطوات', value: '8,420'),
+            SummaryMetric(label: 'الساعات', value: '6.5'),
+            SummaryMetric(label: 'الجلسات', value: '12'),
+          ],
+        ),
+      ),
+      viewport: const Size(360, 640),
+    );
+
+    expect(find.byType(SummaryCard), findsOneWidget);
+    expect(find.text('8,420'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Integrates #431 on top of #427 and the startup/UI changes already merged into `main`.

The only merge conflict was the shared i18n checklist: this keeps both the RTL progress note and the ARB parity CI note.

Supersedes #431 after merge.

## Test plan

- [x] `flutter test test/ui/rtl/arabic_layout_smoke_test.dart test/l10n/arb_key_parity_test.dart`
