### PR TITLE
perf: defer companion avatar load until after the first Timeline frame

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -273,8 +273,7 @@ class RootShellState extends State<RootShell> {
           create: (c) => KnowledgeBaseViewModel(router: c.read<MemexRouter>()),
         ),
         ChangeNotifierProvider<PersonaAvatarViewModel>(
-          create: (c) =>
-              PersonaAvatarViewModel(router: c.read<MemexRouter>())..init(),
+          create: (c) => PersonaAvatarViewModel(router: c.read<MemexRouter>()),
         ),
       ],
       child: const MainScreen(),

--- a/lib/ui/character/view_models/persona_avatar_viewmodel.dart
+++ b/lib/ui/character/view_models/persona_avatar_viewmodel.dart
@@ -23,6 +23,10 @@ class PersonaAvatarViewModel extends ChangeNotifier {
   bool _disposed = false;
   int _refreshGeneration = 0;
 
+  /// Loads the companion summary after the first Timeline frame.
+  /// Safe to call more than once; later calls are no-ops until dispose.
+  Future<void> ensureLoaded() => init();
+
   Future<void> init() async {
     if (_initialized) return;
     _initialized = true;

--- a/lib/ui/character/widgets/persona_avatar_button.dart
+++ b/lib/ui/character/widgets/persona_avatar_button.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:memex/domain/models/character_model.dart';
 import 'package:memex/ui/character/view_models/persona_avatar_viewmodel.dart';
@@ -7,7 +9,7 @@ import 'package:memex/ui/core/widgets/character_avatar.dart';
 /// Small avatar button in the timeline header.
 /// Shows the user's primary companion character with an unread badge.
 /// Tap to open chat.
-class PersonaAvatarButton extends StatelessWidget {
+class PersonaAvatarButton extends StatefulWidget {
   const PersonaAvatarButton({
     super.key,
     required this.viewModel,
@@ -18,17 +20,39 @@ class PersonaAvatarButton extends StatelessWidget {
   final ValueChanged<CharacterModel> onTap;
 
   @override
+  State<PersonaAvatarButton> createState() => _PersonaAvatarButtonState();
+}
+
+class _PersonaAvatarButtonState extends State<PersonaAvatarButton> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(widget.viewModel.ensureLoaded());
+    });
+  }
+
+  @override
+  void didUpdateWidget(PersonaAvatarButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.viewModel != widget.viewModel) {
+      unawaited(widget.viewModel.ensureLoaded());
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
-      listenable: viewModel,
+      listenable: widget.viewModel,
       builder: (context, _) {
-        final character = viewModel.character;
+        final character = widget.viewModel.character;
         if (character == null) {
           return const SizedBox(width: 36, height: 36);
         }
 
         return GestureDetector(
-          onTap: () => onTap(character),
+          onTap: () => widget.onTap(character),
           child: SizedBox(
             width: 36,
             height: 36,
@@ -38,8 +62,8 @@ class PersonaAvatarButton extends StatelessWidget {
                 Center(
                   child: _CompanionAvatarFrame(character: character),
                 ),
-                if (viewModel.unreadCount > 0)
-                  _UnreadBadge(count: viewModel.unreadCount),
+                if (widget.viewModel.unreadCount > 0)
+                  _UnreadBadge(count: widget.viewModel.unreadCount),
               ],
             ),
           ),

--- a/test/ui/character/view_models/persona_avatar_viewmodel_test.dart
+++ b/test/ui/character/view_models/persona_avatar_viewmodel_test.dart
@@ -13,6 +13,32 @@ void main() {
 
   setUpAll(eventBus.connect);
 
+  test('ensureLoaded is a no-op until first call and stays idempotent',
+      () async {
+    final character = CharacterModel(
+      id: 'friend',
+      name: '小安',
+      tags: const [],
+      persona: '温柔的朋友',
+      enabled: true,
+    );
+    final router = _FakeMemexRouter([
+      PersonaAvatarSummary(character: character, unreadCount: 2),
+    ]);
+    final viewModel = PersonaAvatarViewModel(router: router);
+    addTearDown(viewModel.dispose);
+
+    expect(viewModel.character, isNull);
+    expect(router.loadCount, 0);
+
+    await viewModel.ensureLoaded();
+    await viewModel.ensureLoaded();
+
+    expect(viewModel.character?.id, 'friend');
+    expect(viewModel.unreadCount, 2);
+    expect(router.loadCount, 1);
+  });
+
   test('loads avatar summary and refreshes when chat unread state changes',
       () async {
     final character = CharacterModel(

--- a/test/ui/character/widgets/persona_avatar_button_test.dart
+++ b/test/ui/character/widgets/persona_avatar_button_test.dart
@@ -11,6 +11,41 @@ import 'package:memex/utils/result.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  testWidgets('loads the companion after the first frame', (tester) async {
+    final character = CharacterModel(
+      id: 'friend',
+      name: '小安',
+      tags: const [],
+      persona: '温柔的朋友',
+      enabled: true,
+    );
+    final router = _FakeMemexRouter(PersonaAvatarSummary(
+      character: character,
+      unreadCount: 1,
+    ));
+    final viewModel = PersonaAvatarViewModel(router: router);
+    addTearDown(viewModel.dispose);
+
+    expect(router.loadCount, 0);
+    expect(viewModel.character, isNull);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: PersonaAvatarButton(
+            viewModel: viewModel,
+            onTap: (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(router.loadCount, 1);
+    expect(find.byType(CharacterAvatar), findsOneWidget);
+    expect(find.text('1'), findsOneWidget);
+  });
+
   testWidgets('renders an empty slot when no companion is available',
       (tester) async {
     final viewModel = PersonaAvatarViewModel(
@@ -73,9 +108,11 @@ class _FakeMemexRouter implements MemexRouter {
   _FakeMemexRouter(this.summary);
 
   final PersonaAvatarSummary summary;
+  int loadCount = 0;
 
   @override
   Future<Result<PersonaAvatarSummary>> loadPersonaAvatarSummary() async {
+    loadCount += 1;
     return Ok(summary);
   }
 


### PR DESCRIPTION
RootShell started `PersonaAvatarViewModel.init()` at provider create, so companion summary I/O competed with Timeline hydration on the first home frame.

This creates the ViewModel idle and lets the header button load it after the first frame. `ensureLoaded()` stays idempotent.

## Test plan
- `flutter test test/ui/character/view_models/persona_avatar_viewmodel_test.dart test/ui/character/widgets/persona_avatar_button_test.dart test/ui/timeline/widgets/timeline_loading_spinner_test.dart`
- Open Timeline and confirm the companion avatar still appears
- Confirm unread badge still updates after a persona chat message