### PR TITLE
perf(ui): read home tab view models instead of watching them

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1830,8 +1830,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
                       children: [
                         TimelineScreen(
                           key: _timelineKey,
-                          viewModel: context.watch<TimelineViewModel>(),
-                          insightViewModel: context.watch<InsightViewModel>(),
+                          viewModel: context.read<TimelineViewModel>(),
+                          insightViewModel: context.read<InsightViewModel>(),
                           personaAvatarViewModel:
                               context.read<PersonaAvatarViewModel>(),
                           onInputTap: () {
@@ -1841,7 +1841,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
                         ),
                         KnowledgeBaseScreen(
                           key: _knowledgeBaseKey,
-                          viewModel: context.watch<KnowledgeBaseViewModel>(),
+                          viewModel: context.read<KnowledgeBaseViewModel>(),
                         ),
                       ],
                     ),

--- a/test/ui/main_screen/home_tab_rebuild_test.dart
+++ b/test/ui/main_screen/home_tab_rebuild_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/ui/insight/view_models/insight_viewmodel.dart';
+import 'package:memex/ui/knowledge/view_models/knowledge_base_viewmodel.dart';
+import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  testWidgets('reading tab view models does not rebuild siblings on notify',
+      (tester) async {
+    final timeline = TimelineViewModel.forTest(autoLoad: false);
+    final insight = InsightViewModel(router: MemexRouter());
+    final knowledge = KnowledgeBaseViewModel(router: MemexRouter());
+    addTearDown(timeline.dispose);
+    addTearDown(insight.dispose);
+    addTearDown(knowledge.dispose);
+
+    var knowledgeBuilds = 0;
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<TimelineViewModel>.value(value: timeline),
+          ChangeNotifierProvider<InsightViewModel>.value(value: insight),
+          ChangeNotifierProvider<KnowledgeBaseViewModel>.value(value: knowledge),
+        ],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Column(
+                children: [
+                  Text('cards:${context.read<TimelineViewModel>().cards.length}'),
+                  Builder(
+                    builder: (context) {
+                      knowledgeBuilds += 1;
+                      context.read<KnowledgeBaseViewModel>();
+                      return Text('kb:$knowledgeBuilds');
+                    },
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(knowledgeBuilds, 1);
+    timeline.notifyListeners();
+    await tester.pump();
+    expect(knowledgeBuilds, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- `MainScreen` now `read`s Timeline/Insight/Knowledge view models instead of `watch`ing them.
- Each tab already rebuilds from its own `ListenableBuilder`, so a card tick no longer rebuilds the whole home shell.

## Test plan
- [x] `flutter test test/ui/main_screen/home_tab_rebuild_test.dart`
- [x] Open Timeline, add/refresh a card, confirm Knowledge tab and bottom bar do not flicker
- [x] Switch Timeline ↔ Knowledge and confirm both still update from their own VMs