### PR TITLE
perf(timeline): mount HTML WebViews only when they enter the viewport

### DIFF
--- a/lib/ui/core/widgets/viewport_gated.dart
+++ b/lib/ui/core/widgets/viewport_gated.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// Builds [builder] only after this widget intersects the nearest scroll
+/// viewport. Used to keep off-screen Timeline WebViews from mounting.
+class ViewportGated extends StatefulWidget {
+  const ViewportGated({
+    super.key,
+    required this.placeholder,
+    required this.builder,
+    this.cacheExtent = 400,
+    this.keepAlive = true,
+  });
+
+  final Widget placeholder;
+  final WidgetBuilder builder;
+  final double cacheExtent;
+  final bool keepAlive;
+
+  @override
+  State<ViewportGated> createState() => _ViewportGatedState();
+}
+
+class _ViewportGatedState extends State<ViewportGated> {
+  bool _activated = false;
+  ScrollPosition? _position;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final position = Scrollable.maybeOf(context)?.position;
+    if (!identical(position, _position)) {
+      _position?.removeListener(_evaluate);
+      _position = position;
+      _position?.addListener(_evaluate);
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) => _evaluate());
+  }
+
+  @override
+  void dispose() {
+    _position?.removeListener(_evaluate);
+    super.dispose();
+  }
+
+  void _evaluate() {
+    if (!mounted || (_activated && widget.keepAlive)) return;
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox ||
+        !renderObject.hasSize ||
+        !renderObject.attached) {
+      return;
+    }
+    final viewport = RenderAbstractViewport.maybeOf(renderObject);
+    if (viewport == null) {
+      if (_position == null) _activate();
+      return;
+    }
+    if (viewport is! RenderBox) return;
+    final viewportBox = viewport as RenderBox;
+    if (!viewportBox.hasSize) return;
+    final offset = renderObject.localToGlobal(
+      Offset.zero,
+      ancestor: viewportBox,
+    );
+    final itemRect = offset & renderObject.size;
+    final visibleRect =
+        (Offset.zero & viewportBox.size).inflate(widget.cacheExtent);
+    if (itemRect.overlaps(visibleRect)) {
+      _activate();
+    }
+  }
+
+  void _activate() {
+    if (_activated) return;
+    setState(() => _activated = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_activated) return widget.placeholder;
+    return widget.builder(context);
+  }
+}

--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -10,6 +10,7 @@ import 'package:memex/db/app_database.dart';
 import 'package:memex/ui/card_attachments/card_attachment_data.dart';
 import 'package:memex/ui/card_attachments/card_attachment_factory.dart';
 import 'package:memex/ui/core/widgets/html_webview_card.dart';
+import 'package:memex/ui/core/widgets/viewport_gated.dart';
 import 'package:memex/ui/main_screen/widgets/action_center_sheet.dart';
 
 import 'package:memex/ui/core/cards/native_card_factory.dart';
@@ -1109,10 +1110,13 @@ class _TimelineEntryItemState extends State<TimelineEntryItem> {
           children: [
             // Card Content Loop
             if (card.html != null && !_isClassicMode)
-              HtmlWebViewCard(
-                html: card.html!,
-                config: const HtmlWebViewConfig.timeline(),
-                onContentTap: onTap,
+              ViewportGated(
+                placeholder: const SizedBox(height: 160),
+                builder: (context) => HtmlWebViewCard(
+                  html: card.html!,
+                  config: const HtmlWebViewConfig.timeline(),
+                  onContentTap: onTap,
+                ),
               )
             else if (displayConfigs.isNotEmpty)
               ...displayConfigs.asMap().entries.map((entry) {
@@ -1125,10 +1129,13 @@ class _TimelineEntryItemState extends State<TimelineEntryItem> {
                   if (html != null && html.isNotEmpty) {
                     return Padding(
                       padding: EdgeInsets.only(bottom: isLast ? 0 : 8.0),
-                      child: HtmlWebViewCard(
-                        html: html,
-                        config: const HtmlWebViewConfig.timeline(),
-                        onContentTap: onTap,
+                      child: ViewportGated(
+                        placeholder: const SizedBox(height: 160),
+                        builder: (context) => HtmlWebViewCard(
+                          html: html,
+                          config: const HtmlWebViewConfig.timeline(),
+                          onContentTap: onTap,
+                        ),
                       ),
                     );
                   }

--- a/test/ui/core/widgets/viewport_gated_test.dart
+++ b/test/ui/core/widgets/viewport_gated_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/core/widgets/viewport_gated.dart';
+
+void main() {
+  testWidgets('builds the child only after it intersects the viewport',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Align(
+          alignment: Alignment.topCenter,
+          child: SizedBox(
+            width: 400,
+            height: 200,
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  SizedBox(
+                    height: 180,
+                    child: ViewportGated(
+                      cacheExtent: 0,
+                      placeholder:
+                          const SizedBox(height: 160, child: Text('ph-1')),
+                      builder: (_) => const Text('visible-child'),
+                    ),
+                  ),
+                  const SizedBox(height: 400),
+                  SizedBox(
+                    height: 180,
+                    child: ViewportGated(
+                      cacheExtent: 0,
+                      placeholder:
+                          const SizedBox(height: 160, child: Text('ph-2')),
+                      builder: (_) => const Text('offscreen-child'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('visible-child'), findsOneWidget);
+    expect(find.text('offscreen-child'), findsNothing);
+    expect(find.text('ph-2'), findsOneWidget);
+  });
+
+  testWidgets('builds immediately when not inside a scroll view',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ViewportGated(
+          placeholder: const Text('placeholder'),
+          builder: (_) => const Text('visible-child'),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('visible-child'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Timeline HTML cards wait behind a placeholder until they intersect the scroll viewport.
- Off-screen WebViews no longer mount just because they sit in `cacheExtent`.

## Test plan
- [x] `flutter test test/ui/core/widgets/viewport_gated_test.dart`
- [x] Scroll a timeline with several HTML cards and confirm only nearby cards start WebViews
- [x] Tap a newly revealed HTML card and confirm it still opens detail