### PR TITLE
perf(chat): batch Super Agent stream updates onto one frame

### DIFF
--- a/lib/ui/chat/chat_event_batcher.dart
+++ b/lib/ui/chat/chat_event_batcher.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+import 'package:memex/data/model/chat_events.dart';
+
+/// Coalesces high-frequency chat stream events so the dialog can apply them
+/// in one `setState` per frame instead of once per token.
+class ChatEventBatcher {
+  ChatEventBatcher({
+    required this.apply,
+    required this.onFlush,
+    this.interval = const Duration(milliseconds: 32),
+    this.flushImmediately,
+  });
+
+  final void Function(ChatEvent event) apply;
+  final void Function() onFlush;
+  final Duration interval;
+  final bool Function(ChatEvent event)? flushImmediately;
+
+  final List<ChatEvent> _pending = [];
+  Timer? _timer;
+  bool _disposed = false;
+
+  void add(ChatEvent event) {
+    if (_disposed) return;
+    final immediate = flushImmediately?.call(event) ??
+        event is ChatAgentStartedEvent ||
+            event is ChatAgentStoppedEvent ||
+            event is ChatErrorEvent ||
+            event is ChatSessionCreatedEvent;
+    if (immediate) {
+      flush();
+      apply(event);
+      onFlush();
+      return;
+    }
+    _pending.add(event);
+    _timer ??= Timer(interval, flush);
+  }
+
+  void flush() {
+    _timer?.cancel();
+    _timer = null;
+    if (_pending.isEmpty) return;
+    final batch = List<ChatEvent>.of(_pending);
+    _pending.clear();
+    for (final event in batch) {
+      apply(event);
+    }
+    onFlush();
+  }
+
+  void dispose() {
+    _disposed = true;
+    _timer?.cancel();
+    _timer = null;
+    _pending.clear();
+  }
+}

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -36,6 +36,7 @@ import 'package:memex/utils/user_storage.dart';
 import 'package:memex/ui/core/themes/app_colors.dart';
 import 'package:memex/utils/token_usage_utils.dart';
 import 'package:memex/utils/time_context.dart';
+import 'package:memex/ui/chat/chat_event_batcher.dart';
 
 // --- Display Models ---
 
@@ -522,6 +523,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   final Map<String, Future<String?>> _timelineCardArtifactImageSourceFutures =
       {};
   final Map<String, List<ArtifactItem>> _pendingReplyArtifactsByTurn = {};
+  late final ChatEventBatcher _chatEventBatcher;
 
   late AnimationController _controller;
   late Animation<Offset> _slideAnimation;
@@ -531,6 +533,14 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   @override
   void initState() {
     super.initState();
+    _chatEventBatcher = ChatEventBatcher(
+      apply: _applyChatEvent,
+      onFlush: () {
+        if (!mounted) return;
+        setState(() {});
+        _scrollToBottom();
+      },
+    );
     _currentSessionId = widget.initialSessionId;
     _items = List<ChatDisplayItem>.from(widget.initialItems);
     _isLoadingAgent = widget.initialIsLoadingAgent;
@@ -590,6 +600,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
 
   @override
   void dispose() {
+    _chatEventBatcher.dispose();
     _photoSuggestionCancellationToken?.cancel();
     _photoSuggestionCancellationToken = null;
     _chatSubscription?.cancel();
@@ -1519,8 +1530,11 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   }
 
   void _handleChatEvent(ChatEvent event) {
-    setState(() {
-      if (event is ChatAgentStartedEvent) {
+    _chatEventBatcher.add(event);
+  }
+
+  void _applyChatEvent(ChatEvent event) {
+    if (event is ChatAgentStartedEvent) {
         _messageFocusNode.unfocus();
         _isStreaming = true;
         _isLoadingAgent = true;
@@ -1628,8 +1642,6 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         }
         _items.add(ErrorItem(event.error));
       }
-    });
-    _scrollToBottom();
   }
 
   void _attachArtifactsToCurrentReply(

--- a/test/ui/chat/chat_event_batch_test.dart
+++ b/test/ui/chat/chat_event_batch_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/model/chat_events.dart';
+import 'package:memex/ui/chat/chat_event_batcher.dart';
+
+void main() {
+  test('batches token chunks into one flush', () async {
+    final applied = <String>[];
+    var flushes = 0;
+    final batcher = ChatEventBatcher(
+      interval: const Duration(milliseconds: 20),
+      apply: (event) {
+        if (event is ChatResponseChunkEvent) applied.add(event.text);
+      },
+      onFlush: () => flushes += 1,
+    );
+    addTearDown(batcher.dispose);
+
+    batcher.add(ChatResponseChunkEvent('t1', 'Hel'));
+    batcher.add(ChatResponseChunkEvent('t1', 'lo'));
+    expect(applied, isEmpty);
+    expect(flushes, 0);
+
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    expect(applied, ['Hel', 'lo']);
+    expect(flushes, 1);
+  });
+
+  test('flushes immediately on error so the user sees it now', () {
+    final applied = <String>[];
+    var flushes = 0;
+    final batcher = ChatEventBatcher(
+      apply: (event) {
+        if (event is ChatResponseChunkEvent) applied.add(event.text);
+        if (event is ChatErrorEvent) applied.add(event.error);
+      },
+      onFlush: () => flushes += 1,
+    );
+    addTearDown(batcher.dispose);
+
+    batcher.add(ChatResponseChunkEvent('t1', 'Hel'));
+    batcher.add(ChatErrorEvent('t1', 'boom'));
+
+    expect(applied, ['Hel', 'boom']);
+    expect(flushes, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- Super Agent token/thought chunks now flush through `ChatEventBatcher` (~32ms) instead of `setState` per SSE event.
- Errors and session start/stop still flush immediately.

## Test plan
- [x] `flutter test test/ui/chat/chat_event_batch_test.dart test/ui/chat/widgets/agent_chat_dialog_test.dart`
- [x] Stream a long Super Agent reply and confirm typing stays smooth
- [x] Confirm errors still appear immediately