### PR TITLE
perf(agent): cap companion LLM work after capture

### DIFF
--- a/lib/data/repositories/memex_router.dart
+++ b/lib/data/repositories/memex_router.dart
@@ -195,6 +195,7 @@ class MemexRouter {
       subscription: EventTaskSubscription(
         subscriptionId: 'comment_agent',
         taskType: 'comment_agent_task',
+        scheduleDelaySeconds: 20,
         requiresSuccessOf: const ['character_perception'],
         payloadBuilder: (_, event) {
           final p = event.payload as UserInputSubmittedPayload;
@@ -215,6 +216,7 @@ class MemexRouter {
       subscription: EventTaskSubscription(
         subscriptionId: 'character_perception',
         taskType: 'character_perception_task',
+        scheduleDelaySeconds: 20,
         maxRetries: 3,
         payloadBuilder: (_, event) {
           final p = event.payload as UserInputSubmittedPayload;
@@ -233,6 +235,7 @@ class MemexRouter {
       subscription: EventTaskSubscription(
         subscriptionId: 'character_initiative',
         taskType: CharacterInitiativeService.taskType,
+        scheduleDelaySeconds: 20,
         requiresSuccessOf: const ['comment_agent', 'character_perception'],
         maxRetries: 3,
         payloadBuilder: (_, event) {

--- a/lib/data/services/global_event_bus.dart
+++ b/lib/data/services/global_event_bus.dart
@@ -40,6 +40,7 @@ class EventTaskSubscription {
     this.dependenciesBuilder,
     this.successDependenciesBuilder,
     this.shouldEnqueue,
+    this.scheduleDelaySeconds,
   });
 
   final String subscriptionId;
@@ -63,6 +64,10 @@ class EventTaskSubscription {
   /// Dynamically resolved hard dependencies that must succeed.
   final EventTaskDependencyBuilder? successDependenciesBuilder;
   final EventTaskShouldEnqueue? shouldEnqueue;
+
+  /// Optional delay before the task becomes runnable. Used to keep companion
+  /// LLM work off the Super Agent capture critical path.
+  final int? scheduleDelaySeconds;
 
   Iterable<String> get predecessorSubscriptionIds sync* {
     yield* dependsOn;
@@ -264,11 +269,19 @@ class GlobalEventBus {
         );
       }
 
+      int? scheduledAt;
+      final delaySeconds = subscription.scheduleDelaySeconds;
+      if (delaySeconds != null && delaySeconds > 0) {
+        scheduledAt =
+            DateTime.now().millisecondsSinceEpoch ~/ 1000 + delaySeconds;
+      }
+
       final taskId = await _taskExecutor.enqueueTask(
         userId: userId,
         taskType: subscription.taskType,
         payload: payload,
         priority: subscription.priority,
+        scheduledAt: scheduledAt,
         maxRetries: subscription.maxRetries,
         // Use a shared bizId for all tasks spawned by the same event.
         // Handlers that coordinate event-scoped work can use it as a stable

--- a/lib/data/services/local_task_executor.dart
+++ b/lib/data/services/local_task_executor.dart
@@ -801,6 +801,22 @@ class LocalTaskExecutor {
 
   // Max concurrent tasks
   static const int _maxConcurrency = 5;
+  static const int maxAgentFamilyConcurrency = 2;
+
+  /// LLM-heavy task types that should not all run at once after a capture.
+  static const Set<String> agentFamilyTaskTypes = {
+    'super_agent_chat_turn_task',
+    'comment_agent_task',
+    'character_perception_task',
+    'character_initiative_task',
+    'character_conversation_task',
+    'character_history_acquaintance_task',
+    'reprocess_comments_task',
+    'process_ai_reply',
+  };
+
+  static bool isAgentFamilyTaskType(String taskType) =>
+      agentFamilyTaskTypes.contains(taskType);
   static const int _candidatePageSize = 50;
   static const int _maxCandidateScan = 500;
 
@@ -988,10 +1004,24 @@ class LocalTaskExecutor {
 
       // 2. Fetch runnable tasks. Dependency-blocked tasks at the front of the
       // queue should not starve later tasks that can safely run now.
-      final tasksToRun = await _findRunnableTasks(
+      final agentFamilyActive = activeTasks
+          .where((task) => isAgentFamilyTaskType(task.type))
+          .length;
+      var remainingAgentSlots =
+          maxAgentFamilyConcurrency - agentFamilyActive;
+
+      final candidates = await _findRunnableTasks(
         slotsAvailable: slotsAvailable,
         now: now,
       );
+      final tasksToRun = <Task>[];
+      for (final task in candidates) {
+        if (isAgentFamilyTaskType(task.type)) {
+          if (remainingAgentSlots <= 0) continue;
+          remainingAgentSlots -= 1;
+        }
+        tasksToRun.add(task);
+      }
 
       if (tasksToRun.isEmpty) {
         // No runnable tasks found in top candidates

--- a/test/data/services/global_event_bus_dependency_test.dart
+++ b/test/data/services/global_event_bus_dependency_test.dart
@@ -94,6 +94,34 @@ void main() {
       },
     );
   });
+
+  test('honors scheduleDelaySeconds when enqueueing async subscribers',
+      () async {
+    final before = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    eventBus.subscribe(
+      eventType: 'delay-test',
+      subscription: EventTaskSubscription(
+        subscriptionId: 'delayed',
+        taskType: 'delayed-task',
+        scheduleDelaySeconds: 20,
+        payloadBuilder: (_, __) async => const {},
+      ),
+    );
+
+    await eventBus.publish(
+      userId: 'user-a',
+      event: SystemEvent<void>(
+        type: 'delay-test',
+        payload: null,
+        source: 'test',
+        eventId: 'event-delay',
+      ),
+    );
+
+    final task = (await db.select(db.tasks).get()).single;
+    expect(task.scheduledAt, isNotNull);
+    expect(task.scheduledAt! >= before + 20, isTrue);
+  });
 }
 
 Map<String, String> _dependencyConditions(String? encoded) {

--- a/test/data/services/local_task_executor_test.dart
+++ b/test/data/services/local_task_executor_test.dart
@@ -308,6 +308,42 @@ void main() {
       executor.stop();
     });
 
+    test('caps concurrent agent-family tasks while other work can start',
+        () async {
+      final release = Completer<void>();
+      var agentStarted = 0;
+      var otherStarted = 0;
+      executor.registerHandler('super_agent_chat_turn_task', (_, __, ___) async {
+        agentStarted++;
+        await release.future;
+      });
+      executor.registerHandler('fts_index_update', (_, __, ___) async {
+        otherStarted++;
+      });
+
+      await executor.start(userId: 'user-a');
+      for (var i = 0; i < 4; i++) {
+        await executor.enqueueTask(
+          userId: 'user-a',
+          taskType: 'super_agent_chat_turn_task',
+          payload: {'i': i},
+        );
+      }
+      await executor.enqueueTask(
+        userId: 'user-a',
+        taskType: 'fts_index_update',
+        payload: const {},
+      );
+
+      await _waitUntil(() => agentStarted == 2 && otherStarted == 1);
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(agentStarted, 2);
+      expect(otherStarted, 1);
+
+      release.complete();
+      await executor.stop();
+    });
+
     test('serializes tasks that share a concurrency policy key', () async {
       final firstStarted = Completer<void>();
       final releaseFirst = Completer<void>();


### PR DESCRIPTION
## Summary
- Local task executor now runs at most two agent-family LLM tasks at once; FTS and other work can still start.
- Comment, perception, and initiative subscribers wait 20s before becoming runnable so Super Agent capture is not starved.

## Test plan
- [x] `flutter test test/data/services/local_task_executor_test.dart test/data/services/global_event_bus_dependency_test.dart`
- [x] Capture a record while another agent turn is running and confirm Timeline stays responsive
- [x] Confirm companion comment/perception still run after the delay