### PR TITLE
perf(timeline): skip unchanged tag refetches after card events

### DIFF
--- a/lib/ui/timeline/view_models/timeline_viewmodel.dart
+++ b/lib/ui/timeline/view_models/timeline_viewmodel.dart
@@ -186,6 +186,7 @@ class TimelineViewModel extends ChangeNotifier {
   static const int pageLimit = 20;
   static const Duration pollingInterval = Duration(seconds: 5);
   static const Duration defaultAuxiliaryQueryTimeout = Duration(seconds: 2);
+  static const Duration tagsRefreshDelay = Duration(milliseconds: 300);
 
   // Timeline list state
   List<TimelineCardModel> cards = [];
@@ -196,6 +197,7 @@ class TimelineViewModel extends ChangeNotifier {
   int _loadGeneration = 0;
   int? _visibleLoadGeneration;
   String? errorMessage;
+  Timer? _tagsRefreshTimer;
 
   // Card attachments (system actions, clarification requests, etc.)
   // Keyed by factId.
@@ -304,7 +306,7 @@ class TimelineViewModel extends ChangeNotifier {
         address: message.address,
       );
       addCard(newCard);
-      fetchTags();
+      _scheduleFetchTags();
     }
   }
 
@@ -332,7 +334,7 @@ class TimelineViewModel extends ChangeNotifier {
       );
       updateCard(updatedCard);
       unawaited(_refreshPendingCount());
-      fetchTags();
+      _scheduleFetchTags();
     }
   }
 
@@ -626,12 +628,22 @@ class TimelineViewModel extends ChangeNotifier {
     return generation != _loadGeneration || filter != activeFilter;
   }
 
+  void _scheduleFetchTags() {
+    _tagsRefreshTimer?.cancel();
+    _tagsRefreshTimer = Timer(tagsRefreshDelay, () {
+      unawaited(fetchTags());
+    });
+  }
+
   Future<void> fetchTags() async {
     try {
       final result = await _fetchTags();
-      tags = result.when(onOk: (t) => t, onError: (_, __) => <TagModel>[]);
+      final next = result.when(onOk: (t) => t, onError: (_, __) => <TagModel>[]);
+      if (_sameTimelineTags(tags, next)) return;
+      tags = next;
     } catch (e, stackTrace) {
       _logger.warning('Failed to fetch timeline tags: $e', e, stackTrace);
+      if (tags.isEmpty) return;
       tags = <TagModel>[];
     }
     notifyListeners();
@@ -652,6 +664,7 @@ class TimelineViewModel extends ChangeNotifier {
 
   @override
   void dispose() {
+    _tagsRefreshTimer?.cancel();
     _stopPolling();
     if (_eventBusSetup) {
       final eventBus = EventBusService.instance;
@@ -667,4 +680,21 @@ class TimelineViewModel extends ChangeNotifier {
     }
     super.dispose();
   }
+}
+
+@visibleForTesting
+bool sameTimelineTags(List<TagModel> current, List<TagModel> next) =>
+    _sameTimelineTags(current, next);
+
+bool _sameTimelineTags(List<TagModel> current, List<TagModel> next) {
+  if (identical(current, next)) return true;
+  if (current.length != next.length) return false;
+  for (var i = 0; i < current.length; i++) {
+    if (current[i].name != next[i].name ||
+        current[i].icon != next[i].icon ||
+        current[i].iconType != next[i].iconType) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/test/ui/timeline/view_models/timeline_viewmodel_test.dart
+++ b/test/ui/timeline/view_models/timeline_viewmodel_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/domain/models/tag_model.dart';
 import 'package:memex/domain/models/timeline_card_model.dart';
 import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
+import 'package:memex/utils/result.dart';
 
 void main() {
   group('timeline card idempotency helpers', () {
@@ -191,6 +193,48 @@ void main() {
       );
 
       expect(viewModel.cards, isEmpty);
+    });
+  });
+
+  group('timeline tag refresh', () {
+    test('sameTimelineTags compares name icon and type', () {
+      expect(
+        sameTimelineTags(
+          [TagModel(name: 'Work', icon: '💼', iconType: TagIconType.emoji)],
+          [TagModel(name: 'Work', icon: '💼', iconType: TagIconType.emoji)],
+        ),
+        isTrue,
+      );
+      expect(
+        sameTimelineTags(
+          [TagModel(name: 'Work')],
+          [TagModel(name: 'Life')],
+        ),
+        isFalse,
+      );
+    });
+
+    test('fetchTags does not notify when the tag list is unchanged', () async {
+      var fetches = 0;
+      final viewModel = TimelineViewModel.forTest(
+        fetchTags: () async {
+          fetches += 1;
+          return Ok([TagModel(name: 'Work')]);
+        },
+      );
+      addTearDown(viewModel.dispose);
+
+      var notifications = 0;
+      viewModel.addListener(() => notifications += 1);
+
+      await viewModel.fetchTags();
+      expect(fetches, 1);
+      expect(notifications, 1);
+      expect(viewModel.tags.single.name, 'Work');
+
+      await viewModel.fetchTags();
+      expect(fetches, 2);
+      expect(notifications, 1);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Card add/update events debounce tag refetch by 300ms instead of hitting the store on every event.
- `fetchTags` skips `notifyListeners` when name, icon, and type are unchanged.

## Test plan
- [x] `flutter test test/ui/timeline/view_models/timeline_viewmodel_test.dart`
- [x] `dart analyze lib/ui/timeline/view_models/timeline_viewmodel.dart`
- [x] Cold-start the app and confirm first frame still reaches Timeline
- [x] Add several cards quickly and confirm the tag chip row does not flicker unless a new tag appears