### PR TITLE
perf(timeline): keep chrome header out of list rebuilds

### DIFF
--- a/lib/ui/timeline/widgets/timeline_screen.dart
+++ b/lib/ui/timeline/widgets/timeline_screen.dart
@@ -245,19 +245,10 @@ class TimelineScreenState extends State<TimelineScreen> {
     _scrollTagIntoView(index, widget.viewModel);
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return ListenableBuilder(
-      listenable: Listenable.merge([widget.viewModel, widget.viewModel.load]),
-      builder: (context, _) {
-        final vm = widget.viewModel;
-        return Column(
-          children: [
-            // Header: Memex title + action icons
-            // Figma: title top=73, left=20; buttons top=68, left=253, w=120, h=36
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
-              child: Row(
+  Widget _buildChromeHeader() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+      child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
@@ -279,9 +270,11 @@ class TimelineScreenState extends State<TimelineScreen> {
                       children: [
                         // Notification button
                         if (AppDatabase.isInitialized)
-                          Builder(
-                            builder: (context) {
-                              final pendingCount = vm.pendingAttachmentCount;
+                          ListenableBuilder(
+                            listenable: widget.viewModel,
+                            builder: (context, _) {
+                              final pendingCount =
+                                  widget.viewModel.pendingAttachmentCount;
                               return GestureDetector(
                                 onTap: () {
                                   if (pendingCount > 0) {
@@ -378,10 +371,23 @@ class TimelineScreenState extends State<TimelineScreen> {
                   ),
                 ],
               ),
-            ),
-            const SizedBox(height: 16),
+            );
+  }
 
-            // Tag Chips (All + Insight + user tags)
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _buildChromeHeader(),
+        const SizedBox(height: 16),
+        Expanded(
+          child: ListenableBuilder(
+            listenable:
+                Listenable.merge([widget.viewModel, widget.viewModel.load]),
+            builder: (context, _) {
+              final vm = widget.viewModel;
+              return Column(
+                children: [
             TimelineModelConfigBanner(
               onConfigureTap: () async {
                 await Navigator.push(
@@ -593,9 +599,12 @@ class TimelineScreenState extends State<TimelineScreen> {
                 ),
               ),
             ),
-          ],
-        );
-      },
+                ],
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
 

--- a/test/ui/timeline/widgets/timeline_chrome_header_test.dart
+++ b/test/ui/timeline/widgets/timeline_chrome_header_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/repositories/memex_router.dart';
+import 'package:memex/data/services/event_bus_service.dart';
+import 'package:memex/ui/character/view_models/persona_avatar_viewmodel.dart';
+import 'package:memex/ui/core/widgets/memex_brand_title.dart';
+import 'package:memex/ui/insight/view_models/insight_viewmodel.dart';
+import 'package:memex/ui/timeline/view_models/timeline_viewmodel.dart';
+import 'package:memex/ui/timeline/widgets/timeline_screen.dart';
+import 'package:memex/utils/user_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    EventBusService.instance.clearHandlers();
+    SharedPreferences.setMockInitialValues({'language': 'en'});
+    await UserStorage.initL10n();
+  });
+
+  tearDown(EventBusService.instance.clearHandlers);
+
+  testWidgets('chrome header stays mounted when the timeline list notifies',
+      (tester) async {
+    final timeline = TimelineViewModel.forTest(autoLoad: false);
+    final insight = InsightViewModel(router: MemexRouter());
+    final persona = PersonaAvatarViewModel(router: MemexRouter());
+    addTearDown(timeline.dispose);
+    addTearDown(insight.dispose);
+    addTearDown(persona.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TimelineScreen(
+            viewModel: timeline,
+            insightViewModel: insight,
+            personaAvatarViewModel: persona,
+            onInputTap: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(MemexBrandTitle), findsOneWidget);
+    timeline.notifyListeners();
+    await tester.pump();
+    expect(find.byType(MemexBrandTitle), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Timeline brand header and persona chrome now sit outside the full ViewModel `ListenableBuilder`.
- Only the notification badge still rebuilds with the timeline listenable.

## Test plan
- [x] `flutter test test/ui/timeline/widgets/timeline_chrome_header_test.dart test/ui/timeline/widgets/timeline_loading_spinner_test.dart`
- [x] `dart analyze lib/ui/timeline/widgets/timeline_screen.dart`
- [x] Cold-start the app and confirm first frame still reaches Timeline
- [x] Scroll and refresh Timeline and confirm the header stays put while cards update