### PR TITLE
perf(knowledge): virtualize directory listings

### DIFF
--- a/lib/ui/knowledge/widgets/knowledge_directory_page.dart
+++ b/lib/ui/knowledge/widgets/knowledge_directory_page.dart
@@ -110,23 +110,10 @@ class _KnowledgeDirectoryPageState extends State<KnowledgeDirectoryPage> {
       ),
       body: _isLoading
           ? Center(child: AgentLogoLoading())
-          : ListView(
-              padding: const EdgeInsets.all(20),
-              children: [
-                if (_folders.isNotEmpty) ...[
-                  ..._folders.map((f) => _buildFolderCard(f)),
-                ],
-                if (_files.isNotEmpty) ...[
-                  ..._files.map((f) => KnowledgeFileCard(item: f)),
-                ],
-                if (_folders.isEmpty && _files.isEmpty)
-                  Container(
-                    padding: const EdgeInsets.all(40),
-                    alignment: Alignment.center,
-                    child: Text(UserStorage.l10n.emptyFolder,
-                        style: const TextStyle(color: Color(0xFFCBD5E1))),
-                  ),
-              ],
+          : KnowledgeDirectoryBody(
+              folders: _folders,
+              files: _files,
+              folderBuilder: _buildFolderCard,
             ),
     );
   }
@@ -187,6 +174,46 @@ class _KnowledgeDirectoryPageState extends State<KnowledgeDirectoryPage> {
           ],
         ),
       ),
+    );
+  }
+}
+
+class KnowledgeDirectoryBody extends StatelessWidget {
+  const KnowledgeDirectoryBody({
+    super.key,
+    required this.folders,
+    required this.files,
+    required this.folderBuilder,
+  });
+
+  final List<Map<String, dynamic>> folders;
+  final List<Map<String, dynamic>> files;
+  final Widget Function(Map<String, dynamic> item) folderBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    if (folders.isEmpty && files.isEmpty) {
+      return ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          Container(
+            padding: const EdgeInsets.all(40),
+            alignment: Alignment.center,
+            child: Text(UserStorage.l10n.emptyFolder,
+                style: const TextStyle(color: Color(0xFFCBD5E1))),
+          ),
+        ],
+      );
+    }
+    return ListView.builder(
+      padding: const EdgeInsets.all(20),
+      itemCount: folders.length + files.length,
+      itemBuilder: (context, index) {
+        if (index < folders.length) {
+          return folderBuilder(folders[index]);
+        }
+        return KnowledgeFileCard(item: files[index - folders.length]);
+      },
     );
   }
 }

--- a/test/ui/knowledge/widgets/knowledge_directory_body_test.dart
+++ b/test/ui/knowledge/widgets/knowledge_directory_body_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/knowledge/widgets/knowledge_directory_page.dart';
+
+void main() {
+  testWidgets('directory rows are built through ListView.builder',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          height: 200,
+          child: KnowledgeDirectoryBody(
+            folders: [
+              for (var i = 0; i < 20; i++) {'name': 'Folder $i', 'path': '$i'},
+            ],
+            files: const [],
+            folderBuilder: (item) => SizedBox(
+              height: 80,
+              child: Text(item['name'] as String),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(ListView), findsOneWidget);
+    expect(find.text('Folder 0'), findsOneWidget);
+    expect(find.text('Folder 19'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Knowledge directory folders and files now render through `ListView.builder`.
- Extracted `KnowledgeDirectoryBody` so the list can be tested without the full page.

## Test plan
- [x] `flutter test test/ui/knowledge/widgets/knowledge_directory_body_test.dart`
- [x] `dart analyze lib/ui/knowledge/widgets/knowledge_directory_page.dart`
- [x] Cold-start the app and confirm first frame still reaches Timeline
- [x] Open a large PKM folder and confirm only visible rows are built