### PR TITLE
perf(ui): decode LocalImage at display pixel size

### DIFF
--- a/lib/ui/core/widgets/local_image.dart
+++ b/lib/ui/core/widgets/local_image.dart
@@ -13,6 +13,19 @@ import 'package:memex/utils/logger.dart';
 
 final Logger _logger = getLogger('LocalImage');
 
+/// Decode size for [Image.file]/[Image.network] so Timeline thumbnails do not
+/// upload a full-resolution bitmap to the GPU.
+@visibleForTesting
+int? localImageDecodePixels(double? logicalSize, double devicePixelRatio) {
+  if (logicalSize == null || !logicalSize.isFinite || logicalSize <= 0) {
+    return null;
+  }
+  final pixels = (logicalSize * devicePixelRatio).round();
+  if (pixels < 1) return 1;
+  if (pixels > 4096) return 4096;
+  return pixels;
+}
+
 final Uint8List _transparentPng = Uint8List.fromList(const [
   0x89,
   0x50,
@@ -481,6 +494,7 @@ class _LocalImageState extends State<LocalImage> {
           'File not found when loading with Image.file: ${_imageFile!.path}',
         );
       }
+      final dpr = MediaQuery.maybeDevicePixelRatioOf(context) ?? 1;
       return Image.file(
         _imageFile!,
         fit: widget.fit,
@@ -509,14 +523,17 @@ class _LocalImageState extends State<LocalImage> {
         frameBuilder: _getFrameBuilder(),
         semanticLabel: widget.semanticLabel,
         excludeFromSemantics: widget.excludeFromSemantics,
-        cacheWidth: widget.cacheWidth,
-        cacheHeight: widget.cacheHeight,
+        cacheWidth:
+            widget.cacheWidth ?? localImageDecodePixels(widget.width, dpr),
+        cacheHeight:
+            widget.cacheHeight ?? localImageDecodePixels(widget.height, dpr),
         color: widget.color,
         colorBlendMode: widget.colorBlendMode,
       );
     }
 
     // network image mode
+    final dpr = MediaQuery.maybeDevicePixelRatioOf(context) ?? 1;
     return Image.network(
       widget.url,
       fit: widget.fit,
@@ -533,8 +550,9 @@ class _LocalImageState extends State<LocalImage> {
       frameBuilder: _getFrameBuilder(),
       semanticLabel: widget.semanticLabel,
       excludeFromSemantics: widget.excludeFromSemantics,
-      cacheWidth: widget.cacheWidth,
-      cacheHeight: widget.cacheHeight,
+      cacheWidth: widget.cacheWidth ?? localImageDecodePixels(widget.width, dpr),
+      cacheHeight:
+          widget.cacheHeight ?? localImageDecodePixels(widget.height, dpr),
       color: widget.color,
       colorBlendMode: widget.colorBlendMode,
     );

--- a/test/ui/core/widgets/local_image_decode_test.dart
+++ b/test/ui/core/widgets/local_image_decode_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/core/widgets/local_image.dart';
+
+void main() {
+  test('localImageDecodePixels scales by device pixel ratio', () {
+    expect(localImageDecodePixels(120, 2), 240);
+    expect(localImageDecodePixels(120, 3), 360);
+  });
+
+  test('localImageDecodePixels ignores empty or infinite sizes', () {
+    expect(localImageDecodePixels(null, 2), isNull);
+    expect(localImageDecodePixels(0, 2), isNull);
+    expect(localImageDecodePixels(double.infinity, 2), isNull);
+  });
+
+  test('localImageDecodePixels clamps huge bitmaps', () {
+    expect(localImageDecodePixels(8000, 3), 4096);
+  });
+}


### PR DESCRIPTION
## Summary
- `LocalImage` now defaults `cacheWidth` / `cacheHeight` from logical size times device pixel ratio.
- Explicit cache sizes still win; missing or infinite sizes stay unclamped.

## Test plan
- [x] `flutter test test/ui/core/widgets/local_image_decode_test.dart`
- [x] `dart analyze lib/ui/core/widgets/local_image.dart`
- [x] Cold-start the app and confirm first frame still reaches Timeline
- [x] Open a gallery-heavy Timeline and confirm thumbnails still look sharp