### PR TITLE
chore: upgrade dart_agent_core to 2.1.5

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -364,10 +364,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_agent_core
-      sha256: d04522612390bcdde7828651b0e475cef56da87dfa728cd6efff73ad8348625c
+      sha256: "75215f5d2f583b0e533ad4b16af32104d280ae3b0c8d4df63d2f38b6923ff697"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.5"
   dart_jsonwebtoken:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,7 +67,7 @@ dependencies:
   health: ^13.2.1
   pedometer: ^4.0.0
   workmanager: ^0.9.0
-  dart_agent_core: ^2.1.2
+  dart_agent_core: ^2.1.5
   flutter_js: ^0.8.7
   drift: ^2.30.0
   sqlite3_flutter_libs: ^0.5.41


### PR DESCRIPTION
## Summary
- upgrade dart_agent_core from 2.1.2 to 2.1.5
- refresh the pub lockfile checksum and resolved version
- verify the actual upstream code diff, including changes omitted from the release notes

## Compatibility review
- LLMRequestHash.compute adds the optional named toolChoice parameter, which is source-breaking for custom LLMRequestHash implementations; Memex has no implementation or direct call site
- FileStateStorage now rejects empty, path-separated, or dot-dot session IDs; Memex state IDs use UUIDs, hashes, timestamps, and validated agent names
- ImagePart adds hosted URL support while preserving the existing positional base64 constructor used by Memex
- Gemini tool-result roles and required tool configuration were corrected upstream

## Test plan
- PASS: targeted Flutter tests (45 tests) covering agent state persistence, image history, SuperAgent children, character agents, chat-turn resume, and character service defaults
- flutter analyze completed with no errors or warnings introduced by this change; it reports 157 existing info-level lints
- full flutter test was interrupted after 820 passed, 5 skipped, and 0 failed; targeted affected-path tests were then run to completion