### PR TITLE
perf(timeline): load page attachments in two queries

### DIFF
--- a/lib/data/services/card_attachment_service.dart
+++ b/lib/data/services/card_attachment_service.dart
@@ -232,7 +232,11 @@ Map<String, List<CardAttachmentData>> mergeAttachmentsForFacts({
     );
   }
   for (final attachments in map.values) {
-    attachments.sort((a, b) => a.sortKey.compareTo(b.sortKey));
+    attachments.sort((a, b) {
+      final byKey = a.sortKey.compareTo(b.sortKey);
+      if (byKey != 0) return byKey;
+      return a.id.compareTo(b.id);
+    });
   }
   return map;
 }

--- a/lib/data/services/card_attachment_service.dart
+++ b/lib/data/services/card_attachment_service.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:memex/data/services/system_action_service.dart';
 import 'package:memex/data/services/clarification_request_service.dart';
 import 'package:memex/data/services/event_bus_service.dart';
 import 'package:memex/data/services/table_change_notifier.dart';
 import 'package:memex/data/services/user_notification_service.dart';
+import 'package:memex/db/app_database.dart';
 import 'package:memex/ui/card_attachments/card_attachment_data.dart';
 import 'package:memex/utils/user_storage.dart';
 
@@ -94,17 +96,25 @@ class CardAttachmentService {
     return merged;
   }
 
-  /// Fetches attachments for multiple factIds in one call.
+  /// Fetches attachments for multiple factIds in two queries, not N×2.
   /// Returns a map of factId → sorted attachment list.
   Future<Map<String, List<CardAttachmentData>>> getAttachmentsForFacts(
     List<String> factIds,
   ) async {
-    final map = <String, List<CardAttachmentData>>{};
-    final futures = factIds.map((id) async {
-      map[id] = await getAttachments(id);
-    });
-    await Future.wait(futures);
-    return map;
+    final uniqueIds = factIds.toSet().toList();
+    if (uniqueIds.isEmpty) {
+      return <String, List<CardAttachmentData>>{};
+    }
+
+    final actionsFuture =
+        SystemActionService.instance.getVisibleForFacts(uniqueIds);
+    final requestsFuture =
+        ClarificationRequestService.instance.getVisibleForFacts(uniqueIds);
+    return mergeAttachmentsForFacts(
+      factIds: uniqueIds,
+      actions: await actionsFuture,
+      requests: await requestsFuture,
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -182,4 +192,47 @@ class CardAttachmentService {
             ))
         .toList();
   }
+}
+
+@visibleForTesting
+Map<String, List<CardAttachmentData>> mergeAttachmentsForFacts({
+  required List<String> factIds,
+  required List<SystemAction> actions,
+  required List<ClarificationRequest> requests,
+}) {
+  final map = <String, List<CardAttachmentData>>{
+    for (final id in factIds) id: <CardAttachmentData>[],
+  };
+  for (final action in actions) {
+    final factId = action.factId;
+    if (factId == null) continue;
+    final bucket = map[factId];
+    if (bucket == null) continue;
+    bucket.add(
+      CardAttachmentData(
+        id: 'system_action_${action.id}',
+        type: CardAttachmentType.systemAction,
+        data: {'action': action},
+        sortKey: 100,
+      ),
+    );
+  }
+  for (final request in requests) {
+    final factId = request.factId;
+    if (factId == null) continue;
+    final bucket = map[factId];
+    if (bucket == null) continue;
+    bucket.add(
+      CardAttachmentData(
+        id: 'clarification_${request.id}',
+        type: CardAttachmentType.clarificationRequest,
+        data: {'request': request},
+        sortKey: 50,
+      ),
+    );
+  }
+  for (final attachments in map.values) {
+    attachments.sort((a, b) => a.sortKey.compareTo(b.sortKey));
+  }
+  return map;
 }

--- a/lib/data/services/clarification_request_service.dart
+++ b/lib/data/services/clarification_request_service.dart
@@ -201,6 +201,13 @@ class ClarificationRequestService {
   }
 
   Future<List<ClarificationRequest>> getVisibleForFact(String factId) async {
+    return getVisibleForFacts([factId]);
+  }
+
+  Future<List<ClarificationRequest>> getVisibleForFacts(
+    List<String> factIds,
+  ) async {
+    if (factIds.isEmpty) return [];
     final query = _db.select(_db.clarificationRequests)
       ..where((t) =>
           t.status.isIn([
@@ -209,7 +216,7 @@ class ClarificationRequestService {
             ClarificationRequestStatus.completed,
             ClarificationRequestStatus.failed,
           ]) &
-          t.factId.equals(factId))
+          t.factId.isIn(factIds))
       ..orderBy([(t) => OrderingTerm.desc(t.createdAt)]);
     return query.get();
   }

--- a/lib/data/services/system_action_service.dart
+++ b/lib/data/services/system_action_service.dart
@@ -164,9 +164,15 @@ class SystemActionService {
 
   /// Gets non-rejected actions for a given factId (one-shot query).
   Future<List<SystemAction>> getVisibleForFact(String factId) async {
+    return getVisibleForFacts([factId]);
+  }
+
+  /// Gets non-rejected actions for many facts in one query.
+  Future<List<SystemAction>> getVisibleForFacts(List<String> factIds) async {
+    if (factIds.isEmpty) return [];
     return (_db.select(_db.systemActions)
           ..where(
-              (t) => t.factId.equals(factId) & t.status.isNotIn(['rejected'])))
+              (t) => t.factId.isIn(factIds) & t.status.isNotIn(['rejected'])))
         .get();
   }
 

--- a/lib/ui/timeline/view_models/timeline_viewmodel.dart
+++ b/lib/ui/timeline/view_models/timeline_viewmodel.dart
@@ -29,6 +29,8 @@ typedef TimelineCardsFetcher =
 typedef TimelineTagsFetcher = Future<Result<List<TagModel>>> Function();
 typedef TimelineAttachmentFetcher =
     Future<List<CardAttachmentData>> Function(String factId);
+typedef TimelineAttachmentsPageFetcher =
+    Future<Map<String, List<CardAttachmentData>>> Function(List<String> factIds);
 typedef PendingAttachmentsFetcher = Future<List<CardAttachmentData>> Function();
 
 /// Upserts a card into a timeline list by stable card id.
@@ -101,6 +103,7 @@ class TimelineViewModel extends ChangeNotifier {
     TimelineCardsFetcher? fetchTimelineCards,
     TimelineTagsFetcher? fetchTags,
     TimelineAttachmentFetcher? fetchAttachmentForCard,
+    TimelineAttachmentsPageFetcher? fetchAttachmentsForCards,
     PendingAttachmentsFetcher? fetchPendingAttachments,
     Duration auxiliaryQueryTimeout = defaultAuxiliaryQueryTimeout,
     bool autoLoad = true,
@@ -124,6 +127,9 @@ class TimelineViewModel extends ChangeNotifier {
          fetchAttachmentForCard:
              fetchAttachmentForCard ??
              CardAttachmentService.instance.getAttachments,
+         fetchAttachmentsForCards:
+             fetchAttachmentsForCards ??
+             CardAttachmentService.instance.getAttachmentsForFacts,
          fetchPendingAttachments:
              fetchPendingAttachments ??
              CardAttachmentService.instance.getPendingAttachments,
@@ -136,10 +142,13 @@ class TimelineViewModel extends ChangeNotifier {
     TimelineCardsFetcher? fetchTimelineCards,
     TimelineTagsFetcher? fetchTags,
     TimelineAttachmentFetcher? fetchAttachmentForCard,
+    TimelineAttachmentsPageFetcher? fetchAttachmentsForCards,
     PendingAttachmentsFetcher? fetchPendingAttachments,
     Duration auxiliaryQueryTimeout = defaultAuxiliaryQueryTimeout,
     bool autoLoad = false,
   }) {
+    final perCard =
+        fetchAttachmentForCard ?? (_) async => const <CardAttachmentData>[];
     return TimelineViewModel._(
       fetchTimelineCards:
           fetchTimelineCards ??
@@ -151,8 +160,16 @@ class TimelineViewModel extends ChangeNotifier {
             DateTime? dateTo,
           }) async => const Ok(<TimelineCardModel>[]),
       fetchTags: fetchTags ?? () async => const Ok(<TagModel>[]),
-      fetchAttachmentForCard:
-          fetchAttachmentForCard ?? (_) async => const <CardAttachmentData>[],
+      fetchAttachmentForCard: perCard,
+      fetchAttachmentsForCards:
+          fetchAttachmentsForCards ??
+          (ids) async {
+            final map = <String, List<CardAttachmentData>>{};
+            for (final id in ids) {
+              map[id] = await perCard(id);
+            }
+            return map;
+          },
       fetchPendingAttachments:
           fetchPendingAttachments ?? () async => const <CardAttachmentData>[],
       auxiliaryQueryTimeout: auxiliaryQueryTimeout,
@@ -164,12 +181,14 @@ class TimelineViewModel extends ChangeNotifier {
     required TimelineCardsFetcher fetchTimelineCards,
     required TimelineTagsFetcher fetchTags,
     required TimelineAttachmentFetcher fetchAttachmentForCard,
+    required TimelineAttachmentsPageFetcher fetchAttachmentsForCards,
     required PendingAttachmentsFetcher fetchPendingAttachments,
     required Duration auxiliaryQueryTimeout,
     required bool autoLoad,
   }) : _fetchTimelineCards = fetchTimelineCards,
        _fetchTags = fetchTags,
        _fetchAttachmentForCard = fetchAttachmentForCard,
+       _fetchAttachmentsForCards = fetchAttachmentsForCards,
        _fetchPendingAttachments = fetchPendingAttachments,
        _auxiliaryQueryTimeout = auxiliaryQueryTimeout {
     load = Command0<void>(_loadInitial);
@@ -182,6 +201,7 @@ class TimelineViewModel extends ChangeNotifier {
   final TimelineCardsFetcher _fetchTimelineCards;
   final TimelineTagsFetcher _fetchTags;
   final TimelineAttachmentFetcher _fetchAttachmentForCard;
+  final TimelineAttachmentsPageFetcher _fetchAttachmentsForCards;
   final PendingAttachmentsFetcher _fetchPendingAttachments;
   final Duration _auxiliaryQueryTimeout;
 
@@ -369,27 +389,16 @@ class TimelineViewModel extends ChangeNotifier {
   }) async {
     if (cardList.isEmpty) return false;
     final factIds = cardList.map((c) => c.id).toList();
-    final entries = await Future.wait(
-      factIds.map((factId) async {
-        final data = await _runAuxiliaryQuery<List<CardAttachmentData>>(
-          label: 'load attachments for $factId',
-          query: () => _fetchAttachmentForCard(factId),
-        );
-        return data == null ? null : MapEntry(factId, data);
-      }),
+    final map = await _runAuxiliaryQuery<Map<String, List<CardAttachmentData>>>(
+      label: 'load attachments for page',
+      query: () => _fetchAttachmentsForCards(factIds),
     );
     if (generation != null &&
         filter != null &&
         _isStaleTimelineLoad(generation, filter)) {
       return false;
     }
-    final map = <String, List<CardAttachmentData>>{};
-    for (final entry in entries) {
-      if (entry != null) {
-        map[entry.key] = entry.value;
-      }
-    }
-    if (map.isEmpty) return false;
+    if (map == null || map.isEmpty) return false;
     attachments.addAll(map);
     if (notify) notifyListeners();
     return true;

--- a/test/data/services/card_attachment_batch_test.dart
+++ b/test/data/services/card_attachment_batch_test.dart
@@ -46,4 +46,47 @@ void main() {
     expect(merged['fact-b']!.single.id, 'system_action_a2');
     expect(merged['fact-c'], isEmpty);
   });
+
+  test('mergeAttachmentsForFacts is stable for the same sort key', () {
+    const later = SystemAction(
+      id: 'a2',
+      actionType: 'calendar',
+      actionData: '{}',
+      status: 'pending',
+      factId: 'fact-a',
+      createdAt: 1,
+      updatedAt: 1,
+    );
+    const earlier = SystemAction(
+      id: 'a1',
+      actionType: 'calendar',
+      actionData: '{}',
+      status: 'pending',
+      factId: 'fact-a',
+      createdAt: 1,
+      updatedAt: 1,
+    );
+
+    final merged = mergeAttachmentsForFacts(
+      factIds: ['fact-a'],
+      actions: [later, earlier],
+      requests: const [],
+    );
+
+    expect(merged['fact-a']!.map((item) => item.id), [
+      'system_action_a1',
+      'system_action_a2',
+    ]);
+  });
+
+  test('mergeAttachmentsForFacts returns an empty map for no facts', () {
+    expect(
+      mergeAttachmentsForFacts(
+        factIds: const [],
+        actions: const [],
+        requests: const [],
+      ),
+      isEmpty,
+    );
+  });
 }

--- a/test/data/services/card_attachment_batch_test.dart
+++ b/test/data/services/card_attachment_batch_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/card_attachment_service.dart';
+import 'package:memex/db/app_database.dart';
+
+void main() {
+  test('mergeAttachmentsForFacts groups two queries by fact id', () {
+    const first = SystemAction(
+      id: 'a1',
+      actionType: 'calendar',
+      actionData: '{}',
+      status: 'pending',
+      factId: 'fact-a',
+      createdAt: 1,
+      updatedAt: 1,
+    );
+    const second = SystemAction(
+      id: 'a2',
+      actionType: 'calendar',
+      actionData: '{}',
+      status: 'pending',
+      factId: 'fact-b',
+      createdAt: 1,
+      updatedAt: 1,
+    );
+    const request = ClarificationRequest(
+      id: 'c1',
+      question: 'Which day?',
+      responseType: 'confirm',
+      status: 'pending',
+      factId: 'fact-a',
+      createdAt: 1,
+      updatedAt: 1,
+    );
+
+    final merged = mergeAttachmentsForFacts(
+      factIds: ['fact-a', 'fact-b', 'fact-c'],
+      actions: [first, second],
+      requests: [request],
+    );
+
+    expect(merged.keys, ['fact-a', 'fact-b', 'fact-c']);
+    expect(merged['fact-a']!.map((item) => item.id), [
+      'clarification_c1',
+      'system_action_a1',
+    ]);
+    expect(merged['fact-b']!.single.id, 'system_action_a2');
+    expect(merged['fact-c'], isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- Timeline page loads fetch visible system actions and clarifications with `fact_id IN (...)` instead of two queries per card.
- Grouping is shared so empty facts still get an attachment slot.

## Test plan
- [x] `flutter test test/data/services/card_attachment_batch_test.dart test/data/services/system_action_service_test.dart`
- [x] `dart analyze lib/data/services/card_attachment_service.dart lib/data/services/system_action_service.dart lib/data/services/clarification_request_service.dart lib/ui/timeline/view_models/timeline_viewmodel.dart`
- [x] Scroll Timeline with many cards and confirm attachment rows still appear