### PR TITLE
perf(chat): throttle Super Agent scroll while streaming

### DIFF
--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -285,6 +285,7 @@ bool shouldScrollChatToBottom({
 }) {
   if (force) return true;
   if (lastScrollAt == null) return true;
+  if (now.isBefore(lastScrollAt)) return true;
   return now.difference(lastScrollAt) >= minInterval;
 }
 

--- a/lib/ui/chat/widgets/agent_chat_dialog.dart
+++ b/lib/ui/chat/widgets/agent_chat_dialog.dart
@@ -276,6 +276,19 @@ double resolveSuperAgentInputBottomInset({
 }
 
 @visibleForTesting
+@visibleForTesting
+bool shouldScrollChatToBottom({
+  required DateTime now,
+  required DateTime? lastScrollAt,
+  required Duration minInterval,
+  required bool force,
+}) {
+  if (force) return true;
+  if (lastScrollAt == null) return true;
+  return now.difference(lastScrollAt) >= minInterval;
+}
+
+@visibleForTesting
 bool shouldCreateAIMessageForResponseChunk({
   required String text,
   required bool isDone,
@@ -503,6 +516,8 @@ class _AgentChatDialogState extends State<AgentChatDialog>
   // Controllers
   final TextEditingController _messageController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
+  DateTime? _lastChatScrollAt;
+  bool _forceNextChatScroll = false;
   final FocusNode _messageFocusNode = FocusNode();
   final ImagePicker _imagePicker = ImagePicker();
   final List<XFile> _selectedImages = [];
@@ -538,7 +553,9 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       onFlush: () {
         if (!mounted) return;
         setState(() {});
-        _scrollToBottom();
+        final force = _forceNextChatScroll;
+        _forceNextChatScroll = false;
+        _scrollToBottom(force: force);
       },
     );
     _currentSessionId = widget.initialSessionId;
@@ -1544,6 +1561,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
       }
       if (event is ChatAgentStoppedEvent) {
         _isLoadingAgent = false;
+        _forceNextChatScroll = true;
         return;
       }
       if (event is ChatTokenUsageEvent) {
@@ -1630,6 +1648,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
         }
         if (event.isDone) {
           _nextResponseStartsNewMessage = true;
+          _forceNextChatScroll = true;
         } else {
           _nextResponseStartsNewMessage = false;
         }
@@ -1641,6 +1660,7 @@ class _AgentChatDialogState extends State<AgentChatDialog>
           primary.isExpanded = false;
         }
         _items.add(ErrorItem(event.error));
+        _forceNextChatScroll = true;
       }
   }
 
@@ -1703,7 +1723,17 @@ class _AgentChatDialogState extends State<AgentChatDialog>
     return processItem;
   }
 
-  void _scrollToBottom() {
+  void _scrollToBottom({bool force = false}) {
+    final now = DateTime.now();
+    if (!shouldScrollChatToBottom(
+      now: now,
+      lastScrollAt: _lastChatScrollAt,
+      minInterval: const Duration(milliseconds: 250),
+      force: force,
+    )) {
+      return;
+    }
+    _lastChatScrollAt = now;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_scrollController.hasClients) {
         _scrollController.animateTo(

--- a/test/ui/chat/widgets/chat_scroll_throttle_test.dart
+++ b/test/ui/chat/widgets/chat_scroll_throttle_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/ui/chat/widgets/agent_chat_dialog.dart';
+
+void main() {
+  test('throttles chat scroll unless forced', () {
+    final start = DateTime.utc(2026, 9, 10, 12);
+    const gap = Duration(milliseconds: 250);
+
+    expect(
+      shouldScrollChatToBottom(
+        now: start,
+        lastScrollAt: null,
+        minInterval: gap,
+        force: false,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldScrollChatToBottom(
+        now: start.add(const Duration(milliseconds: 100)),
+        lastScrollAt: start,
+        minInterval: gap,
+        force: false,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldScrollChatToBottom(
+        now: start.add(const Duration(milliseconds: 100)),
+        lastScrollAt: start,
+        minInterval: gap,
+        force: true,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldScrollChatToBottom(
+        now: start.add(gap),
+        lastScrollAt: start,
+        minInterval: gap,
+        force: false,
+      ),
+      isTrue,
+    );
+  });
+}

--- a/test/ui/chat/widgets/chat_scroll_throttle_test.dart
+++ b/test/ui/chat/widgets/chat_scroll_throttle_test.dart
@@ -42,5 +42,14 @@ void main() {
       ),
       isTrue,
     );
+    expect(
+      shouldScrollChatToBottom(
+        now: start.subtract(const Duration(seconds: 1)),
+        lastScrollAt: start,
+        minInterval: gap,
+        force: false,
+      ),
+      isTrue,
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Limit automatic Super Agent transcript scrolling to once per 250ms while response tokens stream. Completed replies, agent-stop events, and chat errors force a scroll to the latest content.
- Keep explicit UI actions and approval requests outside the stream throttle. Previously, an approval request or full-screen toggle inside the throttle window could leave the latest content offscreen after the user interrupted auto-scroll to read history.
- Add seven widget regression cases using the real dialog, stream subscription, event batcher, and scroll controller: token coalescing at 249/250ms, completed replies, stop, error, approval visibility, full-screen actions, and disposal with buffered events. Inject an event stream and clock only for deterministic tests.

## Validation
- Passed: `flutter test --no-pub --reporter expanded test/ui/chat/widgets/chat_scroll_throttle_test.dart test/ui/chat/widgets/chat_scroll_throttle_widget_test.dart test/ui/chat/widgets/agent_chat_dialog_test.dart` — 43 tests.
- Verified that the new approval and full-screen regression tests fail with the original non-stream scroll behavior and pass after the fix.
- Passed: `flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings --no-congratulate` — no errors; 157 existing warning/info findings. GitHub CI compares against the current main baseline.
- Local full-suite execution was blocked by automatic approval review because elevated execution of the entire test tree exceeded the allowed targeted test scope. GitHub Flutter Quality run [35048791208](https://github.com/memex-lab/memex/actions/runs/35048791208) passed on `d752c64b`: 0 base/PR test failures and 0 new analyzer issues (161 findings on both base and PR).
- Merged current main (including #457) into this branch before final validation.

The advisory AI-review job completed but returned no parseable report; it is not counted as a successful semantic review. The change was reviewed against the event/scroll call sites and verified with the regression tests above.
