### PR TITLE
perf(timeline): index newest cards first then yield

### DIFF
--- a/lib/data/repositories/get_timeline_cards.dart
+++ b/lib/data/repositories/get_timeline_cards.dart
@@ -36,7 +36,10 @@ Future<List<TimelineCardModel>> getTimelineCards({
     if (await db.cardDao.isCacheEmpty()) {
       _logger.info('Card cache is empty, triggering rebuild...');
       // Synchronous rebuild for first run to ensure data is available
-      await fileSystemService.rebuildCardCache(userId);
+      await fileSystemService.rebuildCardCache(
+        userId,
+        waitUntilIndexed: limit,
+      );
     }
 
     // 2. Query Cards using DAO

--- a/lib/data/services/card_cache_rebuild.dart
+++ b/lib/data/services/card_cache_rebuild.dart
@@ -1,6 +1,7 @@
 const int cardCacheRebuildYieldEvery = 8;
 
 List<String> sortCardFilesNewestFirst(List<String> paths) {
+  if (paths.length <= 1) return List<String>.from(paths);
   final next = List<String>.from(paths)..sort((a, b) => b.compareTo(a));
   return next;
 }

--- a/lib/data/services/card_cache_rebuild.dart
+++ b/lib/data/services/card_cache_rebuild.dart
@@ -1,0 +1,13 @@
+const int cardCacheRebuildYieldEvery = 8;
+
+List<String> sortCardFilesNewestFirst(List<String> paths) {
+  final next = List<String>.from(paths)..sort((a, b) => b.compareTo(a));
+  return next;
+}
+
+bool shouldYieldCardCacheRebuild(
+  int indexedCount, {
+  int every = cardCacheRebuildYieldEvery,
+}) {
+  return every > 0 && indexedCount > 0 && indexedCount % every == 0;
+}

--- a/lib/data/services/file_system_service.dart
+++ b/lib/data/services/file_system_service.dart
@@ -13,6 +13,7 @@ import 'base_file_service.dart';
 import 'api_exception.dart';
 import 'local_asset_server.dart';
 import 'event_log_service.dart';
+import 'package:memex/data/services/card_cache_rebuild.dart';
 import 'package:memex/db/app_database.dart';
 import 'package:memex/domain/models/card_model.dart';
 import 'package:memex/domain/models/system_event.dart';
@@ -164,6 +165,7 @@ class FileSystemService {
 
   /// Flag to indicate if a rebuild is in progress to prevent recursion
   bool _isRebuilding = false;
+  Completer<void>? _rebuildVisibleReady;
 
   static DateTime? _lastServerCheckTime;
   static FileSystemService? _instance;
@@ -617,34 +619,60 @@ class FileSystemService {
     });
   }
 
-  /// Rebuild the entire card cache for a user
-  Future<void> rebuildCardCache(String userId) async {
+  /// Rebuild the entire card cache for a user.
+  ///
+  /// When [waitUntilIndexed] is set, returns after that many cards are indexed
+  /// (newest files first) so Timeline can paint, then finishes in the background.
+  Future<void> rebuildCardCache(
+    String userId, {
+    int? waitUntilIndexed,
+  }) async {
     if (_isRebuilding) {
-      _logger.info('Card cache rebuild already in progress, skipping...');
+      final gate = _rebuildVisibleReady;
+      if (gate != null) await gate.future;
       return;
     }
 
     _isRebuilding = true;
+    _rebuildVisibleReady = Completer<void>();
     _logger.info('Starting card cache rebuild for user $userId');
+
+    final body = _rebuildCardCacheBody(
+      userId,
+      waitUntilIndexed: waitUntilIndexed,
+    );
+    if (waitUntilIndexed == null) {
+      await body;
+      return;
+    }
+    unawaited(body);
+    await _rebuildVisibleReady!.future;
+  }
+
+  Future<void> _rebuildCardCacheBody(
+    String userId, {
+    int? waitUntilIndexed,
+  }) async {
+    void markVisibleReady() {
+      final gate = _rebuildVisibleReady;
+      if (gate != null && !gate.isCompleted) {
+        gate.complete();
+      }
+    }
+
     try {
-      // 1. Clear existing cache
       await AppDatabase.instance.delete(AppDatabase.instance.cardCache).go();
 
-      // 2. List all card files
-      final cardFiles = await listAllCardFiles(userId);
+      final cardFiles =
+          sortCardFilesNewestFirst(await listAllCardFiles(userId));
       _logger.info('Found ${cardFiles.length} card files to index');
 
-      // 3. Process in batches to avoid locking UI too long
-      // Note: reading all files might take time.
       int count = 0;
       for (final cardFile in cardFiles) {
         try {
-          // Parse factId from path
-          // Path: .../Cards/YYYY/MM/DD_ts_X.yaml
           final factId = factIdFromCardPath(cardFile);
           if (factId == null) continue;
 
-          // Read card data
           final cardData = await readCardFile(userId, factId);
           if (cardData == null) continue;
 
@@ -652,6 +680,13 @@ class FileSystemService {
 
           await updateCardCache(userId, factId, cardData);
           count++;
+          if (waitUntilIndexed != null &&
+              count >= waitUntilIndexed) {
+            markVisibleReady();
+          }
+          if (shouldYieldCardCacheRebuild(count)) {
+            await Future<void>.delayed(Duration.zero);
+          }
         } catch (e) {
           _logger.warning('Error indexing card file $cardFile: $e');
         }
@@ -660,6 +695,7 @@ class FileSystemService {
     } catch (e) {
       _logger.severe('Failed to rebuild card cache: $e');
     } finally {
+      markVisibleReady();
       _isRebuilding = false;
     }
   }

--- a/test/data/services/card_cache_rebuild_test.dart
+++ b/test/data/services/card_cache_rebuild_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memex/data/services/card_cache_rebuild.dart';
+
+void main() {
+  test('sorts card files newest-first by path', () {
+    expect(
+      sortCardFilesNewestFirst([
+        '/Cards/2024/01/01_ts_1.yaml',
+        '/Cards/2026/09/10_ts_2.yaml',
+        '/Cards/2025/12/31_ts_9.yaml',
+      ]),
+      [
+        '/Cards/2026/09/10_ts_2.yaml',
+        '/Cards/2025/12/31_ts_9.yaml',
+        '/Cards/2024/01/01_ts_1.yaml',
+      ],
+    );
+  });
+
+  test('yields every eight indexed cards', () {
+    expect(shouldYieldCardCacheRebuild(0), isFalse);
+    expect(shouldYieldCardCacheRebuild(7), isFalse);
+    expect(shouldYieldCardCacheRebuild(8), isTrue);
+    expect(shouldYieldCardCacheRebuild(16), isTrue);
+  });
+}

--- a/test/data/services/card_cache_rebuild_test.dart
+++ b/test/data/services/card_cache_rebuild_test.dart
@@ -3,18 +3,31 @@ import 'package:memex/data/services/card_cache_rebuild.dart';
 
 void main() {
   test('sorts card files newest-first by path', () {
+    final original = [
+      '/Cards/2024/01/01_ts_1.yaml',
+      '/Cards/2026/09/10_ts_2.yaml',
+      '/Cards/2025/12/31_ts_9.yaml',
+    ];
     expect(
-      sortCardFilesNewestFirst([
-        '/Cards/2024/01/01_ts_1.yaml',
-        '/Cards/2026/09/10_ts_2.yaml',
-        '/Cards/2025/12/31_ts_9.yaml',
-      ]),
+      sortCardFilesNewestFirst(original),
       [
         '/Cards/2026/09/10_ts_2.yaml',
         '/Cards/2025/12/31_ts_9.yaml',
         '/Cards/2024/01/01_ts_1.yaml',
       ],
     );
+    expect(original, [
+      '/Cards/2024/01/01_ts_1.yaml',
+      '/Cards/2026/09/10_ts_2.yaml',
+      '/Cards/2025/12/31_ts_9.yaml',
+    ]);
+  });
+
+  test('sortCardFilesNewestFirst copies empty and single-item lists', () {
+    expect(sortCardFilesNewestFirst(const []), isEmpty);
+    expect(sortCardFilesNewestFirst(['/Cards/2026/09/10_ts_1.yaml']), [
+      '/Cards/2026/09/10_ts_1.yaml',
+    ]);
   });
 
   test('yields every eight indexed cards', () {


### PR DESCRIPTION
## Summary
- Empty card cache indexes newest YAML files first and returns after one Timeline page.
- Remaining files keep indexing in the background with a yield every eight cards.

## Test plan
- [x] `flutter test test/data/services/card_cache_rebuild_test.dart`
- [x] `dart analyze lib/data/services/card_cache_rebuild.dart lib/data/services/file_system_service.dart lib/data/repositories/get_timeline_cards.dart`
- [x] Cold-start a large library and confirm Timeline appears before the full cache rebuild finishes