### PR TITLE
perf(search): defer and yield during full FTS rebuilds

### DIFF
--- a/lib/data/services/search_service.dart
+++ b/lib/data/services/search_service.dart
@@ -60,8 +60,8 @@ class SearchService {
       AppDatabase.instance.clearFtsRebuildFlag();
       _logger.info(
           'FTS tables newly created via migration — scheduling full rebuild');
-      // Fire-and-forget so app startup is not blocked.
-      Future(() async {
+      // Defer so first Timeline paint is not competing with jieba + full scans.
+      Future<void>.delayed(const Duration(seconds: 3), () async {
         try {
           await rebuildAll(userId);
           _logger.info('Post-migration FTS rebuild completed');
@@ -323,6 +323,9 @@ class SearchService {
           insight: cardData.insight?.text ?? '',
         );
         count++;
+        if (shouldYieldFtsRebuild(count)) {
+          await Future<void>.delayed(Duration.zero);
+        }
       } catch (e) {
         _logger.warning('Error indexing card file $cardFile: $e');
       }
@@ -371,6 +374,9 @@ class SearchService {
           content: content,
         );
         count++;
+        if (shouldYieldFtsRebuild(count)) {
+          await Future<void>.delayed(Duration.zero);
+        }
       } catch (e) {
         _logger.warning('Error indexing PKM file ${file.path}: $e');
       }
@@ -429,6 +435,14 @@ class SearchService {
         _stringValue(before['fact']) != _stringValue(after['fact']) ||
         _stringListValue(before['tags']) != _stringListValue(after['tags']) ||
         _insightText(before['insight']) != _insightText(after['insight']);
+  }
+
+  @visibleForTesting
+  static const int ftsRebuildYieldEvery = 8;
+
+  @visibleForTesting
+  bool shouldYieldFtsRebuild(int indexedCount) {
+    return indexedCount > 0 && indexedCount % ftsRebuildYieldEvery == 0;
   }
 
   @visibleForTesting

--- a/lib/data/services/search_service.dart
+++ b/lib/data/services/search_service.dart
@@ -34,6 +34,7 @@ class SearchService {
   final Logger _logger = getLogger('SearchService');
 
   bool _initialized = false;
+  int _initGeneration = 0;
 
   // ---------------------------------------------------------------------------
   // Initialization
@@ -48,6 +49,7 @@ class SearchService {
   void init(String userId) {
     if (_initialized) return;
     _initialized = true;
+    _initGeneration++;
 
     // Jieba segmenter loads lazily on first use and auto-releases after idle.
     // No explicit initialization needed here.
@@ -58,10 +60,18 @@ class SearchService {
     // Check if a post-migration FTS rebuild is needed.
     if (AppDatabase.isInitialized && AppDatabase.instance.needsFtsRebuild) {
       AppDatabase.instance.clearFtsRebuildFlag();
+      final scheduledGeneration = _initGeneration;
       _logger.info(
           'FTS tables newly created via migration — scheduling full rebuild');
       // Defer so first Timeline paint is not competing with jieba + full scans.
       Future<void>.delayed(const Duration(seconds: 3), () async {
+        if (!shouldRunDeferredFtsRebuild(
+          scheduledGeneration: scheduledGeneration,
+          currentGeneration: _initGeneration,
+          initialized: _initialized,
+        )) {
+          return;
+        }
         try {
           await rebuildAll(userId);
           _logger.info('Post-migration FTS rebuild completed');
@@ -75,6 +85,7 @@ class SearchService {
   /// Reset state on logout so the next login re-initializes.
   void reset() {
     _initialized = false;
+    _initGeneration++;
     FileOperationService.instance.onFileChanged = null;
     JiebaSegmenter.instance.dispose();
   }
@@ -443,6 +454,15 @@ class SearchService {
   @visibleForTesting
   bool shouldYieldFtsRebuild(int indexedCount) {
     return indexedCount > 0 && indexedCount % ftsRebuildYieldEvery == 0;
+  }
+
+  @visibleForTesting
+  bool shouldRunDeferredFtsRebuild({
+    required int scheduledGeneration,
+    required int currentGeneration,
+    required bool initialized,
+  }) {
+    return initialized && scheduledGeneration == currentGeneration;
   }
 
   @visibleForTesting

--- a/test/data/services/search_service_test.dart
+++ b/test/data/services/search_service_test.dart
@@ -77,4 +77,13 @@ void main() {
       );
     });
   });
+
+  group('FTS rebuild yielding', () {
+    test('yields every eight indexed documents', () {
+      expect(SearchService.instance.shouldYieldFtsRebuild(0), isFalse);
+      expect(SearchService.instance.shouldYieldFtsRebuild(7), isFalse);
+      expect(SearchService.instance.shouldYieldFtsRebuild(8), isTrue);
+      expect(SearchService.instance.shouldYieldFtsRebuild(16), isTrue);
+    });
+  });
 }

--- a/test/data/services/search_service_test.dart
+++ b/test/data/services/search_service_test.dart
@@ -85,5 +85,24 @@ void main() {
       expect(SearchService.instance.shouldYieldFtsRebuild(8), isTrue);
       expect(SearchService.instance.shouldYieldFtsRebuild(16), isTrue);
     });
+
+    test('drops a deferred rebuild after logout', () {
+      expect(
+        SearchService.instance.shouldRunDeferredFtsRebuild(
+          scheduledGeneration: 1,
+          currentGeneration: 1,
+          initialized: true,
+        ),
+        isTrue,
+      );
+      expect(
+        SearchService.instance.shouldRunDeferredFtsRebuild(
+          scheduledGeneration: 1,
+          currentGeneration: 2,
+          initialized: false,
+        ),
+        isFalse,
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Post-migration FTS rebuild waits three seconds so first Timeline paint is not competing with jieba.
- Full card and PKM rebuilds yield every eight documents so scroll can run.

## Test plan
- [x] `flutter test test/data/services/search_service_test.dart`
- [x] `dart analyze lib/data/services/search_service.dart`
- [x] After an FTS migration, scroll Timeline while indexing and confirm it does not freeze for seconds